### PR TITLE
Add the MODEL_, MODEL_WRF pre-processor flags

### DIFF
--- a/GeosCore/cleanup.F
+++ b/GeosCore/cleanup.F
@@ -71,17 +71,15 @@
       USE TOMS_MOD,                ONLY : CLEANUP_TOMS
       USE TPCORE_FVDAS_MOD,        ONLY : EXIT_TPCORE
       USE TPCORE_WINDOW_MOD,       ONLY : EXIT_TPCORE_WINDOW
-#if ! defined( ESMF_ )
+#if !defined( ESMF_ ) && !defined( MODEL_ )
       USE TRANSPORT_MOD,           ONLY : CLEANUP_TRANSPORT
 #endif
       USE UCX_MOD,                 ONLY : CLEANUP_UCX
       USE VDIFF_PRE_Mod,           ONLY : Cleanup_VDIFF_PRE
       USE WETSCAV_MOD,             ONLY : CLEANUP_WETSCAV
 
-      ! HEMCO
-!#if !defined(ESMF_) 
+      ! HEMCO 
       USE EMISSIONS_MOD,           ONLY : EMISSIONS_FINAL
-!#endif
 
 #if   defined( RRTMG )
       USE RRTMG_RAD_TRANSFER_MOD,  ONLY : CLEANUP_SURFACE_RAD
@@ -369,7 +367,7 @@
       CALL CLEANUP_SULFATE()
       CALL CLEANUP_STRAT_CHEM()
       CALL CLEANUP_TAGGED_CO()
-#if ! defined( ESMF_ )
+#if !defined( ESMF_ ) && !defined( MODEL_ )
       CALL CLEANUP_TRANSPORT()
 #endif
       CALL CLEANUP_TOMS()

--- a/GeosCore/main.F
+++ b/GeosCore/main.F
@@ -1,5 +1,13 @@
 !BOC
-#if !defined(ESMF_)
+#if defined( ESMF_ ) || defined( EXTERNAL_GRID ) || defined( MODEL_ )
+      !-----------------------------------------------------------------
+      !         %%%%%%% GEOS-Chem HP (with ESMF & MPI) %%%%%%%
+      !        %%%% GEOS-Chem Coupled with External Models %%%%
+      !
+      ! When GEOS-Chem is connected to an external model or in GCHP,
+      ! the GEOS-Chem classic main.F should not be built.
+      !-----------------------------------------------------------------
+#else
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -144,7 +144,7 @@ CONTAINS
 
     ENDIF
 
-#if !defined( ESMF_ )
+#if !defined( ESMF_ ) && !defined( MODEL_WRF )
     !-----------------------------------------------------------------------
     ! Compute the various PBL quantities with the initial met fields.
     ! This is needed so that HEMCO won't be passed a zero PBL height
@@ -153,6 +153,10 @@ CONTAINS
     ! In ESMF mode this routine should not be called during the init
     ! stage: the required met quantities are not yet defined.
     ! (ckeller, 11/23/16)
+    !
+    ! In GC-WRF, which uses the same entry-point as the GEOS-5 GCM, the
+    ! required met quantities are also not defined until GIGC_Chunk_Run,
+    ! so also skip this here (hplin, 8/9/18)
     !-----------------------------------------------------------------------
     CALL COMPUTE_PBL_HEIGHT( am_I_Root, State_Met, RC )
 

--- a/GeosCore/strat_chem_mod.F90
+++ b/GeosCore/strat_chem_mod.F90
@@ -1821,7 +1821,7 @@ CONTAINS
     IF ( AS /= 0 ) CALL ALLOC_ERR( 'MInit' )
     MInit = 0.0_fp
 
-#if !defined( ESMF_ )
+#if !defined( ESMF_ ) && !defined( MODEL_WRF )
     ! Set MINIT. Ignore in ESMF environment because State_Chm%Species
     ! is not yet filled during initialization. (ckeller, 4/6/16)
     CALL SET_MINIT( am_I_Root, Input_Opt, State_Met, State_Chm, RC )

--- a/GeosUtil/pressure_mod.F
+++ b/GeosUtil/pressure_mod.F
@@ -35,7 +35,7 @@
       PUBLIC  :: CLEANUP_PRESSURE
 
 
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
       PUBLIC  :: Accept_External_Pedge
 #endif
 !
@@ -103,7 +103,7 @@
       REAL(fp), ALLOCATABLE :: PFLT_WET(:,:)          ! "Floating" wet sfc pres
       REAL(fp), ALLOCATABLE :: AP_FULLGRID(:)         ! "A" term for full grid
       REAL(fp), ALLOCATABLE :: BP_FULLGRID(:)         ! "B" term for full grid
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
       REAL(fp), ALLOCATABLE :: EXTERNAL_PEDGE(:,:,:)  ! Pressure edges from 
                                                       !  external grid
 #endif
@@ -329,7 +329,7 @@
 !------------------------------------------------------------------------------
 !BOC
 
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
       ! Pressure [hPa] at bottom edge of level L (see documentation header)
       ! Taken from the GCM fields
       PEDGE = EXTERNAL_PEDGE(I,J,L)
@@ -608,7 +608,7 @@
       IF ( AS /= 0 ) CALL ALLOC_ERR( 'BP_FULLGRID' )
       BP = 0e+0_fp
 
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
       ALLOCATE( EXTERNAL_PEDGE( IIPAR, JJPAR, LLPAR+1 ), STAT=AS )
       IF ( AS /= 0 ) CALL ALLOC_ERR( 'EXTERNAL_PEDGE' )
       EXTERNAL_PEDGE = 0e+0_fp
@@ -770,8 +770,8 @@
       
 #endif
       
-#if !defined( ESMF_ ) 
-      ! Echo info to std output (skip if using ESMF interface to GEOS-5 GCM)
+#if !defined( ESMF_ ) && !defined( MODEL_ )
+      ! Echo info to std output (skip if interfacing with external models)
       IF ( am_I_Root ) THEN
          WRITE( 6, '(a)'   ) REPEAT( '=', 79 )
          WRITE( 6, '(a,/)' ) 'V E R T I C A L   G R I D   S E T U P'
@@ -812,14 +812,13 @@
       IF ( ALLOCATED( BP_FULLGRID ) ) DEALLOCATE( BP_FULLGRID )
       IF ( ALLOCATED( PFLT_DRY    ) ) DEALLOCATE( PFLT_DRY    )
       IF ( ALLOCATED( PFLT_WET    ) ) DEALLOCATE( PFLT_WET    )
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
       IF ( ALLOCATED( EXTERNAL_PEDGE ) ) DEALLOCATE( EXTERNAL_PEDGE )
 #endif
 
       END SUBROUTINE CLEANUP_PRESSURE
 !EOC
-!#if defined( EXTERNAL_GRID ) || defined( EXTERNAL_FORCING )
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
 !------------------------------------------------------------------------------

--- a/GeosUtil/time_mod.F
+++ b/GeosUtil/time_mod.F
@@ -130,7 +130,7 @@
       PUBLIC  :: SET_HISTYR
       PUBLIC  :: GET_HISTYR
 !eml]
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
       PUBLIC  :: Accept_External_Date_Time
 #endif
 !
@@ -4713,7 +4713,7 @@
 
       END FUNCTION GET_NYMD_DIAG
 !EOC
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
 !------------------------------------------------------------------------------

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -980,7 +980,7 @@ CONTAINS
 
     ! Convective fractions are not yet a standard GEOS-FP
     ! field. Only available to online model (ckeller, 3/4/16) 
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
     !-------------------------
     ! CNV_FRC [1]
     !-------------------------
@@ -1530,7 +1530,7 @@ CONTAINS
 
     ! Updraft vertical velocity is not yet a standard GEOS-FP
     ! field. Only available to online model (ckeller, 3/4/16) 
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
     !-------------------------
     ! UPDVVEL [hPa s-1]
     !-------------------------
@@ -2012,7 +2012,7 @@ CONTAINS
     IF ( ASSOCIATED( State_Met%TMPU1      )) DEALLOCATE( State_Met%TMPU1      )
     IF ( ASSOCIATED( State_Met%TMPU2      )) DEALLOCATE( State_Met%TMPU2      )
 
-#if defined( ESMF_ ) 
+#if defined( ESMF_ ) || defined( MODEL_WRF )
 
     !=========================================================================
     ! SDE 2016-03-28: GCHP requires that these are nullified rather than being
@@ -2524,7 +2524,7 @@ CONTAINS
           IF ( isUnits ) Units = 'm'
           IF ( isRank  ) Rank  = 2
 
-#if defined( ESMF_ )
+#if defined( ESMF_ ) || defined( MODEL_ )
        CASE ( 'CNVFRC' )
           IF ( isDesc  ) Desc  = 'Convective fraction'
           IF ( isUnits ) Units = '1'


### PR DESCRIPTION
The added pre-processor flags `MODEL_`, `MODEL_WRF` are now used where "GCHP"-related changes are not ESMF specific.

This update adds two new pre-processor flags: `MODEL_` and `MODEL_WRF`.

The former is used in many places along with the `ESMF_` flag, with the intent of
replacing it (but not done for now, to keep compatibility with the existing GCHP codebase) where code is not ESMF-specific (does not use MAPL/ESMF) but instead
merely intended for GEOS-Chem to interface with an external model (e.g. accept
external date/time, pressure edges). This allows WRF-GC to compile without the `ESMF_` flag, which was essentially lying to the compiler as WRF-to-GEOS-Chem coupling does not use ESMF.

The latter `MODEL_WRF` flag is intended for future uses in the WRF-GC interface.

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>