### PR TITLE
Add flexgrid_read_mod.o to list of dependencies for hcoi_gc_main_mod.o

### DIFF
--- a/GeosCore/Makefile
+++ b/GeosCore/Makefile
@@ -668,7 +668,7 @@ hcoi_gc_main_mod.o          : hcoi_gc_main_mod.F90                           \
                               get_ndep_mod.o          drydep_mod.o           \
                               modis_lai_mod.o         fast_jx_mod.o          \
                               hcoi_gc_diagn_mod.o     tomas_mod.o            \
-                              hco_interface_mod.o
+                              hco_interface_mod.o     flexgrid_read_mod.o
 
 initialize.o                : initialize.F                                   \
                               diag_mod.o              diag03_mod.o           \


### PR DESCRIPTION
This is a minor fix for an error in compiling GEOS-Chem Classic that I noticed in my test build of GCC (in the run directory, `make mpbuild`)

The compile process fails occasionally due to the `Get_Met_Fields` subroutine in `HCOI_GC_Main_Mod` requiring `FlexGrid_Read_Mod` in a `use` statement, but this module was not included in the `Makefile` dependencies. This is fixed by this commit.

The error would look something like this: (Added so future Google searches can find this fix)
```
ifort -cpp -w -auto -noalign -convert big_endian -O2 -vec-report0 -fp-model source -openmp -mcmodel=medium -shared-intel -traceback -DLINUX_IFORT -DBPCH_DIAG -DNC_DIAG -DBPCH_TIMESER -DGEOS_FP -DGRID2x25 -DN
C_HAS_COMPRESSION -DUSE_REAL8 -module ../mod -I/home/hplin/gc/include -I/home/hplin/gc/include -c -free hcoi_gc_main_mod.F90
hcoi_gc_main_mod.F90(3492): error #7002: Error in opening the compiled module file.  Check INCLUDE paths.   [FLEXGRID_READ_MOD]
   USE FlexGrid_Read_Mod
-------^
compilation aborted for hcoi_gc_main_mod.F90 (code 1)
../Makefile_header.mk:1520: recipe for target 'hcoi_gc_main_mod.o' failed
make[4]: *** [hcoi_gc_main_mod.o] Error 1
```

Thanks!

Signed-off-by: Jimmie Lin <jimmie.lin@gmail.com>