### PR TITLE
Add NO_EXE=y option to Makefile to inhibit geos executable build

### DIFF
--- a/GeosCore/Makefile
+++ b/GeosCore/Makefile
@@ -161,6 +161,8 @@
 #  09 Aug 2016 - M. Sulprizio- Remove diag_pl_mod and add diag20_mod
 #  13 Jul 2017 - E. Lundgren - Remove passive_species_mod.F90
 #  24 Aug 2017 - M. Sulprizio- Remove support for GCAP, GEOS-4, GEOS-5 and MERRA
+#  23 Aug 2018 - H.P. Lin    - If NO_EXE is set (for coupled model driving G-C)
+#                              do not build "geos" but instead "libGeosCore.a"
 #EOP
 #------------------------------------------------------------------------------
 #BOC
@@ -212,7 +214,7 @@ MODULES :=$(shell echo $(MODULES) | tr A-Z a-z)
 MODULES :=$(foreach I,$(MODULES),$(MOD)/$(I))
 
 # Library file
-LIBRARY :=libcore.a
+LIBRARY :=libGeosCore.a
 
 ###############################################################################
 ###                                                                         ###
@@ -228,7 +230,10 @@ all:                                               # Build libraries
 ifeq ($(UNAME),Darwin)
 	ranlib -c ../lib/*
 endif
+ifdef NO_EXE
+	# Is GEOS-Chem coupled to and driven by another model?
 	@$(MAKE) exe
+endif
 
 tomas:
 	@$(MAKE) TOMAS=yes lib                     # TOMAS, 30 bins (default)
@@ -265,9 +270,15 @@ lib:                                               # Build all G-C libraries
 	@$(MAKE) libhemco
 	@$(MAKE) libiso
 	@$(MAKE) librad
-	@$(MAKE) libcore			  
+	@$(MAKE) libcore
 
 libcore: $(OBJECTS)                                # Build code in GeosCore/
+ifdef NO_EXE
+	# Is GEOS-Chem coupled to and driven by another model?
+	$(AR) crs $(LIBRARY) $(OBJECTS)
+	mv $(LIBRARY) $(LIB) # ...build a libGeosCore.a for use instead
+endif
+
 
 libgigc:
 ifeq ($(wildcard $(FVDIR)/fvdycore.install),)

--- a/Makefile_header.mk
+++ b/Makefile_header.mk
@@ -202,6 +202,9 @@
 #  03 Jan 2018 - M. Sulprizio- Remove UCX flag. We now solely use Input_Opt%LUCX
 #                              throughout GEOS-Chem.
 #  07 Aug 2018 - R. Yantosca - For now, don't compile TOMAS/ APM when NC_DIAG=y
+#  23 Aug 2018 - H.P. Lin    - Add NO_EXE=y to inhibit "geos" executable build and
+#                              build libGeosCore.a instead for coupled models driving
+#                              GEOS-Chem externally (by calling its libraries)
 #EOP
 #------------------------------------------------------------------------------
 #BOC
@@ -422,6 +425,21 @@ REGEXP               :=(^[Yy]|^[Yy][Ee][Ss])
 ifeq ($(shell [[ "$(EXTERNAL_FORCING)" =~ $(REGEXP) ]] && echo true),true)
   USER_DEFS          += -DEXTERNAL_FORCING
   NO_GRID_NEEDED     :=1
+endif
+
+#------------------------------------------------------------------------------
+# Coupling GEOS-Chem to External Models settings
+#------------------------------------------------------------------------------
+
+# %%%%% NO_EXE %%%%%
+# Setting NO_EXE=y will inhibit the creation of a final "geos" executable
+# and create a "libGeosCore.a" in the lib folder instead.
+# Used if you are linking GEOS-Chem routines to be driven by an external model.
+# (hplin, 8/23/18)
+REGEXP               :=(^[Yy]|^[Yy][Ee][Ss])
+ifeq ($(shell [[ "$(NO_EXE)" =~ $(REGEXP) ]] && echo true),true)
+  USER_DEFS          += -DMODEL_
+  NO_EXE             :=1
 endif
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This update to the Makefiles adds a new option `NO_EXE=y` to the Makefile,
for other models coupled to and driving GEOS-Chem from their routines.

(Hence the `geos` executable would not be used and creating it in the G-C build process
may cause confusion to the user)

When `NO_EXE=y` is enabled, the final `geos` executable is not built,
and `GeosCore` will build all prerequisite libraries leaving `libGeosCore.a`
in the `lib` folder instead for other models to link to in their compile
process.

When `NO_EXE=y` is enabled, the pre-processor directive `MODEL_` is
automatically set as GEOS-Chem must be operating under another model
when this option is enabled.

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>
