### PR TITLE
Add a check for output grid overlap with original grid

### DIFF
--- a/GeosUtil/regrid_a2a_mod.F90
+++ b/GeosUtil/regrid_a2a_mod.F90
@@ -1661,6 +1661,7 @@ CONTAINS
 !                                cause problems with some compilers.
 !  29 Apr 2016 - R. Yantosca   - Don't initialize pointers in declaration stmts 
 !  08 Apr 2017 - C. Keller     - Skip missing values when interpolating.
+!  21 Aug 2018 - H.P. Lin      - Return missing value if no overlap between lon1, lon2
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -1740,6 +1741,15 @@ CONTAINS
     in = n2 - n1
     lon2 => ilon2(n1:n2)
     q2   => iq2(n1:(n2-1),:)
+
+    ! if there is no overlap between original grid and output grid
+    ! reduced will be zero and missing values should be returned
+    if ( in .eq. 0 ) then
+       iq2 = missval
+       lon2 => NULL()
+       q2 => NULL()
+       return
+    endif
 
     ! Periodic BC only valid if the variable is "global"
     xSpan = x1(im+1)-x1(1)
@@ -1954,6 +1964,7 @@ CONTAINS
 !                                cause problems with some compilers. 
 !  29 Apr 2016 - R. Yantosca   - Don't initialize pointers in declaration stmts
 !  08 Apr 2017 - C. Keller     - Skip missing values when interpolating.
+!  21 Aug 2018 - H.P. Lin      - Return missing value if no overlap between lon1, lon2
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -2033,6 +2044,15 @@ CONTAINS
     in = n2 - n1
     lon2 => ilon2(n1:n2)
     q2   => iq2(n1:(n2-1),:)
+
+    ! if there is no overlap between original grid and output grid
+    ! reduced will be zero and missing values should be returned
+    if ( in .eq. 0 ) then
+       iq2 = missval
+       lon2 => NULL()
+       q2 => NULL()
+       return
+    endif
 
     ! shadow variables to selected range
     ! Periodic BC only valid if the variable is "global"


### PR DESCRIPTION
This update to `regrid_a2a_mod` adds a check to the reduced output grid when mapping in the E-W direction.
If the target grid has no overlap with the original grid, `Xmap_R4R4/R8R8` will fail with an error
and halt the entire program. This update fixes this stop with a more graceful failure,
which returns missing values if output grid is determined to be size zero.

This is usually only a problem when running local grids like WRF-GC.

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>