### PR TITLE
Hg Biomass burning bugfix and hg oxidation diag units

### DIFF
--- a/GeosCore/diag03_mod.F
+++ b/GeosCore/diag03_mod.F
@@ -960,11 +960,10 @@
                ! #16: HgBr + Br2 
                !--------------------------------
                CATEGORY          = 'PL-HG2-$'
-               UNIT              = 'ppbv'
+               UNIT              = 'kg'
                LMAX              = LD03
                NN                = N
                ARRAY(:,:,1:LMAX) = AD03_Hg2_Br_Y(:,:,1:LMAX,1)
-     &              / NCHEMSTEP
  
             ELSE IF ( N == 17 ) THEN
 
@@ -972,11 +971,10 @@
                ! #16: HgBr + BrBrO
                !--------------------------------
                CATEGORY          = 'PL-HG2-$'
-               UNIT              = 'ppbv'
+               UNIT              = 'kg'
                LMAX              = LD03
                NN                = N
                ARRAY(:,:,1:LMAX) = AD03_Hg2_Br_Y(:,:,1:LMAX,2)
-     &              / NCHEMSTEP
  
             ELSE IF ( N == 18 ) THEN
 
@@ -984,11 +982,10 @@
                ! #16: HgBr + BrHO2
                !--------------------------------
                CATEGORY          = 'PL-HG2-$'
-               UNIT              = 'ppbv'
+               UNIT              = 'kg'
                LMAX              = LD03
                NN                = N
                ARRAY(:,:,1:LMAX) = AD03_Hg2_Br_Y(:,:,1:LMAX,3)
-     &              / NCHEMSTEP
  
             ELSE IF ( N == 19 ) THEN
 
@@ -996,11 +993,10 @@
                ! #16: HgBr + BrNO2
                !--------------------------------
                CATEGORY          = 'PL-HG2-$'
-               UNIT              = 'ppbv'
+               UNIT              = 'kg'
                LMAX              = LD03
                NN                = N
                ARRAY(:,:,1:LMAX) = AD03_Hg2_Br_Y(:,:,1:LMAX,4)
-     &              / NCHEMSTEP
  
             ELSE IF ( N == 20 ) THEN
 
@@ -1008,11 +1004,10 @@
                ! #16: HgBr + BrClO
                !--------------------------------
                CATEGORY          = 'PL-HG2-$'
-               UNIT              = 'ppbv'
+               UNIT              = 'kg'
                LMAX              = LD03
                NN                = N
                ARRAY(:,:,1:LMAX) = AD03_Hg2_Br_Y(:,:,1:LMAX,5)
-     &              / NCHEMSTEP
  
             ELSE IF ( N == 21 ) THEN
 
@@ -1020,11 +1015,10 @@
                ! #16: HgBr + BrOH
                !--------------------------------
                CATEGORY          = 'PL-HG2-$'
-               UNIT              = 'ppbv'
+               UNIT              = 'kg'
                LMAX              = LD03
                NN                = N
                ARRAY(:,:,1:LMAX) = AD03_Hg2_Br_Y(:,:,1:LMAX,6)
-     &              / NCHEMSTEP
  
             ELSE
 

--- a/GeosCore/hcoi_gc_diagn_mod.F90
+++ b/GeosCore/hcoi_gc_diagn_mod.F90
@@ -5691,6 +5691,15 @@ CONTAINS
     HcoID = HCO_GetHcoID( 'Hg0', HcoState )
     IF ( HcoID > 0 ) THEN
 
+        Cat   = -1
+        ExtNr = GetExtNr( HcoState%Config%ExtList, 'GFED' )
+        IF ( ExtNr <= 0 ) ExtNr = GetExtNr( HcoState%Config%ExtList, 'FINN' )
+        IF ( ExtNr <= 0 ) THEN
+           ExtNr = 0
+           Cat   = CATEGORY_BIOMASS
+        ENDIF
+
+
        ! Create diagnostic container
        DiagnName = 'BIOMASS_HG0'
        CALL Diagn_Create( am_I_Root,                                         & 

--- a/GeosCore/mercury_mod.F
+++ b/GeosCore/mercury_mod.F
@@ -618,7 +618,7 @@
       ! To simplify this code, K_RED_JNO2 should be moved to HEMCO_Config.rc
       ! or input.geos since it will vary with MET/GRID/chemistry (cpt)
 
-      REAL(fp), PARAMETER     :: K_RED_JNO2 = 8.0e-2_fp
+      REAL(fp), PARAMETER     :: K_RED_JNO2 = 14.0e-2_fp
 
       ! Set of Hg/Br rate constants to use
       ! Recommended: DonohoueYBBalabanov, GoodsiteY, or DonohoueYB


### PR DESCRIPTION
This fixes a bug where biomass burning emissions were not being used and anthro emissions were being double-counted. Reduction parameter was re-tuned for these changes. Units of an Hg chem diagnostic were fixed as well. 