### PR TITLE
HEMCO standalone gridfix

### DIFF
--- a/HEMCO/Core/hco_chartools_mod.F90
+++ b/HEMCO/Core/hco_chartools_mod.F90
@@ -871,7 +871,7 @@ CONTAINS
 ! LOCAL VARIABLES:
 !
     INTEGER             :: IOS
-    CHARACTER(LEN=2047) :: DUM
+    CHARACTER(LEN=4095) :: DUM
 
     !=================================================================
     ! GetNextLine begins here
@@ -889,9 +889,24 @@ CONTAINS
        IF ( TRIM(DUM) == ''      ) CYCLE
        IF ( DUM(1:1)  == HCO_CMT ) CYCLE
 
-       ! If we get here, exit loop
-       LINE = DUM
-       EXIT
+       ! Make sure that character string DUM is not longer than LINE
+       IF ( LEN(TRIM(DUM)) > LEN(LINE) ) THEN
+          WRITE( 6, '(a)' ) REPEAT( '=', 79 )
+          WRITE( 6, * ) ' Line is too long - cannot copy into output argument '
+          WRITE( 6, * ) TRIM(DUM)
+          WRITE( 6, * ) ' '
+          WRITE( 6, * ) ' To fix this, increase length of argument `LINE` in '
+          WRITE( 6, * ) ' the subprogram which is calling '
+          WRITE( 6, * ) ' HCO_ReadLine (hco_chartools_mod.F90)'
+          RC = HCO_FAIL
+          RETURN
+          WRITE( 6, '(a)' ) REPEAT( '=', 79 )
+       ELSE
+          ! If we get here, exit loop
+          LINE = DUM
+          EXIT
+       ENDIF
+
     ENDDO
 
     ! Return w/ success

--- a/HEMCO/Interfaces/hcoi_standalone_mod.F90
+++ b/HEMCO/Interfaces/hcoi_standalone_mod.F90
@@ -1019,7 +1019,7 @@ CONTAINS
     CHARACTER(LEN=255)    :: LOC 
     CHARACTER(LEN=  1)    :: COL 
     CHARACTER(LEN=255)    :: MyGridFile, ThisLoc
-    CHARACTER(LEN=2047)   :: DUM,        ErrMsg,  Msg
+    CHARACTER(LEN=4095)   :: DUM,        ErrMsg,  Msg
 
     !=================================================================
     ! SET_GRID begins here

--- a/KPP/Standard/gckpp_HetRates.F90
+++ b/KPP/Standard/gckpp_HetRates.F90
@@ -244,6 +244,7 @@ MODULE GCKPP_HETRATES
 !  17 Oct 2018 - C.D. Holmes - Added cloud heterogeneous chemistry (CloudHet);
 !                              Gamma updates for NOx species
 !  13 Dec 2018 - E. McDuffie - Report gammaN2O5 as a State Chem parameter
+!  04 Nov 2019 - C.D. Holmes - Bug fixes for gammaN2O5 (RH dependence)
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -1542,14 +1543,14 @@ MODULE GCKPP_HETRATES
                xstkcf = 0.01
             case (8)
                ! sulfate
-               if ( relhum < 0.4 ) then
+               if ( relhum < 40 ) then
                   xstkcf = 0.001
                else
                   xstkcf = 0.002
                endif
             case (9)
                ! BC
-               if ( relhum < 0.5 ) then
+               if ( relhum < 50 ) then
                   xstkcf = 2e-4
                else
                   xstkcf = 1e-3
@@ -1559,12 +1560,12 @@ MODULE GCKPP_HETRATES
                xstkcf = 0.005
             case (11:12)
                ! sea salt
-               if ( relhum < 0.4 ) then
+               if ( relhum < 40 ) then
                   xstkcf = 0.05
-               elseif ( relhum > 0.7 ) then
+               elseif ( relhum > 70 ) then
                   xstkcf = 0.002
                else
-                  xstkcf = 0.05 + (0.002 - 0.05) * (relhum-0.4)/(0.7-0.4)
+                  xstkcf = 0.05 + (0.002 - 0.05) * (relhum-40)/(70-40)
                endif
          end select
 
@@ -1662,12 +1663,12 @@ MODULE GCKPP_HETRATES
                xstkcf = 1e-6_fp
             case (11:12)
                ! sea salt
-               if ( relhum < 0.4 ) then
+               if ( relhum < 40 ) then
                   xstkcf = 1e-8_fp
-               elseif ( relhum > 0.7 ) then
+               elseif ( relhum > 70 ) then
                   xstkcf = 1e-4_fp
                else
-                  xstkcf = 1e-8_fp + (1e-4_fp-1e-8_fp) * (relhum-0.4)/(0.7-0.4)
+                  xstkcf = 1e-8_fp + (1e-4_fp-1e-8_fp) * (relhum-40)/(70-40)
                endif
          end select
 
@@ -6031,7 +6032,7 @@ MODULE GCKPP_HETRATES
 !
       INTEGER,   INTENT(IN) :: AEROTYPE  ! Denoting aerosol type (cf FAST_JX)
       REAL(fp),  INTENT(IN) :: TEMP      ! Temperature [K]
-      REAL(fp),  INTENT(IN) :: RH        ! Relative humidity [1]
+      REAL(fp),  INTENT(IN) :: RH        ! Relative humidity [%]
 !
 ! !RETURN VALUE:
 !
@@ -6143,13 +6144,13 @@ MODULE GCKPP_HETRATES
          CASE ( 11, 12 )        
           
             ! IUPAC and Thornton and Abbatt (2005)
-            if (relhum < 0.4) then
+            if (RH_P < 40) then
                gamma = 0.005e0_fp
-            elseif (relhum > 0.7) then
+            elseif (RH_P > 70) then
                gamma = 0.02e0_fp
             else
-               gamma = 0.005e0_fp + (0.02e0_fp - 0.05e0_fp) * &
-                    ( relhum - 0.4e0_fp ) / ( 0.7e0_fp - 0.4e0_fp )
+               gamma = 0.005e0_fp + (0.02e0_fp - 0.005e0_fp) * &
+                    ( RH_P - 40e0_fp ) / ( 70e0_fp - 40e0_fp )
             endif
 
          !----------------


### PR DESCRIPTION
We found that HEMCO standalone was not able to run at the native resolution of GMAO 0.5x0.625 grids (MERRA-2, GEOS-FP). Using these grids in HEMCO standalone requires specifying the grid edges and centers in the HEMCO_sa_Grid.rc file in order to properly treat the half-size polar boxes. However, specifying all of the grid points at this native resolution exceeded the maximum line length that HEMCO standalone could read.

This fix increases the maximum line length and raises an error if the line exceeds this max length.