### PR TITLE
Move domain dependent variables from Linoz and MODIS LAI

### DIFF
--- a/GeosCore/cleanup.F
+++ b/GeosCore/cleanup.F
@@ -47,7 +47,6 @@
       USE History_Mod,             ONLY : History_Cleanup
       USE Input_Opt_Mod,           ONLY : OptInput
       USE ISOROPIAII_MOD,          ONLY : CLEANUP_ISOROPIAII
-      USE LINOZ_MOD,               ONLY : CLEANUP_LINOZ
       USE MERCURY_MOD,             ONLY : CLEANUP_MERCURY
       USE MODIS_LAI_MOD,           ONLY : CLEANUP_MODIS_LAI
       USE ObsPack_Mod,             ONLY : ObsPack_SpeciesMap_Cleanup
@@ -250,6 +249,7 @@
 !  23 Aug 2017 - R. Yantosca - Now call Cleanup_Grid_Registry
 !  06 Nov 2017 - R. Yantosca - Remove call to Cleanup_Chemgrid
 !  09 Nov 2017 - R. Yantosca - Return error condition to calling program
+!  22 Jan 2019 - H.P. Lin    - Remove call to CLEANUP_LINOZ
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -363,7 +363,6 @@
 
       CALL CLEANUP_HDF()  
       CALL CLEANUP_ISOROPIAII()
-      CALL CLEANUP_LINOZ()
       CALL CLEANUP_MAP_A2A()
       CALL CLEANUP_MERCURY()
       CALL CLEANUP_MODIS_LAI()

--- a/GeosCore/dust_mod.F
+++ b/GeosCore/dust_mod.F
@@ -2769,8 +2769,11 @@
       ENDIF
 #endif 
 
-#if defined( EXTERNAL_GRID ) || defined( EXTERNAL_FORCING ) || defined( TOMAS )
+#if defined( ESMF_ ) || defined( TOMAS )
       ! EXPERIMENTAL: For archiving the dust source for GCHP
+      !
+      ! Changed to use the ESMF_ flag and not EXTERNAL_GRID/EXTERNAL_FORCING, as
+      ! WRF-GC which uses these flags does not require SRCE_FUNC (hplin, 1/22/19)
       ALLOCATE( SRCE_FUNC(IIPAR,JJPAR,3), STAT=AS )
       IF ( AS /= 0 ) CALL ALLOC_ERR( 'SRCE_FUNC' )
       SRCE_FUNC = 0.e+0_fp

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -663,7 +663,6 @@ CONTAINS
     USE Global_CH4_Mod,     ONLY : Init_Global_CH4
     USE Input_Mod,          ONLY : Do_Error_Checks
     USE Input_Opt_Mod,      ONLY : OptInput
-    USE Linoz_Mod,          ONLY : Init_Linoz
     USE Land_Mercury_Mod,   ONLY : Init_Land_Mercury
     USE Mercury_Mod,        ONLY : Init_Mercury
     USE Modis_Lai_Mod,      ONLY : Init_Modis_Lai
@@ -912,18 +911,6 @@ CONTAINS
        CALL Init_Aerosol( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_Aerosol"!'
-          CALL GC_Error( ErrMsg, RC, ThisLoc )
-          RETURN
-       ENDIF
-    ENDIF
-
-    !-----------------------------------------------------------------
-    ! Initialize "linoz_mod.F"
-    !-----------------------------------------------------------------
-    IF ( Input_Opt%LLINOZ ) THEN
-       CALL Init_Linoz( am_I_Root, Input_Opt, State_Chm, State_Diag, RC )
-       IF ( RC /= GC_SUCCESS ) THEN
-          ErrMsg = 'Error encountered in "Init_Linoz"!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF

--- a/GeosCore/linoz_mod.F
+++ b/GeosCore/linoz_mod.F
@@ -21,15 +21,9 @@
       IMPLICIT NONE
       PRIVATE
 !
-! !PRIVATE DATA MEMBERS:
-!
-      REAL(fp), ALLOCATABLE :: TLSTT(:,:,:,:)
-!
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-      PUBLIC  :: CLEANUP_LINOZ
-      PUBLIC  :: DO_LINOZ    
-      PUBLIC  :: INIT_LINOZ
+      PUBLIC  :: DO_LINOZ
       PUBLIC  :: LINOZ_READ
 !
 ! !PRIVATE MEMBER FUNCTIONS:
@@ -102,6 +96,7 @@
 !  17 Nov 2014 - M. Yannetti - Added PRECISION_MOD
 !  19 Oct 2015 - C. Keller   - TLSTT is now 4D to work on curvilinear grids
 !  29 Nov 2016 - R. Yantosca - grid_mod.F90 is now gc_grid_mod.F90
+!  22 Jan 2019 - H.P. Lin    - Move TLSTT to State_Met%TLSTT
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -180,7 +175,7 @@
 
       ! if new month, get new parameters?
       IF ( MONTH /= LASTMONTH ) THEN
-         CALL LINOZ_STRATL( am_I_Root, Input_Opt, RC )
+         CALL LINOZ_STRATL( am_I_Root, Input_Opt, State_Chm, RC )
          LASTMONTH =  MONTH
       ENDIF
 
@@ -293,6 +288,10 @@
       ! from the Chemistry State (State_Chm) object. (mpayer, 12/6/12)
       REAL(fp), POINTER :: Spc(:,:,:,:)
 
+      ! Define local arrays to hold the previously global TLSTT array
+      ! from the State_Chm object. (hplin, 1/22/19)
+      REAL(fp), POINTER :: TLSTT (:,:,:,:)   ! IM, JM, LM, Input_Opt%LINOZ_NFIELDS
+
       ! From Input_Opt
       LOGICAL       :: LPRT
 
@@ -319,6 +318,9 @@
 
       ! Point to chemical species array [v/v dry air]
       Spc        => State_Chm%Species
+
+      ! Point to the TLSTT array
+      TLSTT      => State_Chm%TLSTT
 
       ! Look up the species ID of O3 only on the first call
       IF ( FIRST ) THEN
@@ -538,7 +540,7 @@
 !\\
 ! !INTERFACE:
 !
-      SUBROUTINE LINOZ_STRATL( am_I_Root, Input_Opt, RC )
+      SUBROUTINE LINOZ_STRATL( am_I_Root, Input_Opt, State_Chm, RC )
 !
 ! !USES:
 !
@@ -546,6 +548,7 @@
       USE ErrCode_Mod
       USE GC_GRID_MOD,        ONLY : GET_YMID 
       USE Input_Opt_Mod,      ONLY : OptInput
+      USE State_Chm_Mod,      ONLY : ChmState
       USE PRESSURE_MOD
       USE TIME_MOD,           ONLY : GET_MONTH
 !
@@ -553,6 +556,10 @@
 !
       LOGICAL,        INTENT(IN)  :: am_I_Root   ! Is this the root CPU?
       TYPE(OptInput), INTENT(IN)  :: Input_Opt   ! Input Options object
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+      TYPE(ChmState), INTENT(INOUT) :: State_Chm ! Chemistry State object
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -605,6 +612,8 @@
       REAL(fp)            :: STRTX (Input_Opt%LINOZ_NLEVELS)
       REAL(fp)            :: YSTRT (Input_Opt%LINOZ_NLAT   )
 
+      REAL(fp), POINTER   :: TLSTT (:,:,:,:)   ! IM, JM, LM, Input_Opt%LINOZ_NFIELDS
+
       ! Month names
       CHARACTER(LEN=3)  :: CMONTH(12) = (/'jan', 'feb', 'mar', 'apr',
      &                                    'may', 'jun', 'jul', 'aug',
@@ -626,6 +635,9 @@
       NLAT_LINOZ     = Input_Opt%LINOZ_NLAT
       NLEVELS_LINOZ  = Input_Opt%LINOZ_NLEVELS
       NMONTHS_LINOZ  = Input_Opt%LINOZ_NMONTHS
+
+      ! Point to the TLSTT array in state_chm_mod.F90
+      TLSTT          => State_Chm%TLSTT
 
       ! Echo info to stdout
       IF ( am_I_Root ) THEN
@@ -1289,89 +1301,5 @@
       enddo
 
       END SUBROUTINE LINOZ_INTPL
-!EOC
-!----------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE: init_linoz
-!
-! !DESCRIPTION: Subroutine INIT\_LINOZ allocates and zeroes the module arrays 
-!  used in the Linoz stratospheric ozone algorithm.
-!\\
-!\\
-! !INTERFACE:
-!
-      SUBROUTINE INIT_LINOZ( am_I_Root, Input_Opt, 
-     &                       State_Chm, State_Diag, RC )
-!
-! !USES:
-!
-      USE CMN_SIZE_MOD 
-      USE ErrCode_Mod
-      USE ERROR_MOD,          ONLY : ALLOC_ERR
-      USE Input_Opt_Mod,      ONLY : OptInput
-      USE State_Chm_Mod,      ONLY : ChmState
-      USE State_Diag_Mod,     ONLY : DgnState
-!
-! !INPUT PARAMETERS:
-!
-      LOGICAL,        INTENT(IN)    :: am_I_Root   ! Is this the root CPU?
-      TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
-      TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
-      TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
-!
-! !OUTPUT PARAMETERS:
-!
-      INTEGER,        INTENT(OUT) :: RC          ! Success or failure?
-!
-! !REVISION HISTORY: 
-!  16 Oct 2009 - R. Yantosca - Initial version
-!  18 Mar 2013 - R. Yantosca - Remove TPARM array since that is now carried
-!                              within the Input_Opt object.
-!  18 Mar 2013 - R. Yantosca - Accept am_I_Root, Input_Opt, RC arguments
-!  14 Mar 2013 - M. Payer    - Replace Ox with O3 for full-chemistry simulation
-!  19 Oct 2015 - C. Keller   - TLSTT is now 4D to work on curvilinear grids
-!  07 Aug 2018 - H.P. Lin    - Now accepts State_Chm, State_Diag to unify input
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-      ! Assume success
-      RC = GC_SUCCESS
-
-      ! Allocate TLSTT array
-      ALLOCATE( TLSTT( IIPAR, 
-     &                 JJPAR, 
-     &                 LLPAR, 
-     &                 Input_Opt%LINOZ_NFIELDS ), STAT=RC )
-      IF ( RC /= 0 ) CALL ALLOC_ERR( 'TPARM' )
-      TLSTT = 0e+0_fp
-
-      END SUBROUTINE INIT_LINOZ
-!EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE: cleanup_linoz
-!
-! !DESCRIPTION: Subroutine CLEANUP\_LINOZ deallocates all module arrays.
-!\\
-!\\
-! !INTERFACE:
-!
-      SUBROUTINE CLEANUP_LINOZ
-!
-! !REVISION HISTORY: 
-!  16 Oct 2009 - R. Yantosca - Initial version
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-      ! Deallocate arrays
-      IF ( ALLOCATED( TLSTT ) ) DEALLOCATE( TLSTT )
-      
-      END SUBROUTINE CLEANUP_LINOZ
 !EOC
       END MODULE LINOZ_MOD

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -230,6 +230,11 @@ MODULE State_Met_Mod
      REAL(fp), POINTER :: XLAI_NATIVE   (:,:,:) ! avg LAI per type (I,J,type)
      REAL(fp), POINTER :: XCHLR_NATIVE  (:,:,:) ! avg CHLR per type (I,J,type)
 
+     REAL(fp), POINTER :: XLAI2         (:,:,:) ! MODIS LAI per land type, 
+                                                !  for next month
+     REAL(fp), POINTER :: XCHLR2        (:,:,:) ! MODIS CHLR per land type,
+                                                !  for next month    
+
      !----------------------------------------------------------------------
      ! Fields for querying in which vertical regime a grid box is in
      ! or if a grid box is near local noon solar time
@@ -1775,6 +1780,28 @@ CONTAINS
     IF ( RC /= GC_SUCCESS ) RETURN
 
     !-------------------------
+    ! XLAI2 [1]
+    !-------------------------
+    ALLOCATE( State_Met%XLAI2( IM, JM, NSURFTYPE ), STAT=RC )
+    CALL GC_CheckVar( 'State_Met%XLAI2', 0, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+    State_Met%XLAI2 = 0.0_fp
+    CALL Register_MetField( am_I_Root, 'XLAI2', State_Met%XLAI2, &
+                            State_Met, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    !-------------------------
+    ! XCHLR2 [mg m-3]
+    !-------------------------
+    ALLOCATE( State_Met%XCHLR2( IM, JM, NSURFTYPE ), STAT=RC )
+    CALL GC_CheckVar( 'State_Met%XCHLR2', 0, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+    State_Met%XCHLR2 = 0.0_fp
+    CALL Register_MetField( am_I_Root, 'XCHLR2', State_Met%XCHLR2, &
+                            State_Met, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    !-------------------------
     ! MODISCHLR [mg m-3]
     !-------------------------
     ALLOCATE( State_Met%MODISCHLR( IM, JM ), STAT=RC )
@@ -2949,6 +2976,28 @@ CONTAINS
 #endif
     ENDIF
 
+    IF ( ASSOCIATED( State_Met%XLAI2 ) ) THEN
+#if defined( ESMF_ ) || defined( MODEL_WRF )
+       State_Met%XLAI2 => NULL()
+#else
+       DEALLOCATE( State_Met%XLAI2, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%XLAI2', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%XLAI2 => NULL()
+#endif
+    ENDIF
+
+    IF ( ASSOCIATED( State_Met%XCHLR2 ) ) THEN
+#if defined( ESMF_ ) || defined( MODEL_WRF )
+       State_Met%XCHLR2 => NULL()
+#else
+       DEALLOCATE( State_Met%XCHLR2, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%XCHLR2', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%XCHLR2 => NULL()
+#endif
+    ENDIF
+
     IF ( ASSOCIATED( State_Met%XLAI_NATIVE ) ) THEN
 #if defined( ESMF_ ) || defined( MODEL_WRF )
        State_Met%XLAI_NATIVE => NULL()
@@ -3787,6 +3836,12 @@ CONTAINS
           IF ( isUnits ) Units = 'm2 m-2'
           IF ( isRank  ) Rank  = 3
 
+       CASE ( 'XLAI2' )
+          IF ( isDesc  ) Desc  = 'MODIS LAI for each Olson land type, ' // &
+                                 'next month'
+          IF ( isUnits ) Units = 'm2 m-2'
+          IF ( isRank  ) Rank  = 3
+
        CASE ( 'MODISLAI' )
           IF ( isDesc  ) Desc  = 'Daily LAI computed from monthly ' // &
                                  'offline MODIS values'
@@ -3796,6 +3851,12 @@ CONTAINS
        CASE ( 'XCHLR' )
           IF ( isDesc  ) Desc  = 'MODIS chlorophyll-a per land type, ' // &
                                  'current month'
+          IF ( isUnits ) Units = 'mg m-3'
+          IF ( isRank  ) Rank  = 3
+
+       CASE ( 'XCHLR2' )
+          IF ( isDesc  ) Desc  = 'MODIS chlorophyll-a per land type, ' // &
+                                 'next month'
           IF ( isUnits ) Units = 'mg m-3'
           IF ( isRank  ) Rank  = 3
 


### PR DESCRIPTION
This update moves linoz_mod `TLSTT`, modis_lai mod `XLAI2`, `XCHLR2`
module variables to the `State_Chm` and `State_Met` derived type objects.

It disables the dust archive archival for WRF-GC in dust_mod
by using the `ESMF_` pre-processor switch instead of the
generic `EXTERNAL_GRID` switch.

This series of updates is provided as a part of restructuring GEOS-Chem
for integration into the WRF-GC coupled model with multi-domain support.

This update has been verified through GEOS-Chem Difference Tests against
the current `dev/12.2.0` latest commit.

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>