### PR TITLE
Enable KppStop disabling of fail-safe for MODEL_WRF

### DIFF
--- a/GeosCore/flexchem_mod.F90
+++ b/GeosCore/flexchem_mod.F90
@@ -487,7 +487,7 @@ CONTAINS
        CALL DEBUG_MSG( '### Do_FlexChem: after FAST_JX' )
     ENDIF
 
-#ifdef MODEL_GEOS
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
     ! Init diagnostics
     IF ( ASSOCIATED(State_Diag%KppError) ) THEN
        State_Diag%KppError(:,:,:) = 0.0
@@ -867,7 +867,7 @@ CONTAINS
           WRITE(6,*) '### INTEGRATE RETURNED ERROR AT: ', I, J, L
        ENDIF
 
-#ifdef MODEL_GEOS
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
        ! Print grid box indices to screen if integrate failed
        IF ( IERR < 0 ) THEN
           WRITE(6,*) '### INTEGRATE RETURNED ERROR AT: ', I, J, L
@@ -1000,7 +1000,7 @@ CONTAINS
           IF ( IERR < 0 ) THEN
              WRITE(6,*) '## INTEGRATE FAILED TWICE !!! '
              WRITE(ERRMSG,'(a,i3)') 'Integrator error code :',IERR
-#ifdef MODEL_GEOS
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
              IF ( Input_Opt%KppStop ) THEN
                 CALL ERROR_STOP(ERRMSG, 'INTEGRATE_KPP')
              ! Revert to start values

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -393,13 +393,16 @@ MODULE Input_Opt_Mod
      INTEGER, POINTER            :: Jval_IDs(:)             ! J-values to be diagnosed
      INTEGER                     :: FJX_EXTRAL_ITERMAX = 5
      LOGICAL                     :: FJX_EXTRAL_ERR     = .TRUE.
-     LOGICAL                     :: KppStop            = .TRUE. ! Stop KPP if integration fails twice
      ! Toggle for het rates. If true, turns off three Cl producing het reactions
      ! in the stratosphere. In MODEL_GEOS, this flag is set in GEOSCHEMchem_GridComp.rc
      LOGICAL                     :: TurnOffHetRates = .FALSE.
 #else
      LOGICAL                     :: AlwaysSetH2O
      LOGICAL                     :: TurnOffHetRates
+#endif
+
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
+     LOGICAL                     :: KppStop            = .TRUE. ! Stop KPP if integration fails twice
 #endif
 
      !----------------------------------------

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -181,12 +181,15 @@ MODULE State_Diag_Mod
      REAL(f4),  POINTER :: O3concAfterChem (:,:,:  ) ! O3
      REAL(f4),  POINTER :: RO2concAfterChem(:,:,:  ) ! RO2
      REAL(f4),  POINTER :: CH4pseudoFlux   (:,:    ) ! CH4 pseudo-flux
-     REAL(f4),  POINTER :: KppError        (:,:,:  ) ! Kpp integration error
      LOGICAL :: Archive_JValIndiv
      LOGICAL :: Archive_RxnRconst
      LOGICAL :: Archive_O3concAfterChem
      LOGICAL :: Archive_RO2concAfterChem
      LOGICAL :: Archive_CH4pseudoFlux
+#endif
+
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
+     REAL(f4),  POINTER :: KppError        (:,:,:  ) ! Kpp integration error
      LOGICAL :: Archive_KppError
 #endif
 
@@ -898,12 +901,15 @@ CONTAINS
     State_Diag%O3concAfterChem                     => NULL()
     State_Diag%RO2concAfterChem                    => NULL()
     State_Diag%CH4pseudoflux                       => NULL()
-    State_Diag%KppError                            => NULL()
     State_Diag%Archive_JValIndiv                   = .FALSE.
     State_Diag%Archive_RxnRconst                   = .FALSE.
     State_Diag%Archive_O3concAfterChem             = .FALSE.
     State_Diag%Archive_RO2concAfterChem            = .FALSE.
     State_Diag%Archive_CH4pseudoflux               = .FALSE.
+#endif
+
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
+    State_Diag%KppError                            => NULL()
     State_Diag%Archive_KppError                    = .FALSE.
 #endif
 
@@ -3128,7 +3134,9 @@ CONTAINS
                                    State_Chm, State_Diag, RC                )
           IF ( RC /= GC_SUCCESS ) RETURN
        ENDIF
+#endif
 
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
        !--------------------------------------------------------------------
        ! KPP error flag
        !--------------------------------------------------------------------
@@ -7543,7 +7551,9 @@ CONTAINS
        IF ( RC /= GC_SUCCESS ) RETURN
        State_Diag%CH4pseudoflux => NULL()
     ENDIF
+#endif
 
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
     IF ( ASSOCIATED( State_Diag%KppError ) ) THEN
        DEALLOCATE( State_Diag%KppError, STAT=RC )
        CALL GC_CheckVar( 'State_Diag%KppError', 2, RC )
@@ -8946,7 +8956,9 @@ CONTAINS
        IF ( isDesc    ) Desc  = 'CH4 pseudo-flux balancing chemistry'
        IF ( isUnits   ) Units = 'kg m-2 s-1'
        IF ( isRank    ) Rank  = 2
+#endif
 
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
     ELSE IF ( TRIM( Name_AllCaps ) == 'KPPERROR' ) THEN
        IF ( isDesc    ) Desc  = 'KppError'
        IF ( isUnits   ) Units = '1'


### PR DESCRIPTION
Hi GCST,

This minor update extends `MODEL_GEOS`'s functionality for optionally ignoring integrate errors within the GEOS-Chem FlexChem integrator and logging it instead, to WRF-GC (`MODEL_WRF`)

This will be used as a handy debugging feature for WRF-GC's further developments. It does not affect other models.

Thank you!

Best,
Haipeng

~~**Edit:** This seems to cause some problems and registry crashes when printing the list, even if the DiagList is empty, for some reason. Please hold off this PR for now, sorry!~~
Fixed. What a peculiar bug! It was caused because I was using Windows line endings and directly uploaded to Cannon for compiling. It would initialize properly but throw a segmentation error in `diaglist_mod` when checking for `associated( current )`. I switched to Unix line endings to compile `state_diag_mod.F90` and everything was fine!