### PR TITLE
Fix Init_Pressure error for NZ /= 47, 72 in MODEL_WRF

### DIFF
--- a/GeosUtil/pressure_mod.F90
+++ b/GeosUtil/pressure_mod.F90
@@ -794,11 +794,13 @@ CONTAINS
 
     ELSE
 
+#if !defined( MODEL_WRF )
        WRITE( nLev, * ) State_Grid%NZ
        ErrMSg = 'Ap and Bp not defined for ' // TRIM( nLev ) // &
                 ' levels. See subroutine INIT_PRESSURE.'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
        RETURN
+#endif
 
     ENDIF
 


### PR DESCRIPTION
Do not error out in PRESSURE_MOD:INIT_PRESSURE if models are not 47 or 72 in `MODEL_WRF`.

WRF-GC runs on its own set of vertical coordinates which are intentionally not 47 or 72 to avoid a HEMCO hardcoded vertical regridding workaround.
This patch removes an error message thrown in init_pressure notifying that the vertical levels are not hard-coded.

Signed-off-by: Haipeng Lin <hplin@seas.harvard.edu>

Thanks!