### PR TITLE
Move module variables into State_Met, State_Chm

### DIFF
--- a/GeosCore/cleanup.F90
+++ b/GeosCore/cleanup.F90
@@ -49,7 +49,6 @@ SUBROUTINE CLEANUP( Input_Opt, State_Grid, ERROR, RC )
   USE STRAT_CHEM_MOD,          ONLY : CLEANUP_STRAT_CHEM
   USE TAGGED_CO_MOD,           ONLY : CLEANUP_TAGGED_CO
   USE UCX_MOD,                 ONLY : CLEANUP_UCX
-  USE WETSCAV_MOD,             ONLY : CLEANUP_WETSCAV
   USE EMISSIONS_MOD,           ONLY : EMISSIONS_FINAL
   USE SFCVMR_MOD,              ONLY : FixSfcVmr_Final
 #ifdef BPCH_DIAG
@@ -183,14 +182,6 @@ SUBROUTINE CLEANUP( Input_Opt, State_Grid, ERROR, RC )
   CALL CLEANUP_TOMS( RC )
   IF ( RC /= GC_SUCCESS ) THEN
      ErrMsg = 'Error encountered in "Cleanup_TOMS"!'
-     CALL GC_Error( ErrMsg, RC, ThisLoc )
-     RETURN
-  ENDIF
-
-  ! Cleanup wet scavenging module
-  CALL CLEANUP_WETSCAV( RC )
-  IF ( RC /= GC_SUCCESS ) THEN
-     ErrMsg = 'Error encountered in "Cleanup_Wetscav"!'
      CALL GC_Error( ErrMsg, RC, ThisLoc )
      RETURN
   ENDIF

--- a/GeosCore/cleanup.F90
+++ b/GeosCore/cleanup.F90
@@ -44,7 +44,6 @@ SUBROUTINE CLEANUP( Input_Opt, State_Grid, ERROR, RC )
   USE PRESSURE_MOD,            ONLY : CLEANUP_PRESSURE
   USE Regrid_A2A_Mod,          ONLY : Cleanup_Map_A2a
   USE SEASALT_MOD,             ONLY : CLEANUP_SEASALT
-  USE Set_Global_CH4_Mod,      ONLY : Cleanup_Set_Global_CH4
   USE SULFATE_MOD,             ONLY : CLEANUP_SULFATE
   USE State_Grid_Mod,          ONLY : GrdState
   USE STRAT_CHEM_MOD,          ONLY : CLEANUP_STRAT_CHEM
@@ -156,7 +155,6 @@ SUBROUTINE CLEANUP( Input_Opt, State_Grid, ERROR, RC )
   CALL CLEANUP_PJC_PFIX()
   CALL CLEANUP_PRESSURE()
   CALL CLEANUP_SEASALT()
-  Call Cleanup_Set_Global_CH4()
   CALL CLEANUP_SULFATE()
   CALL CLEANUP_STRAT_CHEM()
 

--- a/GeosCore/cleanup.F90
+++ b/GeosCore/cleanup.F90
@@ -61,7 +61,6 @@ SUBROUTINE CLEANUP( Input_Opt, State_Grid, ERROR, RC )
 #ifdef TOMAS
   USE TOMAS_MOD,               ONLY : CLEANUP_TOMAS  !sfarina, 1/16/13
 #endif
-  USE TOMS_MOD,                ONLY : CLEANUP_TOMS
   USE TPCORE_FVDAS_MOD,        ONLY : EXIT_TPCORE
   USE TPCORE_WINDOW_MOD,       ONLY : EXIT_TPCORE_WINDOW
 #if !defined( ESMF_ ) && !defined( MODEL_ )
@@ -174,14 +173,6 @@ SUBROUTINE CLEANUP( Input_Opt, State_Grid, ERROR, RC )
   CALL Cleanup_Grid_Registry( RC )
   IF ( RC /= GC_SUCCESS ) THEN
      ErrMsg = 'Error encountered in "Cleanup_Grid_Registry"!'
-     CALL GC_Error( ErrMsg, RC, ThisLoc )
-     RETURN
-  ENDIF
-
-  ! Cleanup TOMS module
-  CALL CLEANUP_TOMS( RC )
-  IF ( RC /= GC_SUCCESS ) THEN
-     ErrMsg = 'Error encountered in "Cleanup_TOMS"!'
      CALL GC_Error( ErrMsg, RC, ThisLoc )
      RETURN
   ENDIF

--- a/GeosCore/fast_jx_mod.F90
+++ b/GeosCore/fast_jx_mod.F90
@@ -314,7 +314,7 @@ CONTAINS
        ! Overhead ozone column [DU] at (NLON, NLAT)
        ! These values are either from the met fields or TOMS/SBUV,
        ! depending on the settings in input.geos
-       O3_TOMS = GET_OVERHEAD_O3( NLON, NLAT )
+       O3_TOMS = GET_OVERHEAD_O3( State_Chm, NLON, NLAT )
 
        ! CTM ozone densities (molec/cm3) at (NLON, NLAT)
        O3_CTM = 0e+0_fp

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -441,7 +441,6 @@ CONTAINS
     USE Sulfate_Mod,        ONLY : Init_Sulfate
     USE Tagged_CO_Mod,      ONLY : Init_Tagged_CO
     USE Tagged_O3_Mod,      ONLY : Init_Tagged_O3
-    USE Toms_Mod,           ONLY : Init_Toms
     USE Vdiff_Pre_Mod,      ONLY : Set_Vdiff_Values
     USE WetScav_Mod,        ONLY : Init_WetScav
 #ifdef BPCH_DIAG
@@ -649,16 +648,6 @@ CONTAINS
           CALL GC_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
-    ENDIF
-
-    !-----------------------------------------------------------------
-    ! Initialize "toms_mod.F90"
-    !-----------------------------------------------------------------
-    CALL Init_Toms( Input_Opt,  State_Chm, State_Diag, State_Grid, RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       ErrMsg = 'Error encountered in "Init_Toms"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc )
-       RETURN
     ENDIF
 
     !=================================================================

--- a/GeosCore/main.F90
+++ b/GeosCore/main.F90
@@ -1267,7 +1267,7 @@ PROGRAM GEOS_Chem
              IF ( Input_Opt%USE_TOMS_O3 ) THEN
                 ! Get TOMS overhead O3 columns for photolysis from
                 ! the HEMCO data structure (bmy, 3/20/15)
-                CALL Read_TOMS( Input_Opt, RC )
+                CALL Read_TOMS( Input_Opt, State_Chm, RC )
 
                 ! Trap potential errors
                 IF ( RC /= GC_SUCCESS ) THEN
@@ -2560,7 +2560,7 @@ CONTAINS
 
           ! Get the overhead O3 column for FAST-J.  Take either the
           ! TOMS O3 data or the column O3 directly from the met fields
-          CALL Compute_Overhead_O3( Input_Opt, State_Grid, DAY, &
+          CALL Compute_Overhead_O3( Input_Opt, State_Grid, State_Chm, DAY, &
                                     Input_Opt%USE_O3_FROM_MET,  &
                                     State_Met%TO3 )
        ENDIF

--- a/GeosCore/rrtmg_rad_transfer_mod.F90
+++ b/GeosCore/rrtmg_rad_transfer_mod.F90
@@ -721,7 +721,7 @@ CONTAINS
        ! Overhead ozone column [DU]
        ! These values are either from the met fields or TOMS/SBUV,
        ! depending on the settings in input.geos
-       O3COL = GET_OVERHEAD_O3(I,J)
+       O3COL = GET_OVERHEAD_O3(State_Chm, I,J)
 
        ! CTM ozone densities (molec/cm3)
        O3_CTM          = 0d0

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -5812,7 +5812,6 @@ CONTAINS
     USE APM_INIT_MOD,   ONLY : IFEMITBCOCS
     USE APM_DRIV_MOD,   ONLY : PSO4GAS
     USE APM_DRIV_MOD,   ONLY : FCLOUD
-    USE WETSCAV_MOD,    ONLY : PSO4_SO2APM2
 #endif
 !
 ! !INPUT PARAMETERS:
@@ -5859,6 +5858,9 @@ CONTAINS
 
     ! Pointers
     REAL(fp), POINTER :: Spc(:,:,:,:)
+#ifdef APM
+    REAL(fp), POINTER :: PSO4_SO2APM2(:,:,:)
+#endif
 
 #ifdef APM
     REAL*8            :: MASS0, MASS, PMASS
@@ -5885,6 +5887,8 @@ CONTAINS
     CALL WET_SETTLINGBIN( Input_Opt, State_Chm, State_Diag, State_Grid, &
                           State_Met, RC )
 
+    ! Point to PSO4_SO2APM2 now moved to State_Met
+    PSO4_SO2APM2 => State_Met%PSO4_SO2APM2
 #endif
 
     ! Point to chemical species array [kg]

--- a/GeosCore/toms_mod.F90
+++ b/GeosCore/toms_mod.F90
@@ -23,11 +23,9 @@ MODULE TOMS_MOD
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-  PUBLIC :: INIT_TOMS
   PUBLIC :: READ_TOMS
   PUBLIC :: COMPUTE_OVERHEAD_O3
   PUBLIC :: GET_OVERHEAD_O3
-  PUBLIC :: CLEANUP_TOMS
 !
 ! !PUBLIC DATA MEMBERS:
 !
@@ -65,20 +63,6 @@ MODULE TOMS_MOD
 !EOP
 !------------------------------------------------------------------------------
 !BOC
-!
-! !PRIVATE TYPES:
-!
-  ! Arrays
-  REAL(fp), PRIVATE, ALLOCATABLE :: TO3_DAILY(:,:)
-  REAL(f4), PRIVATE, ALLOCATABLE :: STOMS(:,:)
-
-  ! Pointers to fields in the HEMCO data structure
-  REAL(f4), PRIVATE, POINTER     :: TOMS(:,:)
-  REAL(f4), PRIVATE, POINTER     :: TOMS1(:,:)
-  REAL(f4), PRIVATE, POINTER     :: TOMS2(:,:)
-  REAL(f4), PRIVATE, POINTER     :: DTOMS1(:,:)
-  REAL(f4), PRIVATE, POINTER     :: DTOMS2(:,:)
-
 CONTAINS
 !EOC
 !------------------------------------------------------------------------------
@@ -94,7 +78,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE READ_TOMS( Input_Opt, RC )
+  SUBROUTINE READ_TOMS( Input_Opt, State_Chm, RC )
 !
 ! !USES:
 !
@@ -102,10 +86,12 @@ CONTAINS
     USE HCO_Interface_Mod,  ONLY : HcoState
     USE HCO_EmisList_Mod,   ONLY : HCO_GetPtr
     USE Input_Opt_Mod,      ONLY : OptInput
+    USE State_Chm_Mod,      ONLY : ChmState
 !
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput), INTENT(IN)  :: Input_Opt   ! Input Options object
+    TYPE(ChmState), INTENT(IN)  :: State_Chm   ! Chemistry State object
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -180,7 +166,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Read TOMS O3 columns [dobsons]
     !-----------------------------------------------------------------
-    CALL HCO_GetPtr( HcoState, 'TOMS_O3_COL', TOMS, RC )
+    CALL HCO_GetPtr( HcoState, 'TOMS_O3_COL', State_Chm%TOMS, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get pointer to field: TOMS_O3_COL'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -190,7 +176,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Read TOMS O3 columns first day [dobsons]
     !-----------------------------------------------------------------
-    CALL HCO_GetPtr( HcoState, 'TOMS1_O3_COL', TOMS1, RC )
+    CALL HCO_GetPtr( HcoState, 'TOMS1_O3_COL', State_Chm%TOMS1, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get pointer to field: TOMS1_O3_COL!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -200,7 +186,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Read TOMS O3 columns last day [dobsons]
     !-----------------------------------------------------------------
-    CALL HCO_GetPtr( HcoState, 'TOMS2_O3_COL', TOMS2, RC )
+    CALL HCO_GetPtr( HcoState, 'TOMS2_O3_COL', State_Chm%TOMS2, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get pointer to field: TOMS2_O3_COL!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -210,7 +196,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Read d(TOMS)/dt, 1st half of the month [dobsons/day]
     !-----------------------------------------------------------------
-    CALL HCO_GetPtr( HcoState, 'DTOMS1_O3_COL', DTOMS1, RC)
+    CALL HCO_GetPtr( HcoState, 'DTOMS1_O3_COL', State_Chm%DTOMS1, RC)
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get pointer to field: DTOMS1_O3_COL'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -220,7 +206,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Read d(TOMS)/dt, 2nd half of the month [dobsons/day]
     !-----------------------------------------------------------------
-    CALL HCO_GetPtr( HcoState,'DTOMS2_O3_COL', DTOMS2, RC )
+    CALL HCO_GetPtr( HcoState,'DTOMS2_O3_COL', State_Chm%DTOMS2, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get pointer to field: DTOMS2_O3_COL!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -252,18 +238,20 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE COMPUTE_OVERHEAD_O3( Input_Opt, State_Grid, DAY, &
+  SUBROUTINE COMPUTE_OVERHEAD_O3( Input_Opt, State_Grid, State_Chm, DAY, &
                                   USE_O3_FROM_MET, TO3 )
 !
 ! !USES:
 !
     USE Input_Opt_Mod,  ONLY : OptInput
     USE State_Grid_Mod, ONLY : GrdState
+    USE State_Chm_Mod,  ONLY : ChmState
 !
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput), INTENT(IN) :: Input_Opt       ! Input Options object
     TYPE(GrdState), INTENT(IN) :: State_Grid      ! Grid State object
+    TYPE(ChmState), INTENT(IN) :: State_Chm       ! Chemistry State object
     INTEGER,        INTENT(IN) :: DAY             ! Day of month
     LOGICAL,        INTENT(IN) :: USE_O3_FROM_MET ! Use TO3 directly from met?
     REAL(fp),       INTENT(IN) :: TO3(State_Grid%NX,State_Grid%NY) ! Met TO3
@@ -349,7 +337,7 @@ CONTAINS
     INTEGER       :: I, J
 
     ! Initialize
-    TO3_DAILY = 0e+0_fp
+    State_Chm%TO3_DAILY = 0e+0_fp
 
     !=================================================================
     ! Now weight the O3 column by the observed monthly mean TOMS.
@@ -370,7 +358,7 @@ CONTAINS
        ENDIF
 
        ! Get the overhead O3 column directly from the met field O3
-       TO3_DAILY = TO3
+       State_Chm%TO3_DAILY = TO3
 
     ELSE
 
@@ -384,7 +372,7 @@ CONTAINS
        !$OMP DEFAULT( SHARED )
        DO J = 1, State_Grid%NY
        DO I = 1, State_Grid%NX
-          STOMS(I,J) = (TOMS2(I,J)-TOMS1(I,J))/30.0_fp
+          State_Chm%STOMS(I,J) = (State_Chm%TOMS2(I,J)-State_Chm%TOMS1(I,J))/30.0_fp
        ENDDO
        ENDDO
        !$OMP END PARALLEL DO
@@ -395,7 +383,7 @@ CONTAINS
        !$OMP DEFAULT( SHARED )
        DO J = 1, State_Grid%NY
        DO I = 1, State_Grid%NX
-          TO3_DAILY(I,J) = TOMS1(I,J) + (DAY - 1) * STOMS(I,J)
+          State_Chm%TO3_DAILY(I,J) = State_Chm%TOMS1(I,J) + (DAY - 1) * State_Chm%STOMS(I,J)
        ENDDO
        ENDDO
        !$OMP END PARALLEL DO
@@ -418,10 +406,15 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  FUNCTION GET_OVERHEAD_O3( I, J ) RESULT( OVERHEAD_O3 )
+  FUNCTION GET_OVERHEAD_O3( State_Chm, I, J ) RESULT( OVERHEAD_O3 )
+!
+! !USES:
+!
+    USE State_Chm_Mod,  ONLY : ChmState
 !
 ! !INPUT PARAMETERS:
 !
+    TYPE(ChmState), INTENT(IN)  :: State_Chm   ! Chemistry State object
     INTEGER :: I             ! Grid box longitude index
     INTEGER :: J             ! Grid box latitude index
 !
@@ -436,144 +429,7 @@ CONTAINS
 !------------------------------------------------------------------------------
 !BOC
 
-    OVERHEAD_O3 = TO3_DAILY(I,J)
+    OVERHEAD_O3 = State_Chm%TO3_DAILY(I,J)
 
   END FUNCTION GET_OVERHEAD_O3
-!EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE: init_toms
-!
-! !DESCRIPTION: Subroutine INIT\_TOMS allocates and zeroes all module arrays.
-!\\
-!\\
-! !INTERFACE:
-!
-  SUBROUTINE INIT_TOMS( Input_Opt, State_Chm, State_Diag, State_Grid, RC )
-!
-! !USES:
-!
-    USE ErrCode_Mod
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Diag_Mod,     ONLY : DgnState
-    USE State_Grid_Mod,     ONLY : GrdState
-!
-! !INPUT PARAMETERS:
-!
-    TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
-    TYPE(GrdState), INTENT(IN)    :: State_Grid  ! Grid State object
-!
-! !INPUT/OUTPUT PARAMETERS:
-!
-    TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
-    TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
-!
-! !OUTPUT PARAMETERS:
-!
-    INTEGER,        INTENT(OUT)   :: RC          ! Failure or success
-!
-! !REVISION HISTORY:
-!  14 Jul 2003 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/geos-chem for complete history
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-!
-! !LOCAL VARIABLES:
-!
-    !=================================================================
-    ! INIT_TOMS begins here!
-    !=================================================================
-
-    ! Assume success
-    RC = GC_SUCCESS
-
-    ! Exit immediately if this is a dry-run
-    IF ( Input_Opt%DryRun ) RETURN
-
-    ! Allocate arrays
-    IF ( .not. ALLOCATED( TO3_DAILY ) ) THEN
-       ALLOCATE( TO3_DAILY( State_Grid%NX, State_Grid%NY ), STAT=RC )
-       CALL GC_CheckVar( 'toms_mod.F90:TO3_DAILY', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       TO3_DAILY = 0.0_fp
-    ENDIF
-
-    IF ( .not. ALLOCATED( STOMS ) ) THEN
-       ALLOCATE( STOMS( State_Grid%NX, State_Grid%NY ), STAT=RC )
-       CALL GC_CheckVar( 'toms_mod.F90:STOMS', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       STOMS = 0e+0_fp
-    ENDIF
-
-    ! Initialize pointers
-    TOMS   => NULL()
-    TOMS1  => NULL()
-    TOMS2  => NULL()
-    DTOMS1 => NULL()
-    DTOMS2 => NULL()
-
-  END SUBROUTINE INIT_TOMS
-!EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE: cleanup_toms
-!
-! !DESCRIPTION: Subroutine CLEANUP\_TOMS deallocates all module arrays.
-!\\
-!\\
-! !INTERFACE:
-!
-  SUBROUTINE CLEANUP_TOMS( RC )
-!
-! !USES:
-!
-    USE ErrCode_Mod
-!
-! !OUTPUT PARAMETERS:
-!
-    INTEGER, INTENT(OUT) :: RC          ! Success or failure?
-!
-! !REVISION HISTORY:
-!  14 Jul 2003 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/geos-chem for complete history
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-    !=================================================================
-    ! CLEANUP_TOMS begins here!
-    !=================================================================
-
-    ! Assume success
-    RC = GC_SUCCESS
-
-    ! Deallocate variables
-    IF ( ALLOCATED( TO3_DAILY ) ) THEN
-       DEALLOCATE( TO3_DAILY, STAT=RC )
-       CALL GC_CheckVar( 'toms_mod.F90:TO3_DAILY', 2, RC )
-       RETURN
-    ENDIF
-
-    IF ( ALLOCATED( STOMS ) ) THEN
-       DEALLOCATE( STOMS, STAT=RC )
-       CALL GC_CheckVar( 'toms_mod.F90:STOMS', 2, RC )
-       RETURN
-    ENDIF
-
-    ! Free pointers
-    TOMS   => NULL()
-    TOMS1  => NULL()
-    TOMS2  => NULL()
-    DTOMS1 => NULL()
-    DTOMS2 => NULL()
-
-  END SUBROUTINE CLEANUP_TOMS
-!EOC
 END MODULE TOMS_MOD

--- a/GeosCore/wetscav_mod.F90
+++ b/GeosCore/wetscav_mod.F90
@@ -20,16 +20,8 @@ MODULE WETSCAV_MOD
   IMPLICIT NONE
   PRIVATE
 !
-! !PUBLIC DATA MEMBERS:
-!
-#ifdef APM
-  ! NOTE: This should really go into State_Chem! (bmy, 6/17/19)
-  REAL(fp), PUBLIC, ALLOCATABLE, TARGET :: PSO4_SO2APM2(:,:,:)
-#endif
-!
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-  PUBLIC  :: CLEANUP_WETSCAV
   PUBLIC  :: COMPUTE_F
   PUBLIC  :: DO_WETDEP
   PUBLIC  :: INIT_WETSCAV
@@ -87,23 +79,6 @@ MODULE WETSCAV_MOD
 !
 ! !LOCAL VARIABLES:
 !
-  ! Arrays
-  REAL(fp), ALLOCATABLE, TARGET :: C_H2O (:,:,:) ! Mix ratio of H2O [v/v]
-  REAL(fp), ALLOCATABLE, TARGET :: CLDICE(:,:,:) ! Cloud ice mixing ratio
-                                                 !  [cm3 ice/cm3 air]
-  REAL(fp), ALLOCATABLE, TARGET :: CLDLIQ(:,:,:) ! Cloud liquid water
-                                                 !  mixing ratio
-                                                 !  [cm3 H2O/cm3 air]
-  REAL(fp), ALLOCATABLE         :: PDOWN (:,:,:) ! Precipitation thru the
-                                                 !  bottom of the grid box
-                                                 !  [cm3 H2O/cm2 area/s]
-  REAL(fp), ALLOCATABLE         :: QQ    (:,:,:) ! Rate of new precip
-                                                 !  formation
-                                                 !  [cm3 H2O/cm3 air/s]
-  REAL*8,  ALLOCATABLE          :: REEVAP(:,:,:) ! Rate of precip
-                                                 !  reevaporation
-                                                 !  [cm3 H2O/cm3 air/s]
-
   ! Define local shadow variables for values in Input_Opt
   LOGICAL                       :: LGTMM
   LOGICAL                       :: LSOILNOX
@@ -417,8 +392,8 @@ CONTAINS
 
        ! Rate of new precipitation formation in grid box (I,J,L)
        ! [cm3 H2O/cm3 air/s]
-       QQ(L,I,J)     = ( State_Met%DQRLSAN(I,J,L)                 ) &
-                     * ( State_Met%MAIRDEN(I,J,L)     / 1000.0_fp )
+       State_Met%QQ(L,I,J) = ( State_Met%DQRLSAN(I,J,L)                 ) &
+                           * ( State_Met%MAIRDEN(I,J,L)     / 1000.0_fp )
 #ifdef LUO_WETDEP
        ! Luo et al scheme: save QQ to State_Chm for further use
        State_Chm%QQ3D(I,J,L) = QQ(L,I,J)
@@ -426,20 +401,20 @@ CONTAINS
 
        ! Rate of re-evaporation in grid box (I,J,L)
        ! [cm3 H2O/cm3 air/s]
-       REEVAP(L,I,J) = ( State_Met%REEVAPLS(I,J,L)                ) &
-                     * ( State_Met%AIRDEN(I,J,L)      / 1000.0_fp )
+       State_Met%REEVAP(L,I,J) = ( State_Met%REEVAPLS(I,J,L)                ) &
+                               * ( State_Met%AIRDEN(I,J,L)      / 1000.0_fp )
 
        ! Column precipitation [cm3 H2O/cm2 air/s]
 #ifdef LUO_WETDEP
        ! Luo et al scheme: Use level L
-       PDOWN(L,I,J)  = ( ( State_Met%PFLLSAN(I,J,L) / 1000.0_fp )   &
-                     +   ( State_Met%PFILSAN(I,J,L) /  917.0_fp ) ) &
-                     * 100.0_fp
+       State_Met%PDOWN(L,I,J)  = ( ( State_Met%PFLLSAN(I,J,L) / 1000.0_fp )   &
+                               +   ( State_Met%PFILSAN(I,J,L) /  917.0_fp ) ) &
+                               * 100.0_fp
 #else
        ! Default scheme: Use level L+1
-       PDOWN(L,I,J)  = ( ( State_Met%PFLLSAN(I,J,L+1) / 1000.0_fp )   &
-                     +   ( State_Met%PFILSAN(I,J,L+1) /  917.0_fp ) ) &
-                     * 100.0_fp
+       State_Met%PDOWN(L,I,J)  = ( ( State_Met%PFLLSAN(I,J,L+1) / 1000.0_fp )   &
+                               +   ( State_Met%PFILSAN(I,J,L+1) /  917.0_fp ) ) &
+                               * 100.0_fp
 #endif
 
     ENDDO
@@ -764,9 +739,9 @@ CONTAINS
        DO I = 1, State_Grid%NX
 
           ! Set pointers
-          p_C_H2O  => C_H2O (I,J,L)
-          p_CLDICE => CLDICE(I,J,L)
-          p_CLDLIQ => CLDLIQ(I,J,L)
+          p_C_H2O  => State_Met%C_H2O (I,J,L)
+          p_CLDICE => State_Met%CLDICE(I,J,L)
+          p_CLDLIQ => State_Met%CLDLIQ(I,J,L)
           p_T      => State_Met%T(I,J,L)
 
           ! Compute Ki, the loss rate of a gas-phase species from
@@ -1156,9 +1131,9 @@ CONTAINS
     RC       =  GC_SUCCESS
 
     ! Set pointers
-    p_C_H2O  => C_H2O(I,J,L)
-    p_CLDICE => CLDICE(I,J,L)
-    p_CLDLIQ => CLDLIQ(I,J,L)
+    p_C_H2O  => State_Met%C_H2O(I,J,L)
+    p_CLDICE => State_Met%CLDICE(I,J,L)
+    p_CLDLIQ => State_Met%CLDLIQ(I,J,L)
     p_T      => State_Met%T(I,J,L)
     H2O2s    => State_Chm%H2O2AfterChem
     SO2s     => State_Chm%SO2AfterChem
@@ -2775,10 +2750,10 @@ CONTAINS
        L = State_Grid%NZ
 
        ! If precip forms at (I,J,L), assume it all rains out
-       IF ( QQ(L,I,J) > 0.0_fp ) THEN
+       IF ( State_Met%QQ(L,I,J) > 0.0_fp ) THEN
 
           ! Q is the new precip that is forming within grid box (I,J,L)
-          Q = QQ(L,I,J)
+          Q = State_Met%QQ(L,I,J)
 
 !---------------------------------------------------------------------------
 ! Prior to 2/19/20: 
@@ -2874,7 +2849,7 @@ CONTAINS
           QDOWN       = 0e+0_fp
 
           ! If there is new precip forming w/in the grid box ...
-          IF ( QQ(L,I,J) > 0e+0_fp ) THEN
+          IF ( State_Met%QQ(L,I,J) > 0e+0_fp ) THEN
 
 #ifdef LUO_WETDEP
              ! Luo et al scheme: Compute the condensed water
@@ -2882,7 +2857,7 @@ CONTAINS
              ! Then compute K_RAIN and F_PRIME for LS precip.
              ! Now use QL and QI in formula for COND_WATER_CONTENT 
              ! (bmy, 2/7/20)
-             COND_WATER_CONTENT = ( QQ(L,I,J) * DT ) + &
+             COND_WATER_CONTENT = ( State_Met%QQ(L,I,J) * DT ) + &
                                   (( State_Met%QL(I,J,L) + State_Met%QI(I,J,L))&
                                   *( State_Met%AIRDEN(I,J,L) * 1e-3_fp ) )
              COND_WATER_CONTENT = MAX( 1e-30_fp, COND_WATER_CONTENT )
@@ -2890,14 +2865,14 @@ CONTAINS
              K_RAIN  = LS_K_RAIN( QQ(L,I,J), COND_WATER_CONTENT )
              F_PRIME = MAX(1.e-4_fp,State_Met%CLDF(I,J,L))
              F_PRIME = F_PRIME*MIN(1.e+0_fp, &
-                       QQ(L,I,J) / ( K_RAIN * COND_WATER_CONTENT ) )
+                       State_Met%QQ(L,I,J) / ( K_RAIN * COND_WATER_CONTENT ) )
 #else
              ! Default scheme: Compute K_RAIN and F_RAINOUT for LS
              ! precipitation (cf. Eqs. 11-13, Jacob et al, 2000).
              ! Use COND_WATER_CONTENT = 1e-6 [cm3/cm3], which
              ! was recommended by Qiaoqiao Wang et al [2014].
-             K_RAIN  = LS_K_RAIN(  QQ(L,I,J),         1.0e-6_fp )
-             F_PRIME = LS_F_PRIME( QQ(L,I,J), K_RAIN, 1.0e-6_fp )
+             K_RAIN  = LS_K_RAIN(  State_Met%QQ(L,I,J),         1.0e-6_fp )
+             F_PRIME = LS_F_PRIME( State_Met%QQ(L,I,J), K_RAIN, 1.0e-6_fp )
 #endif
 
           ELSE
@@ -2910,7 +2885,7 @@ CONTAINS
           ! Calculate the fractional areas subjected to rainout and
           ! washout. If PDOWN = 0, then all dissolved species returns
           ! to the atmosphere. (cdh, 7/13/10)
-          IF ( PDOWN(L,I,J) > 0e+0_fp ) THEN
+          IF ( State_Met%PDOWN(L,I,J) > 0e+0_fp ) THEN
              F_RAINOUT = F_PRIME
              ! Washout occurs where there is no rainout
              F_WASHOUT = MAX( FTOP - F_RAINOUT, 0e+0_fp )
@@ -2932,8 +2907,8 @@ CONTAINS
 
              ! QDOWN is the precip leaving thru the bottom of box (I,J,L)
              ! Q     is the precip that is evaporating within box (I,J,L) 
-             QDOWN = PDOWN(L,I,J)
-             Q     = REEVAP(L,I,J)
+             QDOWN = State_Met%PDOWN(L,I,J)
+             Q     = State_Met%REEVAP(L,I,J)
              Q     = MAX( Q, 0e+0_fp ) ! Negative values are unphysical
 
              !  Define PDOWN and p
@@ -2941,7 +2916,7 @@ CONTAINS
 
                 ! The precipitation causing washout
                 ! is the precip entering thru the top
-                QDOWN = PDOWN(L+1,I,J)
+                QDOWN = State_Met%PDOWN(L+1,I,J)
 
                 !** GEOS-FP and MERRA-2 distinguish between rates of
                 ! new precipitation (field DQRLSAN) and evaporation of
@@ -3026,23 +3001,23 @@ CONTAINS
              ERRMSG = 'WASHOUT'
 
              ! Do the washout
-             CALL DO_WASHOUT_ONLY( LS         = LS,         &
-                                   I          = I,          &
-                                   J          = J,          &
-                                   L          = L,          &
-                                   IDX        = IDX,        &
-                                   ERRMSG     = ERRMSG,     &
-                                   QDOWN      = QDOWN,      &
-                                   Q          = Q,          &
-                                   F_WASHOUT  = F_WASHOUT,  &
-                                   F_RAINOUT  = F_RAINOUT,  &
-                                   DT         = DT,         &
-                                   PDOWN      = PDOWN,      &
-                                   DSpc       = DSpc,       &
-                                   Input_Opt  = Input_Opt,  &
-                                   State_Chm  = State_Chm,  &
-                                   State_Diag = State_Diag, &
-                                   State_Grid = State_Grid, &
+             CALL DO_WASHOUT_ONLY( LS         = LS,              &
+                                   I          = I,               &
+                                   J          = J,               &
+                                   L          = L,               &
+                                   IDX        = IDX,             &
+                                   ERRMSG     = ERRMSG,          &
+                                   QDOWN      = QDOWN,           &
+                                   Q          = Q,               &
+                                   F_WASHOUT  = F_WASHOUT,       &
+                                   F_RAINOUT  = F_RAINOUT,       &
+                                   DT         = DT,              &
+                                   PDOWN      = State_Met%PDOWN, &
+                                   DSpc       = DSpc,            &
+                                   Input_Opt  = Input_Opt,       &
+                                   State_Chm  = State_Chm,       &
+                                   State_Diag = State_Diag,      &
+                                   State_Grid = State_Grid,      &
                                    State_Met  = State_Met,  &
                                    RC         = EC )
 
@@ -3120,10 +3095,10 @@ CONTAINS
        L = 1
 
        ! Washout at level 1 criteria
-       IF ( PDOWN(L+1,I,J) > 0e+0_fp ) THEN
+       IF ( State_Met%PDOWN(L+1,I,J) > 0e+0_fp ) THEN
 
           ! QDOWN is the precip leaving thru the bottom of box (I,J,L+1)
-          QDOWN = PDOWN(L+1,I,J)
+          QDOWN = State_Met%PDOWN(L+1,I,J)
 
 #ifdef LUO_WETDEP
           ! Luo et al scheme: Only consider washout
@@ -3633,22 +3608,22 @@ CONTAINS
             DSpc(NW,L,I,J) < 0e+0_fp        ) THEN
 
           ! Print error message
-          CALL SAFETY( I, J, L, N, ERRMSG,           &
-                       LS          = LS,             &
-                       PDOWN       = PDOWN(L,I,J),   &
-                       QQ          = QQ(L,I,J),      &
-                       ALPHA       = 0e+0_fp,        &
-                       ALPHA2      = 0e+0_fp,        &
-                       RAINFRAC    = RAINFRAC,       &
-                       WASHFRAC    = 0e+0_fp,        &
-                       MASS_WASH   = 0e+0_fp,        &
-                       MASS_NOWASH = 0e+0_fp,        &
-                       WETLOSS     = WETLOSS,        &
-                       GAINED      = 0e+0_fp,        &
-                       LOST        = 0e+0_fp,        &
-                       State_Grid  = State_Grid,     &
-                       DSpc        = DSpc(NW,:,I,J), &
-                       Spc         = Spc(I,J,:,N),   &
+          CALL SAFETY( I, J, L, N, ERRMSG,                     &
+                       LS          = LS,                       &
+                       PDOWN       = State_Met%PDOWN(L,I,J),   &
+                       QQ          = State_Met%QQ(L,I,J),      &
+                       ALPHA       = 0e+0_fp,                  &
+                       ALPHA2      = 0e+0_fp,                  &
+                       RAINFRAC    = RAINFRAC,                 &
+                       WASHFRAC    = 0e+0_fp,                  &
+                       MASS_WASH   = 0e+0_fp,                  &
+                       MASS_NOWASH = 0e+0_fp,                  &
+                       WETLOSS     = WETLOSS,                  &
+                       GAINED      = 0e+0_fp,                  &
+                       LOST        = 0e+0_fp,                  &
+                       State_Grid  = State_Grid,               &
+                       DSpc        = DSpc(NW,:,I,J),           &
+                       Spc         = Spc(I,J,:,N),             &
                        RC          = RC )
 
           ! Trap potential errors
@@ -3971,7 +3946,7 @@ CONTAINS
                                  + GAINED * 96e+0_fp / 64e+0_fp
 
 #ifdef APM
-             PSO4_SO2APM2(I,J,L) = PSO4_SO2APM2(I,J,L) &
+             State_Met%PSO4_SO2APM2(I,J,L) = State_Met%PSO4_SO2APM2(I,J,L) &
                                    + GAINED * 96e+0_fp / 64e+0_fp
 #endif
 
@@ -4143,22 +4118,22 @@ CONTAINS
             DSpc(NW,L,I,J) < 0e+0_fp      ) THEN
 
           ! Print error message and stop simulaton
-          CALL SAFETY( I, J, L, N, ERRMSG,           &
-                       LS          = LS,             &
-                       PDOWN       = PDOWN(L+1,I,J), &
-                       QQ          = QQ(L,I,J),      &
-                       ALPHA       = ALPHA,          &
-                       ALPHA2      = ALPHA2,         &
-                       RAINFRAC    = 0e+0_fp,        &
-                       WASHFRAC    = WASHFRAC,       &
-                       MASS_WASH   = MASS_WASH,      &
-                       MASS_NOWASH = MASS_NOWASH,    &
-                       WETLOSS     = WETLOSS,        &
-                       GAINED      = GAINED,         &
-                       LOST        = LOST,           &
-                       State_Grid  = State_Grid,     &
-                       DSpc        = DSpc(NW,:,I,J), &
-                       Spc         = Spc(I,J,:,N),   &
+          CALL SAFETY( I, J, L, N, ERRMSG,                     &
+                       LS          = LS,                       &
+                       PDOWN       = State_Met%PDOWN(L+1,I,J), &
+                       QQ          = State_Met%QQ(L,I,J),      &
+                       ALPHA       = ALPHA,                    &
+                       ALPHA2      = ALPHA2,                   &
+                       RAINFRAC    = 0e+0_fp,                  &
+                       WASHFRAC    = WASHFRAC,                 &
+                       MASS_WASH   = MASS_WASH,                &
+                       MASS_NOWASH = MASS_NOWASH,              &
+                       WETLOSS     = WETLOSS,                  &
+                       GAINED      = GAINED,                   &
+                       LOST        = LOST,                     &
+                       State_Grid  = State_Grid,               &
+                       DSpc        = DSpc(NW,:,I,J),           &
+                       Spc         = Spc(I,J,:,N),             &
                        RC          = RC )
 
           ! Trap potential errors
@@ -4284,7 +4259,7 @@ CONTAINS
                               ( WETLOSS * 96e+0_fp / 64e+0_fp )
 
 #ifdef APM
-          PSO4_SO2APM2(I,J,L) = PSO4_SO2APM2(I,J,L) - &
+          State_Met%PSO4_SO2APM2(I,J,L) = State_Met%PSO4_SO2APM2(I,J,L) - &
                                 ( WETLOSS * 96e+0_fp / 64e+0_fp )
 #endif
 
@@ -4943,7 +4918,7 @@ CONTAINS
        F = 1.0_fp - EXP( -K * TMP / Vud )
     ELSE
        F = 0.0_fp
-    ENDIF
+  ENDIF
 
   END FUNCTION GET_F
 !EOC
@@ -5027,64 +5002,6 @@ CONTAINS
     id_SO2   = Ind_('SO2'  )
     id_SO4   = Ind_('SO4'  )
     id_H2O2  = Ind_('H2O2' )
-
-#ifdef APM
-    ! NOTE: This should really go into State_Chm! (bmy, 6/17/19)
-    ALLOCATE( PSO4_SO2APM2( State_Grid%NX, State_Grid%NY, State_Grid%NZ ), &
-              STAT=RC )
-    CALL GC_CheckVar( 'wetscav_mod.F90:PSO4_SO2APM2', 0, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    PSO4_SO2APM2 = 0.0_fp
-#endif
-
-    !-----------------------------------------------------------------
-    ! Only allocate arrays if wetdep or convection is turned on
-    !-----------------------------------------------------------------
-    IF ( Input_Opt%LWETD .or. Input_Opt%LCONV ) THEN
-
-       ! Allocate PDOWN on first call
-       ALLOCATE( PDOWN( State_Grid%NZ, State_Grid%NX, State_Grid%NY ), &
-                 STAT=RC )
-       CALL GC_CheckVar( 'wetscav_mod.F90:PDOWN', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       PDOWN = 0e+0_fp
-
-       ! Allocate QQ on first call
-       ALLOCATE( QQ( State_Grid%NZ, State_Grid%NX, State_Grid%NY ), &
-                 STAT=RC )
-       CALL GC_CheckVar( 'wetscav_mod.F90:QQ', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       QQ = 0e+0_fp
-
-       ! Allocate REEVAP on first call
-       ALLOCATE( REEVAP( State_Grid%NZ, State_Grid%NX, State_Grid%NY), &
-                 STAT=RC )
-       CALL GC_CheckVar( 'wetscav_mod.F90:REEVAP', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       REEVAP = 0e+0_fp
-
-       ! Allocate C_H2O on first call
-       ALLOCATE( C_H2O( State_Grid%NX, State_Grid%NY, State_Grid%NZ), &
-                 STAT=RC )
-       CALL GC_CheckVar( 'wetscav_mod.F90:C_H2O', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       C_H2O = 0.0_fp
-
-       ! Allocate CLDLIQ on first call
-       ALLOCATE( CLDLIQ( State_Grid%NX, State_Grid%NY, State_Grid%NZ), &
-                 STAT=RC )
-       CALL GC_CheckVar( 'wetscav_mod.F90:CLDLIQ', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       CLDLIQ = 0.0_fp
-
-       ! Allocate CLDICE on first call
-       ALLOCATE( CLDICE( State_Grid%NX, State_Grid%NY, State_Grid%NZ), &
-                 STAT=RC )
-       CALL GC_CheckVar( 'wetscav_mod.F90:CLDICE', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       CLDICE = 0.0_fp
-
-    ENDIF
 
     !=================================================================
     ! Print information about wet-depositing species
@@ -5244,16 +5161,16 @@ CONTAINS
           ! Compute CLDLIQ directly from met fields
           !--------------------------------------------------------------
           IF ( TK >= 268.0_fp ) THEN
-             CLDLIQ(I,J,L) = (State_Met%QL(I,J,L)+State_Met%QI(I,J,L))* &
-                             State_Met%AIRDEN(I,J,L) * 1e-3_fp
+             State_Met%CLDLIQ(I,J,L) = (State_Met%QL(I,J,L)+State_Met%QI(I,J,L))* &
+                                        State_Met%AIRDEN(I,J,L) * 1e-3_fp
 
           ELSE IF ( TK > 248.0_fp .and. TK < 268.0_fp ) THEN
-             CLDLIQ(I,J,L) = (State_Met%QL(I,J,L)+State_Met%QI(I,J,L))* &
-                             State_Met%AIRDEN(I,J,L) * 1e-3_fp &
-                             * ((TK - 248.0_fp) / 20.0_fp )
+             State_Met%CLDLIQ(I,J,L) = (State_Met%QL(I,J,L)+State_Met%QI(I,J,L))* &
+                                        State_Met%AIRDEN(I,J,L) * 1e-3_fp &
+                                        * ((TK - 248.0_fp) / 20.0_fp )
 
           ELSE
-             CLDLIQ(I,J,L) = 0.0_fp
+             State_Met%CLDLIQ(I,J,L) = 0.0_fp
 
           ENDIF
 #else
@@ -5267,26 +5184,26 @@ CONTAINS
           !    CLDLIQ = 0                       [     T <= 248 K    ]
           !--------------------------------------------------------------
           IF ( TK >= 268.0_fp ) THEN
-             CLDLIQ(I,J,L) = 1e-6_fp
+             State_Met%CLDLIQ(I,J,L) = 1e-6_fp
 
           ELSE IF ( TK > 248.0_fp .and. TK < 268.0_fp ) THEN
-             CLDLIQ(I,J,L) = 1e-6_fp * ((TK - 248.0_fp) / 20.0_fp )
+             State_Met%CLDLIQ(I,J,L) = 1e-6_fp * ((TK - 248.0_fp) / 20.0_fp )
 
           ELSE
-             CLDLIQ(I,J,L) = 0.0_fp
+             State_Met%CLDLIQ(I,J,L) = 0.0_fp
 
           ENDIF
 #endif
 
-          CLDLIQ(I,J,L) = MAX(CLDLIQ(I,J,L),0.0_fp)
+          State_Met%CLDLIQ(I,J,L) = MAX(State_Met%CLDLIQ(I,J,L),0.0_fp)
 
 #ifdef LUO_WETDEP
           !--------------------------------------------------------------
           ! Luo et al scheme:
           ! ompute CLDICE from met fields
           !--------------------------------------------------------------
-          CLDICE(I,J,L) = (State_Met%QL(I,J,L)+State_Met%QI(I,J,L))* &
-                          State_Met%AIRDEN(I,J,L) * 1e-3_fp - CLDLIQ(I,J,L)
+          State_Met%CLDICE(I,J,L) = (State_Met%QL(I,J,L)+State_Met%QI(I,J,L))* &
+                          State_Met%AIRDEN(I,J,L) * 1e-3_fp - State_Met%CLDLIQ(I,J,L)
 
 #else
           !--------------------------------------------------------------
@@ -5295,11 +5212,11 @@ CONTAINS
           !
           !    CLDICE = 1.0e-6 - CLDLIQ
           !--------------------------------------------------------------
-          CLDICE(I,J,L) = 1e-6_fp - CLDLIQ(I,J,L)
+          State_Met%CLDICE(I,J,L) = 1e-6_fp - State_Met%CLDLIQ(I,J,L)
 #endif
 
           ! Avoid negatives
-          CLDICE(I,J,L) = MAX( CLDICE(I,J,L), 0.0_fp )
+          State_Met%CLDICE(I,J,L) = MAX( State_Met%CLDICE(I,J,L), 0.0_fp )
 
           !--------------------------------------------------------------
           ! C_H2O is given by Dalton's Law as:
@@ -5315,9 +5232,9 @@ CONTAINS
           !       routine E_ICE above.
           !--------------------------------------------------------------
           IF ( PL <= TINY_FP ) THEN
-             C_H2O(I,J,L) = 0.0_fp
+             State_Met%C_H2O(I,J,L) = 0.0_fp
           ELSE
-             C_H2O(I,J,L) = E_ICE( TK ) / PL
+             State_Met%C_H2O(I,J,L) = E_ICE( TK ) / PL
           ENDIF
 
           ! Free pointers
@@ -5367,71 +5284,5 @@ CONTAINS
     ENDIF
 
   END SUBROUTINE SETUP_WETSCAV
-!EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE: cleanup_wetscav
-!
-! !DESCRIPTION: Subroutine CLEANUP\_WETSCAV deallocates all module arrays.
-!\\
-!\\
-! !INTERFACE:
-!
-  SUBROUTINE CLEANUP_WETSCAV( RC )
-!
-! !USES:
-!
-    USE ErrCode_Mod
-!
-! !OUTPUT PARAMETERS:
-!
-    INTEGER, INTENT(OUT) :: RC          ! Success or failure?
-!
-! !REVISION HISTORY:
-!  23 Feb 2000 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/geos-chem for complete history
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-
-    !=================================================================
-    ! CLEANUP_WETSCAV begins here!
-    !=================================================================
-
-    IF ( ALLOCATED( C_H2O  ) ) DEALLOCATE( C_H2O,  STAT=RC )
-    CALL GC_CheckVar( 'wetscav_mod.F90:C_H2O', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-
-    IF ( ALLOCATED( CLDLIQ ) ) DEALLOCATE( CLDLIQ, STAT=RC )
-    CALL GC_CheckVar( 'wetscav_mod.F90:CLDLIQ', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-
-    IF ( ALLOCATED( CLDICE ) ) DEALLOCATE( CLDICE, STAT=RC )
-    CALL GC_CheckVar( 'wetscav_mod.F90:CLDICE', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    
-    IF ( ALLOCATED( PDOWN  ) ) DEALLOCATE( PDOWN,  STAT=RC )
-    CALL GC_CheckVar( 'wetscav_mod.F90:PDOWN', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    
-    IF ( ALLOCATED( QQ     ) ) DEALLOCATE( QQ,     STAT=RC )
-    CALL GC_CheckVar( 'wetscav_mod.F90:QQ', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-
-#if defined ( APM )
-    ! THIS NEEDS TO GO INTO STATE_CHM EVENTUALLY
-    IF (ALLOCATED(PSO4_SO2APM2)) DEALLOCATE(PSO4_SO2APM2,STAT=RC)
-    CALL GC_CheckVar( 'wetscav_mod.F90:PSO4_SO2APM2', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-#endif
-
-    IF ( ALLOCATED( REEVAP ) ) DEALLOCATE( REEVAP, STAT=RC )
-    CALL GC_CheckVar( 'wetscav_mod.F90:REEVAP', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-
-  END SUBROUTINE CLEANUP_WETSCAV
 !EOC
 END MODULE WETSCAV_MOD

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -230,6 +230,17 @@ MODULE State_Chm_Mod
      REAL(f4),          POINTER :: SFC_CH4    (:,:    ) ! Pointer to HEMCO - not allocated
 
      !----------------------------------------------------------------------
+     ! Fields for TOMS overhead ozone column data
+     !----------------------------------------------------------------------
+     REAL(fp),          POINTER :: TO3_DAILY  (:,:    ) ! Daily overhead ozone
+     REAL(f4),          POINTER :: STOMS      (:,:    )
+     REAL(f4),          POINTER :: TOMS       (:,:    ) ! Pointer to HEMCO TOMS_O3_COL
+     REAL(f4),          POINTER :: TOMS1      (:,:    ) ! Pointer to HEMCO TOMS1_O3_COL
+     REAL(f4),          POINTER :: TOMS2      (:,:    ) ! Pointer to HEMCO TOMS2_O3_COL
+     REAL(f4),          POINTER :: DTOMS1     (:,:    ) ! Pointer to HEMCO DTOMS1_O3_COL
+     REAL(f4),          POINTER :: DTOMS2     (:,:    ) ! Pointer to HEMCO DTOMS2_O3_COL
+
+     !----------------------------------------------------------------------
      ! Registry of variables contained within State_Chm
      !----------------------------------------------------------------------
      CHARACTER(LEN=4)           :: State     = 'CHEM'   ! Name of this state
@@ -464,6 +475,16 @@ CONTAINS
     ! For global CH4
     ! This field is not allocated - it points to HEMCO in SET_CH4.
     State_Chm%SFC_CH4           => NULL()
+
+    ! For TOMS module
+    State_Chm%TO3_DAILY         => NULL()
+    State_Chm%STOMS             => NULL()
+    ! The below are not allocated - pointing to HEMCO in READ_TOMS.
+    State_Chm%TOMS              => NULL()
+    State_Chm%TOMS1             => NULL()
+    State_Chm%TOMS2             => NULL()
+    State_Chm%DTOMS1            => NULL()
+    State_Chm%DTOMS2            => NULL()
 
     ! Local variables
     Ptr2data                    => NULL()
@@ -1776,6 +1797,25 @@ CONTAINS
     ENDIF
 
     !------------------------------------------------------------------
+    ! TOMS_MOD
+    ! Not registered to the registry as these are fields internal to the toms_mod
+    ! module state.
+    !------------------------------------------------------------------
+    chmID = 'TO3_DAILY'
+    ALLOCATE( State_Chm%TO3_DAILY( IM, JM ),    &
+              STAT=RC )
+    CALL GC_CheckVar( 'State_Chm%TO3_DAILY', 0, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+    State_Chm%TO3_DAILY = 0.0_fp
+
+    chmID = 'STOMS'
+    ALLOCATE( State_Chm%STOMS( IM, JM ),    &
+              STAT=RC )
+    CALL GC_CheckVar( 'State_Chm%STOMS', 0, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+    State_Chm%STOMS = 0.0_fp
+
+    !------------------------------------------------------------------
     ! Gan Luo et al wetdep fields
     !------------------------------------------------------------------
     IF ( Input_Opt%LWETD .or. Input_Opt%LCONV ) THEN
@@ -2336,6 +2376,20 @@ CONTAINS
        State_Chm%QQ3D => NULL()
     ENDIF
 
+    IF ( ASSOCIATED( State_Chm%TO3_DAILY ) ) THEN
+       DEALLOCATE( State_Chm%TO3_DAILY, STAT=RC )
+       CALL GC_CheckVar( 'State_Chm%TO3_DAILY', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Chm%TO3_DAILY => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( State_Chm%STOMS ) ) THEN
+       DEALLOCATE( State_Chm%STOMS, STAT=RC )
+       CALL GC_CheckVar( 'State_Chm%STOMS', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Chm%STOMS => NULL()
+    ENDIF
+
     !-----------------------------------------------------------------------
     ! Template for deallocating more arrays, replace xxx with field name
     !-----------------------------------------------------------------------
@@ -2349,7 +2403,13 @@ CONTAINS
     !-----------------------------------------------------------------------
     ! Deassociate arrays that are pointers to HEMCO
     !-----------------------------------------------------------------------
-    State_Chm%SFC_CH4 => NULL()
+    State_Chm%SFC_CH4           => NULL()
+
+    State_Chm%TOMS              => NULL()
+    State_Chm%TOMS1             => NULL()
+    State_Chm%TOMS2             => NULL()
+    State_Chm%DTOMS1            => NULL()
+    State_Chm%DTOMS2            => NULL()
 
     !=======================================================================
     ! Deallocate the species database object field

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -225,6 +225,11 @@ MODULE State_Chm_Mod
      REAL(fp),          POINTER :: QQ3D       (:,:,:  )
 
      !----------------------------------------------------------------------
+     ! Fields for setting mean surface CH4 from HEMCO
+     !----------------------------------------------------------------------
+     REAL(f4),          POINTER :: SFC_CH4    (:,:    ) ! Pointer to HEMCO - not allocated
+
+     !----------------------------------------------------------------------
      ! Registry of variables contained within State_Chm
      !----------------------------------------------------------------------
      CHARACTER(LEN=4)           :: State     = 'CHEM'   ! Name of this state
@@ -453,7 +458,12 @@ CONTAINS
     ! For LINOZ
     State_Chm%TLSTT             => NULL()
 
+    ! For dry deposition
     State_Chm%DryDepSav         => NULL()
+
+    ! For global CH4
+    ! This field is not allocated - it points to HEMCO in SET_CH4.
+    State_Chm%SFC_CH4           => NULL()
 
     ! Local variables
     Ptr2data                    => NULL()
@@ -2335,6 +2345,11 @@ CONTAINS
     !   IF ( RC /= GC_SUCCESS ) RETURN
     !   State_Chm%xxx => NULL()
     !ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Deassociate arrays that are pointers to HEMCO
+    !-----------------------------------------------------------------------
+    State_Chm%SFC_CH4 => NULL()
 
     !=======================================================================
     ! Deallocate the species database object field

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -188,6 +188,7 @@ MODULE State_Met_Mod
      REAL(fp), POINTER :: UPDVVEL       (:,:,:) ! Updraft vertical velocity
                                                 !  [hPa/s]
      REAL(fp), POINTER :: V             (:,:,:) ! N/S component of wind [m s-1]
+
      !----------------------------------------------------------------------
      ! Air quantities assigned in AIRQNT
      !----------------------------------------------------------------------
@@ -252,6 +253,21 @@ MODULE State_Met_Mod
      REAL(fp), POINTER :: LocalSolarTime(:,:  ) ! Local solar time
      LOGICAL,  POINTER :: IsLocalNoon   (:,:  ) ! Is it local noon (between 11
                                                 !  and 13 local solar time?
+
+     !----------------------------------------------------------------------
+     ! Fields for wet scavenging module
+     !----------------------------------------------------------------------
+     REAL(fp), POINTER :: C_H2O         (:,:,:) ! Mix ratio of H2O [v/v]
+     REAL(fp), POINTER :: CLDICE        (:,:,:) ! Cloud ice mixing ratio [cm3 ice/cm3 air]
+     REAL(fp), POINTER :: CLDLIQ        (:,:,:) ! Cloud liquid water mixing ratio [cm3 H2O/cm3 air]
+     REAL(fp), POINTER :: PDOWN         (:,:,:) ! Precipitation thru the bottom of the grid box
+                                                ! [cm3 H2O/cm2 area/s]
+     REAL(fp), POINTER :: QQ            (:,:,:) ! Rate of new precip formation [cm3 H2O/cm3 air/s]
+     REAL(fp), POINTER :: REEVAP        (:,:,:) ! Rate of precip reevaporation
+                                                ! [cm3 H2O/cm3 air/s]
+#ifdef APM
+     REAL(fp), POINTER :: PSO4_SO2APM2  (:,:,:)
+#endif
 
      !----------------------------------------------------------------------
      ! Scalars
@@ -481,6 +497,16 @@ CONTAINS
     State_Met%IsLocalNoon    => NULL()
     State_Met%LocalSolarTime => NULL()
     State_Met%AgeOfAir       => NULL()
+
+    State_Met%C_H2O          => NULL()
+    State_Met%CLDICE         => NULL()
+    State_Met%CLDLIQ         => NULL()
+    State_Met%PDOWN          => NULL()
+    State_Met%QQ             => NULL()
+    State_Met%REEVAP         => NULL()
+#ifdef APM
+    State_Met%PSO4_SO2APM2   => NULL()
+#endif
 
     !=======================================================================
     ! Exit if this is a dry-run simulation
@@ -1880,6 +1906,103 @@ CONTAINS
                             State_Met, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
 
+
+    !=======================================================================
+    ! Allocate fields used by wet scavenging and other GeosCore modules.
+    !
+    ! They are currently not registered with the registry but may be done
+    ! if they prove to be useful to diagnostics. (hplin, 5/24/20)
+    !=======================================================================
+
+    !-----------------------------------------------------------------
+    ! For wet deposition (wetscav_mod)
+    ! Note some are memory-order ZXY and some are regular XYZ.
+    !
+    ! Only allocate arrays if wetdep or convection is turned on
+    !-----------------------------------------------------------------
+    IF ( Input_Opt%LWETD .or. Input_Opt%LCONV ) THEN
+
+        !-------------------------
+        ! C_H2O
+        !-------------------------
+        ALLOCATE( State_Met%C_H2O( IM, JM, LM ), STAT=RC )
+        CALL GC_CheckVar( 'State_Met%C_H2O', 0, RC )
+        IF ( RC /= GC_SUCCESS ) RETURN
+        State_Met%C_H2O = 0.0_fp
+        ! CALL Register_MetField( Input_Opt, 'C_H2O', State_Met%C_H2O, &
+        !                         State_Met, RC )
+        ! IF ( RC /= GC_SUCCESS ) RETURN
+
+        !-------------------------
+        ! CLDICE
+        !-------------------------
+        ALLOCATE( State_Met%CLDICE( IM, JM, LM ), STAT=RC )
+        CALL GC_CheckVar( 'State_Met%CLDICE', 0, RC )
+        IF ( RC /= GC_SUCCESS ) RETURN
+        State_Met%CLDICE = 0.0_fp
+        ! CALL Register_MetField( Input_Opt, 'CLDICE', State_Met%CLDICE, &
+        !                         State_Met, RC )
+        ! IF ( RC /= GC_SUCCESS ) RETURN
+
+        !-------------------------
+        ! CLDLIQ
+        !-------------------------
+        ALLOCATE( State_Met%CLDLIQ( IM, JM, LM ), STAT=RC )
+        CALL GC_CheckVar( 'State_Met%CLDLIQ', 0, RC )
+        IF ( RC /= GC_SUCCESS ) RETURN
+        State_Met%CLDLIQ = 0.0_fp
+        ! CALL Register_MetField( Input_Opt, 'CLDLIQ', State_Met%CLDLIQ, &
+        !                         State_Met, RC )
+        ! IF ( RC /= GC_SUCCESS ) RETURN
+
+        !-------------------------
+        ! PDOWN (ZXY)
+        !-------------------------
+        ALLOCATE( State_Met%PDOWN( LM, IM, JM ), STAT=RC )
+        CALL GC_CheckVar( 'State_Met%PDOWN', 0, RC )
+        IF ( RC /= GC_SUCCESS ) RETURN
+        State_Met%PDOWN = 0.0_fp
+        ! CALL Register_MetField( Input_Opt, 'PDOWN', State_Met%PDOWN, &
+        !                         State_Met, RC )
+        ! IF ( RC /= GC_SUCCESS ) RETURN
+
+        !-------------------------
+        ! QQ (ZXY)
+        !-------------------------
+        ALLOCATE( State_Met%QQ( LM, IM, JM ), STAT=RC )
+        CALL GC_CheckVar( 'State_Met%QQ', 0, RC )
+        IF ( RC /= GC_SUCCESS ) RETURN
+        State_Met%QQ = 0.0_fp
+        ! CALL Register_MetField( Input_Opt, 'QQ', State_Met%QQ, &
+        !                         State_Met, RC )
+        ! IF ( RC /= GC_SUCCESS ) RETURN
+
+        !-------------------------
+        ! REEVAP
+        !-------------------------
+        ALLOCATE( State_Met%REEVAP( LM, IM, JM ), STAT=RC )
+        CALL GC_CheckVar( 'State_Met%REEVAP', 0, RC )
+        IF ( RC /= GC_SUCCESS ) RETURN
+        State_Met%REEVAP = 0.0_fp
+        ! CALL Register_MetField( Input_Opt, 'REEVAP', State_Met%REEVAP, &
+        !                         State_Met, RC )
+        ! IF ( RC /= GC_SUCCESS ) RETURN
+
+#ifdef APM
+        !-------------------------
+        ! PSO4_SO2APM2
+        !-------------------------
+        ALLOCATE( State_Met%PSO4_SO2APM2( IM, JM, LM ), STAT=RC )
+        CALL GC_CheckVar( 'State_Met%PSO4_SO2APM2', 0, RC )
+        IF ( RC /= GC_SUCCESS ) RETURN
+        State_Met%PSO4_SO2APM2 = 0.0_fp
+        ! CALL Register_MetField( Input_Opt, 'PSO4_SO2APM2', State_Met%PSO4_SO2APM2, &
+        !                         State_Met, RC )
+        ! IF ( RC /= GC_SUCCESS ) RETURN
+#endif
+
+    ENDIF
+
     !=======================================================================
     ! Allocate fields for querying which vertical regime a grid box is in
     ! or if a grid box is near local solar noontime.
@@ -3138,6 +3261,60 @@ CONTAINS
        IF ( RC /= GC_SUCCESS ) RETURN
        State_Met%LocalSolarTime => NULL()
     ENDIF
+
+    !=======================================================================
+    ! Fields temporaries used in other modules
+    !=======================================================================
+    IF ( ASSOCIATED( State_Met%C_H2O ) ) THEN
+      DEALLOCATE( State_Met%C_H2O, STAT=RC )
+      CALL GC_CheckVar( 'State_Met%C_H2O', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      State_Met%C_H2O => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( State_Met%CLDICE ) ) THEN
+      DEALLOCATE( State_Met%CLDICE, STAT=RC )
+      CALL GC_CheckVar( 'State_Met%CLDICE', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      State_Met%CLDICE => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( State_Met%CLDLIQ ) ) THEN
+      DEALLOCATE( State_Met%CLDLIQ, STAT=RC )
+      CALL GC_CheckVar( 'State_Met%CLDLIQ', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      State_Met%CLDLIQ => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( State_Met%PDOWN ) ) THEN
+      DEALLOCATE( State_Met%PDOWN, STAT=RC )
+      CALL GC_CheckVar( 'State_Met%PDOWN', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      State_Met%PDOWN => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( State_Met%QQ ) ) THEN
+      DEALLOCATE( State_Met%QQ, STAT=RC )
+      CALL GC_CheckVar( 'State_Met%QQ', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      State_Met%QQ => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( State_Met%REEVAP ) ) THEN
+      DEALLOCATE( State_Met%REEVAP, STAT=RC )
+      CALL GC_CheckVar( 'State_Met%REEVAP', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      State_Met%REEVAP => NULL()
+    ENDIF
+
+#ifdef APM
+    IF ( ASSOCIATED( State_Met%PSO4_SO2APM2 ) ) THEN
+      DEALLOCATE( State_Met%PSO4_SO2APM2, STAT=RC )
+      CALL GC_CheckVar( 'State_Met%PSO4_SO2APM2', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      State_Met%PSO4_SO2APM2 => NULL()
+    ENDIF
+#endif
 
     !-----------------------------------------------------------------------
     ! Template for deallocating more arrays, replace xxx with field name

--- a/Interfaces/GCHP/gigc_chunk_mod.F90
+++ b/Interfaces/GCHP/gigc_chunk_mod.F90
@@ -851,7 +851,7 @@ CONTAINS
 
        ! Calculate TOMS O3 overhead. For now, always use it from the
        ! Met field. State_Met%TO3 is imported from PCHEM (ckeller, 10/21/2014).
-       CALL COMPUTE_OVERHEAD_O3( Input_Opt, State_Grid, DAY, .TRUE., &
+       CALL COMPUTE_OVERHEAD_O3( Input_Opt, State_Grid, State_Chm, DAY, .TRUE., &
                                  State_Met%TO3 )
 
 #if !defined( MODEL_GEOS )


### PR DESCRIPTION
Hi GCST,

I've been meaning to finish this for a while but as we discussed two years ago, there are some global module variables that should be moved to `State_Chm` for the sake of avoiding module state and also compatibility with a "nested-grid" version of WRF-GC.

Please find attached three commits to move module variables to state modules from:
* `Set_Global_CH4_Mod`. `SFC_CH4` is now in `State_Chm`.
* `Wetscav_Mod`. Most are met quantities (`CLDICE`, etc.) which I moved to `State_Met` as I thought it would fit better there.
* `Toms_Mod`. Most are HEMCO pointers. Moved to `State_Chm`.

All the relevant interface updates, etc. are also included for GC-Classic and GCHP. The code was tested on GC-Classic using CMake.

Commits were based off `master` as of 12.8.1 release. Please let me know if I should base off the updates on a newer development branch in the future to make merging easier.

Thanks!

Best,
Haipeng