### PR TITLE
Move DEPSAV from DRYDEP_MOD to State_Chm

### DIFF
--- a/GeosCore/aero_drydep.F
+++ b/GeosCore/aero_drydep.F
@@ -21,7 +21,6 @@
 ! !USES:
 !
       USE CMN_SIZE_MOD
-      USE DRYDEP_MOD,         ONLY : DEPSAV
       USE DUST_MOD,           ONLY : SETTLEDUST   
       USE ErrCode_Mod
       USE ERROR_MOD
@@ -127,6 +126,7 @@
       REAL(fp), POINTER  :: Spc     (:,:,:,:)
       REAL(fp), POINTER  :: BXHEIGHT(:,:,:  )
       REAL(fp), POINTER  :: T       (:,:,:  )
+      REAL(fp), POINTER  :: DEPSAV  (:,:,:  )                ! IM, JM, nDryDep
 
       ! SAVEd arrays
       INTEGER,  SAVE     :: DRYD(IBINS)
@@ -162,6 +162,7 @@
       Spc      => State_Chm%Species
       BXHEIGHT => State_Met%BXHEIGHT
       T        => State_Met%T
+      DEPSAV   => State_Chm%DryDepSav
 
       ! First-time setup
       IF ( FIRST ) THEN
@@ -570,6 +571,7 @@ c     &           AD44(I,J,nDryDep+BIN+(JC-2)*IBINS,1)
       Spc      => NULL()
       BXHEIGHT => NULL()
       T        => NULL()
+      DEPSAV   => NULL()
 
       ! Check that species units are still in [kg] (ewl, 8/13/15)
       IF ( TRIM( State_Chm%Spc_Units ) /= 'kg' ) THEN

--- a/GeosCore/drydep_mod.F
+++ b/GeosCore/drydep_mod.F
@@ -43,7 +43,6 @@
 ! !PUBLIC DATA MEMBERS:
 !
       PUBLIC :: DEPNAME
-      PUBLIC :: DEPSAV
       PUBLIC :: NUMDEP
       PUBLIC :: NTRAIND
       PUBLIC :: IDEP,   IRGSS,  IRAC, IRCLS
@@ -194,6 +193,7 @@
 !                              via the HEMCO SeaFlux extension. 
 !  16 Mar 2017 - R. Yantosca - Remove references to obsolete vars in Input_Opt
 !  24 Aug 2017 - M. Sulprizio- Remove support for GCAP, GEOS-4, GEOS-5 and MERRA
+!  01 Dec 2018 - H.P. Lin    - Move DEPSAV to State_Chm%DryDepSav
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -227,7 +227,6 @@
       !  IZO       : Roughness heights for each Olson surface type
       !  NDVZIND   : Index array for ordering drydep species in DEPVEL
       !  NTRAIND   : Stores species numbers of drydep species
-      !  DEPSAV    : Array containing dry deposition frequencies [s-1]
       !  PBLFRAC   : Array for multiplicative factor for drydep freq
       !  DRYCOEFF  : Polynomial coefficients for dry deposition
       !  HSTAR     : Henry's law constant
@@ -241,6 +240,9 @@
       !    NTYPE     : Max # of landtypes / grid box
       !    NPOLY     : Number of drydep polynomial coefficients
       !    NSURFTYPE : Number of Olson land types
+      !
+      !  NOTE: these grid-dependent variables are defined in State_Chm_Mod.F90
+      !    DEPSAV    : Array containing dry deposition frequencies [s-1]
       !========================================================================
 
       ! Scalars
@@ -284,7 +286,6 @@
       CHARACTER(LEN=14), ALLOCATABLE :: DEPNAME (:    ) ! Species name
 
       ! Allocatable arrays
-      REAL(fp), TARGET,  ALLOCATABLE :: DEPSAV  (:,:,:) ! Drydep frequencies
       REAL(f8),          ALLOCATABLE :: DMID    (:    )
       REAL(f8),          ALLOCATABLE :: SALT_V  (:    )
       
@@ -449,6 +450,9 @@
       REAL(f8)      :: SUNCOS_MID(IIPAR,JJPAR)    ! COS(SZA) @ midpoint of the
                                                   !  current chemistry timestep
 
+      ! Pointers
+      REAL(fp), POINTER :: DEPSAV (:,:,:   )      ! Dry deposition frequencies [s-1]
+
       ! For ESMF, need to assign these from Input_Opt
       LOGICAL       :: PBL_DRYDEP 
       LOGICAL       :: LPRT
@@ -467,7 +471,10 @@
       SpcInfo => NULL()
       ErrMsg  = ''
       ThisLoc = 
-     &   ' -> at Do_DryDep  (in module GeosCore/drydep_mod.F)'      
+     &   ' -> at Do_DryDep  (in module GeosCore/drydep_mod.F)'    
+
+      ! Point to columns of derived-type object fields
+      DEPSAV     => State_Chm%DryDepSav  
       
       ! Copy values from the Input Options object to local variables
       PBL_DRYDEP = Input_Opt%PBL_DRYDEP
@@ -655,6 +662,9 @@
       IF ( LPRT .and. am_I_Root ) THEN
          CALL DEBUG_MSG( '### DO_DRYDEP: after dry dep' )
       ENDIF
+
+      ! Nullify pointers
+      NULLIFY( DEPSAV )
 
       END SUBROUTINE DO_DRYDEP
 !EOC
@@ -4341,11 +4351,6 @@
       ! Allocate arrays
       ! add allocation for SALT_V and DMID (jaegle 5/11/11)
       !=================================================================
-      ALLOCATE( DEPSAV( IIPAR, JJPAR, NUMDEP ), STAT=RC )
-      CALL GC_CheckVar( 'drydep_mod:DEPSAV', 0, RC )
-      IF ( RC /= GC_SUCCESS ) RETURN
-      DEPSAV = 0e+0_fp
-
       ALLOCATE( SALT_V( NR_MAX ), STAT=RC )
       CALL GC_CheckVar( 'drydep_mod:SALT_V', 0, RC )
       IF ( RC /= GC_SUCCESS ) RETURN
@@ -4463,7 +4468,6 @@
       IF ( ALLOCATED( A_RADI   ) ) DEALLOCATE( A_RADI   )
       IF ( ALLOCATED( AIROSOL  ) ) DEALLOCATE( AIROSOL  )
       IF ( ALLOCATED( DEPNAME  ) ) DEALLOCATE( DEPNAME  )
-      IF ( ALLOCATED( DEPSAV   ) ) DEALLOCATE( DEPSAV   )
       IF ( ALLOCATED( DMID     ) ) DEALLOCATE( DMID     )
       IF ( ALLOCATED( F0       ) ) DEALLOCATE( F0       )
       IF ( ALLOCATED( FLAG     ) ) DEALLOCATE( FLAG     )

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -357,7 +357,6 @@ CONTAINS
 ! !USES:
 !
     USE CMN_SIZE_MOD,       ONLY : IIPAR,   JJPAR,   LLPAR
-    USE DRYDEP_MOD,         ONLY : DEPSAV
     USE ErrCode_Mod
     USE ERROR_MOD,          ONLY : SAFE_DIV
     USE GET_NDEP_MOD,       ONLY : SOIL_DRYDEP
@@ -467,6 +466,7 @@ CONTAINS
 
     ! Pointers and objects
     TYPE(Species), POINTER  :: SpcInfo
+    REAL(fp),      POINTER  :: DEPSAV       (:,:,:  )  ! IM, JM, nDryDep
 
     ! Temporary save for total ch4 (Xueying Yu, 12/08/2017)
     LOGICAL                 :: ITS_A_CH4_SIM
@@ -501,6 +501,7 @@ CONTAINS
 
     ! Initialize pointer
     SpcInfo           => NULL()
+    DEPSAV            => State_Chm%DryDepSav
 
 #if defined( NC_DIAG )
     !----------------------------------------------------------
@@ -1045,6 +1046,9 @@ CONTAINS
        ENDIF
     ENDIF
 #endif
+
+  ! Nullify pointers
+  NULLIFY( DEPSAV )
 
   END SUBROUTINE DO_TEND 
 !EOC

--- a/GeosCore/pops_mod.F
+++ b/GeosCore/pops_mod.F
@@ -521,7 +521,6 @@
 ! !USES:
 !
       USE CMN_SIZE_MOD
-      USE DRYDEP_MOD,         ONLY : DEPSAV
       USE ErrCode_Mod
       USE Error_Mod,          ONLY : DEBUG_MSG
       USE HCO_Interface_Mod,  ONLY : GetHcoDiagn
@@ -573,6 +572,9 @@
       CHARACTER(LEN=255) :: ThisLoc
       CHARACTER(LEN=512) :: ErrMsg
 
+      ! Pointers
+      REAL(fp),      POINTER  :: DEPSAV(:,:,:  )
+
       !=================================================================
       ! CHEMPOPS begins here!
       !=================================================================
@@ -582,6 +584,9 @@
       prtDebug = ( Input_Opt%LPRT .and. am_I_Root )
       ErrMsg   = ''
       ThisLoc  = ' -> at ChemPops (in module Headers/state_chm_mod.F90)'
+
+      ! Point to columns of derived-type object fields (hplin, 12/1/18)
+      DEPSAV            => State_Chm%DryDepSav
 
 #if defined( NC_DIAG )
       !-----------------------------------------------------------------
@@ -779,6 +784,9 @@
       ENDIF      
 
       IF ( prtDebug ) CALL DEBUG_MSG( 'CHEMPOPS: a CHEM_GASPART' )
+
+      ! Nullify pointers
+      NULLIFY( DEPSAV )
    
       END SUBROUTINE CHEMPOPS
 !EOC

--- a/GeosCore/vdiff_mod.F90
+++ b/GeosCore/vdiff_mod.F90
@@ -1924,7 +1924,6 @@ contains
 #if defined( BPCH_DIAG )
     USE DIAG_MOD,           ONLY : AD44
 #endif
-    USE DRYDEP_MOD,         ONLY : DEPSAV
     USE ErrCode_Mod
     USE GET_NDEP_MOD,       ONLY : SOIL_DRYDEP
     USE GLOBAL_CH4_MOD,     ONLY : CH4_EMIS
@@ -2095,6 +2094,8 @@ contains
     REAL(fp),  POINTER :: p_t1    (:,:,:  )
     REAL(fp),  POINTER :: p_as2   (:,:,:,:)
 
+    REAL(fp),  POINTER :: DEPSAV  (:,:,:  )  ! IM, JM, nDryDep
+
     ! For values from Input_Opt
     LOGICAL            :: IS_CH4,    IS_FULLCHEM, IS_Hg
     LOGICAL            :: IS_TAGCO,  IS_AEROSOL,  IS_RnPbBe, LDYNOCEAN
@@ -2150,6 +2151,7 @@ contains
 
     ! Initialize pointers
     SpcInfo => NULL()
+    DEPSAV  => State_Chm%DryDepSav
 
     ! Initialize local arrays. (ccc, 12/21/10)
     pmid    = 0e+0_fp
@@ -2822,6 +2824,9 @@ contains
 
 !      !### Debug
     IF ( LPRT ) CALL DEBUG_MSG( '### VDIFFDR: VDIFFDR finished' )
+
+    ! Nullify pointers
+    NULLIFY( DEPSAV )
 
   END SUBROUTINE VDIFFDR
 !EOC


### PR DESCRIPTION
This update moves `DRYDEP_MOD:DEPSAV (IIPAR, JJPAR, nDryDep)` to the
`State_Chm%DryDepSav` derived type object field.

Existing modules which use `DEPSAV` have been modified to have pointers in
subroutines to point to the appropriate column(s) of the derived type
objects.

This update is made as part of a series of updates to move grid-size
dependent module global variables into GC's derived type objects, for GC
to better interface with external models (WRF).

I have tested this update using GEOS-Chem's difference tests (this commit, against `dev/12.2.0`), however I was only able to compare the bpch files (which were identical). The netCDF files, even though they have identical contents, will fail checksum tests for some reason (as mentioned in previous communication).

I have submitted this one small change separately so that we can discuss if this way of moving the variables fits the previous recommendations set by GCST in the previous pull request. Please let me know if this format & approach is acceptable so I can develop and test the moving of the other grid-dependent module variables.

Thank you!

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>