### PR TITLE
GEOS-Chem CI Pipelines!

### DIFF
--- a/.ci-pipelines/build-matrix.yml
+++ b/.ci-pipelines/build-matrix.yml
@@ -1,0 +1,80 @@
+# Build matrix pipeline:
+# 
+# This pipeline checks that pre-releases and the master branch
+# compile in a wide variety of build environments. This pipeline
+# is intended to be a rigorous check of GEOS-Chem's build.
+
+
+# This pipeline triggers on tagged pre-releases (alpha and beta 
+# versions, as well as release candidates). Commits to the master 
+# branch also trigger this pipeline.
+trigger:
+  branches:
+    include:
+      - master
+  tags:
+    include:        # Semantic versioning 2.0.0 examples:
+      - '*-alpha*'  # 12.7.1-alpha.3
+      - '*-beta*'   # 12.7.0-beta.1
+      - '*-rc*'     # 12.7.0-rc.1
+pr: none
+
+
+# Basic agent set up
+pool:
+  vmImage: 'ubuntu-latest'
+
+
+# Define the "matrix" of build images to try building GEOS-Chem in
+strategy:
+  matrix:
+    ubuntu_gcc4:
+      GCC_VERSION: 4
+      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc4-netcdf4.5.0-netcdff4.4.4
+    ubuntu_gcc5:
+      GCC_VERSION: 5
+      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc5-netcdf4.5.0-netcdff4.4.4
+    ubuntu_gcc6:
+      GCC_VERSION: 6
+      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc6-netcdf4.5.0-netcdff4.4.4
+    ubuntu_gcc7:
+      GCC_VERSION: 7
+      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc7-netcdf4.5.0-netcdff4.4.4
+    ubuntu_gcc8:
+      GCC_VERSION: 8
+      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc8-netcdf4.5.0-netcdff4.4.4
+    ubuntu_gcc9:
+      GCC_VERSION: 9
+      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc9-netcdf4.5.0-netcdff4.4.4
+    ubuntu_netcdf_new:
+      GCC_VERSION: 9
+      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-netcdf4.7.1-netcdff4.5.2
+    ubuntu_netcdf_old:
+      GCC_VERSION: 9
+      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-netcdf4.1.3
+    centos_gcc4:
+      GCC_VERSION: 4
+      containerImage: liambindle/penelope:0.1.0-centos7-gcc4-netcdf4.5.0-netcdff4.4.4
+    centos_gcc7:
+      GCC_VERSION: 7
+      containerImage: liambindle/penelope:0.1.0-centos7-gcc7-netcdf4.5.0-netcdff4.4.4
+    centos_gcc8:
+      GCC_VERSION: 8
+      containerImage: liambindle/penelope:0.1.0-centos7-gcc8-netcdf4.5.0-netcdff4.4.4
+container: $[ variables['containerImage'] ]
+
+
+# Try building GEOS-Chem (this is run for each "matrix" entry above)
+steps:
+- script: |
+    source /init.rc
+    module load gcc/${GCC_VERSION}
+    spack load hdf5 
+    spack load netcdf 
+    spack load netcdf-fortran
+    mkdir build
+    cd build
+    cmake -DRUNDIR=IGNORE -DRUNDIR_SIM=standard $(Build.Repository.LocalPath)
+    make -j
+    make install
+  displayName: 'Building GEOS-Chem'

--- a/.ci-pipelines/quick-build.yml
+++ b/.ci-pipelines/quick-build.yml
@@ -1,0 +1,42 @@
+# Quick build pipeline:
+# 
+# This pipeline checks that commits and open pull requests don't 
+# introduce compiler errors. This is meant to be a quick and simple 
+# check that runs frequently.
+
+
+# This pipeline triggers on commits to development and bug-fix 
+# branches. Commits to the master branch do not trigger this pipeline
+# because those are tested against the build matrix. Commits to 
+# feature branches do not trigger this pipeline, but open pull requests
+# and commits to pull requests do.
+trigger:
+  branches:
+    include:
+      - dev/*
+      - bugfix/*
+pr:
+  branches:
+    include:
+      - '*'
+
+
+# Basic agent and container set up
+pool:
+  vmImage: 'ubuntu-latest'
+container: liambindle/penelope:0.1.0-ubuntu16.04-gcc7-netcdf4.5.0-netcdff4.4.4
+
+
+# Try building GEOS-Chem
+steps:
+- script: |
+    module load gcc/7 
+    spack load hdf5 
+    spack load netcdf 
+    spack load netcdf-fortran
+    mkdir build
+    cd build
+    cmake -DRUNDIR=IGNORE -DRUNDIR_SIM=standard -DCMAKE_COLOR_MAKEFILE=FALSE $(Build.Repository.LocalPath)
+    make -j
+    make install
+  displayName: 'Building GEOS-Chem'

--- a/.ci-pipelines/release.dockerfile
+++ b/.ci-pipelines/release.dockerfile
@@ -1,0 +1,45 @@
+FROM liambindle/penelope:0.1.0-ubuntu16.04-gcc7-netcdf4.5.0-netcdff4.4.4
+
+# Make a directory to install GEOS-Chem to
+RUN mkdir /opt/geos-chem && mkdir /opt/geos-chem/bin
+
+# Copy the GEOS-Chem repository (".") to /gc-src
+# This means this docker build command's context must be 
+# GEOS-Chem's root source code directory
+COPY . /gc-src
+RUN cd /gc-src \
+&&  mkdir build
+
+# Commands to properly set up the environment inside the container
+RUN echo "module load gcc/7" >> /init.rc \
+&&  echo "spack load hdf5" >> /init.rc \
+&&  echo "spack load netcdf" >> /init.rc \
+&&  echo "spack load netcdf-fortran" >> /init.rc \
+&&  echo "export PATH=$PATH:/opt/geos-chem/bin" >> /init.rc \
+&&  echo "source /init.rc >> /etc/bash.bashrc"
+
+# Make bash the default shell
+SHELL ["/bin/bash", "-c"]
+
+# Build Standard and copy the executable to /opt/geos-chem/bin
+RUN cd /gc-src/build \
+&&  cmake -DRUNDIR=IGNORE -DRUNDIR_SIM=standard .. \
+&&  make -j install \
+&&  cp geos /opt/geos-chem/bin/geos-chem-standard \
+&& rm -rf /gc-src/build/*
+
+# Build Tropchem and copy the executable to /opt/geos-chem/bin
+RUN cd /gc-src/build \
+&&  cmake -DRUNDIR=IGNORE -DRUNDIR_SIM=tropchem .. \
+&&  make -j install \
+&&  cp geos /opt/geos-chem/bin/geos-chem-tropchem \
+&& rm -rf /gc-src/build/*
+
+# Build SOA_SVPOA and copy the executable to /opt/geos-chem/bin
+RUN cd /gc-src/build \
+&&  cmake -DRUNDIR=IGNORE -DRUNDIR_SIM=complexSOA_SVPOA .. \
+&&  make -j install \
+&&  cp geos /opt/geos-chem/bin/geos-chem-soa_svpoa\
+&& rm -rf /gc-src/build/*
+
+RUN rm -rf /gc-src

--- a/.ci-pipelines/release.yml
+++ b/.ci-pipelines/release.yml
@@ -38,14 +38,14 @@ steps:
     displayName: Build image
     inputs:
       command: build
-      buildContext: $(Build.Repository.LocalPath) # The path to the source code repo
+      buildContext: $(Build.Repository.LocalPath)   # The path to the source code repo
       Dockerfile: .ci-pipelines/release.dockerfile
-      repository: liambindle/geos-chem            # Docker Hub repository 
-      tags: $(Build.SourceBranchName)             # Source code repo's tag
+      repository: geoschem/geos-chem                # Docker Hub repository 
+      tags: $(Build.SourceBranchName)               # Source code repo's tag
   - task: Docker@2
     displayName: Push image
     inputs:
       containerRegistry: DockerHub
-      repository: liambindle/geos-chem            # Docker Hub repository 
+      repository: geoschem/geos-chem                # Docker Hub repository 
       command: push
       tags: $(Build.SourceBranchName)

--- a/.ci-pipelines/release.yml
+++ b/.ci-pipelines/release.yml
@@ -1,0 +1,51 @@
+# Release pipeline:
+# 
+# This pipeline performs deployment actions upon a GEOS-Chem release.
+# Currently, the only deployment action is to build and push a docker 
+# container with prebuilt GEOS-Chem executables (geos-chem-standard, 
+# geos-chem-tropchem, and geos-chem-soa_svpoa) for the newly released 
+# version.
+
+# This pipeline is triggered by tagged versions excluding 
+# pre-releases.
+trigger:
+  branches:
+    exclude:
+      - '*'
+  tags:
+    include:
+      - '*'
+    exclude:
+      - '*-alpha*'
+      - '*-beta*'
+      - '*-rc*'
+pr: none
+
+
+# Basic agent set up
+pool:
+  vmImage: 'ubuntu-latest'
+
+# Login to Docker Hub, build the image, and push the built image
+# to Docker Hub
+steps:
+  - task: Docker@2
+    displayName: Login to Docker Hub
+    inputs:
+      command: login
+      containerRegistry: DockerHub    # The name of the service connection in the Azure project
+  - task: Docker@2
+    displayName: Build image
+    inputs:
+      command: build
+      buildContext: $(Build.Repository.LocalPath) # The path to the source code repo
+      Dockerfile: .ci-pipelines/release.dockerfile
+      repository: liambindle/geos-chem            # Docker Hub repository 
+      tags: $(Build.SourceBranchName)             # Source code repo's tag
+  - task: Docker@2
+    displayName: Push image
+    inputs:
+      containerRegistry: DockerHub
+      repository: liambindle/geos-chem            # Docker Hub repository 
+      command: push
+      tags: $(Build.SourceBranchName)


### PR DESCRIPTION
# GEOS-Chem CI Pipelines!

Hi everyone,

This is a pull request for adding CI pipelines to GEOS-Chem Classic. I've set these CI pipelines up on my fork, and I've given you all the permissions to commit/push/tag/release on my fork so that you can try it out if you want. You can find the Azure pipelines for my GEOS-Chem fork here: https://dev.azure.com/lrbindle/geos-chem/_build?definitionId=10 (let me know if you can't access that link).

Sorry, this PR is long because there are a number of moving parts. Please don't think this means any cause for concern though, because the Azure pipeline is independent of the GitHub repo (besides a few YAML config files). I think we can start moving forward with this any time now.

I set up three pipelines. The first, "quick-build", is a fast and simple build pipeline that tries to compile GEOS-Chem in a "normal" build environment. This pipeline is triggered by commits to `dev/*` and `bugfix/*`, as well as pull requests (and commits to open pull requests). The second, "build-matrix", tries to build GEOS-Chem in 11 different environments (I call them lines) which each focus on a specific GEOS-Chem dependency (e.g. there are lines for GCC 4-9, lines for old and new NetCDF's, etc.). This pipeline is triggered by pre-releases and commits to the master branch. The third pipeline, "release", builds a docker container with GEOS-Chem prebuilt in it (with separate executables for standard, tropchem, and soa_svpoa mechanisms) and automatically pushes it to Docker Hub. This pipeline is triggered by GitHub releases.

**Note**: The build matrix pipeline already identified a problem with building with GCC 9! (see #113)

Please feel free to play around with pushing, making PRs, merging, and tagging on my GEOS-Chem fork to explore the behavior if you're interested (there's nothing important on my fork...I plan to re-fork soon anyways). Note that I've added some weird tags like 12.7.4 to my fork to test the CI behaviour...ignore these.

## Moving forward
To merge this PR a few things need to happen. These things will need to be done by someone with admin privileges for the GEOS-Chem repo. The first of these is setting up the Azure pipelines. To do this, they need to:
1. Create a GEOS-Chem organization account on Azure DevOps (I think you can do that [here](https://azure.microsoft.com/en-us/services/devops/)) (try to do this with the GEOS-Chem GitHub organization if it's possible)
2. Create a GEOS-Chem project (GEOS-Chem Classic and GCHP should have their own projects)
3. Click on the GEOS-Chem project
4. Click on "Pipelines" in the left column
5. Click "New" (it's in the second column from the left side of the screen) and then "New build pipeline"
6. Click "GitHub" for the next window which asks "Where is your code"
7. Select the GEOS-Chem repository
8. The screen will say "Configure your pipeline". Select "Existing Azure Pipeline YAML file"
9. It will ask you to select an existing YAML file. Put "feature/ci-pipelines" for the branch and ".ci-pipelines/quick-build.yml" for the Path (this is the Azure pipeline config file).
10. Repeat 4-9 for ".ci-pipelines/build-matrix.yml" and ".ci-pipelines/release.yml"

## Service connections
The "release" pipeline requires a service connection because it automatically pushes the built docker container to Docker Hub. To do this you should
1. Navigate to the GEOS-Chem project on Azure DevOps (where Step 3 in the instructions above got you)
2. Click Project settings (in the bottom left) > Service connections (under Project Settings/Pipelines) > New service connection > Docker Registry
3. Select "Docker Hub" for the "Registry type"
4. Make the connection name "DockerHub"
5. Set the Docker Registry to "https://index.docker.io/v1/" if it isn't already
6. Enter the GEOS-Chem organization's Docker Hub username as the Docker ID
7. Enter the GEOS-Chem organization's Docker Hub password
8. Click "Verify this connection"
9. Click OK

To whoever sets this up: If you would like some help with this when you are setting this up, feel free to let me know and I can make sure I'm on Slack. We could message and/or video call with screen share if that would be helpful.

## Release Docker container
The containers that the release pipeline builds have `geos-chem-standard`, `geos-chem-tropchem`, `geos-chem-soa_svpoa` executables in the PATH and their environments are configured. To run GEOS-Chem, the user should

1. Mount their run directory and ExtData as volumes when they do `docker run ...`
2. `cd` to their run directory (in the docker container)
3. Call `geos-chem-xxxxx` where `xxxxx` is the chemistry they want

Btw, these docker containers are going to be useful for us here at WashU because our new cluster runs docker images (when you log in you specify the docker container you want to load).

## Penelope
All of this relies on my `penelope` Docker Hub registry which is a set of consistent containers for various build environments. By consistent I mean that if you run `penelope:0.1.0-ubuntu16.04-mvapich2.3.1-esmf8.0.0` it looks the same as `penelope:0.1.0-ubuntu16.04-openmpi3.1.4-esmf8.0.0`. This is important so that our CI pipelines can run the same commands in the various containers which makes the build matrix easy.

 These containers are built by an Azure pipeline that I set up for [LiamBindle/penelope](https://github.com/LiamBindle/penelope). I'm not convinced going with an Azure pipeline for building/deploying these was the best approach, but it was easy so that's why I did it. It's a bit finicky (it build containers for 35 different build environments every time). I'm not sure if this project should be moved to GEOS-Chem control or spun off as it's own standalone project. Any thoughts?

## I think this can be done immediately
Keep in mind that none of this affects the GEOS-Chem repo. I've already added the pipeline YAML files to `feature/ci-pipelines` and that should be all we need to set up the DevOps project (i.e. this PR doesn't need to be merged before we start using the Azure pipelines). The only public-facing thing is the release containers that will automatically be pushed to Docker Hub upon tagged releases on GitHub.


Looking forward to hearing your thoughts on moving forward.

Liam