### PR TITLE
Do not call OMP external functions outside of MODEL_CLASSIC

### DIFF
--- a/GeosCore/flexchem_mod.F90
+++ b/GeosCore/flexchem_mod.F90
@@ -180,7 +180,9 @@ CONTAINS
     INTEGER,  SAVE         :: CH4_YEAR  = -1
     REAL(fp), SAVE         :: C3090S,   C0030S,   C0030N,    C3090N
 
+#ifdef MODEL_CLASSIC
     INTEGER, EXTERNAL      :: OMP_GET_THREAD_NUM
+#endif
 
     ! Arrays
     INTEGER                :: ICNTRL     (                  20               )
@@ -625,8 +627,10 @@ CONTAINS
        ! mje H2O arrives in g/kg needs to be in mol cm-3
        H2O       = State_Met%AVGW(I,J,L) * State_Met%AIRNUMDEN(I,J,L)
 
+#ifdef MODEL_CLASSIC
        ! Get the thread number
        Thread    = OMP_GET_THREAD_NUM() + 1
+#endif
 
        !====================================================================
        ! Get photolysis rates (daytime only)

--- a/GeosUtil/timers_mod.F90
+++ b/GeosUtil/timers_mod.F90
@@ -120,7 +120,9 @@ CONTAINS
 !
     ! Scalars
     INTEGER            :: RC
+#if defined( MODEL_CLASSIC )
     INTEGER, EXTERNAL  :: OMP_GET_NUM_THREADS
+#endif
 
     ! Strings
     CHARACTER(LEN=255) :: WarnMsg, ThisLoc
@@ -145,11 +147,13 @@ CONTAINS
 
     TimerMode = TheMode
 
+#if defined( MODEL_CLASSIC )
     ! Determine the number of threads available for parallel loops
     !$OMP PARALLEL
     nThreads   = OMP_GET_NUM_THREADS()
     d_nThreads = DBLE( nThreads )
     !$OMP END PARALLEL
+#endif
 
     ! Debug
     !PRINT*, "Timer_Setup: Done setting up GEOS-Chem timers"


### PR DESCRIPTION
Hi GCST,

In GEOS-Chem 12.8.0 the new timers request OMP thread information, which is unavailable in non-OpenMP environments. This minor change encloses these calls within `MODEL_CLASSIC` pre-processor statements.

I've used `#ifdef MODEL_CLASSIC` here because I'm not aware if hybrid MPI/OMP is used in GCHP, but please otherwise feel free to set this as `#if !defined(MODEL_WRF)` instead. Thank you!

Best,
Haipeng