### PR TITLE
Fix a ESMF_ only declaration that applies to external models (MODEL_)

### DIFF
--- a/GeosCore/input_mod.F
+++ b/GeosCore/input_mod.F
@@ -802,7 +802,7 @@
 !
       ! Scalars
       INTEGER            :: N, C
-#if defined(  ESMF_ ) 
+#if defined( ESMF_ ) || defined( MODEL_ )
       INTEGER            :: H,       M,       S
       REAL(f4)           :: init_UTC
 #endif


### PR DESCRIPTION
This is a minor update that declares H, M, S, init_UTC for `input_mod.F` to accept external date/time when coupled to an external model. It was previously declared as `ESMF_` only, and should now include the new `MODEL_` pre-processor flag.

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>