### PR TITLE
Add a State_Grid%ID field for MODEL_WRF

### DIFF
--- a/Headers/state_grid_mod.F90
+++ b/Headers/state_grid_mod.F90
@@ -37,6 +37,9 @@ MODULE State_Grid_Mod
      !----------------------------------------
      ! User-defined grid fields
      !----------------------------------------
+#if defined( MODEL_WRF )
+     INTEGER            :: ID          ! Grid identifier number
+#endif
      CHARACTER(LEN=255) :: GridRes     ! Grid resolution
      REAL(fp)           :: DX          ! Delta X         [degrees longitude]
      REAL(fp)           :: DY          ! Delta Y         [degrees latitude]
@@ -136,6 +139,9 @@ CONTAINS
     !----------------------------------------
     ! User-defined grid fields
     !----------------------------------------
+#if defined( MODEL_WRF )
+    State_Grid%ID           = -1
+#endif
     State_Grid%GridRes      = ''
     State_Grid%DX           = 0e+0_fp
     State_Grid%DY           = 0e+0_fp


### PR DESCRIPTION
Hi,

This is a minor add to State_Grid_Mod to add a `State_Grid%ID` field for `MODEL_WRF` operating in multiple-domain mode. This will be later used in a few WRF-specific changes in GEOS-Chem but I wanted to add this field as a standalone PR first so I don't keep a branched copy of the code.

Thanks!

Signed-off-by: Haipeng Lin <hplin@seas.harvard.edu>