### PR TITLE
polarbr

### DIFF
--- a/GeosCore/mercury_mod.F
+++ b/GeosCore/mercury_mod.F
@@ -5295,12 +5295,13 @@ c$$$         k3ano2 = 3.4d-12 * exp(391d0/T)
       !----------------------------------------------------------------
       ! Add Br in the MBL
       !----------------------------------------------------------------
-      IF ( (L_ADD_MBL_BR) .OR. (LPOLARBR) ) THE
+      IF ( (L_ADD_MBL_BR) .OR. (LPOLARBR) ) THEN
          ! Fraction of grid box mass which is within the mixed layer
          FPBL = GET_FRAC_UNDER_PBLTOP(I,J,L) 
       ENDIF
       
       IF ( L_ADD_MBL_BR ) THEN
+
          IF ( IS_WATER( I, J, State_Met ) .AND. (FPBL > 0e+0_fp) ) THEN
 
             ! Convert BrO concentration to corresponding Br based on

--- a/GeosCore/mercury_mod.F
+++ b/GeosCore/mercury_mod.F
@@ -620,7 +620,7 @@
       ! To simplify this code, K_RED_JNO2 should be moved to HEMCO_Config.rc
       ! or input.geos since it will vary with MET/GRID/chemistry (cpt)
 
-      REAL(fp), PARAMETER     :: K_RED_JNO2 = 14.0e-2_fp
+      REAL(fp), PARAMETER     :: K_RED_JNO2 = 16.0e-2_fp
 
       ! Set of Hg/Br rate constants to use
       ! Recommended: DonohoueYBBalabanov, GoodsiteY, or DonohoueYB
@@ -5295,10 +5295,12 @@ c$$$         k3ano2 = 3.4d-12 * exp(391d0/T)
       !----------------------------------------------------------------
       ! Add Br in the MBL
       !----------------------------------------------------------------
+      IF ( (L_ADD_MBL_BR) .OR. (LPOLARBR) ) THEN
+         FPBL = GET_FRAC_UNDER_PBLTOP(I,J,L) 
+      ENDIF
       
       IF ( L_ADD_MBL_BR ) THEN
          ! Fraction of grid box mass which is within the mixed layer
-         FPBL = GET_FRAC_UNDER_PBLTOP(I,J,L)
 
          IF ( IS_WATER( I, J, State_Met ) .AND. (FPBL > 0e+0_fp) ) THEN
 
@@ -7275,7 +7277,7 @@ c$$$         k3ano2 = 3.4d-12 * exp(391d0/T)
       L_ADD_MBL_BR=.FALSE.
 
       ! Switch adds bromine explosion in Northern springtime
-      LPOLARBR=.FALSE.
+      LPOLARBR=.TRUE.
 
       ! Switch for only doing reduction in cloud water
       LRED_CLOUDONLY = .TRUE.

--- a/GeosCore/mercury_mod.F
+++ b/GeosCore/mercury_mod.F
@@ -5295,13 +5295,12 @@ c$$$         k3ano2 = 3.4d-12 * exp(391d0/T)
       !----------------------------------------------------------------
       ! Add Br in the MBL
       !----------------------------------------------------------------
-      IF ( (L_ADD_MBL_BR) .OR. (LPOLARBR) ) THEN
+      IF ( (L_ADD_MBL_BR) .OR. (LPOLARBR) ) THE
+         ! Fraction of grid box mass which is within the mixed layer
          FPBL = GET_FRAC_UNDER_PBLTOP(I,J,L) 
       ENDIF
       
       IF ( L_ADD_MBL_BR ) THEN
-         ! Fraction of grid box mass which is within the mixed layer
-
          IF ( IS_WATER( I, J, State_Met ) .AND. (FPBL > 0e+0_fp) ) THEN
 
             ! Convert BrO concentration to corresponding Br based on


### PR DESCRIPTION
Hg Simulation: polar bromine enhancement. Switching the default value of LPOLARBR to TRUE. This provides a more realistic springtime response of Hg at high latitudes. Fixed a bug that prevented this from working independently of L_ADD_MBL_BR. Minorly re-tuned K_RED_JNO2.