### PR TITLE
Prevent repeat allocation of dry deposition module variables.

### DIFF
--- a/GeosCore/drydep_mod.F
+++ b/GeosCore/drydep_mod.F
@@ -4137,6 +4137,15 @@
       ErrMsg    = ''
       ThisLoc   = ' -> at Init_Drydep (in module GeosCore/drydep_mod.F)'
 
+      ! If the dry deposition module has already been initialized,
+      ! the arrays do not need to be allocated again, as they are only
+      ! dependent on the chemistry configuration (State_Chm%nDryDep)
+      !
+      ! This is necessary for integrating GEOS-Chem with a variable
+      ! domain model like WRF-GC, where multiple instances of GEOS-Chem
+      ! run in the same CPU. (hplin, 2/16/2019)
+      IF ( ALLOCATED( A_DEN ) ) RETURN
+
       !===================================================================
       ! Arrays that hold information about dry-depositing species
       ! Only allocate these if dry deposition is activated


### PR DESCRIPTION
This is a minor code update for INIT_DRYDEP to skip variable allocation
if it has already been allocated once. This is correct because all the
grid-dependent variables in DRYDEP_MOD have been moved to State_Chm,
thus the dry deposition module only contains data generic to the species
list, which is consistent in a given run and does not need to be read
more than once.

This scenario is only possible in the multiple domain configuration of
WRF-GC model, and does not affect other GEOS-Chem configurations at this
time.

Signed-off-by: Haipeng Lin <linhaipeng@pku.edu.cn>