### PR TITLE
[PULL REQUEST] Disable writing out of diaginfo.dat and tracerinfo.dat for WRF-GC.

### DIFF
--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -941,7 +941,7 @@ CONTAINS
     ! Enable Mean OH (or CH3CCl3) diag for runs which need it
     CALL Init_Diag_OH( am_I_Root, Input_Opt, State_Grid, RC )
 
-#if !defined( ESMF_ )
+#if !defined( ESMF_ ) && !defined( MODEL_WRF )
     !--------------------------------------------------------------------
     ! Write out diaginfo.dat, tracerinfo.dat files for this simulation
     !


### PR DESCRIPTION
Hi GCST,

Please find below a very simple fix that was causing massively slowdowns for WRF-GC. Details are in the original commit message below. This does not affect anything other than `MODEL_WRF`.

Thanks!
Haipeng

```
In WRF-GC, a bug in the preprocessor constant code in gc_environment_mod
caused a writeout of diaginfo and tracerinfo.dat files in a massively
parallel environment, because the code was only walled off for `ESMF_`
and not `MODEL_WRF`. This has now been fixed, as it was causing massive
slowdowns in WRF-GC initialization above hundreds of cores.

Signed-off-by: Haipeng Lin <hplin@seas.harvard.edu>
```