### PR TITLE
Unify GeosCore module initializations to accept the same arguments

### DIFF
--- a/GeosCore/aerosol_mod.F
+++ b/GeosCore/aerosol_mod.F
@@ -2501,7 +2501,8 @@
 !\\
 ! !INTERFACE:
 !
-      SUBROUTINE Init_Aerosol( am_I_Root, Input_Opt, State_Diag, RC )
+      SUBROUTINE Init_Aerosol( am_I_Root, Input_Opt, 
+     &                         State_Chm, State_Diag, RC )
 !
 ! !USES:
 !
@@ -2509,13 +2510,15 @@
       USE ErrCode_Mod
       USE Input_Opt_Mod,  ONLY : OptInput
       USE State_Chm_Mod,  ONLY : Ind_
+      USE State_Chm_Mod,  ONLY : ChmState
       USE State_Diag_Mod, ONLY : DgnState
 !
 ! !INPUT PARAMETERS:
 !
-      LOGICAL,        INTENT(IN)  :: am_I_Root   ! Are we on the root CPU?
-      TYPE(OptInput), INTENT(IN)  :: Input_Opt   ! Input Options object
-      TYPE(DgnState), INTENT(IN)  :: State_Diag  ! Diagnostics State object
+      LOGICAL,        INTENT(IN)    :: am_I_Root   ! Are we on the root CPU?
+      TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+      TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
+      TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -2527,6 +2530,7 @@
 !  05 Mar 2013 - R. Yantosca - Now accept am_I_Root, Input_Opt, RC arguments
 !  17 Jun 2016 - R. Yantosca - Now use locally-defined species ID flags,
 !  13 Dec 2017 - R. Yantosca - Now accept State_Diag as an argument
+!  07 Aug 2018 - H.P. Lin    - Now accept State_Chm as an argument
 !EOP
 !------------------------------------------------------------------------------
 !BOC

--- a/GeosCore/carbon_mod.F
+++ b/GeosCore/carbon_mod.F
@@ -7647,7 +7647,8 @@ ccc
 !\\
 ! !INTERFACE:
 !
-      SUBROUTINE INIT_CARBON( am_I_Root, Input_Opt, State_Diag, RC )
+      SUBROUTINE INIT_CARBON( am_I_Root, Input_Opt, 
+     &                        State_Chm, State_Diag, RC )
 !
 ! !USES:
 !
@@ -7656,6 +7657,7 @@ ccc
       USE ERROR_MOD,          ONLY : ALLOC_ERR, ERROR_STOP
       USE Input_Opt_Mod,      ONLY : OptInput
       USE State_Chm_Mod,      ONLY : Ind_
+      USE State_Chm_Mod,      ONLY : ChmState
       USE State_Diag_Mod,     ONLY : DgnState
 #if defined( TOMAS )
       USE TOMAS_MOD,          ONLY : IBINS
@@ -7663,9 +7665,10 @@ ccc
 !
 ! !INPUT PARAMETERS:
 !
-      LOGICAL,        INTENT(IN)  :: am_I_Root   ! Is this the root CPU?
-      TYPE(OptInput), INTENT(IN)  :: Input_Opt   ! Input Options object
-      TYPE(DgnState), INTENT(IN)  :: State_Diag  ! Diagnostics State object
+      LOGICAL,        INTENT(IN)    :: am_I_Root   ! Is this the root CPU?
+      TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+      TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
+      TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -7697,6 +7700,7 @@ ccc
 !  11 Aug 2015 - R. Yantosca - Add support for MERRA2 data
 !  23 Sep 2015 - R. Yantosca - Remove reference to DRY* flags, they're obsolete
 !  02 Nov 2017 - R. Yantosca - Now accept State_Diag as an argument
+!  07 Aug 2018 - H.P. Lin    - Now accept State_Chm as an argument
 !EOP
 !------------------------------------------------------------------------------
 !BOC

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -731,6 +731,8 @@ CONTAINS
 !  07 Nov 2017 - R. Yantosca - Now accept Diag_List as an argument
 !  07 Nov 2017 - R. Yantosca - Return error condition to main level
 !  26 Jan 2018 - M. Sulprizio- Moved to gc_environment_mod.F90 from input_mod.F
+!  07 Aug 2018 - H.P. Lin    - Unify init routines to accept Input_Opt, State_Chm,
+!                              State_Diag
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -819,7 +821,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Initialize the MODIS leaf area index module
     !-----------------------------------------------------------------
-    CALL Init_Modis_LAI( am_I_Root, Input_Opt, RC )
+    CALL Init_Modis_LAI( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "Init_Modis_LAI"!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -843,7 +845,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Initialize the GET_NDEP_MOD for soil NOx deposition (bmy, 6/17/16)
     !-----------------------------------------------------------------
-    CALL Init_Get_Ndep( am_I_Root, RC )
+    CALL Init_Get_Ndep( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "Init_Get_Ndep"!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -854,7 +856,7 @@ CONTAINS
     ! Initialize "carbon_mod.F"
     !-----------------------------------------------------------------
     IF ( Input_Opt%LCARB ) THEN
-       CALL Init_Carbon( am_I_Root, Input_Opt, State_Diag, RC )
+       CALL Init_Carbon( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in ""!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -903,7 +905,7 @@ CONTAINS
     !-----------------------------------------------------------------
     IF ( Input_Opt%LSULF .or. Input_Opt%LCARB    .or. &
          Input_Opt%LDUST .or. Input_Opt%LSSALT ) THEN
-       CALL Init_Aerosol( am_I_Root, Input_Opt, State_Diag, RC )
+       CALL Init_Aerosol( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_Aerosol"!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -915,7 +917,7 @@ CONTAINS
     ! Initialize "linoz_mod.F"
     !-----------------------------------------------------------------
     IF ( Input_Opt%LLINOZ ) THEN
-       CALL Init_Linoz( am_I_Root, Input_Opt, RC )
+       CALL Init_Linoz( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_Linoz"!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -926,7 +928,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Initialize "toms_mod.F"
     !-----------------------------------------------------------------
-    CALL Init_Toms( am_I_Root, Input_Opt, RC )
+    CALL Init_Toms( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "Init_Toms"!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/get_ndep_mod.F
+++ b/GeosCore/get_ndep_mod.F
@@ -218,17 +218,24 @@
 !\\
 ! !INTERFACE:
 !
-      SUBROUTINE Init_Get_Ndep( am_I_Root, RC )
+      SUBROUTINE Init_Get_Ndep( am_I_Root, Input_Opt, 
+     &                          State_Chm, State_Diag, RC )
 !
 ! !USES:
 !
       USE CMN_SIZE_Mod
       USE ErrCode_Mod
       USE State_Chm_Mod,      ONLY : Ind_
+      USE Input_Opt_Mod,      ONLY : OptInput
+      USE State_Chm_Mod,      ONLY : ChmState
+      USE State_Diag_Mod,     ONLY : DgnState
 !
 ! !INPUT PARAMETERS: 
 !
-      LOGICAL, INTENT(IN)  :: am_I_Root   ! Are we on the root CPU?
+      LOGICAL, INTENT(IN)           :: am_I_Root   ! Are we on the root CPU?
+      TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+      TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
+      TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -242,6 +249,7 @@
 ! !REVISION HISTORY: 
 !  25 Jul 2014 - R. Yantosca - Initial version
 !  09 Oct 2014 - C. Keller   - Removed obsolete variable DEP_RESERVOIR
+!  07 Aug 2018 - H.P. Lin    - Now accepts State_Chm, State_Diag to unify input
 !EOP
 !------------------------------------------------------------------------------
 !BOC

--- a/GeosCore/linoz_mod.F
+++ b/GeosCore/linoz_mod.F
@@ -1303,7 +1303,8 @@
 !\\
 ! !INTERFACE:
 !
-      SUBROUTINE INIT_LINOZ( am_I_Root, Input_Opt, RC )
+      SUBROUTINE INIT_LINOZ( am_I_Root, Input_Opt, 
+     &                       State_Chm, State_Diag, RC )
 !
 ! !USES:
 !
@@ -1311,11 +1312,15 @@
       USE ErrCode_Mod
       USE ERROR_MOD,          ONLY : ALLOC_ERR
       USE Input_Opt_Mod,      ONLY : OptInput
+      USE State_Chm_Mod,      ONLY : ChmState
+      USE State_Diag_Mod,     ONLY : DgnState
 !
 ! !INPUT PARAMETERS:
 !
-      LOGICAL,        INTENT(IN)  :: am_I_Root   ! Is this the root CPU?
-      TYPE(OptInput), INTENT(IN)  :: Input_Opt   ! Input Options object
+      LOGICAL,        INTENT(IN)    :: am_I_Root   ! Is this the root CPU?
+      TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+      TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
+      TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -1328,6 +1333,7 @@
 !  18 Mar 2013 - R. Yantosca - Accept am_I_Root, Input_Opt, RC arguments
 !  14 Mar 2013 - M. Payer    - Replace Ox with O3 for full-chemistry simulation
 !  19 Oct 2015 - C. Keller   - TLSTT is now 4D to work on curvilinear grids
+!  07 Aug 2018 - H.P. Lin    - Now accepts State_Chm, State_Diag to unify input
 !EOP
 !------------------------------------------------------------------------------
 !BOC

--- a/GeosCore/modis_lai_mod.F90
+++ b/GeosCore/modis_lai_mod.F90
@@ -1071,21 +1071,25 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Init_Modis_Lai( am_I_Root, Input_Opt, RC )
+  SUBROUTINE Init_Modis_Lai( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
 !
 ! !USES:
 !
       USE ErrCode_Mod
       USE Input_Opt_Mod,      ONLY : OptInput
+      USE State_Chm_Mod,      ONLY : ChmState
+      USE State_Diag_Mod,     ONLY : DgnState
 !
 ! !INPUT PARAMETERS:
 !
-      LOGICAL,        INTENT(IN)  :: am_I_Root   ! Are we on the root CPU?
-      TYPE(OptInput), INTENT(IN)  :: Input_Opt   ! Input Options object
+      LOGICAL,        INTENT(IN)    :: am_I_Root   ! Are we on the root CPU?
+      TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+      TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
+      TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
 !
 ! !OUTPUT PARAMETERS:
 !
-      INTEGER,        INTENT(OUT) :: RC          ! Success or failure?
+      INTEGER,        INTENT(OUT)   :: RC          ! Success or failure?
 !
 ! !REVISION HISTORY:
 !  03 Apr 2012 - R. Yantosca - Initial version
@@ -1097,6 +1101,7 @@ CONTAINS
 !  13 Sep 2017 - M. Sulprizio- Remove Input_Opt%USE_OLSON_2001. Olson 2001 is
 !                              now the default.
 !  15 Mar 2018 - M. Sulprizio- Update MODIS LAI end year to 2011.
+!  07 Aug 2018 - H.P. Lin    - Now accepts State_Chm, State_Diag to unify input
 !EOP
 !------------------------------------------------------------------------------
 !BOC

--- a/GeosCore/toms_mod.F
+++ b/GeosCore/toms_mod.F
@@ -485,7 +485,8 @@
 !\\
 ! !INTERFACE:
 !
-      SUBROUTINE INIT_TOMS( am_I_Root, Input_Opt, RC )
+      SUBROUTINE INIT_TOMS( am_I_Root, Input_Opt, 
+     &                      State_Chm, State_Diag, RC )
 !
 ! !USES:
 !
@@ -494,11 +495,15 @@
       USE ERROR_MOD,          ONLY : ALLOC_ERR
       USE ERROR_MOD,          ONLY : ERROR_STOP
       USE Input_Opt_Mod,      ONLY : OptInput
+      USE State_Chm_Mod,      ONLY : ChmState
+      USE State_Diag_Mod,     ONLY : DgnState
 !
 ! !INPUT PARAMETERS:
 !
-      LOGICAL,        INTENT(IN)  :: am_I_Root  ! root CPU?
-      TYPE(OptInput), INTENT(IN)  :: Input_Opt  ! Input opts
+      LOGICAL, INTENT(IN)           :: am_I_Root   ! Are we on the root CPU?
+      TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+      TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
+      TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -511,6 +516,7 @@
 !  16 Mar 2015 - R. Yantosca - TOMS, DTOMS1, DTOMS2 are now pointers
 !  16 Mar 2015 - R. Yantosca - Add Input_Opt, RC arguments for std interface
 !  03 Nov 2016 - B. Henderson- Add extra fields to fix OH issue for GEOS-5
+!  07 Aug 2018 - H.P. Lin    - Now accepts State_Chm, State_Diag to unify input
 !EOP
 !------------------------------------------------------------------------------
 !BOC


### PR DESCRIPTION
This commit unifies all modules in `GeosCore` to accept the same set of arguments - `(am_I_Root, Input_Opt, State_Chm, State_Diag, RC)`

This is done in preparation for moving USE-associated arrays that are dependent on grid sizing (i.e. `(IIPAR, JJPAR, LLPAR)`) in these modules
to `State_Chm`, permitting multi-domain GC-WRF coupling and, in a broader sense, running simultaneous instances of GEOS-Chem modules in the same CPU.

**Important Note: GCHP Code Update Necessary**
This commit changes the entry point for `Init_TOMS` which is being called in GCHP by `gigc_chunk_mod.F90`, breaking compilation for GCHP. 

**Solution:** That entry point should be *removed* - please refer to the following code context taken from `gigc_chunk_mod`, around lines 305:

```fortran
    ! Initialize other GEOS-Chem modules
    CALL GC_Init_Extra( am_I_Root, HistoryConfig%DiagList, Input_Opt,    &
                        State_Chm, State_Diag, RC ) 
    ASSERT_(RC==GC_SUCCESS)

    ! ...

    ! Allocate array of overhead O3 columns for TOMS if chemistry is on
    IF ( Input_Opt%LCHEM ) THEN
       CALL Init_TOMS( am_I_Root, Input_Opt, RC )
       ASSERT_(RC==GC_SUCCESS)
    ENDIF
```

Within `GC_Init_Extra` (from `GC_Environment_Mod`), the following already exists:

```fortran
    !-----------------------------------------------------------------
    ! Initialize "toms_mod.F"
    !-----------------------------------------------------------------
    CALL Init_Toms( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
    IF ( RC /= GC_SUCCESS ) THEN
       ErrMsg = 'Error encountered in "Init_Toms"!'
       CALL GC_Error( ErrMsg, RC, ThisLoc )
       RETURN
    ENDIF
```

Which runs independent of `Input_Opt%LCHEM` selection. Therefore I believe that in the GCHP source, the `Init_TOMS` code is redundant and should be removed. It does not throw a duplicate allocation error, because there are `ALLOCATED` sanity checks within `Init_TOMS` code.


Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>