### PR TITLE
Update planeflight_mod.F

### DIFF
--- a/GeosCore/planeflight_mod.F
+++ b/GeosCore/planeflight_mod.F
@@ -1057,14 +1057,54 @@
          ENDIF
         
          ! Skip observations outside the nested domain
-#if   defined( NESTED_NA )
-         IF ( LAT <   10e0 .OR. LAT >  70e0  .OR. 
-     &        LON < -140e0 .OR. LON > -40e0 ) THEN
-            PRINT*, ' Outside nested domain, skipping record ', N
+         ! Now consider all nest domains, lei, 11/24/18
+#if   defined( MERRA2 ) && defined( GRID05x0625 ) && defined( NESTED_AS)
+         IF ( LAT < -11e0 .OR. LAT > 55e0  .OR.
+     &        LON < 60e0 .OR. LON > 150e0 ) THEN
+            PRINT*, ' Outside the AS nested domain, skipping record ', N
             CYCLE
          ENDIF
 #endif
 
+#if   defined( MERRA2 ) && defined( GRID05x0625 ) && defined( NESTED_NA)
+         IF ( LAT <   10e0 .OR. LAT >  70e0  .OR.
+     &        LON < -140e0 .OR. LON > -40e0 ) THEN
+            PRINT*, ' Outside the NA nested domain, skipping record ', N
+            CYCLE
+         ENDIF
+#endif
+
+#if   defined( MERRA2 ) && defined( GRID05x0625 ) && defined( NESTED_EU)
+         IF ( LAT <   30e0 .OR. LAT >  70e0  .OR.
+     &        LON < -30e0 .OR. LON > 50e0 ) THEN
+            PRINT*, ' Outside the EU nested domain, skipping record ', N
+            CYCLE
+         ENDIF
+#endif
+
+#if   defined( GEOS_FP ) && defined( GRID025x03125 ) && defined(NESTED_CH)
+         IF ( LAT <   15e0 .OR. LAT >  55e0  .OR.
+     &        LON < 70e0 .OR. LON > 140e0 ) THEN
+            PRINT*, ' Outside the CH nested domain, skipping record ', N
+            CYCLE
+         ENDIF
+#endif
+
+#if   defined( GEOS_FP ) && defined( GRID025x03125 ) && defined(NESTED_NA)
+         IF ( LAT <   9.75e0 .OR. LAT >  60e0  .OR.
+     &        LON < -130e0 .OR. LON > -60e0 ) THEN
+            PRINT*, ' Outside the NA nested domain, skipping record ', N
+            CYCLE
+         ENDIF
+#endif
+
+#if   defined( GEOS_FP ) && defined( GRID025x03125 ) && defined(NESTED_EU)
+         IF ( LAT <   32.75e0 .OR. LAT >  61.25e0  .OR.
+     &        LON < -15e0 .OR. LON > 40e0 ) THEN
+            PRINT*, ' Outside the EU nested domain, skipping record ', N
+            CYCLE
+         ENDIF
+#endif         
          ! Convert from altitude to pressure if we have CCCG data or
          ! tower data
          NAME = ADJUSTL(PTYPE(N))


### PR DESCRIPTION
Skip flight observations outside the nested domains. Now the code works for all 0.5 and 0.25 nested domains. LAT and LON ranges are defined as in http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_horizontal_grids.