### PR TITLE
Fixes CMake error message for when NetCDF is not found

### DIFF
--- a/CMakeScripts/FindNetCDF.cmake
+++ b/CMakeScripts/FindNetCDF.cmake
@@ -110,7 +110,7 @@ find_library(NETCDF_F_LIBRARY
 )
 
 # Make a readable error message 
-set(GFTL_ERRMSG "\nCounldn't find one or more of NetCDF's files! The following files/directories weren't found:")
+set(NetCDF_ERRMSG "\nCounldn't find one or more of NetCDF's files! The following files/directories weren't found:")
 if(NOT NETCDF_F_LIBRARY)
     set(NetCDF_ERRMSG "${NetCDF_ERRMSG}
     NETCDF_F_LIBRARY: Path to \"libnetcdff.so\"")


### PR DESCRIPTION
This PR makes the following difference to the error message CMake prints when NetCDF isn't found on the host.
```diff
CMake Error at /usr/share/cmake-3.5/Modules/FindPackageHandleStandardArgs.cmake:148 (message):
+
+  Counldn't find one or more of NetCDF's files! The following
+  files/directories weren't found:

      NETCDF_F_LIBRARY: Path to "libnetcdff.so"
      NETCDF_C_LIBRARY: Path to "libnetcdf.so"
      NETCDF_C_INCLUDE_DIR: Directory containing "netcdf.h"
      NETCDF_F90_INCLUDE_DIR: Directory containing "netcdf.mod"
      NETCDF_F77_INCLUDE_DIR: Directory containing "netcdf.inc"

  Find the directories/files that are listed above.  Specify the directories
  you want CMake to search with the CMAKE_PREFIX_PATH variable (or the
  NetCDF_ROOT environment variable).

   (missing:  NETCDF_F_LIBRARY NETCDF_C_LIBRARY NETCDF_C_INCLUDE_DIR NETCDF_F90_INCLUDE_DIR NETCDF_F77_INCLUDE_DIR) 
Call Stack (most recent call first):
  /usr/share/cmake-3.5/Modules/FindPackageHandleStandardArgs.cmake:388 (_FPHSA_FAILURE_MESSAGE)
  CMakeScripts/FindNetCDF.cmake:138 (find_package_handle_standard_args)
  CMakeLists.txt:44 (find_package)


 -- Configuring incomplete, errors occurred!
 See also "/stetson-home/bindle/geos-chem/build/CMakeFiles/CMakeOutput.log".
```