### PR TITLE
Use ENTRYPOINT in release.dockerfile

### DIFF
--- a/.ci-pipelines/release.dockerfile
+++ b/.ci-pipelines/release.dockerfile
@@ -15,8 +15,7 @@ RUN echo "module load gcc/7" >> /init.rc \
 &&  echo "spack load hdf5" >> /init.rc \
 &&  echo "spack load netcdf" >> /init.rc \
 &&  echo "spack load netcdf-fortran" >> /init.rc \
-&&  echo "export PATH=$PATH:/opt/geos-chem/bin" >> /init.rc \
-&&  echo "source /init.rc >> /etc/bash.bashrc"
+&&  echo "export PATH=$PATH:/opt/geos-chem/bin" >> /init.rc
 
 # Make bash the default shell
 SHELL ["/bin/bash", "-c"]
@@ -43,3 +42,9 @@ RUN cd /gc-src/build \
 && rm -rf /gc-src/build/*
 
 RUN rm -rf /gc-src
+
+RUN echo "#!/usr/bin/env bash" > /usr/bin/start-container.sh \
+&&  echo ". /init.rc" >> /usr/bin/start-container.sh \
+&&  echo 'if [ $# -gt 0 ]; then exec "$@"; else /bin/bash ; fi' >> /usr/bin/start-container.sh \
+&&  chmod +x /usr/bin/start-container.sh
+ENTRYPOINT ["start-container.sh"]


### PR DESCRIPTION
Yesterday I learned that a better way to get `/opt/geos-chem/bin` into `$PATH` is to use ENTRYPOINT rather than a source line in `/etc/bash.bashrc`. This PR includes that change to `.ci-pipelines/release.dockerfile`.