### PR TITLE
Fixes #70: Generating version number in gc_classic_version.H based off CMake project number

### DIFF
--- a/GeosCore/.gitignore
+++ b/GeosCore/.gitignore
@@ -10,3 +10,4 @@ geosapm
 *.inst.*
 *.continue.*
 *.ppk
+gc_classic_version.H

--- a/GeosCore/CMakeLists.txt
+++ b/GeosCore/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Generate gc_classic_version.H with GEOS-Chem's version number
+configure_file(gc_classic_version.H.in ${CMAKE_CURRENT_SOURCE_DIR}/gc_classic_version.H @ONLY)
+
 add_library(Transport STATIC EXCLUDE_FROM_ALL
 	diag_mod.F
 	dao_mod.F

--- a/GeosCore/gc_classic_version.H.in
+++ b/GeosCore/gc_classic_version.H.in
@@ -13,4 +13,4 @@
       ! Z = updated for patches that do not break backwards compatibility
       !     with run directories from the last benchmarked version X.Y.0.
       !-----------------------------------------------------------------------
-      GC_CLASSIC_VERSION = '12.6.0'
+      GC_CLASSIC_VERSION = '@GEOS_Chem_VERSION@'

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -1,0 +1,21 @@
+trigger:
+- feature/AzurePipeline
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+strategy:
+  matrix:
+    gcc6:
+      containerImage: "liambindle/gcc-netcdf-c-netcdf-fortran:6-4.7.1-4.4.5"
+
+container: $[ variables['containerImage'] ]
+
+steps:
+- script: |
+    mkdir build
+    cd build
+    cmake -DRUNDIR=IGNORE -DRUNDIR_SIM=standard $(Build.Repository.LocalPath)
+    make -j
+    make install
+  displayName: 'Building GEOS-Chem'


### PR DESCRIPTION
This PR is a draft (it breaks Make because I removed `gc_classic_version.H`) so it can't actually be merged. This is just an example of how #70 could be done with option (2).