### PR TITLE
Move MODEL_WRF return to top of INIT_DRYDEP.

### DIFF
--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -4064,6 +4064,18 @@ CONTAINS
     ErrMsg    = ''
     ThisLoc   = ' -> at Init_Drydep (in module GeosCore/drydep_mod.F)'
 
+
+#ifdef MODEL_WRF
+    ! If the dry deposition module has already been initialized,
+    ! the arrays do not need to be allocated again, as they are only
+    ! dependent on the chemistry configuration (State_Chm%nDryDep)
+    !
+    ! This is necessary for integrating GEOS-Chem with a variable
+    ! domain model like WRF-GC, where multiple instances of GEOS-Chem
+    ! run in the same CPU. (hplin, 2/16/2019)
+    IF ( ALLOCATED( A_DEN ) ) RETURN
+#endif
+
     !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     !%%% NOTE: Because READ_DRYDEP_INPUTS reads info from a netCDF %%%
     !%%% file, we may have to broadcast these.  However, the file  %%%
@@ -4109,17 +4121,6 @@ CONTAINS
     id_HNO3   = IND_('HNO3'  )
     id_PAN    = IND_('PAN'   )
     id_IHN1   = IND_('IHN1'  )
-
-#ifdef MODEL_WRF
-    ! If the dry deposition module has already been initialized,
-    ! the arrays do not need to be allocated again, as they are only
-    ! dependent on the chemistry configuration (State_Chm%nDryDep)
-    !
-    ! This is necessary for integrating GEOS-Chem with a variable
-    ! domain model like WRF-GC, where multiple instances of GEOS-Chem
-    ! run in the same CPU. (hplin, 2/16/2019)
-    IF ( ALLOCATED( A_DEN ) ) RETURN
-#endif
 
     !===================================================================
     ! Arrays that hold information about dry-depositing species


### PR DESCRIPTION
Hi GCST,

This change for `MODEL_WRF` fixes the issue that an allocation check and return was not early enough, resulting in a second function call zeroing out internal species indices and breaking dry deposition instead.

Nothing except 4 hours of weekend debugging was harmed during the production of this pull request.

Best,
Haipeng