### PR TITLE
Fix handling of NOx coefficients for meso-chem

### DIFF
--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -4231,8 +4231,7 @@ CONTAINS
 ! !IROUTINE: get_jjnox
 !
 ! !DESCRIPTION: Subroutine GET\_JJNOX maps grid box at location IISIM, JJSIM of
-! the simulation grid onto the latitude grid of the NOXCOEFF array. JJNOX can
-! differ from JJSIM if it's not a 4x5 or 2x25 simulation.
+! the simulation grid onto the latitude grid of the NOXCOEFF array.
 !\\
 !\\
 ! This routine simply returns the index of the NOx latitude vector that covers
@@ -4273,27 +4272,20 @@ CONTAINS
     ! GET_JJNOX begins here!
     !=================================================================
 
-    ! Nothing to do for 'standard' grids
-    IF ( .not. State_Grid%NestedGrid ) THEN
-       JJNOX = JJSIM
-    ELSE
+    ! Init
+    JJNOX = -1
 
-       ! Init
-       JJNOX = -1
+    ! Get latitude in degrees north on simulation grid
+    LAT = State_Grid%YMid( IISIM, JJSIM )
 
-       ! Get latitude in degrees north on simulation grid
-       LAT = State_Grid%YMid( IISIM, JJSIM )
-
-       ! Loop over all latitudes of the NOx grid until we reach the grid
-       ! box where the simulation latitude sits in.
-       DO I = 1,JJNOXCOEFF
-          IF ( LAT < NOXLAT(I+1) ) THEN
-             JJNOX = I
-             EXIT
-          ENDIF
-       ENDDO
-
-    ENDIF
+    ! Loop over all latitudes of the NOx grid until we reach the grid
+    ! box where the simulation latitude sits in.
+    DO I = 1,JJNOXCOEFF
+       IF ( LAT < NOXLAT(I+1) ) THEN
+          JJNOX = I
+          EXIT
+       ENDIF
+    ENDDO
 
   END FUNCTION GET_JJNOX
 !EOC


### PR DESCRIPTION
The GET_JJNOX routine in ucx_mod.F90 has a generic approach which can function for any
grid resolution, but is only used for nested grids. However, this approach is also needed for
any grid other than 2x2.5 and 4x5. As such, mesospheric chemistry currently uses incorrect
NOx coefficients in GCHP simulations, or any simulation other than 2x2.5 or 4x5. Using the
generic routine for all simulations resolves this problem.