### PR TITLE
Disables UCXNETCDF for WRF-GC (MODEL_WRF)

### DIFF
--- a/GeosCore/ucx_mod.F
+++ b/GeosCore/ucx_mod.F
@@ -136,8 +136,9 @@
       INTEGER,  PARAMETER           :: I_SPA=2
       INTEGER,  PARAMETER           :: INITMR_BASIS = 2005
 
-#if defined(ESMF_)
-      ! Never use NETCDF in ESMF environment (ckeller, 12/05/14). 
+#if defined( ESMF_ ) || defined( MODEL_WRF )
+      ! Never use NETCDF in ESMF environment (ckeller, 12/05/14).
+      ! Don't use UCXNETCDF for WRF-GC as NetCDF NOx coeffs not preprocessed for external grid (hplin, 8/15/18).
       LOGICAL, PARAMETER            :: UCXNETCDF = .FALSE.
 #else
       LOGICAL, PARAMETER            :: UCXNETCDF = .TRUE.


### PR DESCRIPTION
This is a minor update that sets `UCXNETCDF` to `.FALSE.` for WRF-GC,
as NetCDF NOx coefficients are not pre-processed for the WRF grid.

This update might apply for any `EXTERNAL_GRID`, but conservatively
I chose to only apply it for MODEL_WRF for now. In fact UCX will STOP
if `GRID4x5` and `GRID2x25` is not defined and `UCXNETCDF = .TRUE.`.

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>