### PR TITLE
FIxes 64

### DIFF
--- a/GeosCore/CMakeLists.txt
+++ b/GeosCore/CMakeLists.txt
@@ -107,6 +107,14 @@ add_library(GeosCore STATIC EXCLUDE_FROM_ALL
 	$<$<BOOL:${TOMAS}>:tomas_mod.F>
 	$<$<BOOL:${APM}>:apm_driv_mod.F>
 )
+
+# Fixes #64: If GCC>=8.0.0 then ocean_mercury_mod.F should be compiled with -O1
+if(("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU") AND NOT (CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "8.0.0") AND NOT("${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
+	set_source_files_properties(ocean_mercury_mod.F
+		PROPERTIES COMPILE_FLAGS -O1
+	)
+endif()
+
 target_link_libraries(GeosCore
 	PUBLIC 
 		Transport ObsPack HCOI History 


### PR DESCRIPTION
Hi @yantosca,

This should fix #64. If GCC >= 8 then `ocean_mercury_mod.F` is compiled with the `-O1` flag. According to gfortran's documentation, if multiple optimizer flags are given, only the last one is obeyed [[1](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html)]. Therefore, this fix just checks if GCC >= 8, and if so, it adds a `COMPILE_FLAG` property to the source file `ocean_mercury_mod.F` with the `-O1` flag.

## References
1. https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
2. https://cmake.org/cmake/help/v3.3/command/set_source_files_properties.html
3. https://cmake.org/cmake/help/latest/prop_tgt/COMPILE_FLAGS.html