### PR TITLE
Reset NSFCMR count in CLEANUP_UCX to allow re-initialization.

### DIFF
--- a/GeosCore/ucx_mod.F
+++ b/GeosCore/ucx_mod.F
@@ -6200,6 +6200,11 @@
          DEALLOCATE(SFCMR)
       ENDIF
 
+      ! Reset the NSFCMR count on cleanup. The NSFCMR counter counts the
+      ! objects in SFCMR%, which is deallocated above.
+      ! This is to allow CLEANUP_UCX to fully reset the internal state.
+      NSFCMR = 0
+
       ! Cleanup the NOx coeff arrays 
       IF ( ALLOCATED( NOXCOEFF ) ) DEALLOCATE( NOXCOEFF )
       IF ( ALLOCATED( NOXLAT   ) ) DEALLOCATE( NOXLAT   )


### PR DESCRIPTION
This is a minor change for WRF-GC which only affects the UCX cleanup
routine to reset a counter for the `SFCMR` array which is deallocated
in said routine.

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>