### PR TITLE
Bug fix for tiny SNA aerosol

### DIFF
--- a/GeosCore/aerosol_mod.F
+++ b/GeosCore/aerosol_mod.F
@@ -2019,7 +2019,7 @@
 
                   ! Wet effective radius, um
                   REFF = RW(1) * min( 3d0, 
-     &                 ( 1d0 + safe_div( VH2O, VDry, 0d0 ) )**(1d0/3d0) )
+     &                ( 1d0 + safe_div( VH2O, VDry, 0d0 ) )**(1d0/3d0) )
 
                ENDIF
 

--- a/GeosCore/aerosol_mod.F
+++ b/GeosCore/aerosol_mod.F
@@ -2013,10 +2013,13 @@
                   ! Volume of wet aerosol is also: VWet = 4/3*pi * RWet**3 * n
                   ! So RWet = ( 3*VWet / (4 pi n) )**(1/3)
                   ! RWet = RDry * ( 1 + VH2O/Vdry )**(1/3)
+                  ! In cases where VDry is tiny, VH2O/VDry can be huge
+                  ! because VH2O includes fine sea salt water. Limit
+                  ! growth to 3X dry radius (27X volume growth)
 
                   ! Wet effective radius, um
-                  REFF = RW(1) * ( 1d0 +
-     &                 safe_div( VH2O, VDry, 0d0 ) )**(1d0/3d0)
+                  REFF = RW(1) * min( 3d0, 
+     &                 ( 1d0 + safe_div( VH2O, VDry, 0d0 ) )**(1d0/3d0) )
 
                ENDIF
 

--- a/KPP/Standard/gckpp_HetRates.F90
+++ b/KPP/Standard/gckpp_HetRates.F90
@@ -2125,8 +2125,8 @@ MODULE GCKPP_HETRATES
       H2Ototal = H2Oinorg + H2Oorg
 
       ! Ratio of inorganic to total (organic+inorganic) volumes when dry, unitless
-      volRatioDry = safe_div( max( volInorg - H2Oinorg, 0d0), 
-     &                        max( volTotal - H2Ototal, 0d0), 0e+0_fp )
+      volRatioDry = safe_div( max( volInorg - H2Oinorg, 0d0), &
+                             max( volTotal - H2Ototal, 0d0), 0e+0_fp )
 
       ! Particle radius, cm
       ! Derived from spherical geometry

--- a/KPP/Standard/gckpp_HetRates.F90
+++ b/KPP/Standard/gckpp_HetRates.F90
@@ -2082,6 +2082,7 @@ MODULE GCKPP_HETRATES
 ! !REVISION HISTORY:
 !    13 Dec 2018 - E. McDuffie - Initial version
 !    23 Jul 2019 - C.D. Holmes - Consolidated into one function
+!    07 Apr 2020 - C.D. Holmes - Prevent tiny negative values of volRatioDry
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -2124,7 +2125,8 @@ MODULE GCKPP_HETRATES
       H2Ototal = H2Oinorg + H2Oorg
 
       ! Ratio of inorganic to total (organic+inorganic) volumes when dry, unitless
-      volRatioDry = safe_div((volInorg - H2Oinorg), (volTotal - H2Ototal), 0e+0_fp)
+      volRatioDry = safe_div( max( volInorg - H2Oinorg, 0d0), 
+     &                        max( volTotal - H2Ototal, 0d0), 0e+0_fp )
 
       ! Particle radius, cm
       ! Derived from spherical geometry


### PR DESCRIPTION
Fix bugs identified by Liam Bindle #263 

When sulfate-nitrate-ammonium mass is tiny,
aerosol water from ISORROPIA can be too large because
it includes fine sea salt aerosol water. This can
cause unrealistic hygroscopic growth and FPEs in some cases.

Add limits on affected variables.

Signed-off-by: Christopher Holmes <cdholmes@fsu.edu>