### PR TITLE
Minimal working example for continuous integration on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+language: c
+services:
+    - docker
+
+before_install:
+- docker pull zhuangjw/docker_gc
+
+script:
+- docker run -it --rm -v $(pwd):/root/workdir zhuangjw/docker_gc /bin/bash -c "cd /root/workdir && make MET=geosfp GRID=4x5"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # README for the GEOS-Chem Source code repository
 
+[![Build
+Status](https://travis-ci.org/JiaweiZhuang/geos-chem.svg?branch=travis_ci)](https://travis-ci.org/JiaweiZhuang/geos-chem)
+
 This repository (https://github.com/gcst/geos-chem) contains the source code for the GEOS-Chem model of atmospheric chemistry and composition. 
 
 ---


### PR DESCRIPTION
The build page https://travis-ci.org/JiaweiZhuang/geos-chem shows that GEOS-Chem is successfully compiled.

**1. Note on software environment**

[Available languages on Travis](https://docs.travis-ci.com/user/languages/) do not include Fortran. The environment for C [can be used for Fortran code](https://github.com/codecov/example-fortran), but another issue is that the available OS is too old (travis-ci/travis-ci#5821). Ubuntu 14.04's package manager only gives the old gfortran 4.8.4 and netcdf 4.1.3 library.

Thus I recommend [using Docker](https://docs.travis-ci.com/user/docker/). It allows custom OS, simplifies the build process, and also effectively tests our GC-container environment that other users might use. This PR uses
- Dockerfile: https://github.com/geoschem/Docker_GC
- DockerHub: https://hub.docker.com/r/zhuangjw/docker_gc/

**2. Note on test scripts**

I simply call `make MET=geosfp GRID=4x5` in the source code directory. For more formal testing, we might want to call `make` from the run directory. Custom shell commands to configure the rundir can be added under the `script` section in `.travis.yml`.

TODO:

- [ ] Use official GCST account for TravisCI. **Note that only merging this PR will not enable CI. Need to first hook travis to this repo.**
- [ ] Use official GCST account for Docker Hub. 
- [ ] Test more compile options, probably using unit tester and run directory.
- [ ] Think about what run-time tests are possible. Note that [OpenMP and MPI](https://docs.travis-ci.com/user/languages/c/#openmp-projects) programs are perfectly allowed. But GEOS-Chem needs too many input data to execute.