### PR TITLE
Grid-independent lightning NOx emission code updates.

### DIFF
--- a/GeosCore/flexgrid_read_mod.F90
+++ b/GeosCore/flexgrid_read_mod.F90
@@ -1073,6 +1073,7 @@ CONTAINS
 !  26 Sep 2013 - R. Yantosca - Now read CMFMC from GEOSFP*.nc files
 !  14 Aug 2014 - R. Yantosca - Now compute CLDTOPS here; it depends on CMFMC
 !  03 Dec 2015 - R. Yantosca - Now open file only once per day
+!  16 Jan 2019 - L. Murray   - Add offline lightning met fields 
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -1086,6 +1087,7 @@ CONTAINS
                                              
     ! Arrays                                 
     REAL*4             :: Qe(IIPAR,JJPAR,LLPAR+1)  ! Temporary data arrray
+    REAL*4             :: Q2(IIPAR,JJPAR        )  ! Temporary data arrray
 
     !======================================================================
     ! Get met fields from HEMCO
@@ -1111,11 +1113,21 @@ CONTAINS
     CALL Get_Met_3De( Qe, TRIM(v_name) )
     State_Met%PFLCU = Qe
 
-    ! Read  from file
+    ! Read PLLSAN
     v_name = "PFLLSAN"
     CALL Get_Met_3De( Qe, TRIM(v_name) )
     State_Met%PFLLSAN = Qe
 
+    ! Read FLASH_DENS
+    v_name = "FLASH_DENS"
+    CALL Get_Met_2D( Q2, TRIM(v_name) )
+    State_Met%FLASH_DENS = Q2
+
+    ! Read CONV_DEPTH
+    v_name = "CONV_DEPTH"
+    CALL Get_Met_2D( Q2, TRIM(v_name) )
+    State_Met%CONV_DEPTH = Q2
+    
     ! Echo info
     stamp = TimeStamp_String( YYYYMMDD, HHMMSS )
     WRITE( 6, 10 ) stamp

--- a/GeosCore/hcoi_gc_main_mod.F90
+++ b/GeosCore/hcoi_gc_main_mod.F90
@@ -86,6 +86,7 @@ MODULE HCOI_GC_Main_Mod
 !                              so that we can define them in HCOI_GC_INIT
 !  29 Nov 2016 - R. Yantosca - grid_mod.F90 is now gc_grid_mod.F90
 !  24 Aug 2017 - M. Sulprizio- Remove support for GCAP, GEOS-4, GEOS-5 and MERRA
+!  16 Jan 2019 - L. Murray   - Add offline lightning flash rates for LNOx emissions
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -1305,6 +1306,34 @@ CONTAINS
        ENDIF
     ENDIF
 
+    ! FLASH_DENS
+    IF ( ExtState%FLASH_DENS%DoUse ) THEN
+       CALL HCO_ArrAssert( ExtState%FLASH_DENS%Arr, IIPAR, JJPAR, HMRC )
+
+       ! Trap potential errors
+       IF ( HMRC /= HCO_SUCCESS ) THEN
+          RC     = HMRC
+          ErrMsg = 'Error encountered in "HCO_ArrAssert( FLASH_DENS )"!'
+          CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+          CALL Flush( HcoState%Config%Err%Lun )
+          RETURN
+       ENDIF
+    ENDIF
+
+    ! CONV_DEPTH
+    IF ( ExtState%CONV_DEPTH%DoUse ) THEN
+       CALL HCO_ArrAssert( ExtState%CONV_DEPTH%Arr, IIPAR, JJPAR, HMRC )
+    
+       ! Trap potential errors
+       IF ( HMRC /= HCO_SUCCESS ) THEN
+          RC     = HMRC 
+          ErrMsg = 'Error encountered in "HCO_ArrAssert( CONV_DEPTH )"!'
+          CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+          CALL Flush( HcoState%Config%Err%Lun )
+          RETURN
+       ENDIF
+    ENDIF
+
     ! SUNCOS: HEMCO now calculates SUNCOS values based on its own
     ! subroutine 
     IF ( ExtState%SUNCOS%DoUse ) THEN
@@ -2147,6 +2176,16 @@ CONTAINS
     IF ( ExtState%SPHU%DoUse ) THEN
        ExtState%SPHU%Arr%Val(:,:,1) = State_Met%SPHU(:,:,1) / 1000.0_hp
     ENDIF
+
+    ! FLASH_DENS: flash density [#/km2/s]
+    IF ( ExtState%FLASH_DENS%DoUse ) THEN
+       ExtState%FLASH_DENS%Arr%Val = State_Met%FLASH_DENS
+    ENDIF
+
+    ! CONV_DEPTH: convective cloud depth [m]
+    IF ( ExtState%CONV_DEPTH%DoUse ) THEN
+       ExtState%CONV_DEPTH%Arr%Val = State_Met%CONV_DEPTH
+    ENDIF    
 
     ! SUNCOS
     IF ( ExtState%SUNCOS%DoUse ) THEN

--- a/HEMCO/Extensions/hcox_state_mod.F90
+++ b/HEMCO/Extensions/hcox_state_mod.F90
@@ -156,6 +156,8 @@ MODULE HCOX_STATE_MOD
      TYPE(ExtDat_2R),  POINTER :: JOH         ! J-Value for O3->OH  [1/s]
      TYPE(ExtDat_2R),  POINTER :: LAI         ! daily leaf area index [cm2/cm2]
      TYPE(ExtDat_2R),  POINTER :: CHLR        ! daily chlorophyll-a [mg/m3]
+     TYPE(ExtDat_2R),  POINTER :: FLASH_DENS  ! Lightning flash density [#/km2/s]
+     TYPE(ExtDat_2R),  POINTER :: CONV_DEPTH  ! Convective cloud depth [m]
      INTEGER,          POINTER :: PBL_MAX     ! Max height of PBL [level]
      TYPE(ExtDat_3R),  POINTER :: CNV_MFC     ! Convective cloud mass flux [kg/m2/s] 
      TYPE(ExtDat_3R),  POINTER :: FRAC_OF_PBL ! Fraction of grid box in PBL
@@ -423,6 +425,12 @@ CONTAINS
     CALL ExtDat_Init ( ExtState%CHLR, RC ) 
     IF ( RC /= HCO_SUCCESS ) RETURN
 
+    CALL ExtDat_Init ( ExtState%FLASH_DENS, RC )
+    IF ( RC /= HCO_SUCCESS ) RETURN
+
+    CALL ExtDat_Init ( ExtState%CONV_DEPTH, RC )
+    IF ( RC /= HCO_SUCCESS ) RETURN
+
     CALL ExtDat_Init ( ExtState%JNO2, RC ) 
     IF ( RC /= HCO_SUCCESS ) RETURN
 
@@ -550,6 +558,8 @@ CONTAINS
        CALL ExtDat_Cleanup( ExtState%CLDFRC     )
        CALL ExtDat_Cleanup( ExtState%LAI        )
        CALL ExtDat_Cleanup( ExtState%CHLR       )
+       CALL ExtDat_Cleanup( ExtState%FLASH_DENS )
+       CALL ExtDat_Cleanup( ExtState%CONV_DEPTH )
        CALL ExtDat_Cleanup( ExtState%JNO2       )
        CALL ExtDat_Cleanup( ExtState%JOH        )
        CALL ExtDat_Cleanup( ExtState%CNV_MFC    )

--- a/HEMCO/Interfaces/hcoi_standalone_mod.F90
+++ b/HEMCO/Interfaces/hcoi_standalone_mod.F90
@@ -1970,6 +1970,12 @@ CONTAINS
     CALL ExtDat_Set ( am_I_Root, HcoState, ExtState%LAI, 'LAI', RC, FIRST )
     IF ( RC /= HCO_SUCCESS ) RETURN
 
+    CALL ExtDat_Set ( am_I_Root, HcoState, ExtState%FLASH_DENS, 'FLASH_DENS', RC, FIRST )
+    IF ( RC /= HCO_SUCCESS ) RETURN
+
+    CALL ExtDat_Set ( am_I_Root, HcoState, ExtState%CONV_DEPTH, 'CONV_DEPTH', RC, FIRST )
+    IF ( RC /= HCO_SUCCESS ) RETURN
+
     CALL ExtDat_Set ( am_I_Root, HcoState, ExtState%CHLR, 'CHLR', RC, FIRST )
     IF ( RC /= HCO_SUCCESS ) RETURN
 

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -240,6 +240,12 @@ MODULE State_Met_Mod
                                                 !  and 13 local solar time?
 
      !----------------------------------------------------------------------
+     ! Offline lightning fields
+     !----------------------------------------------------------------------
+     REAL(fp), POINTER :: FLASH_DENS    (:,:  ) ! Lightning flash density [#/km2/s]
+     REAL(fp), POINTER :: CONV_DEPTH    (:,:  ) ! Convective cloud depth [m]
+
+     !----------------------------------------------------------------------
      ! Registry of variables contained within State_Met
      !----------------------------------------------------------------------
      CHARACTER(LEN=3)             :: State     = 'MET'    ! Name of this state
@@ -303,6 +309,7 @@ MODULE State_Met_Mod
 !  07 Nov 2017 - R. Yantosca - Add tropht and troplev fields
 !  08 Jan 2018 - R. Yantosca - Added logical query fields
 !  31 Jan 2018 - E. Lundgren - Remove underscores from diagnostic names
+!  20 Jan 2019 - L. Murray   - Add offline lightning flash rates
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -521,6 +528,8 @@ CONTAINS
     State_Met%InTroposphere  => NULL()
     State_Met%IsLocalNoon    => NULL()
     State_Met%LocalSolarTime => NULL()
+    State_Met%FLASH_DENS     => NULL()
+    State_Met%CONV_DEPTH     => NULL()
 
     !=======================================================================
     ! Allocate 2-D Fields
@@ -1869,6 +1878,28 @@ CONTAINS
                             State_Met, RC                             )
     IF ( RC /= GC_SUCCESS ) RETURN
 
+    !-----------------------------
+    ! Lightning density [#/km2/s]
+    !-----------------------------
+    ALLOCATE( State_Met%FLASH_DENS( IM, JM ), STAT=RC )
+    CALL GC_CheckVar( 'State_Met%FLASH_DENS', 0, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+    State_Met%FLASH_DENS = 0.0_fp
+    CALL Register_MetField( am_I_Root, 'FLASH_DENS', State_Met%FLASH_DENS, &
+                            State_Met, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    !-------------------------
+    ! Convective Depth [m]
+    !-------------------------
+    ALLOCATE( State_Met%CONV_DEPTH( IM, JM ), STAT=RC )
+    CALL GC_CheckVar( 'State_Met%CONV_DEPTH', 0, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+    State_Met%CONV_DEPTH = 0.0_fp
+    CALL Register_MetField( am_I_Root, 'CONV_DEPTH', State_Met%CONV_DEPTH, &
+                            State_Met, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
     !=======================================================================
     ! Print information about the registered fields (short format)
     !=======================================================================
@@ -2385,6 +2416,20 @@ CONTAINS
        CALL GC_CheckVar( 'State_Met%IREG', 2, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
        State_Met%IREG => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( State_Met%FLASH_DENS ) ) THEN
+       DEALLOCATE( State_Met%FLASH_DENS, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%FLASH_DENS', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%FLASH_DENS => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( State_Met%CONV_DEPTH ) ) THEN
+       DEALLOCATE( State_Met%CONV_DEPTH, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%CONV_DEPTH', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%CONV_DEPTH => NULL()
     ENDIF
 
     !========================================================================
@@ -3451,6 +3496,16 @@ CONTAINS
        CASE ( 'LOCALSOLARTIME' )
           IF ( isDesc  ) Desc  = 'Local solar time'
           IF ( isUnits ) Units = 'hours'
+          IF ( isRank  ) Rank  = 2
+
+       CASE ( 'FLASH_DENS' )
+          IF ( isDesc  ) Desc  = 'Lightning flash density'
+          IF ( isUnits ) Units = 'km-2 s-1'
+          IF ( isRank  ) Rank  = 2
+
+       CASE ( 'CONV_DEPTH' )
+          IF ( isDesc  ) Desc  = 'Convective cloud depth'
+          IF ( isUnits ) Units = 'm'
           IF ( isRank  ) Rank  = 2
 
        CASE ( 'AD' )


### PR DESCRIPTION
Lightning flash densities (flashes km-2 s-1) are now calculated offline at the native GEOS-FP or MERRA-2 model resolution, as well as the depth of convection. The offline flash density calculation and its climatological constraint to the LIS/OTD satellite climatology are otherwise as described in Murray et al. (2012).

Flash densities and convective depths are now specified as external meteorological fields in HEMCO_Config.rc and re-gridded to the simulation resolution, creating consistent lightning NOx emissions across all model configurations.