### PR TITLE
Fix libGeosCore.a not being built when NO_EXE=y

### DIFF
--- a/GeosCore/Makefile
+++ b/GeosCore/Makefile
@@ -273,7 +273,7 @@ lib:                                               # Build all G-C libraries
 	@$(MAKE) libcore
 
 libcore: $(OBJECTS)                                # Build code in GeosCore/
-ifeq ($(EXE_NEEDED),1)
+ifeq ($(EXE_NEEDED),0)
 	$(AR) crs $(LIBRARY) $(OBJECTS)
 	mv $(LIBRARY) $(LIB) # ...build a libGeosCore.a for use instead
 endif


### PR DESCRIPTION
This update fixes an issue with the NO_EXE option introduced for
coupling GEOS-Chem with WRF.

The intended behavior is when coupled with other models, GEOS-Chem
compilation is initialized with the `NO_EXE=y` option. The internal
makefile flag `EXE_NEEDED` is thus set to 0, and the ./bin/geos executable
building is inhibited: instead GEOS-Chem builds a `libGeosCore.a` for use
by external models.

There was a bug in the previous code where the `ar crs ...` command to build
`libGeosCore.a` was executed when `EXE_NEEDED` eq to 1 and not 0, thus if
`NO_EXE=y`, neither the `geos` executable nor the `libGeosCore.a` library was
built. This update fixes this issue.

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>