### PR TITLE
[PULL REQUEST] HEMCO intermediate processing grid feature (Batch 1)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -144,7 +144,7 @@ Xianglan Li
 K. J. Liao
 Qing Liang
 Hong Liao
-Hiapeng Lin
+Haipeng Lin
 Jintai Lin
 Shian-Jiann Lin
 John Linford

--- a/GeosCore/aerosol_mod.F90
+++ b/GeosCore/aerosol_mod.F90
@@ -169,21 +169,21 @@ CONTAINS
 !
 ! !USES:
 !
-    USE CMN_FJX_MOD,       ONLY : REAA
+    USE CMN_FJX_MOD,          ONLY : REAA
     USE ErrCode_Mod
     USE ERROR_MOD
-    USE HCO_State_GC_Mod,  ONLY : HcoState
-    USE HCO_Calc_Mod,      ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,     ONLY : OptInput
-    USE State_Chm_Mod,     ONLY : ChmState
-    USE State_Diag_Mod,    ONLY : DgnState
-    USE State_Grid_Mod,    ONLY : GrdState
-    USE State_Met_Mod,     ONLY : MetState
-    USE UCX_MOD,           ONLY : KG_STRAT_AER
-    USE UnitConv_Mod,      ONLY : Convert_Spc_Units
-    USE TIME_MOD,          ONLY : GET_MONTH
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
+    USE UCX_MOD,              ONLY : KG_STRAT_AER
+    USE UnitConv_Mod,         ONLY : Convert_Spc_Units
+    USE TIME_MOD,             ONLY : GET_MONTH
 #ifdef TOMAS
-    USE TOMAS_MOD,         ONLY : IBINS
+    USE TOMAS_MOD,            ONLY : IBINS
 #endif
 !
 ! !INPUT PARAMETERS:
@@ -338,7 +338,7 @@ CONTAINS
     ALLOCATE( OMOC(State_Grid%NX, State_Grid%NY), STAT=RC )
     CALL GC_CheckVar( 'aerosol_mod.F: OMOC', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
-    CALL HCO_EvalFld( HcoState, Trim(FieldName), OMOC, RC, FOUND=FND )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, Trim(FieldName), OMOC, RC, FOUND=FND )
 
     IF ( RC == GC_SUCCESS .AND. FND ) THEN
 

--- a/GeosCore/calc_met_mod.F90
+++ b/GeosCore/calc_met_mod.F90
@@ -941,7 +941,7 @@ CONTAINS
     ! Assume success
     RC = GC_SUCCESS
 
-      ! Return if option not set
+    ! Return if option not set
 #ifdef MODEL_GEOS
     IF ( .NOT. Input_Opt%LCAPTROP ) RETURN
 #endif
@@ -1251,6 +1251,9 @@ CONTAINS
     ! Compute cosine(SZA) quantities for the current time
     CALL COSSZA( DOY, HOUR, State_Grid, State_Met )
 
+    ! Compute sum of COSSZA for HEMCO
+    CALL Calc_SumCosZa ( State_Grid, State_Met )
+
   END SUBROUTINE GET_COSINE_SZA
 !EOC
 !------------------------------------------------------------------------------
@@ -1425,6 +1428,147 @@ CONTAINS
     !$OMP END PARALLEL DO
 
   END SUBROUTINE COSSZA
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: calc_sumcosza
+!
+! !DESCRIPTION:
+!  Subroutine CALC\_SUMCOSZA computes the sum of cosine of the solar zenith
+!  angle over a 24 hour day, as well as the total length of daylight.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE Calc_SumCosZa( State_Grid, State_Met )
+!
+! !USES:
+!
+    USE PhysConstants
+    USE State_Grid_Mod, ONLY : GrdState
+    USE State_Met_Mod,  ONLY : MetState
+    USE TIME_MOD,       ONLY : GET_NHMSb,   GET_ELAPSED_SEC
+    USE TIME_MOD,       ONLY : GET_TS_CHEM, GET_DAY_OF_YEAR, GET_GMT
+!
+! !INPUT PARAMETERS:
+!
+    TYPE(GrdState), INTENT(IN) :: State_Grid  ! Grid State object
+    TYPE(MetState), INTENT(IN) :: State_Met   ! Meteorology State
+!
+! !REVISION HISTORY:
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    INTEGER, SAVE :: SAVEDOY = -1
+    INTEGER       :: I, J, L, N, NT, NDYSTEP
+    REAL(fp)      :: A0, A1, A2, A3, B1, B2, B3
+    REAL(fp)      :: LHR0, R, AHR, DEC, TIMLOC, YMID_R
+    REAL(fp)      :: SUNTMP(State_Grid%NX,State_Grid%NY)
+
+    !=======================================================================
+    ! CALC_SUMCOSZA begins here!
+    !=======================================================================
+
+    !  Solar declination angle (low precision formula, good enough for us):
+    A0 = 0.006918
+    A1 = 0.399912
+    A2 = 0.006758
+    A3 = 0.002697
+    B1 = 0.070257
+    B2 = 0.000907
+    B3 = 0.000148
+    R  = 2.* PI * float( GET_DAY_OF_YEAR() - 1 ) / 365.
+
+    DEC = A0 - A1*cos(  R) + B1*sin(  R) &
+             - A2*cos(2*R) + B2*sin(2*R) &
+             - A3*cos(3*R) + B3*sin(3*R)
+
+    LHR0 = int(float( GET_NHMSb() )/10000.)
+
+    ! Only do the following at the start of a new day
+    IF ( SAVEDOY /= GET_DAY_OF_YEAR() ) THEN
+
+       ! Zero arrays
+       State_Met%SUNCOSsum(:,:) = 0e+0_fp
+
+       ! NDYSTEP is # of chemistry time steps in this day
+       NDYSTEP = ( 24 - INT( GET_GMT() ) ) * 3600 / GET_TS_CHEM()
+
+       ! NT is the elapsed time [s] since the beginning of the run
+       NT = GET_ELAPSED_SEC()
+
+       ! Loop forward through NDYSTEP "fake" timesteps for this day
+       DO N = 1, NDYSTEP
+
+          ! Zero SUNTMP array
+          SUNTMP = 0e+0_fp
+
+          ! Loop over surface grid boxes
+!!$OMP PARALLEL DO
+!!$OMP DEFAULT( SHARED )
+!!$OMP PRIVATE( I, J, YMID_R, TIMLOC, AHR )
+          DO J = 1, State_Grid%NY
+          DO I = 1, State_Grid%NX
+
+             ! Grid box latitude center [radians]
+             YMID_R = State_Grid%YMid_R(I,J)
+
+             TIMLOC = real(LHR0) + real(NT)/3600.0 + &
+                      State_Grid%XMid(I,J) / 15.0
+
+             DO WHILE (TIMLOC .lt. 0)
+                TIMLOC = TIMLOC + 24.0
+             ENDDO
+
+             DO WHILE (TIMLOC .gt. 24.0)
+                TIMLOC = TIMLOC - 24.0
+             ENDDO
+
+             AHR = abs(TIMLOC - 12.) * 15.0 * PI_180
+
+             !===========================================================
+             ! The cosine of the solar zenith angle (SZA) is given by:
+             !
+             !  cos(SZA) = sin(LAT)*sin(DEC) + cos(LAT)*cos(DEC)*cos(AHR)
+             !
+             ! where LAT = the latitude angle,
+             !       DEC = the solar declination angle,
+             !       AHR = the hour angle, all in radians.
+             !
+             ! If SUNCOS < 0, then the sun is below the horizon, and
+             ! therefore does not contribute to any solar heating.
+             !===========================================================
+
+             ! Compute Cos(SZA)
+             SUNTMP(I,J) = sin(YMID_R) * sin(DEC) +          &
+                           cos(YMID_R) * cos(DEC) * cos(AHR)
+
+             ! SUMCOSZA is the sum of SUNTMP at location (I,J)
+             ! Do not include negative values of SUNTMP
+             State_Met%SUNCOSsum(I,J) = State_Met%SUNCOSsum(I,J) + &
+                             MAX(SUNTMP(I,J),0e+0_fp)
+
+          ENDDO
+          ENDDO
+!!$OMP END PARALLEL DO
+
+          ! Increment elapsed time [sec]
+          NT = NT + GET_TS_CHEM()
+       ENDDO
+
+       ! Set saved day of year to current day of year
+       SAVEDOY = GET_DAY_OF_YEAR()
+
+    ENDIF
+
+  END SUBROUTINE Calc_SumCosZa
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !

--- a/GeosCore/carbon_mod.F90
+++ b/GeosCore/carbon_mod.F90
@@ -4756,7 +4756,7 @@ CONTAINS
       ! Add sesquiterpene emissions from HEMCO to ORVC_SESQ array.
       ! We assume all SESQ emissions are placed in surface level.
       IF ( SESQID > 0 ) THEN
-         CALL GetHcoValEmis ( SESQID, I, J, 1, FOUND, EMIS )
+         CALL GetHcoValEmis ( Input_Opt, State_Grid, SESQID, I, J, 1, FOUND, EMIS )
          IF ( FOUND ) THEN
             ! Units from HEMCO are kgC/m2/s. Convert to kgC/box here.
             TMPFLX           = Emis * GET_TS_EMIS() * State_Grid%Area_M2(I,J)

--- a/GeosCore/carbon_mod.F90
+++ b/GeosCore/carbon_mod.F90
@@ -4636,7 +4636,7 @@ CONTAINS
    USE ErrCode_Mod
    USE HCO_State_GC_Mod,      ONLY : HcoState
    USE HCO_STATE_MOD,         ONLY : HCO_GetHcoID
-   USE HCO_Utilities_GC_Mod,  ONLY : GetHcoValEmis
+   USE HCO_Utilities_GC_Mod,  ONLY : GetHcoValEmis, LoadHcoValEmis
    USE Input_Opt_Mod,         ONLY : OptInput
    USE State_Grid_Mod,        ONLY : GrdState
    USE State_Met_Mod,         ONLY : MetState
@@ -4742,6 +4742,11 @@ CONTAINS
 
    ! Maximum extent of PBL [model levels]
    PBL_MAX = State_Met%PBL_MAX_L
+
+   ! First load SESQID into emissions buffer if available
+   IF ( SESQID > 0 ) THEN
+       CALL LoadHcoValEmis ( Input_Opt, State_Grid, SESQID )
+   ENDIF
 
    !$OMP PARALLEL DO       &
    !$OMP DEFAULT( SHARED ) &

--- a/GeosCore/carbon_mod.F90
+++ b/GeosCore/carbon_mod.F90
@@ -311,31 +311,31 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE ERROR_MOD,          ONLY : DEBUG_MSG
-    USE ERROR_MOD,          ONLY : ERROR_STOP
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Diag_Mod,     ONLY : DgnState
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE State_Met_Mod,      ONLY : MetState
-    USE TIME_MOD,           ONLY : ITS_A_NEW_MONTH
-    USE TIME_MOD,           ONLY : GET_TS_CHEM
+    USE ERROR_MOD,            ONLY : DEBUG_MSG
+    USE ERROR_MOD,            ONLY : ERROR_STOP
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
+    USE TIME_MOD,             ONLY : ITS_A_NEW_MONTH
+    USE TIME_MOD,             ONLY : GET_TS_CHEM
 #ifdef APM
-    USE APM_INIT_MOD,       ONLY : APMIDS
-    USE APM_INIT_MOD,       ONLY : NBCOC,CEMITBCOC1
+    USE APM_INIT_MOD,         ONLY : APMIDS
+    USE APM_INIT_MOD,         ONLY : NBCOC,CEMITBCOC1
     USE HCO_DIAGN_MOD
-    USE HCO_TYPES_MOD,      ONLY : DiagnCont
-    USE HCO_STATE_MOD,      ONLY : HCO_GetHcoID
+    USE HCO_TYPES_MOD,        ONLY : DiagnCont
+    USE HCO_STATE_MOD,        ONLY : HCO_GetHcoID
 #endif
 #ifdef BPCH_DIAG
-    USE CMN_O3_MOD,         ONLY : SAVEOA
+    USE CMN_O3_MOD,           ONLY : SAVEOA
 #endif
 #ifdef TOMAS
-    USE TOMAS_MOD,          ONLY : SOACOND, IBINS              !(win, 1/25/10)
-    USE TOMAS_MOD,          ONLY : CHECKMN                     !(sfarina)
-    USE PRESSURE_MOD,       ONLY : GET_PCENTER
+    USE TOMAS_MOD,            ONLY : SOACOND, IBINS              !(win, 1/25/10)
+    USE TOMAS_MOD,            ONLY : CHECKMN                     !(sfarina)
+    USE PRESSURE_MOD,         ONLY : GET_PCENTER
 #endif
 !
 ! !INPUT PARAMETERS:
@@ -478,7 +478,7 @@ CONTAINS
     IF ( IT_IS_AN_AEROSOL_SIM .AND. LSOA ) THEN
 
        ! Evaluate offline oxidant fields from HEMCO: global OH
-       CALL HCO_EvalFld(HcoState, 'GLOBAL_OH', OFFLINE_OH, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_OH', OFFLINE_OH, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find offline GLOBAL_OH in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, LOC )
@@ -486,7 +486,7 @@ CONTAINS
        ENDIF
 
        ! Evaluate offline oxidant fields from HEMCO: global O3
-       CALL HCO_EvalFld( HcoState, 'GLOBAL_O3', OFFLINE_O3, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_O3', OFFLINE_O3, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find offline GLOBAL_O3 in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, LOC )
@@ -494,7 +494,7 @@ CONTAINS
        ENDIF
 
        ! Evaluate offline oxidant fields from HEMCO: global NO3
-       CALL HCO_EvalFld(HcoState, 'GLOBAL_NO3', OFFLINE_NO3, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_NO3', OFFLINE_NO3, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find offline GLOBAL_NO3 in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, LOC )
@@ -4830,7 +4830,7 @@ CONTAINS
    USE HCO_State_GC_Mod,     ONLY : HcoState, ExtState
    USE HCO_Interface_Common, ONLY : GetHcoDiagn
    USE HCO_EMISLIST_MOD,     ONLY : HCO_GetPtr !(ramnarine 12/27/2018)
-   USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
+   USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
 !
 ! !INPUT PARAMETERS:
 !
@@ -5052,7 +5052,7 @@ CONTAINS
       ! Number of BB fires for parameterization (ramnarine 12/27/2018)
       ! Evalulate the fire number from HEMCO every timestep to apply masks
       ! and scaling configured in HEMCO config
-      CALL HCO_EvalFld( HcoState, 'FINN_DAILY_NUMBER', FIRE_NUM, RC )
+      CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'FINN_DAILY_NUMBER', FIRE_NUM, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Error evaluating FINN_DAILY_NUMBER in HEMCO data list!'
          CALL GC_Error( ErrMsg, RC, 'carbon_mod.F90: EMISSCARBONTOMAS' )

--- a/GeosCore/co2_mod.F90
+++ b/GeosCore/co2_mod.F90
@@ -143,13 +143,13 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Diag_Mod,     ONLY : DgnState
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE State_Met_Mod,      ONLY : MetState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
 !
 ! !INPUT PARAMETERS:
 !
@@ -169,6 +169,8 @@ CONTAINS
 ! !REMARKS:
 !  The initial condition for CO2 has to be at least 50 ppm or higher or else
 !  the balanced biosphere fluxes will make STT negative. (pns, bmy, 8/16/05)
+!
+!  The HEMCO grid no longer is restricted to the model grid (hplin, 6/14/20)
 !
 ! !REVISION HISTORY:
 !  16 Aug 2005 - P. Suntharalingam - Initial version
@@ -229,19 +231,6 @@ CONTAINS
     ! Species ID setup and error checks (first-time only)
     !=================================================================
     IF ( FIRST ) THEN
-
-       !--------------------------------------------------------------
-       ! Error check: For now, the emission grid must be
-       ! on the simulation grid.
-       !--------------------------------------------------------------
-       IF ( HcoState%NX /= State_Grid%NX .OR. &
-            Hcostate%NY /= State_Grid%NY .OR. &
-            Hcostate%NZ /= State_Grid%NZ     ) THEN
-          ErrMsg = 'The HEMCO grid not same as the sim. grid!'
-          CALL GC_Error( ErrMsg, RC, ThisLoc )
-          RETURN
-       ENDIF
-
        ! Set first-time flag to false
        FIRST = .FALSE.
     ENDIF
@@ -262,7 +251,7 @@ CONTAINS
        Spc => State_Chm%Species
 
        ! Evalulate the CO2 production from HEMCO
-       CALL HCO_EvalFld( HcoState, 'CO2_COPROD', CO2_COPROD, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'CO2_COPROD', CO2_COPROD, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'CO_COPROD not found in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -869,22 +869,21 @@ CONTAINS
 !
 ! !USES:
 !
-    USE CMN_SIZE_MOD,       ONLY : NTYPE
-    USE Drydep_Toolbox_Mod, ONLY : BioFit
+    USE CMN_SIZE_MOD,         ONLY : NTYPE
+    USE Drydep_Toolbox_Mod,   ONLY : BioFit
     USE ErrCode_Mod
     USE ERROR_MOD
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE Species_Mod,        ONLY : Species
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Diag_Mod,     ONLY : DgnState
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE State_Met_Mod,      ONLY : MetState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE Species_Mod,          ONLY : Species
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
 #ifdef APM
-    USE APM_INIT_MOD,       ONLY : APMIDS
-    USE APM_INIT_MOD,       ONLY : RDRY, RSALT, RDST, DENDST
-    USE APM_DRIV_MOD,       ONLY : GFTOT3D, DENWET3D, MWSIZE3D
+    USE APM_INIT_MOD,         ONLY : APMIDS
+    USE APM_INIT_MOD,         ONLY : RDRY, RSALT, RDST, DENDST
+    USE APM_DRIV_MOD,         ONLY : GFTOT3D, DENWET3D, MWSIZE3D
 #endif
 !
 ! !INPUT PARAMETERS:
@@ -1143,13 +1142,13 @@ CONTAINS
 
     ! Evaluate iodide and salinity from HEMCO for O3 oceanic dry deposition
     IF ( id_O3 > 0 ) THEN
-       CALL HCO_EvalFld( HcoState, 'surf_iodide', HCO_Iodide, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'surf_iodide', HCO_Iodide, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find surf_iodide in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, 'drydep_mod.F90' )
           RETURN
        ENDIF
-       CALL HCO_EvalFld( HcoState, 'surf_salinity', HCO_Salinity, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'surf_salinity', HCO_Salinity, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find surf_salinity in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, 'drydep_mod.F90' )

--- a/GeosCore/emissions_mod.F90
+++ b/GeosCore/emissions_mod.F90
@@ -277,7 +277,7 @@ CONTAINS
     ! diagnostics output. (bmy, mps, 10/19/18)
     IF ( Input_Opt%ITS_A_CH4_SIM .OR.            &
        ( id_CH4 > 0 .and. Input_Opt%LCH4EMIS ) ) THEN
-       CALL EmissCh4( Input_Opt, State_Met, RC )
+       CALL EmissCh4( Input_Opt, State_Grid, State_Met, RC )
 
        ! Trap potential errors
        IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/fast_jx_mod.F90
+++ b/GeosCore/fast_jx_mod.F90
@@ -1566,7 +1566,7 @@ CONTAINS
     ! print error and cut off JXTRAL at lower L if too many levels
     if ( failed ) then
        IF ( Input_Opt%FJX_EXTRAL_ERR ) THEN
-          write(6,'(A,2I5,F9.2)') 'N_/L2_/L2-cutoff JXTRA:',NX,L2X,L2
+          write(6,'(A,7I5)') 'N_/L2_/L2-cutoff JXTRA:',ILON,ILAT,NX,L2X,L2,JXTRA(L2),JTOTL
        ENDIF
        do L = L2,1,-1
           JXTRA(L) = 0
@@ -1584,7 +1584,7 @@ CONTAINS
     do L2 = L2X,1,-1
        JTOTL  = JTOTL + JXTRA(L2)
        if (JTOTL .gt. NX/2)  then
-          write(6,'(A,2I5,F9.2)') 'N_/L2_/L2-cutoff JXTRA:',NX,L2X,L2
+          write(6,'(A,7I5)') 'N_/L2_/L2-cutoff JXTRA:',ILON,ILAT,NX,L2X,L2,JXTRA(L2),JTOTL
           do L = L2,1,-1
              JXTRA(L) = 0
           enddo

--- a/GeosCore/flexgrid_read_mod.F90
+++ b/GeosCore/flexgrid_read_mod.F90
@@ -109,27 +109,27 @@ CONTAINS
 
     ! Read FRLAKE
     v_name = "FRLAKE"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name) )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name) )
     State_Met%FRLAKE = Q
 
     ! Read FRLAND
     v_name = "FRLAND"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name) )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name) )
     State_Met%FRLAND = Q
 
     ! Read FRLANDIC
     v_name = "FRLANDIC"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name) )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name) )
     State_Met%FRLANDIC = Q
 
     ! Read FROCEAN
     v_name = "FROCEAN"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name) )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name) )
     State_Met%FROCEAN = Q
 
     ! Read PHIS
     v_name = "PHIS"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name) )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name) )
     State_Met%PHIS = Q
 
     ! Echo info
@@ -263,75 +263,75 @@ CONTAINS
 
     ! Read ALBEDO
     v_name = "ALBEDO"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%ALBD = Q
 
     ! Read CLDTOT
     v_name = "CLDTOT"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%CLDFRC = Q
 
     ! Read EFLUX
     v_name = "EFLUX"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%EFLUX = Q
 
     !--------------------------------------------------------------------------
     ! For now, skip reading EVAP. It's not used in GEOS-Chem. (mps, 9/14/17)
     !! Read EVAP
     !v_name = "EVAP"
-    !CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    !CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     !State_Met%EVAP = Q
     !--------------------------------------------------------------------------
 
     ! Read FRSEAICE
     v_name = "FRSEAICE"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%FRSEAICE = Q
 
     ! Read FRSNO
     v_name = "FRSNO"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%FRSNO = Q
 
     !--------------------------------------------------------------------------
     ! For now, skip reading GRN. It's not used in GEOS-Chem. (mps, 9/14/17)
     !! Read GRN
     !v_name = "GRN"
-    !CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    !CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     !State_Met%GRN = Q
     !--------------------------------------------------------------------------
 
     ! Read GWETROOT
     v_name = "GWETROOT"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%GWETROOT = Q
 
     ! Read GWETTOP
     v_name = "GWETTOP"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%GWETTOP = Q
 
     ! Read HFLUX from file
     v_name = "HFLUX"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%HFLUX = Q
 
     ! Read LAI
     v_name = "LAI"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%LAI = Q
 
     ! Read LWI
     v_name = "LWI"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%LWI = Q
 
     !--------------------------------------------------------------------------
     ! For now, skip reading RADLWG. It's not used in GEOS-Chem. (mps, 9/14/17)
     !! Read LWGNT
     !v_name = "LWGNT"
-    !CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    !CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     !State_Met%RADLWG = Q
     !--------------------------------------------------------------------------
 
@@ -339,169 +339,169 @@ CONTAINS
     ! Comment this out for now, this field isn't needed (bmy, 2/2/12)
     !! Read LWTUP
     !v_name = "LWTUP"
-    !CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    !CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     !State_Met%LWTUP = Q
     !-----------------------------------------------------------------------
 
     ! Read PARDF
     v_name = "PARDF"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%PARDF = Q
 
     ! Read PARDR
     v_name = "PARDR"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%PARDR = Q
 
     ! Read PBLH
     v_name = "PBLH"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%PBLH = Q
 
     ! Read PRECANV
     v_name = "PRECANV"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%PRECANV = Q
 
     ! Read PRECCON
     v_name = "PRECCON"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%PRECCON = Q
 
     ! Read PRECLSC
     v_name = "PRECLSC"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%PRECLSC = Q
 
     !--------------------------------------------------------------------------
     ! For now, skip reading PRECSNO. It's not used in GEOS-Chem. (mps, 9/14/17)
     !! Read PRECSNO
     !v_name = "PRECSNO"
-    !CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    !CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     !State_Met%PRECSNO = Q
     !--------------------------------------------------------------------------
 
     ! Read PRECTOT
     v_name = "PRECTOT"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%PRECTOT = Q
 
     !-----------------------------------------------------------------------
     ! Comment this out for now, this field isn't needed (bmy, 2/2/12)
     !! Read QV2M
     !v_name = "QV2M"
-    !CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    !CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     !State_Met%QV2M = Q
     !-----------------------------------------------------------------------
 
     ! Read SEAICE00
     v_name = "SEAICE00"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE00 = Q
 
     ! Read SEAICE10
     v_name = "SEAICE10"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE10 = Q
 
     ! Read SEAICE20
     v_name = "SEAICE20"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE20 = Q
 
     ! Read SEAICE30
     v_name = "SEAICE30"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE30 = Q
 
     ! Read SEAICE40
     v_name = "SEAICE40"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE40 = Q
 
     ! Read SEAICE50
     v_name = "SEAICE50"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE50 = Q
 
     ! Read SEAICE60
     v_name = "SEAICE60"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE60 = Q
 
     ! Read SEAICE70
     v_name = "SEAICE70"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE70 = Q
 
     ! Read SEAICE80
     v_name = "SEAICE80"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE80 = Q
 
     ! Read SEAICE90
     v_name = "SEAICE90"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SEAICE90 = Q
 
     ! Read SLP
     v_name = "SLP"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SLP = Q
 
     ! Read SNODP
     v_name = "SNODP"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SNODP = Q
 
     ! Read SNOMAS
     v_name = "SNOMAS"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SNOMAS = Q
 
     ! Read SWGDN
     v_name = "SWGDN"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%SWGDN  = Q
 
     ! Read TO3
     v_name = "TO3"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%TO3 = Q
 
     ! Read TROPPT
     v_name = "TROPPT"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%TROPP = Q
 
     ! Read TS
     v_name = "TS"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%TSKIN = Q
 
     ! Read T2M
     v_name = "T2M"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%TS = Q
 
     ! Read U10M
     v_name = "U10M"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%U10M = Q
 
     ! Read USTAR
     v_name = "USTAR"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%USTAR = Q
 
     ! Read V10M
     v_name = "V10M"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met% V10M = Q
 
     ! Read Z0M
     v_name = "Z0M"
-    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%Z0 = Q
 
     ! Echo info
@@ -715,32 +715,32 @@ CONTAINS
 
     ! Read CLOUD
     v_name = "CLOUD"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%CLDF = Q
 
     ! Read OPTDEPTH
     v_name = "OPTDEPTH"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%OPTD = Q
 
     ! Read QI
     v_name = "QI"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%QI = Q
 
     ! Read QL
     v_name = "QL"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%QL = Q
 
     ! Read TAUCLI
     v_name = "TAUCLI"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%TAUCLI = Q
 
     ! Read TAUCLW
     v_name = "TAUCLW"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%TAUCLW = Q
 
     ! Echo info
@@ -835,27 +835,27 @@ CONTAINS
 
     ! Read DTRAIN
     v_name = "DTRAIN"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%DTRAIN = Q
 
     ! Read OMEGA
     v_name = "OMEGA"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%OMEGA = Q
 
     ! Read RH
     v_name = "RH"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%RH = Q
 
     ! Read U
     v_name = "U"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%U = Q
 
     ! Read V
     v_name = "V"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%V = Q
 
     ! Echo info
@@ -958,22 +958,22 @@ CONTAINS
 
     ! Read DQRCU  from file
     v_name = "DQRCU"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%DQRCU = Q
 
     ! Read DQRLSAN
     v_name = "DQRLSAN"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%DQRLSAN = Q
 
     ! Read REEVAPCN
     v_name = "REEVAPCN"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%REEVAPCN = Q
 
     ! Read  from file
     v_name = "REEVAPLS"
-    CALL Get_Met_3D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%REEVAPLS = Q
 
     ! Echo info
@@ -1075,37 +1075,37 @@ CONTAINS
 
     ! Read CMFMC (only in GEOSFP*.nc files)
     v_name = "CMFMC"
-    CALL Get_Met_3De( State_Grid, Qe, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3De( Input_Opt, State_Grid, Qe, TRIM(v_name), t_index=t_index )
     State_Met%CMFMC = Qe
 
     ! Read PFICU
     v_name = "PFICU"
-    CALL Get_Met_3De( State_Grid, Qe, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3De( Input_Opt, State_Grid, Qe, TRIM(v_name), t_index=t_index )
     State_Met%PFICU = Qe
 
     ! Read PFILSAN
     v_name = "PFILSAN"
-    CALL Get_Met_3De( State_Grid, Qe, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3De( Input_Opt, State_Grid, Qe, TRIM(v_name), t_index=t_index )
     State_Met%PFILSAN = Qe
 
     ! Read PFLCU
     v_name = "PFLCU"
-    CALL Get_Met_3De( State_Grid, Qe, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3De( Input_Opt, State_Grid, Qe, TRIM(v_name), t_index=t_index )
     State_Met%PFLCU = Qe
 
     ! Read PLLSAN
     v_name = "PFLLSAN"
-    CALL Get_Met_3De( State_Grid, Qe, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3De( Input_Opt, State_Grid, Qe, TRIM(v_name), t_index=t_index )
     State_Met%PFLLSAN = Qe
 
     ! Read FLASH_DENS
     v_name = "FLASH_DENS"
-    CALL Get_Met_2D( State_Grid, Q2, TRIM(v_name) )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q2, TRIM(v_name) )
     State_Met%FLASH_DENS = Q2
 
     ! Read CONV_DEPTH
     v_name = "CONV_DEPTH"
-    CALL Get_Met_2D( State_Grid, Q2, TRIM(v_name) )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q2, TRIM(v_name) )
     State_Met%CONV_DEPTH = Q2
 
     ! Echo info
@@ -1221,7 +1221,7 @@ CONTAINS
 
     ! Read PS
     v_name = "PS"
-    CALL Get_Met_2D( State_Grid, Q2, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q2, TRIM(v_name), t_index=t_index )
     State_Met%PS1_WET = Q2
 
     !-------------------------------------------------
@@ -1233,19 +1233,19 @@ CONTAINS
     ! For now, skip reading Potential Vorticity (bmy, 2/3/12)
     !! Read PV
     !v_name = "PV"
-    !CALL Get_Met_3D( State_Grid, Q3, TRIM(v_name), t_index=t_index )
+    !CALL Get_Met_3D( Input_Opt, State_Grid, Q3, TRIM(v_name), t_index=t_index )
     !!Q3 = ABS(1.0e6*Q3) ! PV to PVU
     !State_Met%PV = Q3
     !----------------------------------------------------------------
 
     ! Read QV
     v_name = "SPHU"
-    CALL Get_Met_3D( State_Grid, Q3, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q3, TRIM(v_name), t_index=t_index )
     State_Met%SPHU1 = Q3
 
     ! Read T
     v_name = "TMPU"
-    CALL Get_Met_3D( State_Grid, Q3, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q3, TRIM(v_name), t_index=t_index )
     State_Met%TMPU1 = Q3
 
     ! Echo info
@@ -1386,7 +1386,7 @@ CONTAINS
     ELSE
        v_name = "PS"
     ENDIF
-    CALL Get_Met_2D( State_Grid, Q2, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_2D( Input_Opt, State_Grid, Q2, TRIM(v_name), t_index=t_index )
     State_Met%PS2_WET = Q2
 
     !-------------------------------------------------
@@ -1402,7 +1402,7 @@ CONTAINS
     !ELSE
     !   v_name = "PV"
     !ENDIF
-    !CALL Get_Met_3D( State_Grid, Q3, TRIM(v_name), t_index=t_index )
+    !CALL Get_Met_3D( Input_Opt, State_Grid, Q3, TRIM(v_name), t_index=t_index )
     !!Q3 = ABS(1.0e6*Q3) ! PV to PVU
     !State_Met%PV = Q3
     !----------------------------------------------------------------
@@ -1413,7 +1413,7 @@ CONTAINS
     ELSE
        v_name = "SPHU"
     ENDIF
-    CALL Get_Met_3D( State_Grid, Q3, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q3, TRIM(v_name), t_index=t_index )
     State_Met%SPHU2 = Q3
 
     ! Read T
@@ -1422,7 +1422,7 @@ CONTAINS
     ELSE
        v_name = "TMPU"
     ENDIF
-    CALL Get_Met_3D( State_Grid, Q3, TRIM(v_name), t_index=t_index )
+    CALL Get_Met_3D( Input_Opt, State_Grid, Q3, TRIM(v_name), t_index=t_index )
     State_Met%TMPU2 = Q3
 
     ! Echo info

--- a/GeosCore/flexgrid_read_mod.F90
+++ b/GeosCore/flexgrid_read_mod.F90
@@ -497,7 +497,7 @@ CONTAINS
     ! Read V10M
     v_name = "V10M"
     CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
-    State_Met% V10M = Q
+    State_Met%V10M = Q
 
     ! Read Z0M
     v_name = "Z0M"

--- a/GeosCore/get_met_mod.F90
+++ b/GeosCore/get_met_mod.F90
@@ -48,26 +48,28 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Get_Met_2D( State_Grid, Q, v_name, t_index )
+  SUBROUTINE Get_Met_2D( Input_Opt, State_Grid, Q, v_name, t_index )
 !
 ! !USES:
 !
     USE ErrCode_Mod
-    USE Error_Mod,          ONLY : Error_Stop
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_EmisList_Mod,   ONLY : HCO_GetPtr
-    USE State_Grid_Mod,     ONLY : GrdState
+    USE Error_Mod,            ONLY : Error_Stop
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetPtr
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Grid_Mod,       ONLY : GrdState
 !
 !
 ! !INPUT PARAMETERS:
 !
+    TYPE(OptInput),  INTENT(IN)            :: Input_Opt  ! Input options
     TYPE(GrdState),  INTENT(IN)            :: State_Grid ! Grid State object
     CHARACTER(LEN=*),INTENT(IN)            :: v_name     ! netCDF variable name
     INTEGER,         INTENT(IN), OPTIONAL  :: t_index    ! Time index(default=1)
 !
 ! !OUTPUT PARAMETERS:
 !
-    REAL*4,          INTENT(OUT)           :: Q(State_Grid%NX, & ! Temporary
+    REAL(f4),        INTENT(OUT)           :: Q(State_Grid%NX, & ! Temporary
                                                 State_Grid%NY)   !  data array
 !
 ! !REVISION HISTORY:
@@ -105,9 +107,9 @@ CONTAINS
     ENDIF
 
     ! Get the pointer to the data in the HEMCO data structure
-    CALL HCO_GetPtr( HcoState, v_name, Ptr2D, RC, TIDX=T, FOUND=FND )
+    CALL HCO_GC_GetPtr( Input_Opt, State_Grid, v_name, Ptr2D, RC, TIDX=T, FOUND=FND )
 
-      ! Stop with error message
+    ! Stop with error message
     IF ( RC /= GC_SUCCESS .or. ( .not. FND ) ) THEN
        CALL ERROR_STOP (trim('Could not find '//v_name//' in HEMCO data list!'), &
                          'GET_MET_2D (get_met_mod.F90)' )
@@ -133,26 +135,29 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Get_Met_3D( State_Grid, Q, v_name, t_index )
+  SUBROUTINE Get_Met_3D( Input_Opt, State_Grid, Q, v_name, t_index )
 !
 ! !USES:
 !
     USE ErrCode_Mod
-    USE Error_Mod,          ONLY : Error_Stop
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_EmisList_Mod,   ONLY : HCO_GetPtr
-    USE State_Grid_Mod,     ONLY : GrdState
+    USE Error_Mod,            ONLY : Error_Stop
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetPtr
+
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Grid_Mod,       ONLY : GrdState
 !
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(GrdState),  INTENT(IN)            :: State_Grid ! Grid State object
-    CHARACTER(LEN=*),INTENT(IN)            :: v_name     ! netCDF variable name
-    INTEGER,         INTENT(IN), OPTIONAL  :: t_index    ! Time index(default=1)
+    TYPE(OptInput),   INTENT(IN   )        :: Input_Opt  ! Input options
+    TYPE(GrdState),   INTENT(IN)           :: State_Grid ! Grid State object
+    CHARACTER(LEN=*), INTENT(IN)           :: v_name     ! netCDF variable name
+    INTEGER,          INTENT(IN), OPTIONAL :: t_index    ! Time index(default=1)
 !
 ! !OUTPUT PARAMETERS:
 !
-    REAL*4,          INTENT(OUT)           :: Q(State_Grid%NX, & ! Temporary
+    REAL(f4),          INTENT(OUT)         :: Q(State_Grid%NX, & ! Temporary
                                                 State_Grid%NY, & !  data array
                                                 State_Grid%NZ)
 !
@@ -191,7 +196,7 @@ CONTAINS
     ENDIF
 
     ! Get the pointer to the data in the HEMCO data structure
-    CALL HCO_GetPtr( HcoState, v_name, Ptr3D, RC, TIDX=T, FOUND=FND )
+    CALL HCO_GC_GetPtr( Input_Opt, State_Grid, v_name, Ptr3D, RC, TIDX=T, FOUND=FND )
 
       ! Stop with error message
     IF ( RC /= GC_SUCCESS .or. ( .not. FND ) ) THEN
@@ -219,26 +224,28 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Get_Met_3De( State_Grid, Q, v_name, t_index )
+  SUBROUTINE Get_Met_3De( Input_Opt, State_Grid, Q, v_name, t_index )
 !
 ! !USES:
 !
     USE ErrCode_Mod
-    USE Error_Mod,          ONLY : Error_Stop
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_EmisList_Mod,   ONLY : HCO_GetPtr
-    USE State_Grid_Mod,     ONLY : GrdState
+    USE Error_Mod,            ONLY : Error_Stop
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetPtr
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Grid_Mod,       ONLY : GrdState
 !
 !
 ! !INPUT PARAMETERS:
 !
+    TYPE(OptInput),   INTENT(IN   )        :: Input_Opt  ! Input options
     TYPE(GrdState),  INTENT(IN)            :: State_Grid ! Grid State object
     CHARACTER(LEN=*),INTENT(IN)            :: v_name     ! netCDF variable name
     INTEGER,         INTENT(IN), OPTIONAL  :: t_index    ! Time index(default=1)
 !
 ! !OUTPUT PARAMETERS:
 !
-    REAL*4,          INTENT(OUT)           :: Q(State_Grid%NX, & ! Temporary
+    REAL(f4),        INTENT(OUT)           :: Q(State_Grid%NX, & ! Temporary
                                                 State_Grid%NY, & ! data array
                                                 State_Grid%NZ+1)
 !
@@ -277,7 +284,7 @@ CONTAINS
     ENDIF
 
     ! Get the pointer to the data in the HEMCO data structure
-    CALL HCO_GetPtr( HcoState, v_name, Ptr3D, RC, TIDX=T, FOUND=FND )
+    CALL HCO_GC_GetPtr( Input_Opt, State_Grid, v_name, Ptr3D, RC, TIDX=T, FOUND=FND )
 
       ! Stop with error message
     IF ( RC /= GC_SUCCESS .or. ( .not. FND ) ) THEN

--- a/GeosCore/global_br_mod.F90
+++ b/GeosCore/global_br_mod.F90
@@ -80,13 +80,12 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE ERROR_MOD,          ONLY : ERROR_STOP
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE OCEAN_MERCURY_MOD,  ONLY : LGCBROMINE     !eds 4/19/12
-    USE State_Met_Mod,      ONLY : MetState
-    USE State_Grid_Mod,     ONLY : GrdState
+    USE ERROR_MOD,            ONLY : ERROR_STOP
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE OCEAN_MERCURY_MOD,    ONLY : LGCBROMINE     !eds 4/19/12
+    USE State_Met_Mod,        ONLY : MetState
+    USE State_Grid_Mod,       ONLY : GrdState
 !
 ! !INPUT PARAMETERS:
 !
@@ -148,7 +147,7 @@ CONTAINS
        !-----------------------------------------------------------------
        ! Evaluate Br_GC from HEMCO to set Br_TROP
        !-----------------------------------------------------------------
-       CALL HCO_EvalFld(HcoState, 'Br_GC', Br_TROP, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'Br_GC', Br_TROP, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find Br_GC in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -161,7 +160,7 @@ CONTAINS
        !-----------------------------------------------------------------
        ! Evaluate BrO_GC from HEMCO to set BrO_TROP
        !-----------------------------------------------------------------
-       CALL HCO_EvalFld(HcoState, 'BrO_GC', Br_TROP, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'BrO_GC', Br_TROP, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find BrO_GC in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -176,7 +175,7 @@ CONTAINS
        !-----------------------------------------------------------------
        ! Evaluate Br from pTOMCAT biogenic bromocarbons [pptv]
        !-----------------------------------------------------------------
-       CALL HCO_EvalFld(HcoState, 'Br_TOMCAT', Br_TROP, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'Br_TOMCAT', Br_TROP, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find Br_TOMCAT in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -186,7 +185,7 @@ CONTAINS
        !-----------------------------------------------------------------
        ! Evaluate BrO from pTOMCAT biogenic bromocarbons [pptv]
        !-----------------------------------------------------------------
-       CALL HCO_EvalFld(HcoState, 'BrO_TOMCAT', Br_TROP, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'BrO_TOMCAT', Br_TROP, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find BrO_TOMCAT in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -198,7 +197,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Evaluate Br from GMI for stratosphere [pptv]
     !-----------------------------------------------------------------
-    CALL HCO_EvalFld(HcoState, 'Br_GMI', Br_STRAT, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'Br_GMI', Br_STRAT, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Could not find Br_GMI in HEMCO data list!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -208,7 +207,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Evaluate BrO from GMI for stratosphere [pptv]
     !-----------------------------------------------------------------
-    CALL HCO_EvalFld(HcoState, 'BrO_GMI', BrO_STRAT, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'BrO_GMI', BrO_STRAT, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Could not find BrO_GMI in HEMCO data list!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -254,7 +253,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! Evaluate J_BrO
     !-----------------------------------------------------------------
-    CALL HCO_EvalFld(HcoState, 'JBrO', J_BrO, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'JBrO', J_BrO, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Could not find JBrO in HEMCO data list!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/global_ch4_mod.F90
+++ b/GeosCore/global_ch4_mod.F90
@@ -512,13 +512,12 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Diag_Mod,     ONLY : DgnState
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE State_Met_Mod,      ONLY : MetState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_Gc_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
 !
 ! !INPUT PARAMETERS:
 !
@@ -632,7 +631,7 @@ CONTAINS
     !================================================================
 
     ! Evalulate the global OH from HEMCO
-    CALL HCO_EvalFld( HcoState, 'GLOBAL_OH', BOH, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_OH', BOH, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'GLOBAL_OH not found in HEMCO data list!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -640,7 +639,7 @@ CONTAINS
     ENDIF
 
     ! Evalulate the global Cl from HEMCO
-    CALL HCO_EvalFld( HcoState, 'GLOBAL_Cl', BOH, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_Cl', BOH, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'GLOBAL_Cl not found in HEMCO data list!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -1076,14 +1075,13 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE HCO_State_GC_Mod,  ONLY : HcoState
-    USE HCO_Calc_Mod,      ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,     ONLY : OptInput
-    USE State_Chm_Mod,     ONLY : ChmState
-    USE State_Diag_Mod,    ONLY : DgnState
-    USE State_Grid_Mod,    ONLY : GrdState
-    USE State_Met_Mod,     ONLY : MetState
-    USE TIME_MOD,          ONLY : GET_TS_CHEM
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
+    USE TIME_MOD,             ONLY : GET_TS_CHEM
 !
 ! !INPUT PARAMETERS:
 !
@@ -1149,7 +1147,7 @@ CONTAINS
 
     ! Evalulate CH4 loss frequency from HEMCO. This must be done
     ! every timestep to allow masking or scaling in HEMCO config.
-    CALL HCO_EvalFld( HcoState, 'CH4_LOSS', CH4LOSS, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'CH4_LOSS', CH4LOSS, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'CH4_LOSS not found in HEMCO data list!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/global_ch4_mod.F90
+++ b/GeosCore/global_ch4_mod.F90
@@ -87,20 +87,22 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE EMISSCH4( Input_Opt, State_Met, RC )
+  SUBROUTINE EMISSCH4( Input_Opt, State_Grid, State_Met, RC )
 !
 ! !USES:
 !
     USE HCO_State_GC_Mod,     ONLY : HcoState, ExtState
-    USE HCO_Interface_Common, ONLY : GetHcoDiagn
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetDiagn
     USE ErrCode_Mod
     USE Input_Opt_Mod,        ONLY : OptInput
     USE State_Met_Mod,        ONLY : MetState
+    USE State_Grid_Mod,       ONLY : GrdState
 !
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
     TYPE(MetState), INTENT(IN)    :: State_Met   ! Meteorology State object
+    TYPE(GrdState), INTENT(IN)    :: State_Grid  ! Grid State object
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -199,7 +201,7 @@ CONTAINS
     ! Oil
     !-------------------
     DgnName = 'CH4_OIL'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -218,7 +220,7 @@ CONTAINS
     ! Gas
     !-------------------
     DgnName = 'CH4_GAS'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -237,7 +239,7 @@ CONTAINS
     ! Coal
     !-------------------
     DgnName = 'CH4_COAL'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -256,7 +258,7 @@ CONTAINS
     ! Livestock
     !-------------------
     DgnName = 'CH4_LIVESTOCK'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -275,7 +277,7 @@ CONTAINS
     ! Landfills
     !-------------------
     DgnName = 'CH4_LANDFILLS'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -294,7 +296,7 @@ CONTAINS
     ! Wastewater
     !-------------------
     DgnName = 'CH4_WASTEWATER'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -313,7 +315,7 @@ CONTAINS
     ! Rice
     !-------------------
     DgnName = 'CH4_RICE'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -332,7 +334,7 @@ CONTAINS
     ! Other anthropogenic
     !-------------------
     DgnName = 'CH4_ANTHROTHER'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -351,7 +353,7 @@ CONTAINS
     ! Biomass burning
     !-------------------
     DgnName = 'CH4_BIOMASS'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -370,7 +372,7 @@ CONTAINS
     ! Wetland
     !-------------------
     DgnName = 'CH4_WETLAND'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -389,7 +391,7 @@ CONTAINS
     ! Global seeps
     !-------------------
     DgnName = 'CH4_SEEPS'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -408,7 +410,7 @@ CONTAINS
     ! Lakes
     !-------------------
     DgnName = 'CH4_LAKES'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -427,7 +429,7 @@ CONTAINS
     ! Termites
     !-------------------
     DgnName = 'CH4_TERMITES'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN
@@ -446,7 +448,7 @@ CONTAINS
     ! Soil absorption (those are negative!)
     !-------------------
     DgnName = 'CH4_SOILABSORB'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., RC, Ptr2D=Ptr2D )
 
     ! Trap potential errors and assign HEMCO pointer to array
     IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -52,7 +52,6 @@ MODULE HCO_Interface_GC_Mod
 !
 ! !PRIVATE MEMBER FUNCTIONS:
 !
-  PRIVATE :: Calc_SumCosZa
   PRIVATE :: ExtState_InitTargets
   PRIVATE :: ExtState_SetFields
   PRIVATE :: ExtState_UpdateFields
@@ -61,6 +60,10 @@ MODULE HCO_Interface_GC_Mod
   PRIVATE :: CheckSettings
   PRIVATE :: SetHcoGrid
   PRIVATE :: SetHcoSpecies
+
+#if defined( MODEL_CLASSIC )
+  PRIVATE :: Get_Met_Fields
+#endif
 !
 ! !REMARKS:
 !  Formerly HCOI\_GC\_Main\_Mod.
@@ -90,19 +93,70 @@ MODULE HCO_Interface_GC_Mod
 
   ! Internal met fields (will be used by some extensions)
   INTEGER,  TARGET    :: HCO_PBL_MAX                      ! level
-  REAL(hp), POINTER   :: HCO_FRAC_OF_PBL(:,:,:)
-  REAL(hp), POINTER   :: HCO_SZAFACT(:,:)
+  REAL(hp), POINTER, PUBLIC   :: HCO_SZAFACT(:,:)
 
   ! Arrays to store J-values (used by Paranox extension)
-  REAL(hp), POINTER   :: JNO2(:,:)
-  REAL(hp), POINTER   :: JOH(:,:)
+  REAL(hp), POINTER, PUBLIC   :: JNO2(:,:)
+  REAL(hp), POINTER, PUBLIC   :: JOH(:,:)
 
-  ! Sigma coordinate (temporary)
-  REAL(hp), POINTER   :: ZSIGMA(:,:,:)
+#if defined( MODEL_CLASSIC )
 
-  ! Sum of cosine of the solar zenith angle. Used to impose a
-  ! diurnal variability on OH concentrations
-  REAL(fp), POINTER   :: SUMCOSZA(:,:)
+  !------------------------------------------------
+  ! %%% Internal HEMCO intermediate resolution %%% 
+  ! %%%        meteorological fields           %%% 
+  !------------------------------------------------
+
+  ! These will ONLY be allocated and used if HEMCO-intermediate grid
+  ! is enabled (resolutions differ)
+  !
+  ! Note: These could be migrated to inside a derived-type object
+  ! by storing directly in ExtState through array assertions. However,
+  ! this would involve a lot of code path branching as we do not want
+  ! to assert arrays for other models when not running IMGrid and incurring
+  ! waste of memory. For the sake of maintaining old code implementations
+  ! "as-is" and making the intermediate an as-seamless-possible patch over
+  ! the original implementation, we list all these module variables here.
+  ! I am aware that there is a cleaner implementation. (hplin, 6/9/20)
+
+  ! 2-D fields
+  REAL(hp), POINTER :: H_SZAFACT   (:,:)
+  REAL(hp), POINTER :: H_JNO2      (:,:)
+  REAL(hp), POINTER :: H_JOH       (:,:)
+  REAL(hp), POINTER :: H_PSC2_WET  (:,:)
+  REAL(hp), POINTER :: H_FRCLND    (:,:)
+  REAL(hp), POINTER :: H_MODISLAI  (:,:)
+  REAL(hp), POINTER :: H_CNV_FRC   (:,:)
+  INTEGER, POINTER  :: H_TropLev   (:,:)
+
+  REAL(hp), POINTER :: H_TROPP     (:,:)
+  REAL(hp), POINTER :: H_FLASH_DENS(:,:)
+  REAL(hp), POINTER :: H_CONV_DEPTH(:,:)
+  REAL(hp), POINTER :: H_SUNCOS    (:,:)
+
+  REAL(hp), POINTER :: H_DRY_TOTN  (:,:)
+  REAL(hp), POINTER :: H_WET_TOTN  (:,:)
+
+  ! 3-D fields
+  REAL(hp), POINTER :: H_T         (:,:,:)
+  REAL(hp), POINTER :: H_AD        (:,:,:)
+  REAL(hp), POINTER :: H_AIRVOL    (:,:,:)
+  REAL(hp), POINTER :: H_AIRDEN    (:,:,:)
+  REAL(hp), POINTER :: H_F_OF_PBL  (:,:,:)
+
+  REAL(hp), POINTER :: H_SPHU      (:,:,:)                ! Note: Only need ZBND = 1 sfc value
+
+  REAL(hp), POINTER :: H_SpcO3     (:,:,:)
+  REAL(hp), POINTER :: H_SpcNO2    (:,:,:)
+  REAL(hp), POINTER :: H_SpcNO     (:,:,:)
+  REAL(hp), POINTER :: H_SpcHNO3   (:,:,:)
+  REAL(hp), POINTER :: H_SpcPOPG   (:,:,:)
+
+  ! Intermediate temporaries for regridding
+  REAL(hp), POINTER :: REGR_3DI    (:,:,:)                ! Regridding temporary pointer (in)
+  REAL(hp), POINTER :: REGR_3DO    (:,:,:)                ! (out)
+
+#endif
+
 !
 ! !DEFINED PARAMETERS:
 !
@@ -126,6 +180,14 @@ CONTAINS
 ! provide a (previously read) HEMCO configuration object via input argument
 ! `HcoConfig`. In this case the HEMCO configuration file will not be read
 ! any more.
+!\\
+!\\
+! It is also possible to specify an optional, State_Grid_HCO argument.
+! If this is specified, the HEMCO 'intermediate grid' implementation will be
+! enabled and HEMCO will operate on a distinct grid from the GEOS-Chem simulation,
+! and met fields and emissions will be regridded on-demand in memory. This permits
+! the use of higher resolution masks, scaling factors and HEMCO extensions.
+! (hplin, 6/2/20)
 !\\
 !\\
 ! !INTERFACE:
@@ -159,18 +221,26 @@ CONTAINS
     USE HCOI_GC_Diagn_Mod,  ONLY : HCOI_GC_Diagn_Init
     USE HCOX_Driver_Mod,    ONLY : HCOX_Init
     USE HCOX_State_Mod,     ONLY : ExtStateInit
+
+#ifdef MODEL_CLASSIC
+    ! HEMCO Intermediate Grid specification
+    USE HCO_State_GC_Mod,   ONLY : State_Grid_HCO
+    USE GC_Grid_Mod,        ONLY : Compute_Grid
+    USE State_Grid_Mod,     ONLY : Allocate_State_Grid
+#endif
+
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(ChmState),   INTENT(IN   )          :: State_Chm  ! Chemistry state
-    TYPE(GrdState),   INTENT(IN   )          :: State_Grid ! Grid state
-    TYPE(MetState),   INTENT(IN   )          :: State_Met  ! Met state
+    TYPE(ChmState),   INTENT(IN   )           :: State_Chm  ! Chemistry state
+    TYPE(GrdState),   INTENT(IN   )           :: State_Grid ! Grid state
+    TYPE(MetState),   INTENT(IN   )           :: State_Met  ! Met state
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    TYPE(OptInput),   INTENT(INOUT)          :: Input_Opt  ! Input opts
-    TYPE(ConfigObj),  POINTER,      OPTIONAL :: HcoConfig  ! HEMCO config object
-    INTEGER,          INTENT(INOUT)          :: RC         ! Failure or success
+    TYPE(OptInput),   INTENT(INOUT)           :: Input_Opt  ! Input opts
+    TYPE(ConfigObj),  POINTER,      OPTIONAL  :: HcoConfig  ! HEMCO config object
+    INTEGER,          INTENT(INOUT)           :: RC         ! Failure or success
 !
 ! !REVISION HISTORY:
 !  12 Sep 2013 - C. Keller   - Initial version
@@ -202,7 +272,7 @@ CONTAINS
     RC       = GC_SUCCESS
     HMRC     = HCO_SUCCESS
     ErrMsg   = ''
-    ThisLoc  = ' -> at HCOI_GC_Init (in module GeosCore/hcoi_gc_main_mod.F90)'
+    ThisLoc  = ' -> at HCOI_GC_Init (in module GeosCore/hco_interface_gc_mod.F90)'
     Instr    = 'THIS ERROR ORIGINATED IN HEMCO!  Please check the '       // &
                'HEMCO log file for additional error messages!'
 
@@ -214,10 +284,90 @@ CONTAINS
     id_O3    = Ind_('O3'  )
     id_POPG  = Ind_('POPG')
 
+#ifdef MODEL_CLASSIC
+    ! Initialize the intermediate grid descriptor.
+    ! To disable the HEMCO intermediate grid feature, simply set this DY, DX to
+    ! equal to State_Grid%DY, State_Grid%DX (e.g. 2x2.5, 4x5, ...)
+    !
+    ! TODO: Read in the grid parameters via input.geos. For now, hardcode the DY and DX
+    ! as 1.0x1.0 degree.
+    ! State_Grid_HCO%DY = 1.0_fp
+    ! State_Grid_HCO%DX = 1.0_fp
+
+    ! To test GC-Classic WITHOUT intermediate grid
+    State_Grid_HCO%DY = State_Grid%DY
+    State_Grid_HCO%DX = State_Grid%DX
+
+    ! Are we using HEMCO intermediate grid implementation?
+    ! Note: The mere presence of State_Grid_HCO does not mean
+    ! that the intermediate grid is necessarily different. 
+    ! The code path is decided if the intermediate is actually a different grid.
+    IF ( State_Grid_HCO%DX .ne. State_Grid%DX .or. &
+         State_Grid_HCO%DY .ne. State_Grid%DY ) THEN
+      Input_Opt%LIMGRID = .true.
+
+      write(State_Grid_HCO%GridRes, '(f10.4,a,f10.4)') State_Grid_HCO%DX, "x", State_Grid_HCO%DY
+    
+      ! In intermediate grid implementation
+      ! Compute the grid parameters exactly like GEOS-Chem model grid. Copy params over.
+      State_Grid_HCO%HalfPolar  = State_Grid%HalfPolar
+      State_Grid_HCO%NestedGrid = State_Grid%NestedGrid
+      State_Grid_HCO%XMin = State_Grid%XMin
+      State_Grid_HCO%XMax = State_Grid%XMax
+
+      ! Compute the new NX
+      State_Grid_HCO%NX   = FLOOR((State_Grid_HCO%XMax - State_Grid_HCO%XMin) / State_Grid_HCO%DX)
+      IF( State_Grid_HCO%NestedGrid ) THEN
+         State_Grid_HCO%NX = State_Grid_HCO%NX + 1
+         State_Grid_HCO%HalfPolar = .false.
+      ENDIF
+
+      State_Grid_HCO%YMin = State_Grid%YMin
+      State_Grid_HCO%YMax = State_Grid%YMax
+
+      ! Compute the new NY
+      State_Grid_HCO%NY   = FLOOR((State_Grid_HCO%YMax - State_Grid_HCO%YMin) / State_Grid_HCO%DY) + 1
+
+      ! The intermediate grid has the same vertical discretization as the model grid.
+      State_Grid_HCO%NZ   = State_Grid%NZ
+
+      ! Allocate State_Grid_HCO arrays
+      CALL Allocate_State_Grid( Input_Opt, State_Grid_HCO, RC )
+      IF ( RC /= GC_SUCCESS ) THEN
+         ErrMsg = 'Error encountered in "Allocate_State_Grid"!'
+         CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+      ENDIF
+
+      ! Reuse GC_Grid_Mod to compute the grid information
+      ! This will output the grid information too.
+      WRITE(6, *) "HEMCO INTERMEDIATE GRID:"
+      CALL Compute_Grid ( Input_Opt, State_Grid_HCO, RC )
+      IF ( RC /= GC_SUCCESS ) THEN
+         ErrMsg = 'Error encountered in "Compute_Grid"!'
+         CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+      ENDIF
+
+      ! Initialize module temporaries for regridding
+      ALLOCATE( REGR_3DI( State_Grid%NX, State_Grid%NY, State_Grid%NZ+1 ), STAT=RC )
+      CALL GC_CheckVar( 'hco_interface_gc_mod.F90:HCOI_GC_Init:REGR_3DI', 0, RC )
+      IF ( RC /= HCO_SUCCESS ) RETURN
+
+      ALLOCATE( REGR_3DO( State_Grid_HCO%NX, State_Grid_HCO%NY, State_Grid_HCO%NZ+1 ), STAT=RC )
+      CALL GC_CheckVar( 'hco_interface_gc_mod.F90:HCOI_GC_Init:REGR_3DO', 0, RC )
+      IF ( RC /= HCO_SUCCESS ) RETURN
+    ELSE
+      ! Intermediate grid is same as model grid. Maintain current implementation
+      ! all computations about State_Grid_HCO can be skipped to save memory.
+    ENDIF
+#endif
+
     ! Create a splash page
     IF ( Input_Opt%amIRoot ) THEN
        WRITE( 6, '(a)' ) REPEAT( '%', 79 )
        WRITE( 6, 100   ) 'HEMCO: Harvard-NASA Emissions Component'
+       IF ( Input_Opt%LIMGRID ) THEN
+         WRITE( 6, '(a)' ) 'HEMCO is running on a different grid than the model', State_Grid_HCO%GridRes
+       ENDIF
        WRITE( 6, 101   ) 'You are using HEMCO version ', ADJUSTL(HCO_VERSION)
        WRITE( 6, '(a)' ) REPEAT( '%', 79 )
  100   FORMAT( '%%%%%', 15x, a,      15x, '%%%%%' )
@@ -259,6 +409,14 @@ CONTAINS
 
     ! Met and grid parameters
     iHcoConfig%MetField = Input_Opt%MetField
+
+    ! In any way, even if the intermediate grid is enabled, the grid resolution
+    ! tokens ($RES$) should be replaced with the token that is most appropriate
+    ! with the model native resolution.
+    !
+    ! This might not be the case in the future, but it involves other
+    ! science implications that should be discussed with the scientific GCSC!
+    ! (hplin, 6/4/20)
     iHcoConfig%GridRes  = State_Grid%GridRes
 
     ! Pass GEOS-Chem species information to HEMCO config object to
@@ -398,7 +556,15 @@ CONTAINS
     !-----------------------------------------------------------------------
     ! Set the HEMCO grid
     !-----------------------------------------------------------------------
-    CALL SetHcoGrid( State_Grid, State_Met, HcoState, RC )
+#ifdef MODEL_CLASSIC
+    IF ( Input_Opt%LIMGRID ) THEN
+      CALL SetHcoGrid( State_Grid_HCO, State_Met, HcoState, RC )
+    ELSE
+#endif
+      CALL SetHcoGrid( State_Grid, State_Met, HcoState, RC )
+#ifdef MODEL_CLASSIC
+    ENDIF
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -578,7 +744,12 @@ CONTAINS
     ! Here, we need to make sure that these pointers are properly
     ! connected.
     !-----------------------------------------------------------------------
-    CALL ExtState_InitTargets( HcoState, ExtState, State_Grid, HMRC )
+    IF ( Input_Opt%LIMGRID ) THEN
+      ! Use the HEMCO "intermediate" grid -- allocate arrays accordingly
+      CALL ExtState_InitTargets( HcoState, ExtState, Input_Opt, State_Grid, HMRC, State_Grid_HCO )
+    ELSE
+      CALL ExtState_InitTargets( HcoState, ExtState, Input_Opt, State_Grid, HMRC )
+    ENDIF
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -655,7 +826,6 @@ CONTAINS
 #if defined( MODEL_CLASSIC )
     ! HEMCO utility routines for GEOS-Chem
     USE HCO_Utilities_GC_Mod, ONLY : Get_GC_Restart
-    USE HCO_Utilities_GC_Mod, ONLY : Get_Met_Fields
     USE HCO_Utilities_GC_Mod, ONLY : Get_Boundary_Conditions
 #endif
 !
@@ -792,7 +962,7 @@ CONTAINS
     ! At Phase 0, the pressure field is not known yet.
     !=======================================================================
     IF ( Phase /= 0 .and. notDryRun ) THEN
-       CALL GridEdge_Set( State_Grid, State_Met, HcoState, HMRC  )
+       CALL GridEdge_Set( Input_Opt, State_Grid, State_Met, HcoState, HMRC  )
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -804,7 +974,7 @@ CONTAINS
        ENDIF
     ENDIF
 
-#if !defined( ESMF_ )
+#if !defined( ESMF_ ) && !defined( MODEL_WRF )
     ! Check if HEMCO has already been called for this timestep
     IF ( ( Phase == 1 ) .and. ( GET_TAU() == PrevTAU ) .and. Input_Opt%amIRoot ) THEN
        Print*, 'HEMCO already called for this timestep. Returning.'
@@ -910,7 +1080,9 @@ CONTAINS
        ! connected.
        !--------------------------------------------------------------------
        IF ( notDryRun ) THEN
-          CALL ExtState_SetFields( State_Chm, State_Met, &
+          ! Set fields either as pointer targets or else.
+          ! TODO: Eventually need to regrid those for ImGrid.
+          CALL ExtState_SetFields( Input_Opt, State_Chm, State_Met, &
                                    HcoState,  ExtState,  HMRC )
 
           ! Trap potential errors
@@ -922,6 +1094,8 @@ CONTAINS
              RETURN
           ENDIF
 
+          ! Update fields directly from State_Met.
+          ! TODO: Eventually need to regrid those for ImGrid.
           CALL ExtState_UpdateFields( Input_Opt, State_Chm,            &
                                       State_Grid, State_Met, HcoState, &
                                       ExtState,   HMRC )
@@ -1106,41 +1280,38 @@ CONTAINS
     !-----------------------------------------------------------------------
     ! Deallocate module variables
     !-----------------------------------------------------------------------
-    IF ( ASSOCIATED( ZSIGMA ) ) THEN
-       DEALLOCATE( ZSIGMA, STAT=RC )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:ZSIGMA', 2, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-    ENDIF
-
-    IF ( ASSOCIATED( HCO_FRAC_OF_PBL ) ) THEN
-       DEALLOCATE( HCO_FRAC_OF_PBL, STAT=RC )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:HCO_FRAC_OF_PBL', 2, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-    ENDIF
 
     IF ( ASSOCIATED( HCO_SZAFACT ) ) THEN
        DEALLOCATE( HCO_SZAFACT, STAT=RC )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:HCO_SZAFACT', 2, RC )
+       CALL GC_CheckVar( 'hco_interface_gc_mod.F90:HCO_SZAFACT', 2, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
     ENDIF
 
     IF ( ASSOCIATED( JNO2 ) ) THEN
        DEALLOCATE( JNO2, STAT=RC )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:JNO2', 2, RC )
+       CALL GC_CheckVar( 'hco_interface_gc_mod.F90:JNO2', 2, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
     ENDIF
 
     IF ( ASSOCIATED( JOH ) ) THEN
        DEALLOCATE( JOH, STAT=RC )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:JOH', 2, RC )
+       CALL GC_CheckVar( 'hco_interface_gc_mod.F90:JOH', 2, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
     ENDIF
 
-    IF ( ASSOCIATED( SUMCOSZA ) ) THEN
-       DEALLOCATE( SUMCOSZA, STAT=RC )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:SUMCOSZA', 2, RC )
+#if defined( MODEL_CLASSIC )
+    IF ( ASSOCIATED( REGR_3DI ) ) THEN
+       DEALLOCATE( REGR_3DI  )
+       CALL GC_CheckVar( 'hco_interface_gc_mod.F90:HCOI_GC_Final:REGR_3DI', 2, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
     ENDIF
+
+    IF ( ASSOCIATED( REGR_3DO ) ) THEN
+       DEALLOCATE( REGR_3DO  )
+       CALL GC_CheckVar( 'hco_interface_gc_mod.F90:HCOI_GC_Final:REGR_3DO', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+    ENDIF
+#endif
 
   END SUBROUTINE HCOI_GC_Final
 !EOC
@@ -1260,24 +1431,33 @@ CONTAINS
 ! !DESCRIPTION: SUBROUTINE ExtState\_InitTargets allocates some local arrays
 ! that act as targets for the ExtState object.
 !\\
-! Note that for now, this explicitly assumes that the HEMCO emissions grid is
-! the same as the GEOS-Chem simulation grid. To support other grids, the met
-! data has to be regridded explicitly at every time step!
+! If State_Grid_HCO is not given or Input_Opt%LIMGRID is set to false (from Init),
+! this explicitly assumes that the HEMCO emissions grid is the same as the GEOS-Chem 
+! simulation grid. 
+! 
+! Otherwise, the met data has to be regridded explicitly at every time step!
+! This is performed by creating a set of in-memory array temporaries within this module,
+! that can be pointed to by ExtState. Note that a SET of temporaries MUST be always
+! present -- you cannot cheat and swap them in memory.
 !\\
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE ExtState_InitTargets( HcoState, ExtState, State_Grid, RC )
+  SUBROUTINE ExtState_InitTargets( HcoState, ExtState, Input_Opt, State_Grid, RC, &
+                                   State_Grid_HCO )
 !
 ! !USES:
 !
     USE ErrCode_Mod
     USE HCO_Arr_Mod,    ONLY : HCO_ArrAssert
     USE State_Grid_Mod, ONLY : GrdState
+    USE Input_Opt_Mod,  ONLY : OptInput
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(GrdState),   INTENT(IN   )  :: State_Grid ! Grid State object
+    TYPE(OptInput),   INTENT(IN   )           :: Input_Opt      ! Input options
+    TYPE(GrdState),   INTENT(IN   )           :: State_Grid     ! Grid State object
+    TYPE(GrdState),   INTENT(IN   ), OPTIONAL :: State_Grid_HCO ! HEMCO ImGrid
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -1297,6 +1477,9 @@ CONTAINS
     ! Scalars
     INTEGER            :: HMRC
 
+    INTEGER            :: IM, JM, LM
+    INTEGER            :: IMh, JMh              ! HEMCO grid sizes
+
     ! Strings
     CHARACTER(LEN=255) :: ThisLoc, Instr
     CHARACTER(LEN=512) :: ErrMsg
@@ -1310,9 +1493,209 @@ CONTAINS
     HMRC     = HCO_SUCCESS
     ErrMsg   = ''
     ThisLoc  = &
-       ' -> at ExtState_InitTargets (in module GeosCore/hcoi_gc_main_mod.F90)'
+       ' -> at ExtState_InitTargets (in module GeosCore/hco_interface_gc_mod.F90)'
     Instr    = 'THIS ERROR ORIGINATED IN HEMCO!  Please check the '       // &
                'HEMCO log file for additional error messages!'
+
+    ! Shorthands
+    IM     = State_Grid%NX
+    JM     = State_Grid%NY
+    LM     = State_Grid%NZ
+
+    ! By default, HEMCO grid sizes are the same as model. These values will be
+    ! overwritten later
+    IMh    = IM
+    JMh    = JM
+
+#if defined( MODEL_CLASSIC )
+    IF ( Input_Opt%LIMGRID ) THEN
+      IMh  = State_Grid_HCO%NX
+      JMh  = State_Grid_HCO%NY
+    ENDIF
+
+    
+    !-----------------------------------------------------------------------
+    ! Notes for HEMCO Intermediate Grid:
+    ! Due to the extensions requiring met fields and some of them are derived
+    ! data, we need to initialize targets here.
+    !
+    ! Some variables are stored on the MODEL grid, e.g. SZAFACT, JNO2, JOH.
+    ! Because they need to be computed here, before a regrid.
+    !
+    ! Shadow targets for all derived met fields (not read from HEMCO) are
+    ! initialized if Input_Opt%LIMGRID (Intermediate enabled) and kept updated
+    ! at every ExtState_UpdateFields.
+    !-----------------------------------------------------------------------
+    IF ( Input_Opt%LIMGRID ) THEN
+
+      ! 2-D Fields
+      IF ( ExtState%SZAFACT%DoUse ) THEN
+         ALLOCATE( H_SZAFACT( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_SZAFACT', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_SZAFACT = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%JNO2%DoUse ) THEN
+         ALLOCATE( H_JNO2( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_JNO2', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_JNO2 = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%JOH%DoUse ) THEN
+         ALLOCATE( H_JOH( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_JOH', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_JOH = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%PSC2_WET%DoUse ) THEN
+         ALLOCATE( H_PSC2_WET( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_PSC2_WET', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_PSC2_WET = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%FRCLND%DoUse ) THEN
+         ALLOCATE( H_FRCLND( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_FRCLND', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_FRCLND = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%LAI%DoUse ) THEN
+         ALLOCATE( H_MODISLAI( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_MODISLAI', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_MODISLAI = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%CNV_FRC%DoUse ) THEN
+         ALLOCATE( H_CNV_FRC( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_CNV_FRC', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_CNV_FRC = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%TropLev%DoUse ) THEN
+         ALLOCATE( H_TropLev( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_TropLev', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_TropLev = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%TROPP%DoUse ) THEN
+         ALLOCATE( H_TROPP( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_TROPP', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_TROPP = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%FLASH_DENS%DoUse ) THEN
+         ALLOCATE( H_FLASH_DENS( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_FLASH_DENS', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_FLASH_DENS = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%CONV_DEPTH%DoUse ) THEN
+         ALLOCATE( H_CONV_DEPTH( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_CONV_DEPTH', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_CONV_DEPTH = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%DRY_TOTN%DoUse ) THEN
+         ALLOCATE( H_DRY_TOTN( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_DRY_TOTN', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_DRY_TOTN = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%WET_TOTN%DoUse ) THEN
+         ALLOCATE( H_WET_TOTN( IMh, JMh ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_WET_TOTN', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_WET_TOTN = 0.0e0_hp
+      ENDIF
+
+      ! Almost 3-D Fields
+      IF ( ExtState%SPHU%DoUse ) THEN
+         ALLOCATE( H_SPHU( IMh, JMh, 1 ), STAT=RC )         ! Only need SURFACE SPHU
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_SPHU', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_SPHU = 0.0e0_hp
+      ENDIF
+
+      ! 3-D Fields
+      IF ( ExtState%TK%DoUse ) THEN
+         ALLOCATE( H_T( IMh, JMh, LM ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_T', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_T = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%AIR%DoUse ) THEN
+         ALLOCATE( H_AD( IMh, JMh, LM ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_AD', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_AD = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%AIRVOL%DoUse ) THEN
+         ALLOCATE( H_AIRVOL( IMh, JMh, LM ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_AIRVOL', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_AIRVOL = 0.0e0_hp
+      ENDIF
+
+      IF ( ExtState%FRAC_OF_PBL%DoUse ) THEN
+         ALLOCATE( H_F_OF_PBL( IMh, JMh, LM ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_F_OF_PBL', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_F_OF_PBL = 0.0e0_hp
+      ENDIF
+
+      ! 3-D State_Chm fields
+      IF ( id_O3 > 0 ) THEN
+        ALLOCATE( H_SpcO3( IMh, JMh, LM ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_SpcO3', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_SpcO3 = 0.0e0_hp
+      ENDIF
+
+      IF ( id_NO2 > 0 ) THEN
+        ALLOCATE( H_SpcNO2( IMh, JMh, LM ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_SpcNO2', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_SpcNO2 = 0.0e0_hp
+      ENDIF
+
+      IF ( id_NO > 0 ) THEN
+        ALLOCATE( H_SpcNO( IMh, JMh, LM ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_SpcNO', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_SpcNO = 0.0e0_hp
+      ENDIF
+
+      IF ( id_HNO3 > 0 ) THEN
+        ALLOCATE( H_SpcHNO3( IMh, JMh, LM ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_SpcHNO3', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_SpcHNO3 = 0.0e0_hp
+      ENDIF
+
+      IF ( id_POPG > 0 ) THEN
+        ALLOCATE( H_SpcPOPG( IMh, JMh, LM ), STAT=RC )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:H_SpcPOPG', 0, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+         H_SpcPOPG = 0.0e0_hp
+      ENDIF
+
+    ENDIF
+#endif
+
 
     !-----------------------------------------------------------------------
     ! HCO_SZAFACT is not defined in Met_State.  Hence need to
@@ -1320,27 +1703,18 @@ CONTAINS
     !
     ! Now include HCO_FRAC_OF_PBL and HCO_PBL_MAX for POPs specialty
     ! simulation (mps, 8/20/14)
+    !
+    ! Removed HCO_FRAC_OF_PBL, can directly point to State_Met%F_OF_PBL.
+    ! Moved SUMCOSZA to State_Met%SUNCOSsum
+    ! (hplin, 6/9/20)
     ! ----------------------------------------------------------------------
     IF ( ExtState%SZAFACT%DoUse ) THEN
 
-       ALLOCATE( SUMCOSZA( State_Grid%NX, State_Grid%NY ), STAT=RC )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:SUMCOSZA', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       SUMCOSZA = 0.0_fp
-
-       ALLOCATE( HCO_SZAFACT( State_Grid%NX, State_Grid%NY ), STAT=RC )
+       ALLOCATE( HCO_SZAFACT( IM, JM ), STAT=RC )
        CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:HCO_SZAFACT', 0, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
        HCO_SZAFACT = 0e0_hp
 
-    ENDIF
-
-    IF ( ExtState%FRAC_OF_PBL%DoUse ) THEN
-       ALLOCATE( HCO_FRAC_OF_PBL( State_Grid%NX, State_Grid%NY, &
-                                  State_Grid%NZ ), STAT=RC )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:HCO_FRAC_OF_PBL', 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       HCO_FRAC_OF_PBL = 0.0_hp
     ENDIF
 
     ! Initialize max. PBL
@@ -1351,14 +1725,14 @@ CONTAINS
     ! need to compute them separately.
     ! ----------------------------------------------------------------------
     IF ( ExtState%JNO2%DoUse ) THEN
-       ALLOCATE( JNO2( State_Grid%NX, State_Grid%NY ), STAT=RC )
+       ALLOCATE( JNO2( IM, JM ), STAT=RC )
        CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:JNO2', 0, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
        JNO2 = 0.0e0_hp
     ENDIF
 
     IF ( ExtState%JOH%DoUse ) THEN
-       ALLOCATE( JOH( State_Grid%NX, State_Grid%NY ), STAT=RC )
+       ALLOCATE( JOH( IM, JM ), STAT=RC )
        CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:JOH', 0, RC )
        JOH = 0.0e0_hp
     ENDIF
@@ -1366,12 +1740,13 @@ CONTAINS
     ! ----------------------------------------------------------------------
     ! Arrays to be copied physically because HEMCO units are not the
     ! same as in GEOS-Chem
+    !
+    ! In ImGrid, they also need to be regridded on the fly.
     ! ----------------------------------------------------------------------
 
     ! TROPP: GEOS-Chem TROPP is in hPa, while HEMCO uses Pa.
     IF ( ExtState%TROPP%DoUse ) THEN
-       CALL HCO_ArrAssert( ExtState%TROPP%Arr, State_Grid%NX, State_Grid%NY, &
-                           HMRC )
+       CALL HCO_ArrAssert( ExtState%TROPP%Arr, IMh, JMh, HMRC )
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1386,8 +1761,7 @@ CONTAINS
     ! SPHU: GEOS-Chem SPHU is in g/kg, while HEMCO uses kg/kg.
     ! NOTE: HEMCO only uses SPHU surface values.
     IF ( ExtState%SPHU%DoUse ) THEN
-       CALL HCO_ArrAssert( ExtState%SPHU%Arr, State_Grid%NX, State_Grid%NY, &
-                           1, HMRC )
+       CALL HCO_ArrAssert( ExtState%SPHU%Arr, IMh, JMh, 1, HMRC )
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1401,8 +1775,7 @@ CONTAINS
 
     ! FLASH_DENS
     IF ( ExtState%FLASH_DENS%DoUse ) THEN
-       CALL HCO_ArrAssert( ExtState%FLASH_DENS%Arr, State_Grid%NX, &
-                           State_Grid%NY, HMRC )
+       CALL HCO_ArrAssert( ExtState%FLASH_DENS%Arr, IMh, JMh, HMRC )
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1416,8 +1789,7 @@ CONTAINS
 
     ! CONV_DEPTH
     IF ( ExtState%CONV_DEPTH%DoUse ) THEN
-       CALL HCO_ArrAssert( ExtState%CONV_DEPTH%Arr, State_Grid%NX, &
-                           State_Grid%NY, HMRC )
+       CALL HCO_ArrAssert( ExtState%CONV_DEPTH%Arr, IMh, JMh, HMRC )
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1432,8 +1804,7 @@ CONTAINS
     ! SUNCOS: HEMCO now calculates SUNCOS values based on its own
     ! subroutine
     IF ( ExtState%SUNCOS%DoUse ) THEN
-       CALL HCO_ArrAssert( ExtState%SUNCOS%Arr, State_Grid%NX, State_Grid%NY, &
-                           HMRC )
+       CALL HCO_ArrAssert( ExtState%SUNCOS%Arr, IMh, JMh, HMRC )
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1485,12 +1856,13 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE ExtState_SetFields( State_Chm, State_Met, HcoState, ExtState, RC )
+  SUBROUTINE ExtState_SetFields( Input_Opt, State_Chm, State_Met, HcoState, ExtState, RC )
 !
 ! !USES:
 !
     USE Hcox_State_Mod, ONLY : ExtDat_Set
     USE ErrCode_Mod
+    USE Input_Opt_Mod,  ONLY : OptInput
     USE State_Met_Mod,  ONLY : MetState
     USE State_Chm_Mod,  ONLY : ChmState
     USE Drydep_Mod,     ONLY : DryCoeff
@@ -1500,6 +1872,7 @@ CONTAINS
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
+    TYPE(OptInput),   INTENT(INOUT)  :: Input_Opt  ! Input options
     TYPE(MetState),   INTENT(INOUT)  :: State_Met  ! Met state
     TYPE(ChmState),   INTENT(INOUT)  :: State_Chm  ! Chemistry state
     TYPE(HCO_STATE),  POINTER        :: HcoState   ! HEMCO state
@@ -1541,13 +1914,31 @@ CONTAINS
     Instr    = 'THIS ERROR ORIGINATED IN HEMCO!  Please check the '       // &
                'HEMCO log file for additional error messages!'
 
+    ! If using intermediate grid (MODEL_CLASSIC and LIMGRID), then load data
+    ! from the shadow H_* arrays which have been regridded to HEMCO sizes.
+    ! The data is regridded at every call to ExtState_UpdateFields.
+    !
+    ! Otherwise, simply load as before, either from module variables or
+    ! directly from State_Met.
+    ! To avoid code duplication, in GEOS-Chem classic data is also loaded
+    ! directly from HEMCO met pointers, when possible.
+
     !-----------------------------------------------------------------------
     ! Pointers to local module arrays
     !-----------------------------------------------------------------------
 
     ! SZAFACT
-    CALL ExtDat_Set( HcoState, ExtState%SZAFACT, 'SZAFACT_FOR_EMIS', &
-                     HMRC,     FIRST,            HCO_SZAFACT )
+#if defined( MODEL_CLASSIC )
+    IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+      CALL ExtDat_Set( HcoState, ExtState%SZAFACT, 'SZAFACT_FOR_EMIS', &
+                       HMRC,     FIRST,            HCO_SZAFACT )
+#if defined( MODEL_CLASSIC )
+    ELSE
+      CALL ExtDat_Set( HcoState, ExtState%SZAFACT, 'SZAFACT_FOR_EMIS', &
+                       HMRC,     FIRST,            H_SZAFACT )
+    ENDIF
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1558,8 +1949,17 @@ CONTAINS
     ENDIF
 
     ! JNO2
-    CALL ExtDat_Set( HcoState, ExtState%JNO2, 'JNO2_FOR_EMIS', &
-                     HMRC,     FIRST,         JNO2 )
+#if defined( MODEL_CLASSIC )
+    IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+      CALL ExtDat_Set( HcoState, ExtState%JNO2, 'JNO2_FOR_EMIS', &
+                       HMRC,     FIRST,         JNO2 )
+#if defined( MODEL_CLASSIC )
+    ELSE
+      CALL ExtDat_Set( HcoState, ExtState%JNO2, 'JNO2_FOR_EMIS', &
+                       HMRC,     FIRST,         H_JNO2 )
+    ENDIF
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1570,8 +1970,17 @@ CONTAINS
     ENDIF
 
     ! JOH
-    CALL ExtDat_Set( HcoState, ExtState%JOH, 'JOH_FOR_EMIS', &
-                     HMRC,     FIRST,        JOH )
+#if defined( MODEL_CLASSIC )
+    IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+      CALL ExtDat_Set( HcoState, ExtState%JOH, 'JOH_FOR_EMIS', &
+                       HMRC,     FIRST,        JOH )
+#if defined( MODEL_CLASSIC )
+    ELSE
+      CALL ExtDat_Set( HcoState, ExtState%JOH, 'JOH_FOR_EMIS', &
+                       HMRC,     FIRST,        H_JOH )
+    ENDIF
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1581,9 +1990,241 @@ CONTAINS
        RETURN
     ENDIF
 
+    ! ----------------------------------------------------------------------
+    ! 2D fields requiring interpolation (for GC-Classic)
+    ! ----------------------------------------------------------------------
+
+    ! PSC2_WET
+    ! Computed in calc_met_mod
+    IF ( ExtState%PSC2_WET%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%PSC2_WET, 'PSC2_WET_FOR_EMIS', &
+                         HMRC,     FIRST,             State_Met%PSC2_WET )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%PSC2_WET, 'PSC2_WET_FOR_EMIS', &
+                         HMRC,     FIRST,             H_PSC2_WET )
+      ENDIF
+#endif
+    ENDIF
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( PSC2_WET_FOR_EMIS )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
+    ! FRCLND
+    ! Computed in olson_landmap_mod
+    IF ( ExtState%FRCLND%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%FRCLND, 'FRCLND_FOR_EMIS', &
+                         HMRC,     FIRST,           State_Met%FRCLND )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%FRCLND, 'FRCLND_FOR_EMIS', &
+                         HMRC,     FIRST,           H_FRCLND )
+      ENDIF
+#endif
+    ENDIF
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( FRCLND_FOR_EMIS )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
+    ! LAI
+    ! Calculated in modis_lai_mod from XLAI_NATIVE
+    IF ( ExtState%LAI%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%LAI, 'LAI_FOR_EMIS', &
+                         HMRC,     FIRST,        State_Met%MODISLAI )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%LAI, 'LAI_FOR_EMIS', &
+                         HMRC,     FIRST,        H_MODISLAI )
+      ENDIF
+#endif
+    ENDIF
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( LAI_FOR_EMIS )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
+    ! CNV_FRC Convective fractions
+    ! Apparently this is not used anywhere right now? maybe it is a GCHP thing
+    IF ( ExtState%CNV_FRC%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%CNV_FRC,  'CNV_FRC_FOR_EMIS', &
+                         HMRC,     FIRST,             State_Met%CNV_FRC,  &
+                         NotFillOk=.TRUE. )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%CNV_FRC,  'CNV_FRC_FOR_EMIS', &
+                         HMRC,     FIRST,             H_CNV_FRC,  &
+                         NotFillOk=.TRUE. )
+      ENDIF
+#endif
+    ENDIF
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( CNV_FRC_FOR_EMIS )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
+    ! Tropopause level
+    IF ( ExtState%TropLev%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%TropLev, 'TropLev', &
+                         HMRC,     FIRST,            State_Met%TropLev )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%TropLev, 'TropLev', &
+                         HMRC,     FIRST,            H_TropLev )
+      ENDIF
+#endif
+    ENDIF
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( TropLev )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
+    ! ----------------------------------------------------------------------
+    ! 3D fields requiring interpolation (for GC-Classic)
+    ! ----------------------------------------------------------------------
+
+    ! TK
+    IF ( ExtState%TK%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%TK, 'TK_FOR_EMIS', &
+                         HMRC,     FIRST,       State_Met%T )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%TK, 'TK_FOR_EMIS', &
+                         HMRC,     FIRST,       H_T )
+      ENDIF
+#endif
+    ENDIF
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( TK_FOR_EMIS )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
+    ! Air mass [kg/grid box]
+    IF ( ExtState%AIR%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%AIR, 'AIR_FOR_EMIS', &
+                         HMRC,     FIRST,        State_Met%AD )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%AIR, 'AIR_FOR_EMIS', &
+                         HMRC,     FIRST,        H_AD )
+      ENDIF
+#endif
+    ENDIF
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( AIR_FOR_EMIS )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
+    ! AIRVOL_FOR_EMIS
+    IF ( ExtState%AIRVOL%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%AIRVOL, 'AIRVOL_FOR_EMIS', &
+                         HMRC,     FIRST,           State_Met%AIRVOL )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%AIRVOL, 'AIRVOL_FOR_EMIS', &
+                         HMRC,     FIRST,           H_AIRVOL )
+      ENDIF
+#endif
+    ENDIF
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( AIRVOL_FOR_EMIS )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
+    ! Dry air density [kg/m3]
+    IF ( ExtState%AIRDEN%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%AIRDEN, 'AIRDEN', &
+                         HMRC,     FIRST,           State_Met%AIRDEN )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%AIRDEN, 'AIRDEN', &
+                         HMRC,     FIRST,           H_AIRDEN )
+      ENDIF
+#endif
+    ENDIF
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( AIRDEN )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
     ! Frac of PBL
-    CALL ExtDat_Set( HcoState, ExtState%FRAC_OF_PBL, 'FRAC_OF_PBL_FOR_EMIS', &
-                     HMRC,     FIRST,                HCO_FRAC_OF_PBL )
+    IF ( ExtState%FRAC_OF_PBL%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%FRAC_OF_PBL, 'FRAC_OF_PBL_FOR_EMIS', &
+                         HMRC,     FIRST,                State_Met%F_OF_PBL )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%FRAC_OF_PBL, 'FRAC_OF_PBL_FOR_EMIS', &
+                         HMRC,     FIRST,                H_F_OF_PBL )
+      ENDIF
+#endif
+    ENDIF
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1594,12 +2235,26 @@ CONTAINS
     ENDIF
 
     ! ----------------------------------------------------------------------
-    ! 2D fields
+    ! 2D fields directly readable from HEMCO (for GC-Classic)
+    ! 2D fields (for other models)
     ! ----------------------------------------------------------------------
 
+    ! For MODEL_CLASSIC with the optional HEMCO intermediate grid option,
+    ! the meteorological field pointers point to the HEMCO pointers directly.
+    ! This avoids an extra regridding in the GC -> HEMCO direction.
+    !
+    ! For this, simply specify the met field name directly in the FldName arg
+    ! call to ExtDat_Set. This will prompt HEMCO to call HCO_EvalFld directly
+    ! (hplin, 6/2/20)
+
     ! U10M
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%U10M, 'U10M', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%U10M, 'U10M_FOR_EMIS', &
                      HMRC,     FIRST,         State_Met%U10M )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1610,8 +2265,13 @@ CONTAINS
     ENDIF
 
     ! V10M
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%V10M, 'V10M', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%V10M, 'V10M_FOR_EMIS', &
                      HMRC,     FIRST,         State_Met%V10M )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1623,8 +2283,13 @@ CONTAINS
     ENDIF
 
     ! ALBD
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%ALBD, 'ALBEDO', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%ALBD, 'ALBD_FOR_EMIS', &
                      HMRC,     FIRST,         State_Met%ALBD )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1634,9 +2299,14 @@ CONTAINS
        RETURN
     ENDIF
 
-    ! WLI
+    ! WLI (LWI)
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%WLI, 'LWI', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%WLI, 'WLI_FOR_EMIS', &
                      HMRC,     FIRST,        State_Met%LWI )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1646,8 +2316,14 @@ CONTAINS
        RETURN
     ENDIF
 
+    ! T2M
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%T2M, 'T2M', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%T2M, 'T2M_FOR_EMIS', &
                      HMRC,     FIRST,        State_Met%TS )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1658,8 +2334,13 @@ CONTAINS
     ENDIF
 
     ! TSKIN
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%TSKIN, 'TS', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%TSKIN, 'TSKIN_FOR_EMIS', &
                      HMRC,     FIRST,          State_Met%TSKIN )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1670,8 +2351,13 @@ CONTAINS
     ENDIF
 
     ! GWETROOT
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%GWETROOT, 'GWETROOT', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%GWETROOT, 'GWETROOT_FOR_EMIS', &
                      HMRC,     FIRST,             State_Met%GWETROOT )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1682,8 +2368,13 @@ CONTAINS
     ENDIF
 
     ! GWETTOP
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%GWETTOP, 'GWETTOP', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%GWETTOP, 'GWETTOP_FOR_EMIS', &
                      HMRC,     FIRST,            State_Met%GWETTOP )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1693,8 +2384,14 @@ CONTAINS
        RETURN
     ENDIF
 
+    ! USTAR
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%USTAR, 'USTAR', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%USTAR, 'USTAR_FOR_EMIS', &
                      HMRC,     FIRST,          State_Met%USTAR )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1705,8 +2402,13 @@ CONTAINS
     ENDIF
 
     ! Z0
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%Z0, 'Z0M', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%Z0, 'Z0_FOR_EMIS', &
                      HMRC,     FIRST,       State_Met%Z0 )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1716,8 +2418,14 @@ CONTAINS
        RETURN
     ENDIF
 
+    ! PARDR
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%PARDR, 'PARDR', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%PARDR, 'PARDR_FOR_EMIS', &
                      HMRC,     FIRST,          State_Met%PARDR )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1728,8 +2436,13 @@ CONTAINS
     ENDIF
 
     ! PARDF
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%PARDF, 'PARDF', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%PARDF, 'PARDF_FOR_EMIS', &
                      HMRC, FIRST,              State_Met%PARDF )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1739,21 +2452,14 @@ CONTAINS
        RETURN
     ENDIF
 
-    ! PSC2_WET
-    CALL ExtDat_Set( HcoState, ExtState%PSC2_WET, 'PSC2_WET_FOR_EMIS', &
-                     HMRC,     FIRST,             State_Met%PSC2_WET )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "ExtDat_Set( PSC2_WET_FOR_EMIS )"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       RETURN
-    ENDIF
-
     ! RADSWG
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%RADSWG, 'SWGDN', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%RADSWG, 'RADSWG_FOR_EMIS', &
                      HMRC,     FIRST,           State_Met%SWGDN )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1763,21 +2469,14 @@ CONTAINS
        RETURN
     ENDIF
 
-    ! FRCLND
-    CALL ExtDat_Set( HcoState, ExtState%FRCLND, 'FRCLND_FOR_EMIS', &
-                     HMRC,     FIRST,           State_Met%FRCLND )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "ExtDat_Set( FRCLND_FOR_EMIS )"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       RETURN
-    ENDIF
-
     ! CLDFRC
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%CLDFRC, 'CLDTOT', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%CLDFRC, 'CLDFRC_FOR_EMIS', &
                      HMRC,     FIRST,           State_Met%CLDFRC )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1789,8 +2488,13 @@ CONTAINS
 
     ! SNOWHGT is is mm H2O, which is the same as kg H2O/m2.
     ! This is the unit of SNOMAS.
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%SNOWHGT, 'SNOMAS', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%SNOWHGT, 'SNOWHGT_FOR_EMIS', &
                      HMRC,     FIRST,            State_Met%SNOMAS )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1800,9 +2504,14 @@ CONTAINS
        RETURN
     ENDIF
 
-    ! SNOWDP is in m
+    ! SNOWDP [m]
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%SNODP, 'SNODP', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%SNODP, 'SNODP_FOR_EMIS', &
-                     HMRC,    FIRST,           State_Met%SNODP )
+                     HMRC,     FIRST,          State_Met%SNODP )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1813,8 +2522,13 @@ CONTAINS
     ENDIF
 
     ! FRLAND
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%FRLAND, 'FRLAND', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%FRLAND, 'FRLAND_FOR_EMIS', &
                      HMRC,     FIRST,           State_Met%FRLAND )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1825,8 +2539,13 @@ CONTAINS
     ENDIF
 
     ! FROCEAN
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%FROCEAN, 'FROCEAN', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%FROCEAN, 'FROCEAN_FOR_EMIS', &
                      HMRC,     FIRST,            State_Met%FROCEAN )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1837,8 +2556,13 @@ CONTAINS
     ENDIF
 
     ! FRLAKE
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%FRLAKE, 'FRLAKE', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%FRLAKE, 'FRLAKE_FOR_EMIS', &
                      HMRC,     FIRST,           State_Met%FRLAKE )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1849,8 +2573,13 @@ CONTAINS
     ENDIF
 
     ! FRLANDIC
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%FRLANDIC, 'FRLANDIC', &
+                     HMRC,     FIRST=FIRST )
+#else
     CALL ExtDat_Set( HcoState, ExtState%FRLANDIC, 'FRLANDIC_FOR_EMIS', &
                      HMRC,     FIRST,             State_Met%FRLANDIC )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1860,39 +2589,19 @@ CONTAINS
        RETURN
     ENDIF
 
-    ! LAI
-    CALL ExtDat_Set( HcoState, ExtState%LAI, 'LAI_FOR_EMIS', &
-                     HMRC,     FIRST,        State_Met%MODISLAI )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "ExtDat_Set( LAI_FOR_EMIS )"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       RETURN
-    ENDIF
-
-    ! Convective fractions
-    CALL ExtDat_Set( HcoState, ExtState%CNV_FRC,  'CNV_FRC_FOR_EMIS', &
-                     HMRC,     FIRST,             State_Met%CNV_FRC,  &
-                     NotFillOk=.TRUE. )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "ExtDat_Set( CNV_FRC_FOR_EMIS )"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       RETURN
-    ENDIF
-
     !-----------------------------------------------------------------------
     ! 3D fields
     !-----------------------------------------------------------------------
 
     ! CNV_MFC
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState,  ExtState%CNV_MFC, 'CMFMC', &
+                     HMRC,      FIRST,            OnLevEdge=.TRUE. )
+#else
     CALL ExtDat_Set( HcoState,  ExtState%CNV_MFC, 'CNV_MFC_FOR_EMIS', &
                      HMRC,      FIRST,            State_Met%CMFMC,    &
                      OnLevEdge=.TRUE. )
+#endif
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1902,72 +2611,34 @@ CONTAINS
        RETURN
     ENDIF
 
-    CALL ExtDat_Set( HcoState, ExtState%TK, 'TK_FOR_EMIS', &
-                     HMRC,     FIRST,       State_Met%T )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "ExtDat_Set( TK_FOR_EMIS )"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       RETURN
-    ENDIF
-
-    ! Air mass [kg/grid box]
-    CALL ExtDat_Set( HcoState, ExtState%AIR, 'AIR_FOR_EMIS', &
-                     HMRC,     FIRST,        State_Met%AD )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "ExtDat_Set( AIR_FOR_EMIS )"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       RETURN
-    ENDIF
-
-    ! AIRVOL_FOR_EMIS
-    CALL ExtDat_Set( HcoState, ExtState%AIRVOL, 'AIRVOL_FOR_EMIS', &
-                     HMRC,     FIRST,           State_Met%AIRVOL )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "ExtDat_Set( AIRVOL_FOR_EMIS )"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       RETURN
-    ENDIF
-
-    ! Dry air density [kg/m3]
-    CALL ExtDat_Set( HcoState, ExtState%AIRDEN, 'AIRDEN', &
-                     HMRC,     FIRST,           State_Met%AIRDEN )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "ExtDat_Set( AIRDEN )"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       RETURN
-    ENDIF
-
-    ! Tropopause level
-    CALL ExtDat_Set( HcoState, ExtState%TropLev, 'TropLev', &
-                     HMRC,     FIRST,            State_Met%TropLev )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "ExtDat_Set( TropLev )"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       RETURN
-    ENDIF
-
     ! ----------------------------------------------------------------
     ! Species concentrations
+    ! All of these require interpolation on-demand.
     ! ----------------------------------------------------------------
+
+    ! Note: ExtDat_Set points DIRECTLY to the assigned target when received
+    ! through ExtDat%Arr%Val => Trgt. This means that the array temporary
+    ! must be maintained through time in memory. It may be particularly taxing
+    ! for a GC-classic run with intermediate grid option, as all of these must
+    ! be maintained in regridded HIGH-RESOLUTION (HEMCO resolution) array
+    ! temporaries now! (hplin, 6/2/20)
+
     IF ( id_O3 > 0 ) THEN
-       Trgt3D => State_Chm%Species(:,:,:,id_O3)
-       CALL ExtDat_Set( HcoState, ExtState%O3, 'HEMCO_O3_FOR_EMIS', &
-                        HMRC,     FIRST,       Trgt3D )
+
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        Trgt3D => State_Chm%Species(:,:,:,id_O3)
+        CALL ExtDat_Set( HcoState, ExtState%O3, 'HEMCO_O3_FOR_EMIS', &
+                         HMRC,     FIRST,       Trgt3D )
+
+        Trgt3D => NULL()
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%O3, 'HEMCO_O3_FOR_EMIS', &
+                         HMRC,     FIRST,       H_SpcO3 )
+      ENDIF
+#endif
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1976,14 +2647,24 @@ CONTAINS
           CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
           RETURN
        ENDIF
-
-       Trgt3D => NULL()
     ENDIF
 
     IF ( id_NO2 > 0 ) THEN
-       Trgt3D => State_Chm%Species(:,:,:,id_NO2)
-       CALL ExtDat_Set( HcoState, ExtState%NO2, 'HEMCO_NO2_FOR_EMIS', &
-                        HMRC,     FIRST,        Trgt3D )
+
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        Trgt3D => State_Chm%Species(:,:,:,id_NO2)
+        CALL ExtDat_Set( HcoState, ExtState%NO2, 'HEMCO_NO2_FOR_EMIS', &
+                         HMRC,     FIRST,        Trgt3D )
+
+        Trgt3D => NULL()
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%NO2, 'HEMCO_NO2_FOR_EMIS', &
+                         HMRC,     FIRST,        H_SpcNO2 )
+      ENDIF
+#endif
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -1992,14 +2673,24 @@ CONTAINS
           CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
           RETURN
        ENDIF
-
-       Trgt3D => NULL()
     ENDIF
 
     IF ( id_NO > 0 ) THEN
-       Trgt3D => State_Chm%Species(:,:,:,id_NO)
-       CALL ExtDat_Set( HcoState, ExtState%NO, 'HEMCO_NO_FOR_EMIS', &
-                        HMRC,     FIRST,       Trgt3D )
+
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        Trgt3D => State_Chm%Species(:,:,:,id_NO)
+        CALL ExtDat_Set( HcoState, ExtState%NO, 'HEMCO_NO_FOR_EMIS', &
+                         HMRC,     FIRST,       Trgt3D )
+
+        Trgt3D => NULL()
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%NO, 'HEMCO_NO_FOR_EMIS', &
+                         HMRC,     FIRST,       H_SpcNO )
+      ENDIF
+#endif
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -2008,14 +2699,24 @@ CONTAINS
           CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
           RETURN
        ENDIF
-
-       Trgt3D => NULL()
     ENDIF
 
     IF ( id_HNO3 > 0 ) THEN
-       Trgt3D => State_Chm%Species(:,:,:,id_HNO3)
-       CALL ExtDat_Set( HcoState, ExtState%HNO3, 'HEMCO_HNO3_FOR_EMIS', &
-                        HMRC,     FIRST,         Trgt3D )
+
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        Trgt3D => State_Chm%Species(:,:,:,id_HNO3)
+        CALL ExtDat_Set( HcoState, ExtState%HNO3, 'HEMCO_HNO3_FOR_EMIS', &
+                         HMRC,     FIRST,         Trgt3D )
+
+        Trgt3D => NULL()
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%HNO3, 'HEMCO_HNO3_FOR_EMIS', &
+                         HMRC,     FIRST,         H_SpcHNO3 )
+      ENDIF
+#endif
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -2024,14 +2725,24 @@ CONTAINS
           CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
           RETURN
        ENDIF
-
-       Trgt3D => NULL()
     ENDIF
 
     IF ( id_POPG > 0 ) THEN
-       Trgt3D => State_Chm%Species(:,:,:,id_POPG)
-       CALL ExtDat_Set( HcoState, ExtState%POPG, 'HEMCO_POPG_FOR_EMIS', &
-                        HMRC,     FIRST,         Trgt3D )
+
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        Trgt3D => State_Chm%Species(:,:,:,id_POPG)
+        CALL ExtDat_Set( HcoState, ExtState%POPG, 'HEMCO_POPG_FOR_EMIS', &
+                         HMRC,     FIRST,         Trgt3D )
+
+        Trgt3D => NULL()
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%POPG, 'HEMCO_POPG_FOR_EMIS', &
+                         HMRC,     FIRST,         H_SpcPOPG )
+      ENDIF
+#endif
 
        ! Trap potential errors
        IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -2040,8 +2751,6 @@ CONTAINS
           CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
           RETURN
        ENDIF
-
-       Trgt3D => NULL()
     ENDIF
 
     ! ----------------------------------------------------------------------
@@ -2049,8 +2758,19 @@ CONTAINS
     ! ----------------------------------------------------------------------
 
     ! DRY_TOTN
-    CALL ExtDat_Set( HcoState, ExtState%DRY_TOTN, 'DRY_TOTN_FOR_EMIS', &
-                     HMRC,     FIRST,             State_Chm%DryDepNitrogen )
+    IF ( ExtState%DRY_TOTN%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%DRY_TOTN, 'DRY_TOTN_FOR_EMIS', &
+                         HMRC,     FIRST,             State_Chm%DryDepNitrogen )
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%DRY_TOTN, 'DRY_TOTN_FOR_EMIS', &
+                         HMRC,     FIRST,             H_DRY_TOTN )
+      ENDIF
+#endif
+    ENDIF
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -2061,8 +2781,20 @@ CONTAINS
     ENDIF
 
     ! WET_TOTN
-    CALL ExtDat_Set( HcoState, ExtState%WET_TOTN, 'WET_TOTN_FOR_EMIS', &
-                     HMRC,     FIRST,             State_Chm%WetDepNitrogen )
+    IF ( ExtState%WET_TOTN%DoUse ) THEN
+#if defined( MODEL_CLASSIC )
+      IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+        CALL ExtDat_Set( HcoState, ExtState%WET_TOTN, 'WET_TOTN_FOR_EMIS', &
+                         HMRC,     FIRST,             State_Chm%WetDepNitrogen )  
+#if defined( MODEL_CLASSIC )
+      ELSE
+        CALL ExtDat_Set( HcoState, ExtState%WET_TOTN, 'WET_TOTN_FOR_EMIS', &
+                         HMRC,     FIRST,             H_WET_TOTN )
+      ENDIF
+#endif
+    ENDIF
+
 
     ! Trap potential errors
     IF ( HMRC /= HCO_SUCCESS ) THEN
@@ -2077,6 +2809,7 @@ CONTAINS
     ! ----------------------------------------------------------------
     IF ( FIRST ) THEN
        IF ( ExtState%WET_TOTN%DoUse .OR. ExtState%DRY_TOTN%DoUse ) THEN
+          ! Polynomial coefficients for dry deposition, array target in drydep_mod
           ExtState%DRYCOEFF => DRYCOEFF
        ENDIF
 
@@ -2133,16 +2866,20 @@ CONTAINS
 !
 ! !USES:
 !
-    USE CMN_FJX_MOD,      ONLY : ZPJ
+    USE CMN_FJX_MOD,          ONLY : ZPJ
     USE ErrCode_Mod
-    USE FAST_JX_MOD,      ONLY : RXN_NO2, RXN_O3_1, RXN_O3_2a
-    USE HCO_GeoTools_Mod, ONLY : HCO_GetSUNCOS
-    USE Input_Opt_Mod,    ONLY : OptInput
-    USE State_Chm_Mod,    ONLY : ChmState
-    USE State_Grid_Mod,   ONLY : GrdState
-    USE State_Met_Mod,    ONLY : MetState
+    USE FAST_JX_MOD,          ONLY : RXN_NO2, RXN_O3_1, RXN_O3_2a
+    USE HCO_GeoTools_Mod,     ONLY : HCO_GetSUNCOS
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
 #ifdef ESMF_
-    USE HCOI_ESMF_MOD,    ONLY : HCO_SetExtState_ESMF
+    USE HCOI_ESMF_MOD,        ONLY : HCO_SetExtState_ESMF
+#endif
+#if defined( MODEL_CLASSIC )
+    USE HCO_State_GC_Mod,     ONLY : State_Grid_HCO    ! HEMCO intermediate grid
+    USE HCO_Utilities_GC_Mod, ONLY : Regrid_MDL2HCO
 #endif
 !
 ! !INPUT PARAMETERS:
@@ -2190,29 +2927,36 @@ CONTAINS
 
     !=======================================================================
     ! Update fields in the HEMCO Extension state
+    ! Directly from State_Met if not intermediate
     !=======================================================================
 
-    ! TROPP: convert from hPa to Pa
-    IF ( ExtState%TROPP%DoUse ) THEN
-       ExtState%TROPP%Arr%Val = State_Met%TROPP * 100.0_hp
-    ENDIF
+    IF ( .not. Input_Opt%LIMGRID ) THEN
 
-    ! SPHU: convert from g/kg to kg/kg. Only need surface value.
-    IF ( ExtState%SPHU%DoUse ) THEN
-       ExtState%SPHU%Arr%Val(:,:,1) = State_Met%SPHU(:,:,1) / 1000.0_hp
-    ENDIF
+      ! TROPP: convert from hPa to Pa
+      IF ( ExtState%TROPP%DoUse ) THEN
+         ExtState%TROPP%Arr%Val = State_Met%TROPP * 100.0_hp
+      ENDIF
 
-    ! FLASH_DENS: flash density [#/km2/s]
-    IF ( ExtState%FLASH_DENS%DoUse ) THEN
-       ExtState%FLASH_DENS%Arr%Val = State_Met%FLASH_DENS
-    ENDIF
+      ! SPHU: convert from g/kg to kg/kg. Only need surface value.
+      IF ( ExtState%SPHU%DoUse ) THEN
+         ExtState%SPHU%Arr%Val(:,:,1) = State_Met%SPHU(:,:,1) / 1000.0_hp
+      ENDIF
 
-    ! CONV_DEPTH: convective cloud depth [m]
-    IF ( ExtState%CONV_DEPTH%DoUse ) THEN
-       ExtState%CONV_DEPTH%Arr%Val = State_Met%CONV_DEPTH
+      ! FLASH_DENS: flash density [#/km2/s]
+      IF ( ExtState%FLASH_DENS%DoUse ) THEN
+         ExtState%FLASH_DENS%Arr%Val = State_Met%FLASH_DENS
+      ENDIF
+
+      ! CONV_DEPTH: convective cloud depth [m]
+      IF ( ExtState%CONV_DEPTH%DoUse ) THEN
+         ExtState%CONV_DEPTH%Arr%Val = State_Met%CONV_DEPTH
+      ENDIF
+
     ENDIF
 
     ! SUNCOS
+    ! Calculated by HEMCO on its own grid - simply need to allocate
+    ! at correct sizes
     IF ( ExtState%SUNCOS%DoUse ) THEN
        CALL HCO_GetSUNCOS( HcoState, ExtState%SUNCOS%Arr%Val, 0, HMRC )
 
@@ -2225,14 +2969,7 @@ CONTAINS
        ENDIF
     ENDIF
 
-    ! If we need to use the SZAFACT scale factor (i.e. to put a diurnal
-    ! variation on monthly mean OH concentrations), then call CALC_SUMCOSZA
-    ! here.  CALC_SUMCOSZA computes the sum of cosine of the solar zenith
-    ! angle over a 24 hour day, as well as the total length of daylight.
-    ! This information is required by GET_SZAFACT. (bmy, 3/11/15)
-    IF ( ExtState%SZAFACT%DoUse ) THEN
-       CALL Calc_SumCosZa( State_Grid )
-    ENDIF
+    ! Compute SZAFACT, JNO2 and JOH on MODEL GRID
 
 !$OMP PARALLEL DO                                                 &
 !$OMP DEFAULT( SHARED )                                           &
@@ -2247,11 +2984,6 @@ CONTAINS
        ! scale factor has to be imposed on monthly mean OH concentrations.)
        IF ( ExtState%SZAFACT%DoUse .AND. L==1 ) THEN
           HCO_SZAFACT(I,J) = GET_SZAFACT(I,J,State_Met)
-       ENDIF
-
-       ! Fraction of PBL for each box [unitless]
-       IF ( ExtState%FRAC_OF_PBL%DoUse ) THEN
-          HCO_FRAC_OF_PBL(I,J,L) = State_Met%F_OF_PBL(I,J,L)
        ENDIF
 
        ! Maximum extent of the PBL [model level]
@@ -2289,6 +3021,262 @@ CONTAINS
     ENDDO
 !$OMP END PARALLEL DO
 
+#if defined ( MODEL_CLASSIC )
+    IF ( Input_Opt%LIMGRID ) THEN
+    !=======================================================================
+    ! GEOS-Chem Classic HEMCO "Intermediate" Grid: Regrid appropriate met fields
+    !=======================================================================
+
+    ! Template for 3D Edge
+    ! REGR_3DI(:,:,:) = State_Met%PEDGE * 100.0_hp
+    ! CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+    !                      REGR_3DI,  REGR_3DO,   ZBND=State_Grid_HCO%NZ+1, &
+    !                      ResetRegrName=.true. )
+    ! PEDGE(:,:,:)    = REGR_3DO(:,:,:)
+
+    ! Template for 2D
+    ! REGR_3DI(:,:,1) = State_Met%PHIS(:,:)
+    ! CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+    !                      REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+    !                      ResetRegrName=.true. )
+    ! ZSFC(:,:)       = REGR_3DO(:,:,1)
+
+    !-----------------------------------------------------------------------
+    ! Local module arrays
+    !-----------------------------------------------------------------------
+
+    ! SZAFACT
+    IF ( ExtState%SZAFACT%DoUse ) THEN
+      REGR_3DI(:,:,1) = HCO_SZAFACT(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_SZAFACT(:,:)  = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! JNO2
+    IF ( ExtState%JNO2%DoUse ) THEN
+      REGR_3DI(:,:,1) = JNO2(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_JNO2(:,:)     = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! JOH
+    IF ( ExtState%JOH%DoUse ) THEN
+      REGR_3DI(:,:,1) = JOH(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_JOH(:,:)     = REGR_3DO(:,:,1)
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! 2-D State_Met
+    !-----------------------------------------------------------------------
+
+    ! PSC2_WET
+    IF ( ExtState%PSC2_WET%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Met%PSC2_WET(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_PSC2_WET(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! FRCLND
+    IF ( ExtState%FRCLND%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Met%FRCLND(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_FRCLND(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! MODISLAI
+    IF ( ExtState%LAI%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Met%MODISLAI(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_MODISLAI(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! CNV_FRC
+    IF ( ExtState%CNV_FRC%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Met%FRCLND(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_FRCLND(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! TropLev
+    IF ( ExtState%TropLev%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Met%TropLev(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_TropLev(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! TROPP - requires conversion
+    IF ( ExtState%TROPP%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Met%TROPP(:,:) * 100.0_hp    ! hPa -> Pa
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_TROPP(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! FLASH_DENS
+    IF ( ExtState%FLASH_DENS%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Met%FLASH_DENS(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_FLASH_DENS(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! CONV_DEPTH
+    IF ( ExtState%CONV_DEPTH%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Met%CONV_DEPTH(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_CONV_DEPTH(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! 3-D State_Met
+    !-----------------------------------------------------------------------
+
+    ! SPHU - 3-D up to level 1
+    IF ( ExtState%SPHU%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Met%SPHU(:,:,1) / 1000.0_hp
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_SPHU(:,:,:) = 0.0_hp
+      H_SPHU(:,:,1) = REGR_3DO(:,:,1)
+    ENDIF
+
+    ! TK/T
+    IF ( ExtState%TK%DoUse ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Met%SPHU(:,:,1:State_Grid%NZ)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_T(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    ! AIR/AD
+    IF ( ExtState%AIR%DoUse ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Met%AD(:,:,1:State_Grid%NZ)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_AD(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    ! AIRVOL
+    IF ( ExtState%AIRVOL%DoUse ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Met%AIRVOL(:,:,1:State_Grid%NZ)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_AIRVOL(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    ! AIRDEN
+    IF ( ExtState%AIRDEN%DoUse ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Met%AIRDEN(:,:,1:State_Grid%NZ)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_AIRDEN(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    ! FRAC_OF_PBL
+    IF ( ExtState%FRAC_OF_PBL%DoUse ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Met%F_OF_PBL(:,:,1:State_Grid%NZ)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_F_OF_PBL(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! 3-D State_Chm
+    !-----------------------------------------------------------------------
+
+    ! O3
+    IF ( id_O3 > 0 ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Chm%Species(:,:,1:State_Grid%NZ,id_O3)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_SpcO3(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    ! NO2
+    IF ( id_NO2 > 0 ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Chm%Species(:,:,1:State_Grid%NZ,id_NO2)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_SpcNO2(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    ! NO
+    IF ( id_NO > 0 ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Chm%Species(:,:,1:State_Grid%NZ,id_NO)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_SpcNO(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    ! HNO3
+    IF ( id_HNO3 > 0 ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Chm%Species(:,:,1:State_Grid%NZ,id_HNO3)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_SpcHNO3(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    ! POPG
+    IF ( id_POPG > 0 ) THEN
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Chm%Species(:,:,1:State_Grid%NZ,id_POPG)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid%NZ,       & ! 3D data
+                           ResetRegrName=.true. )
+      H_SpcPOPG(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+
+    ! DRY_TOTN
+    IF ( ExtState%DRY_TOTN%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Chm%DryDepNitrogen(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_DRY_TOTN(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+    IF ( ExtState%WET_TOTN%DoUse ) THEN
+      REGR_3DI(:,:,1) = State_Chm%WetDepNitrogen(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      H_WET_TOTN(:,:) = REGR_3DO(:,:,1)
+    ENDIF
+
+
+    ENDIF
+#endif
+
   END SUBROUTINE ExtState_UpdateFields
 !EOC
 !------------------------------------------------------------------------------
@@ -2304,7 +3292,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE GridEdge_Set( State_Grid, State_Met, HcoState, RC )
+  SUBROUTINE GridEdge_Set( Input_Opt, State_Grid, State_Met, HcoState, RC )
 !
 ! !USES:
 !
@@ -2314,20 +3302,26 @@ CONTAINS
     USE HCO_GeoTools_Mod, ONLY : HCO_SetPBLm
     USE State_Grid_Mod,   ONLY : GrdState
     USE State_Met_Mod,    ONLY : MetState
+    USE Input_Opt_Mod,    ONLY : OptInput
+#if defined( MODEL_CLASSIC )
+    USE HCO_State_GC_Mod, ONLY : State_Grid_HCO    ! HEMCO intermediate grid
+    USE HCO_Utilities_GC_Mod, ONLY : Regrid_MDL2HCO
+#endif
 !
 ! !INPUT PARAMETERS:
 !
+    TYPE(OptInput),   INTENT(IN   )  :: Input_Opt  ! Input options
     TYPE(GrdState),   INTENT(IN   )  :: State_Grid ! Grid state
     TYPE(MetState),   INTENT(IN   )  :: State_Met  ! Met state
     TYPE(HCO_STATE),  POINTER        :: HcoState   ! HEMCO state
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    INTEGER,          INTENT(INOUT)  :: RC          ! Success or failure?
+    INTEGER,          INTENT(INOUT)  :: RC         ! Success or failure?
 !
 ! !REMARKS:
 !  GridEdge_Set defines the HEMCO vertical grid used in GEOS-Chem "classic"
-!  simulations.  (GCHP uses its own interface to HEMCO.)
+!  and WRF-GC simulations.  (GCHP and HEMCO-CESM-GC uses their own interface to HEMCO.)
 !
 ! !REVISION HISTORY:
 !  08 Oct 2014 - C. Keller   - Initial version
@@ -2363,27 +3357,94 @@ CONTAINS
     HMRC     = HCO_SUCCESS
     ErrMsg   = ''
     ThisLoc  = &
-       ' -> at GridEdge_Set (in module GeosCore/hcoi_gc_main_mod.F90)'
+       ' -> at GridEdge_Set (in module GeosCore/hco_interface_gc_mod.F90)'
     Instr    = 'THIS ERROR ORIGINATED IN HEMCO!  Please check the '       // &
-               'HEMCO log file for additional error messages!'
+               'HEMCO log file for additional error messages!'  
 
     !-----------------------------------------------------------------------
-    ! Allocate the PEDGE array, which holds level edge pressures [Pa]
-    ! NOTE: Hco_CalcVertGrid expects pointer-based arguments, so we must
-    ! make PEDGE be a pointer and allocate/deallocate it on each call.
+    ! Allocate all arrays.
     !-----------------------------------------------------------------------
-    ALLOCATE( PEDGE( State_Grid%NX, State_Grid%NY, State_Grid%NZ+1 ), STAT=RC )
-    CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:GridEdge_Set:PEDGE', 0, RC )
-    IF ( RC /= HCO_SUCCESS ) RETURN
 
-    ! Edge and surface pressures [Pa]
-    PEDGE    =  State_Met%PEDGE * 100.0_hp  ! Convert hPa -> Pa
-    PSFC     => PEDGE(:,:,1)
+#if defined( MODEL_CLASSIC )
+    IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+      ! NOTE: Hco_CalcVertGrid expects pointer-based arguments, so we must
+      ! make PEDGE be a pointer and allocate/deallocate it on each call.
+      ALLOCATE( PEDGE( State_Grid%NX, State_Grid%NY, State_Grid%NZ+1 ), STAT=RC )
+      CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:PEDGE', 0, RC )
+      IF ( RC /= HCO_SUCCESS ) RETURN
 
-    ! Point to other fields of State_Met
-    ZSFC     => State_Met%PHIS
-    BXHEIGHT => State_Met%BXHEIGHT
-    TK       => State_Met%T
+      ! Edge and surface pressures [Pa]
+      PEDGE    =  State_Met%PEDGE * 100.0_hp  ! Convert hPa -> Pa
+      PSFC     => PEDGE(:,:,1)
+
+      ! Point to other fields of State_Met
+      ZSFC     => State_Met%PHIS
+      BXHEIGHT => State_Met%BXHEIGHT
+      TK       => State_Met%T
+
+      ALLOCATE( PBLM( State_Grid%NX, State_Grid%NY ), STAT=RC )
+      CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:PBLM', 0, RC )
+      IF ( RC /= HCO_SUCCESS ) RETURN
+#if defined( MODEL_CLASSIC )
+    ELSE
+      ! If intermediate grid, allocate and manually regrid meteorological fields.
+      ALLOCATE( PEDGE( State_Grid_HCO%NX, State_Grid_HCO%NY, State_Grid_HCO%NZ+1 ), STAT=RC )
+      CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:IMG_PEDGE', 0, RC )
+      IF ( RC /= HCO_SUCCESS ) RETURN
+
+      ALLOCATE( ZSFC( State_Grid_HCO%NX, State_Grid_HCO%NY ), STAT=RC )
+      CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:IMG_PHIS', 0, RC )
+      IF ( RC /= HCO_SUCCESS ) RETURN
+
+      ALLOCATE( BXHEIGHT( State_Grid_HCO%NX, State_Grid_HCO%NY, State_Grid_HCO%NZ ), STAT=RC )
+      CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:IMG_BXHEIGHT', 0, RC )
+      IF ( RC /= HCO_SUCCESS ) RETURN
+
+      ALLOCATE( TK( State_Grid_HCO%NX, State_Grid_HCO%NY, State_Grid_HCO%NZ ), STAT=RC )
+      CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:IMG_TK', 0, RC )
+      IF ( RC /= HCO_SUCCESS ) RETURN
+
+      ALLOCATE( PBLM( State_Grid_HCO%NX, State_Grid_HCO%NY ), STAT=RC )
+      CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:IMG_PBLM', 0, RC )
+      IF ( RC /= HCO_SUCCESS ) RETURN
+
+      ! Fill and respectively regrid to targets.
+      ! IO, SG, SGH, PtrIn, PtrOut, ZBND, ResetRegrName=.true.
+
+      ! Edge pressures [Pa] (hPa->Pa convert)
+      REGR_3DI(:,:,:) = State_Met%PEDGE * 100.0_hp
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid_HCO%NZ+1, &
+                           ResetRegrName=.true. )
+      PEDGE(:,:,:)    = REGR_3DO(:,:,:)
+
+      ! Surface pressure
+      PSFC            => PEDGE(:,:,1)
+
+      ! ZSFC
+      REGR_3DI(:,:,1) = State_Met%PHIS(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      ZSFC(:,:)       = REGR_3DO(:,:,1)
+
+      ! BXHEIGHT
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Met%BXHEIGHT(:,:,1:State_Grid%NZ)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid_HCO%NZ,   & ! 2D data
+                           ResetRegrName=.true. )
+      BXHEIGHT(:,:,1:State_Grid%NZ) = REGR_3DO(:,:,1:State_Grid%NZ)
+
+      ! TK
+      REGR_3DI(:,:,1:State_Grid%NZ) = State_Met%T(:,:,1:State_Grid%NZ)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=State_Grid_HCO%NZ,   & ! 2D data
+                           ResetRegrName=.true. )
+      TK(:,:,1:State_Grid%NZ)       = REGR_3DO(:,:,1:State_Grid%NZ)
+    ENDIF
+#endif
+    
 
     !-----------------------------------------------------------------------
     ! Calculate vertical grid properties
@@ -2401,19 +3462,29 @@ CONTAINS
     !-----------------------------------------------------------------------
     ! Set PBL heights
     !-----------------------------------------------------------------------
-    ALLOCATE( PBLM( State_Grid%NX, State_Grid%NY ), STAT=RC )
-    CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:GridEdge_Set:PBLM', 0, RC )
-    IF ( RC /= HCO_SUCCESS ) RETURN
-
+#if defined( MODEL_CLASSIC )
+    IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
 !$OMP PARALLEL DO                                                 &
 !$OMP DEFAULT( SHARED )                                           &
 !$OMP PRIVATE( I, J )
-    DO J=1,State_Grid%NY
-    DO I=1,State_Grid%NX
-       PBLM(I,J) = State_Met%PBL_TOP_m(I,J)
-    ENDDO
-    ENDDO
+      DO J=1,State_Grid%NY
+      DO I=1,State_Grid%NX
+         PBLM(I,J) = State_Met%PBL_TOP_m(I,J)
+      ENDDO
+      ENDDO
 !$OMP END PARALLEL DO
+#if defined( MODEL_CLASSIC )
+    ELSE
+      ! Intermediate grid
+      ! PBLM
+      REGR_3DI(:,:,1) = State_Met%PBL_TOP_m(:,:)
+      CALL Regrid_MDL2HCO( Input_Opt, State_Grid, State_Grid_HCO,           &
+                           REGR_3DI,  REGR_3DO,   ZBND=1,                   & ! 2D data
+                           ResetRegrName=.true. )
+      PBLM(:,:)       = REGR_3DO(:,:,1)
+    ENDIF
+#endif
 
     ! Use the met field PBL field to initialize HEMCO
     CALL HCO_SetPBLm( HcoState, FldName='PBL_HEIGHT', &
@@ -2434,24 +3505,63 @@ CONTAINS
     ! Deallocate and PEDGE
     IF ( ASSOCIATED( PEDGE ) ) THEN
        DEALLOCATE( PEDGE, STAT=RC )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:GridEdge_Set:PEDGE', 2, RC )
+       CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:PEDGE', 2, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
     ENDIF
 
     ! Deallocate PBLM
     IF ( ASSOCIATED( PBLM ) ) THEN
        DEALLOCATE( PBLM  )
-       CALL GC_CheckVar( 'hcoi_gc_main_mod.F90:GridEdge_Set:PBLM', 2, RC )
+       CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:PBLM', 2, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
     ENDIF
 
-    ! Free pointers
-    ZSFC     => NULL()
-    BXHEIGHT => NULL()
-    TK       => NULL()
-    PSFC     => NULL()
-    PEDGE    => NULL()
-    PBLM     => NULL()
+#if defined( MODEL_CLASSIC )
+    IF ( .not. Input_Opt%LIMGRID ) THEN
+#endif
+      ! Free pointers
+      ZSFC     => NULL()
+      BXHEIGHT => NULL()
+      TK       => NULL()
+      PSFC     => NULL()
+      PEDGE    => NULL()
+      PBLM     => NULL()
+#if defined( MODEL_CLASSIC )
+    ELSE
+      ! Deallocate arrays
+      IF ( ASSOCIATED( ZSFC ) ) THEN
+         DEALLOCATE( ZSFC  )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:ZSFC', 2, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+      ENDIF
+
+      IF ( ASSOCIATED( BXHEIGHT ) ) THEN
+         DEALLOCATE( BXHEIGHT  )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:BXHEIGHT', 2, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+      ENDIF
+
+      IF ( ASSOCIATED( TK ) ) THEN
+         DEALLOCATE( TK  )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:TK', 2, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+      ENDIF
+
+      PSFC     => NULL()
+
+      IF ( ASSOCIATED( PEDGE ) ) THEN
+         DEALLOCATE( PEDGE  )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:PEDGE', 2, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+      ENDIF
+
+      IF ( ASSOCIATED( PBLM ) ) THEN
+         DEALLOCATE( PBLM  )
+         CALL GC_CheckVar( 'hco_interface_gc_mod.F90:GridEdge_Set:PBLM', 2, RC )
+         IF ( RC /= GC_SUCCESS ) RETURN
+      ENDIF
+    ENDIF
+#endif
 
   END SUBROUTINE GridEdge_Set
 !EOC
@@ -3220,10 +4330,10 @@ CONTAINS
 
     ! Test for sunlight...
     IF ( State_Met%SUNCOS(I,J) > 0e+0_fp  .AND. &
-         SUMCOSZA(I,J)         > 0e+0_fp ) THEN
+         State_Met%SUNCOSsum(I,J) > 0e+0_fp ) THEN
 
        ! Impose a diurnal variation on OH during the day
-       FACT = ( State_Met%SUNCOS(I,J) / SUMCOSZA(I,J) ) &
+       FACT = ( State_Met%SUNCOS(I,J) / State_Met%SUNCOSsum(I,J) ) &
               * ( 86400e+0_fp / GET_TS_CHEM() )
 
     ELSE
@@ -3235,34 +4345,52 @@ CONTAINS
 
   END FUNCTION Get_SzaFact
 !EOC
+#if defined ( MODEL_CLASSIC )
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
 !------------------------------------------------------------------------------
 !BOP
 !
-! !IROUTINE: calc_sumcosza
+! !IROUTINE: get_met_fields
 !
-! !DESCRIPTION:
-!  Subroutine CALC\_SUMCOSZA computes the sum of cosine of the solar zenith
-!  angle over a 24 hour day, as well as the total length of daylight.
+! !DESCRIPTION: Subroutine GET\_MET\_FIELDS calls the various routines to get
+! met fields from HEMCO.
 !\\
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Calc_SumCosZa( State_Grid )
+ SUBROUTINE Get_Met_Fields( Input_Opt, State_Chm, State_Grid, &
+                            State_Met, Phase, RC )
 !
-! !USES:
+! ! USES:
 !
-    USE PhysConstants
-    USE State_Grid_Mod, ONLY : GrdState
-    USE TIME_MOD,       ONLY : GET_NHMSb,   GET_ELAPSED_SEC
-    USE TIME_MOD,       ONLY : GET_TS_CHEM, GET_DAY_OF_YEAR, GET_GMT
+   USE Calc_Met_Mod
+   USE ErrCode_Mod
+   USE FlexGrid_Read_Mod 
+   USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetPtr
+   USE Input_Opt_Mod,        ONLY : OptInput
+   USE Pressure_Mod,         ONLY : Set_Floating_Pressures
+   USE State_Chm_Mod,        ONLY : ChmState
+   USE State_Grid_Mod,       ONLY : GrdState
+   USE State_Met_Mod,        ONLY : MetState
+   USE Time_Mod
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(GrdState), INTENT(IN) :: State_Grid  ! Grid State object
+   TYPE(OptInput),   INTENT(IN   )          :: Input_Opt  ! Input options
+   TYPE(GrdState),   INTENT(IN   )          :: State_Grid ! Grid State
+   INTEGER,          INTENT(IN   )          :: Phase      ! Run phase
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+   TYPE(MetState),   INTENT(INOUT)          :: State_Met  ! Meteorology State
+   TYPE(ChmState),   INTENT(INOUT)          :: State_Chm  ! Chemistry State
+   INTEGER,          INTENT(INOUT)          :: RC         ! Failure or success
+!
+! !REMARKS:
 !
 ! !REVISION HISTORY:
+!  07 Feb 2012 - R. Yantosca - Initial version
 !  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
@@ -3270,108 +4398,236 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER, SAVE :: SAVEDOY = -1
-    INTEGER       :: I, J, L, N, NT, NDYSTEP
-    REAL(fp)      :: A0, A1, A2, A3, B1, B2, B3
-    REAL(fp)      :: LHR0, R, AHR, DEC, TIMLOC, YMID_R
-    REAL(fp)      :: SUNTMP(State_Grid%NX,State_Grid%NY)
+   INTEGER              :: N_DYN              ! Dynamic timestep in seconds
+   INTEGER              :: D(2)               ! Variable for date and time
+   LOGICAL              :: FOUND              ! Found in restart file?
+   LOGICAL              :: Update_MR          ! Update species mixing ratio?
+   CHARACTER(LEN=255)   :: v_name             ! Variable name
 
-    !=======================================================================
-    ! CALC_SUMCOSZA begins here!
-    !=======================================================================
+   ! Pointers
+   REAL*4,  POINTER     :: Ptr2D(:,:)
+   REAL*4,  POINTER     :: Ptr3D(:,:,:)
 
-    !  Solar declination angle (low precision formula, good enough for us):
-    A0 = 0.006918
-    A1 = 0.399912
-    A2 = 0.006758
-    A3 = 0.002697
-    B1 = 0.070257
-    B2 = 0.000907
-    B3 = 0.000148
-    R  = 2.* PI * float( GET_DAY_OF_YEAR() - 1 ) / 365.
+   !=================================================================
+   !    *****  R E A D   M E T   F I E L D S    *****
+   !    *****  At the start of the GEOS-Chem simulation  *****
+   !=================================================================
 
-    DEC = A0 - A1*cos(  R) + B1*sin(  R) &
-             - A2*cos(2*R) + B2*sin(2*R) &
-             - A3*cos(3*R) + B3*sin(3*R)
+   ! Assume success
+   RC        = GC_SUCCESS
 
-    LHR0 = int(float( GET_NHMSb() )/10000.)
+   ! Initialize pointers
+   Ptr2D       => NULL()
+   Ptr3D       => NULL()
 
-    ! Only do the following at the start of a new day
-    IF ( SAVEDOY /= GET_DAY_OF_YEAR() ) THEN
+   !----------------------------------
+   ! Read time-invariant data (Phase 0 only)
+   !----------------------------------
+   IF ( PHASE == 0 ) THEN
+      CALL FlexGrid_Read_CN( Input_Opt, State_Grid, State_Met )
+   ENDIF
 
-       ! Zero arrays
-       SUMCOSZA(:,:) = 0e+0_fp
+   !----------------------------------
+   ! Read 1-hr time-averaged data
+   !----------------------------------
+   IF ( PHASE == 0 ) THEN
+      D = GET_FIRST_A1_TIME()
+   ELSE
+      D = GET_A1_TIME()
+   ENDIF
+   IF ( PHASE == 0 .or. ITS_TIME_FOR_A1() .and. &
+        .not. ITS_TIME_FOR_EXIT() ) THEN
+      CALL FlexGrid_Read_A1( D(1), D(2), Input_Opt, State_Grid, State_Met )
+   ENDIF
 
-       ! NDYSTEP is # of chemistry time steps in this day
-       NDYSTEP = ( 24 - INT( GET_GMT() ) ) * 3600 / GET_TS_CHEM()
+   !----------------------------------
+   ! Read 3-hr time averaged data
+   !----------------------------------
+   IF ( PHASE == 0 ) THEN
+      D = GET_FIRST_A3_TIME()
+   ELSE
+      D = GET_A3_TIME()
+   ENDIF
+   IF ( PHASE == 0 .or. ITS_TIME_FOR_A3() .and. &
+        .not. ITS_TIME_FOR_EXIT() ) THEN
+      CALL FlexGrid_Read_A3( D(1), D(2), Input_Opt, State_Grid, State_Met )
+   ENDIF
 
-       ! NT is the elapsed time [s] since the beginning of the run
-       NT = GET_ELAPSED_SEC()
+   !----------------------------------
+   ! Read 3-hr instantanous data
+   !----------------------------------
+   IF ( PHASE == 0 ) THEN
+      D = GET_FIRST_I3_TIME()
+      CALL FlexGrid_Read_I3_1( D(1), D(2), Input_Opt, State_Grid, State_Met )
 
-       ! Loop forward through NDYSTEP "fake" timesteps for this day
-       DO N = 1, NDYSTEP
+      ! On first call, attempt to get instantaneous met fields for prior
+      ! timestep from the GEOS-Chem restart file. Otherwise, initialize
+      ! to met fields for this timestep.
 
-          ! Zero SUNTMP array
-          SUNTMP = 0e+0_fp
+      !-------------
+      ! TMPU
+      !-------------
 
-          ! Loop over surface grid boxes
-!!$OMP PARALLEL DO
-!!$OMP DEFAULT( SHARED )
-!!$OMP PRIVATE( I, J, YMID_R, TIMLOC, AHR )
-          DO J = 1, State_Grid%NY
-          DO I = 1, State_Grid%NX
+      ! Define variable name
+      v_name = 'TMPU1'
 
-             ! Grid box latitude center [radians]
-             YMID_R = State_Grid%YMid_R(I,J)
+      ! Get variable from HEMCO and store in local array
+      CALL HCO_GC_GetPtr( Input_Opt, State_Grid, TRIM(v_name), Ptr3D, RC, FOUND=FOUND )
 
-             TIMLOC = real(LHR0) + real(NT)/3600.0 + &
-                      State_Grid%XMid(I,J) / 15.0
+      ! Check if variable is in file
+      IF ( FOUND ) THEN
+         State_Met%TMPU1 = Ptr3D
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'Initialize TMPU1    from restart file'
+         ENDIF
+      ELSE
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'TMPU1    not found in restart, keep as value at t=0'
+         ENDIF
+      ENDIF
 
-             DO WHILE (TIMLOC .lt. 0)
-                TIMLOC = TIMLOC + 24.0
-             ENDDO
+      ! Nullify pointer
+      Ptr3D => NULL()
 
-             DO WHILE (TIMLOC .gt. 24.0)
-                TIMLOC = TIMLOC - 24.0
-             ENDDO
+      !-------------
+      ! SPHU
+      !-------------
 
-             AHR = abs(TIMLOC - 12.) * 15.0 * PI_180
+      ! Define variable name
+      v_name = 'SPHU1'
 
-             !===========================================================
-             ! The cosine of the solar zenith angle (SZA) is given by:
-             !
-             !  cos(SZA) = sin(LAT)*sin(DEC) + cos(LAT)*cos(DEC)*cos(AHR)
-             !
-             ! where LAT = the latitude angle,
-             !       DEC = the solar declination angle,
-             !       AHR = the hour angle, all in radians.
-             !
-             ! If SUNCOS < 0, then the sun is below the horizon, and
-             ! therefore does not contribute to any solar heating.
-             !===========================================================
+      ! Get variable from HEMCO and store in local array
+      CALL HCO_GC_GetPtr( Input_Opt, State_Grid, TRIM(v_name), Ptr3D, RC, FOUND=FOUND )
 
-             ! Compute Cos(SZA)
-             SUNTMP(I,J) = sin(YMID_R) * sin(DEC) +          &
-                           cos(YMID_R) * cos(DEC) * cos(AHR)
+      ! Check if variable is in file
+      IF ( FOUND ) THEN
+         State_Met%SPHU1 = Ptr3D
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'Initialize SPHU1    from restart file'
+         ENDIF
+      ELSE
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'SPHU1    not found in restart, keep as value at t=0'
+         ENDIF
+      ENDIF
 
-             ! SUMCOSZA is the sum of SUNTMP at location (I,J)
-             ! Do not include negative values of SUNTMP
-             SUMCOSZA(I,J) = SUMCOSZA(I,J) +             &
-                             MAX(SUNTMP(I,J),0e+0_fp)
+      ! Nullify pointer
+      Ptr3D => NULL()
 
-          ENDDO
-          ENDDO
-!!$OMP END PARALLEL DO
+      !-------------
+      ! PS1_WET
+      !-------------
 
-          ! Increment elapsed time [sec]
-          NT = NT + GET_TS_CHEM()
-       ENDDO
+      ! Define variable name
+      v_name = 'PS1WET'
 
-       ! Set saved day of year to current day of year
-       SAVEDOY = GET_DAY_OF_YEAR()
+      ! Get variable from HEMCO and store in local array
+      CALL HCO_GC_GetPtr( Input_Opt, State_Grid, TRIM(v_name), Ptr2D, RC, FOUND=FOUND )
 
-    ENDIF
+      ! Check if variable is in file
+      IF ( FOUND ) THEN
+         State_Met%PS1_WET = Ptr2D
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'Initialize PS1_WET  from restart file'
+         ENDIF
+      ELSE
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'PS1_WET  not found in restart, keep as value at t=0'
+         ENDIF
+      ENDIF
 
-  END SUBROUTINE Calc_SumCosZa
+      ! Nullify pointer
+      Ptr2D => NULL()
+
+      !-------------
+      ! PS1_DRY
+      !-------------
+
+      ! Define variable name
+      v_name = 'PS1DRY'
+
+      ! Get variable from HEMCO and store in local array
+      CALL HCO_GC_GetPtr( Input_Opt, State_Grid, TRIM(v_name), Ptr2D, RC, FOUND=FOUND )
+
+      ! Check if variable is in file
+      IF ( FOUND ) THEN
+         State_Met%PS1_DRY = Ptr2D
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'Initialize PS1_DRY  from restart file'
+         ENDIF
+      ELSE
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'PS1_DRY  not found in restart, keep as value at t=0'
+         ENDIF
+      ENDIF
+
+      ! Nullify pointer
+      Ptr2D => NULL()
+
+      !-------------
+      ! DELP_DRY
+      !-------------
+
+      ! Define variable name
+      v_name = 'DELPDRY'
+
+      ! Get variable from HEMCO and store in local array
+      CALL HCO_GC_GetPtr( Input_Opt, State_Grid, TRIM(v_name), Ptr3D, RC, FOUND=FOUND )
+
+      ! Check if variable is in file
+      IF ( FOUND ) THEN
+         State_Met%DELP_DRY = Ptr3D
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'Initialize DELP_DRY from restart file'
+         ENDIF
+      ELSE
+         IF ( Input_Opt%amIRoot ) THEN
+            WRITE(6,*) 'DELP_DRY not found in restart, set to zero'
+         ENDIF
+      ENDIF
+
+      ! Nullify pointer
+      Ptr3D => NULL()
+
+      ! Set dry surface pressure (PS1_DRY) from State_Met%PS1_WET
+      ! and compute avg dry pressure near polar caps
+      CALL Set_Dry_Surface_Pressure( State_Grid, State_Met, 1 )
+      CALL AvgPole( State_Grid, State_Met%PS1_DRY )
+
+      ! Compute avg moist pressure near polar caps
+      CALL AvgPole( State_Grid, State_Met%PS1_WET )
+
+      ! Initialize surface pressures prior to interpolation
+      ! to allow initialization of floating pressures
+      State_Met%PSC2_WET = State_Met%PS1_WET
+      State_Met%PSC2_DRY = State_Met%PS1_DRY
+      CALL Set_Floating_Pressures( State_Grid, State_Met, RC )
+
+      ! Call AIRQNT to compute initial air mass quantities
+      ! Do not update initial tracer concentrations since not read
+      ! from restart file yet (ewl, 10/28/15)
+      CALL AirQnt( Input_Opt, State_Chm, State_Grid, State_Met, &
+                   RC, update_mixing_ratio=.FALSE. )
+
+   ENDIF
+
+   ! Read in I3 fields at t+3hours for this timestep
+   IF ( ITS_TIME_FOR_I3() .and. .not. ITS_TIME_FOR_EXIT() ) THEN
+
+      D = GET_I3_TIME()
+      CALL FlexGrid_Read_I3_2( D(1), D(2), Input_Opt, State_Grid, State_Met )
+      
+      ! Set dry surface pressure (PS2_DRY) from State_Met%PS2_WET
+      ! and compute avg dry pressure near polar caps
+      CALL Set_Dry_Surface_Pressure( State_Grid, State_Met, 2 )
+      CALL AvgPole( State_Grid, State_Met%PS2_DRY )
+
+      ! Compute avg moist pressure near polar caps
+      CALL AvgPole( State_Grid, State_Met%PS2_WET )
+
+   ENDIF
+
+ END SUBROUTINE Get_Met_Fields
 !EOC
+#endif
 END MODULE Hco_Interface_GC_Mod

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -4627,6 +4627,7 @@ CONTAINS
     USE Get_Ndep_Mod,         ONLY : Soil_Drydep
     USE Global_CH4_Mod,       ONLY : CH4_Emis
     USE HCO_Utilities_GC_Mod, ONLY : GetHcoValEmis, GetHcoValDep, InquireHco
+    USE HCO_Utilities_GC_Mod, ONLY : LoadHcoValEmis, LoadHcoValDep
     USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetDiagn
     USE HCO_State_GC_Mod,     ONLY : ExtState
     USE HCO_State_GC_Mod,     ONLY : HcoState   
@@ -4821,6 +4822,17 @@ CONTAINS
 
       ! Check if there is emissions or deposition for this species
       CALL InquireHco ( N, Emis=EmisSpec, Dep=DepSpec )
+
+      ! If there is emissions for this species, it must be loaded into memory first.
+      ! This is achieved by attempting to retrieve a grid box while NOT in a parallel
+      ! loop. Failure to load this will result in severe performance issues!! (hplin, 9/27/20)
+      IF ( EmisSpec ) THEN
+          CALL LoadHcoValEmis ( Input_Opt, State_Grid, NA )
+      ENDIF
+
+      IF ( DepSpec ) THEN
+          CALL LoadHcoValDep ( Input_Opt, State_Grid, NA )
+      ENDIF
 
       !$OMP PARALLEL DO                                                        &
       !$OMP DEFAULT( SHARED )                                                  &

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -49,6 +49,8 @@ MODULE HCO_Interface_GC_Mod
   PUBLIC  :: HCOI_GC_Run
   PUBLIC  :: HCOI_GC_Final
   PUBLIC  :: HCOI_GC_WriteDiagn
+
+  PUBLIC  :: Compute_Sflx_For_Vdiff
 !
 ! !PRIVATE MEMBER FUNCTIONS:
 !
@@ -93,11 +95,11 @@ MODULE HCO_Interface_GC_Mod
 
   ! Internal met fields (will be used by some extensions)
   INTEGER,  TARGET    :: HCO_PBL_MAX                      ! level
-  REAL(hp), POINTER, PUBLIC   :: HCO_SZAFACT(:,:)
+  REAL(hp), POINTER   :: HCO_SZAFACT(:,:)
 
   ! Arrays to store J-values (used by Paranox extension)
-  REAL(hp), POINTER, PUBLIC   :: JNO2(:,:)
-  REAL(hp), POINTER, PUBLIC   :: JOH(:,:)
+  REAL(hp), POINTER   :: JNO2(:,:)
+  REAL(hp), POINTER   :: JOH(:,:)
 
 #if defined( MODEL_CLASSIC )
 
@@ -225,8 +227,7 @@ CONTAINS
 #ifdef MODEL_CLASSIC
     ! HEMCO Intermediate Grid specification
     USE HCO_State_GC_Mod,   ONLY : State_Grid_HCO
-    USE GC_Grid_Mod,        ONLY : Compute_Grid
-    USE State_Grid_Mod,     ONLY : Allocate_State_Grid
+    USE GC_Grid_Mod,        ONLY : Compute_Scaled_Grid
 #endif
 
 !
@@ -289,63 +290,30 @@ CONTAINS
     ! To disable the HEMCO intermediate grid feature, simply set this DY, DX to
     ! equal to State_Grid%DY, State_Grid%DX (e.g. 2x2.5, 4x5, ...)
     !
-    ! TODO: Read in the grid parameters via input.geos. For now, hardcode the DY and DX
-    ! as 1.0x1.0 degree.
-    ! State_Grid_HCO%DY = 1.0_fp
-    ! State_Grid_HCO%DX = 1.0_fp
+    ! TODO: Read in the grid parameters via input.geos. For now, hardcode the scale factor.
+    Input_Opt%IMGRID_XSCALE = 1
+    Input_Opt%IMGRID_YSCALE = 1
 
     ! To test GC-Classic WITHOUT intermediate grid
-    State_Grid_HCO%DY = State_Grid%DY
-    State_Grid_HCO%DX = State_Grid%DX
+    ! Input_Opt%IMGRID_SCALE = 1
 
     ! Are we using HEMCO intermediate grid implementation?
     ! Note: The mere presence of State_Grid_HCO does not mean
     ! that the intermediate grid is necessarily different. 
     ! The code path is decided if the intermediate is actually a different grid.
-    IF ( State_Grid_HCO%DX .ne. State_Grid%DX .or. &
-         State_Grid_HCO%DY .ne. State_Grid%DY ) THEN
+    IF ( Input_Opt%IMGRID_XSCALE .ne. 1 .or. Input_Opt%IMGRID_XSCALE .ne. 1 ) THEN 
+      ! Force .or. .true. to waste CPU cycles in regridding and debug Map_A2A above
       Input_Opt%LIMGRID = .true.
 
-      write(State_Grid_HCO%GridRes, '(f10.4,a,f10.4)') State_Grid_HCO%DX, "x", State_Grid_HCO%DY
-    
       ! In intermediate grid implementation
-      ! Compute the grid parameters exactly like GEOS-Chem model grid. Copy params over.
-      State_Grid_HCO%HalfPolar  = State_Grid%HalfPolar
-      State_Grid_HCO%NestedGrid = State_Grid%NestedGrid
-      State_Grid_HCO%XMin = State_Grid%XMin
-      State_Grid_HCO%XMax = State_Grid%XMax
-
-      ! Compute the new NX
-      State_Grid_HCO%NX   = FLOOR((State_Grid_HCO%XMax - State_Grid_HCO%XMin) / State_Grid_HCO%DX)
-      IF( State_Grid_HCO%NestedGrid ) THEN
-         State_Grid_HCO%NX = State_Grid_HCO%NX + 1
-         State_Grid_HCO%HalfPolar = .false.
-      ENDIF
-
-      State_Grid_HCO%YMin = State_Grid%YMin
-      State_Grid_HCO%YMax = State_Grid%YMax
-
-      ! Compute the new NY
-      State_Grid_HCO%NY   = FLOOR((State_Grid_HCO%YMax - State_Grid_HCO%YMin) / State_Grid_HCO%DY) + 1
-
-      ! The intermediate grid has the same vertical discretization as the model grid.
-      State_Grid_HCO%NZ   = State_Grid%NZ
-
-      ! Allocate State_Grid_HCO arrays
-      CALL Allocate_State_Grid( Input_Opt, State_Grid_HCO, RC )
-      IF ( RC /= GC_SUCCESS ) THEN
-         ErrMsg = 'Error encountered in "Allocate_State_Grid"!'
-         CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-      ENDIF
-
-      ! Reuse GC_Grid_Mod to compute the grid information
-      ! This will output the grid information too.
       WRITE(6, *) "HEMCO INTERMEDIATE GRID:"
-      CALL Compute_Grid ( Input_Opt, State_Grid_HCO, RC )
+      CALL Compute_Scaled_Grid ( Input_Opt, State_Grid, State_Grid_HCO, Input_Opt%IMGRID_XSCALE, Input_Opt%IMGRID_YSCALE, RC )
       IF ( RC /= GC_SUCCESS ) THEN
-         ErrMsg = 'Error encountered in "Compute_Grid"!'
+         ErrMsg = 'Error encountered in "Compute_Scaled_Grid"!'
          CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
       ENDIF
+
+      write(State_Grid_HCO%GridRes, '(f10.4,a,f10.4)') State_Grid_HCO%DX, "x", State_Grid_HCO%DY
 
       ! Initialize module temporaries for regridding
       ALLOCATE( REGR_3DI( State_Grid%NX, State_Grid%NY, State_Grid%NZ+1 ), STAT=RC )
@@ -1513,7 +1481,6 @@ CONTAINS
       JMh  = State_Grid_HCO%NY
     ENDIF
 
-    
     !-----------------------------------------------------------------------
     ! Notes for HEMCO Intermediate Grid:
     ! Due to the extensions requiring met fields and some of them are derived
@@ -4630,4 +4597,537 @@ CONTAINS
  END SUBROUTINE Get_Met_Fields
 !EOC
 #endif
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: HCOI_Compute_Sflx_for_Vdiff
+!
+! !DESCRIPTION: Computes the surface flux (\= emissions - drydep) for the
+!  non-local PBL mixing.  This code was removed from within the non-local
+!  PBL mixing driver routine VDIFFDR.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE Compute_Sflx_for_Vdiff( Input_Opt,  State_Chm, State_Diag,      &
+                                     State_Grid, State_Met, RC              )
+!
+! ! USES:
+!
+    USE Depo_Mercury_Mod,     ONLY : Add_Hg2_DD
+    USE Depo_Mercury_Mod,     ONLY : Add_HgP_DD
+    USE Depo_Mercury_Mod,     ONLY : Add_Hg2_SnowPack
+    USE ErrCode_Mod
+    USE Get_Ndep_Mod,         ONLY : Soil_Drydep
+    USE Global_CH4_Mod,       ONLY : CH4_Emis
+    USE HCO_Interface_Common, ONLY : GetHcoDiagn
+    USE HCO_Utilities_GC_Mod, ONLY : GetHcoValEmis, GetHcoValDep
+    USE HCO_EmisList_Mod,     ONLY : HCO_GetPtr
+    USE HCO_State_GC_Mod,     ONLY : ExtState
+    USE HCO_State_GC_Mod,     ONLY : HcoState   
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE Mercury_Mod,          ONLY : HG_Emis
+    USE PhysConstants
+    USE Species_Mod,          ONLY : Species
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Chm_Mod,        ONLY : Ind_
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
+    USE Time_Mod,             ONLY : Get_Ts_Conv
+    USE Time_Mod,             ONLY : Get_Ts_Emis
+    USE UnitConv_Mod,         ONLY : Convert_Spc_Units
+!
+! !INPUT PARAMETERS:
+!
+    TYPE(OptInput),   INTENT(IN)    :: Input_Opt   ! Input options
+    TYPE(GrdState),   INTENT(IN)    :: State_Grid  ! Grid State
+    TYPE(MetState),   INTENT(IN)    :: State_Met   ! Meteorology State
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(ChmState),   INTENT(INOUT) :: State_Chm   ! Chemistry State
+    TYPE(DgnState),   INTENT(INOUT) :: State_Diag  ! Diagnostics State
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,          INTENT(INOUT) :: RC          ! Success or failure?
+!
+! !REMARKS:
+!  The loop order of this routine was changed from I,J,N to N,I,J. This allows
+!  us to keep one species in memory at a time, to avoid regridding over and over
+!  again when the HEMCO grid is not the same as the model grid.
+!  The on-demand regridder caches the LAST SPECIES information, so the outermost
+!  loop should be based on the species ID.
+!
+! !REVISION HISTORY:
+!  18 May 2020 - R. Yantosca - Initial version
+!  See the subsequent Git history with the gitk browser!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! SAVEd scalars
+    LOGICAL, SAVE           :: first    = .TRUE.
+    INTEGER, SAVE           :: id_O3    = -1
+    INTEGER, SAVE           :: id_HNO3  = -1
+
+    ! Scalars
+    LOGICAL                 :: found,   zeroHg0Dep
+    INTEGER                 :: I,       J
+    INTEGER                 :: L,       NA
+    INTEGER                 :: ND,      N
+    INTEGER                 :: Hg_Cat,  topMix
+    REAL(fp)                :: dep,     emis
+    REAL(fp)                :: EmMW_kg, fracNoHg0Dep
+    REAL(fp)                :: tmpFlx
+
+    ! Strings
+    CHARACTER(LEN=63)       :: origUnit
+    CHARACTER(LEN=255)      :: errMsg,  thisLoc
+
+    ! Arrays
+    REAL(fp), TARGET        :: eflx(State_Grid%NX,                           &
+                                    State_Grid%NY,                           &
+                                    State_Chm%nAdvect                       )
+    REAL(fp), TARGET        :: dflx(State_Grid%NX,                           &
+                                    State_Grid%NY,                           &
+                                    State_Chm%nAdvect                       )
+
+    ! Pointers and Objects
+    REAL(fp),       POINTER :: spc(:,:,:)
+    REAL(f4), SAVE, POINTER :: PNOxLoss_O3  (:,:) => NULL()
+    REAL(f4), SAVE, POINTER :: PNoxLoss_HNO3(:,:) => NULL()
+    TYPE(Species),  POINTER :: ThisSpc
+
+    !=======================================================================
+    ! Compute_Sflx_For_Vdiff begins here!
+    !=======================================================================
+
+    ! Initialize
+    RC      =  GC_SUCCESS
+    dflx    =  0.0_fp
+    eflx    =  0.0_fp
+    spc     => State_Chm%Species(:,:,1,1:State_Chm%nAdvect)
+    ThisSpc => NULL()
+    errMsg  = ''
+    thisLoc = &
+    ' -> at Compute_Sflx_for_Vdiff (in module GeosCore/hcoi_gc_main_mod.F90)'
+
+    ! Reset DryDepMix diagnostic so as not to accumulate from prior timesteps
+    IF ( State_Diag%Archive_DryDepMix .or. State_Diag%Archive_DryDep ) THEN
+       State_Diag%DryDepMix = 0.0_f4
+    ENDIF
+
+    !=======================================================================
+    ! Convert units to v/v dry
+    !=======================================================================
+    CALL Convert_Spc_Units( Input_Opt, State_Chm, State_Grid, State_Met,     &
+                            'v/v dry', RC,        OrigUnit=OrigUnit         )
+
+    ! Trap potential error
+    IF ( RC /= GC_SUCCESS ) THEN
+       ErrMsg = 'Error encountred in "Convert_Spc_Units" (to v/v dry)!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+
+    !=======================================================================
+    ! First-time setup: Get pointers to the PARANOX loss fluxes.
+    ! These are stored in diagnostics 'PARANOX_O3_DEPOSITION_FLUX' and
+    ! 'PARANOX_HNO3_DEPOSITION_FLUX'. The call below links pointers
+    ! PNOXLOSS_O3 and PNOXLOSS_HNO3 to the data values stored in the
+    ! respective diagnostics. The pointers will remain unassociated if
+    ! the diagnostics do not exist.
+    !=======================================================================
+    IF ( FIRST ) THEN
+
+       ! Get species IDs
+       id_O3   = Ind_('O3'  )
+       id_HNO3 = Ind_('HNO3')
+
+       IF ( id_O3 > 0 ) THEN
+          CALL GetHcoDiagn(                                                  &
+               HcoState       = HcoState,                                    &
+               ExtState       = ExtState,                                    &
+               DiagnName      = 'PARANOX_O3_DEPOSITION_FLUX',                &
+               StopIfNotFound = .FALSE.,                                     &
+               Ptr2D          = PNOxLoss_O3,                                 &
+               RC             = RC                                          )
+       ENDIF
+
+       IF ( id_HNO3 > 0 ) THEN
+          CALL GetHcoDiagn(                                                  &
+               HcoState       = HcoState,                                    &
+               ExtState       = ExtState,                                    &
+               DiagnName      = 'PARANOX_HNO3_DEPOSITION_FLUX',              &
+               StopIfNotFound = .FALSE.,                                     &
+               Ptr2D          = PNOxLoss_HNO3,                               &
+               RC             = RC                                          )
+       ENDIF
+
+       ! Reset first-time flag
+       FIRST = .FALSE.
+    ENDIF
+
+    !=======================================================================
+    ! Add emissions & deposition values calculated in HEMCO.
+    ! Here we only consider emissions below the PBL top.
+    !
+    ! The loop has been separated to go over N, J, I in order to optimize
+    ! for retrieving regridded data from HEMCO. There is only one regrid
+    ! buffer per field (emis/dep, N) so these must not be intertwined,
+    ! or there will be a large performance penalty.
+    !=======================================================================
+
+    ! Advected species loop
+    DO NA = 1, State_Chm%nAdvect
+
+      ! Get the modelId
+      N = State_Chm%Map_Advect(NA)
+
+      ! Point to the corresponding entry in the species database
+      ThisSpc => State_Chm%SpcData(N)%Info
+
+      !$OMP PARALLEL DO                                                        &
+      !$OMP DEFAULT( SHARED )                                                  &
+      !$OMP PRIVATE( I,       J,            topMix                            )&
+      !$OMP PRIVATE( tmpflx,  found,        emis,      dep                    )
+      DO J = 1, State_Grid%NY
+      DO I = 1, State_Grid%NX
+
+        ! PBL top level [integral model levels]
+        topMix = MAX( 1, FLOOR( State_Met%PBL_TOP_L(I,J) ) )
+
+        !------------------------------------------------------------------
+        ! Add total emissions in the PBL to the EFLX array
+        ! which tracks emission fluxes.  Units are [kg/m2/s].
+        !------------------------------------------------------------------
+        IF ( Input_Opt%ITS_A_CH4_SIM ) THEN
+
+           ! CH4 emissions become stored in CH4_EMIS in global_ch4_mod.F90.
+           ! We use CH4_EMIS here instead of the HEMCO internal emissions
+           ! only to make sure that total CH4 emissions are properly defined
+           ! in a multi-tracer CH4 simulation. For a single-tracer simulation
+           ! and/or all other source types, we could use the HEMCO internal
+           ! values set above and would not need the code below.
+           ! Units are already in kg/m2/s. (ckeller, 10/21/2014)
+           !
+           !%%% NOTE: MAYBE THIS CAN BE REMOVED SOON (bmy, 5/18/19)%%%
+           eflx(I,J,NA) = CH4_EMIS(I,J,NA)
+
+        ELSE IF ( Input_Opt%ITS_A_MERCURY_SIM ) THEN
+
+           ! HG emissions become stored in HG_EMIS in mercury_mod.F90.
+           ! This is a workaround to ensure backwards compatibility.
+           ! Units are already in kg/m2/s. (ckeller, 10/21/2014)
+           !
+           !%%% NOTE: MAYBE THIS CAN BE REMOVED SOON (bmy, 5/18/19)%%%
+           eflx(I,J,NA) = HG_EMIS(I,J,NA)
+
+        ELSE
+
+           ! Compute emissions for all other simulation
+           tmpFlx = 0.0_fp
+           DO L = 1, topMix
+              CALL GetHcoValEmis( Input_Opt, State_Grid, NA, I, J, L, found, emis )
+              IF ( .NOT. found ) EXIT
+              tmpFlx = tmpFlx + emis
+           ENDDO
+           eflx(I,J,NA) = eflx(I,J,NA) + tmpFlx
+
+        ENDIF
+
+        !------------------------------------------------------------------
+        ! Also add drydep frequencies calculated by HEMCO (e.g. from the
+        ! air-sea exchange module) to DFLX.  These values are stored
+        ! in 1/s.  They are added in the same manner as the DEPSAV values
+        ! from drydep_mod.F90.  DFLX will be converted to kg/m2/s later.
+        ! (ckeller, 04/01/2014)
+        !------------------------------------------------------------------
+        CALL GetHcoValDep( Input_Opt, State_Grid, NA, I, J, L, found, dep )
+        IF ( found ) THEN
+           dflx(I,J,NA) = dflx(I,J,NA)                                     &
+                        + ( dep * spc(I,J,NA) / (AIRMW / ThisSpc%EmMW_g)  )
+        ENDIF
+      ENDDO ! I
+      ENDDO ! J
+      !$OMP END PARALLEL DO
+
+      ! Free pointers
+      ThisSpc => NULL()
+    ENDDO   ! NA
+
+    !=======================================================================
+    ! Add emissions & deposition values calculated in HEMCO.
+    ! Here we only consider emissions below the PBL top.
+    !
+    ! For the full-chemistry simulations, emissions above the PBL
+    ! top will be applied in routine SETEMIS, which occurs just
+    ! before the SMVGEAR/KPP solvers are invoked.
+    !
+    ! For the specialty simulations, emissions above the PBL top
+    ! will be applied in the chemistry routines for each
+    ! specialty simulation.
+    !
+    ! For more information, please see this wiki page:
+    ! http://wiki.geos-chem.org/Distributing_emissions_in_the_PBL
+    !========================================================================
+    !$OMP PARALLEL DO                                                        &
+    !$OMP DEFAULT( SHARED )                                                  &
+    !$OMP PRIVATE( I,       J,            N                                 )&
+    !$OMP PRIVATE( thisSpc, dep                                             )&
+    !$OMP PRIVATE( ND,      fracNoHg0Dep, zeroHg0Dep, Hg_cat                )
+    DO J = 1, State_Grid%NY
+    DO I = 1, State_Grid%NX
+
+       !=====================================================================
+       ! Apply dry deposition frequencies
+       ! These are the frequencies calculated in drydep_mod.F90
+       ! The HEMCO drydep frequencies (from air-sea exchange and
+       ! PARANOX) were already added above.
+       !
+       ! NOTES:
+       ! (1) Loops over only the drydep species
+       ! (2) If drydep is turned off, nDryDep=0 and the loop won't execute
+       ! (3) Tagged species are included in this loop. via species database
+       !=====================================================================
+       DO ND = 1, State_Chm%nDryDep
+
+          ! Get the species ID from the drydep ID
+          N = State_Chm%Map_DryDep(ND)
+
+          IF ( N <= 0 ) CYCLE
+
+          ! Point to the corresponding Species Database entry
+          ThisSpc => State_Chm%SpcData(N)%Info
+
+          ! only use the lowest model layer for calculating drydep fluxes
+          ! given that spc is in v/v
+          dflx(I,J,N) = dflx(I,J,N) &
+                      + State_Chm%DryDepSav(I,J,ND) * spc(I,J,N)             &
+                      /  ( AIRMW                    / ThisSpc%EmMW_g        )
+
+
+          IF ( Input_Opt%ITS_A_MERCURY_SIM .and. ThisSpc%Is_Hg0 ) THEN
+
+             ! Hg(0) exchange with the ocean is handled by ocean_mercury_mod
+             ! so disable deposition over water here.
+             ! Turn off Hg(0) deposition to snow and ice because we haven't yet
+             ! included emission from these surfaces and most field studies
+             ! suggest Hg(0) emissions exceed deposition during sunlit hours.
+             fracNoHg0Dep = MIN( State_Met%FROCEAN(I,J) + &
+                                 State_Met%FRSNO(I,J)   + &
+                                 State_Met%FRLANDIC(I,J), 1e+0_fp)
+             zeroHg0Dep   = ( fracNoHg0Dep > 0e+0_fp )
+
+             IF ( zeroHg0Dep ) THEN
+                dflx(I,J,N) = dflx(I,J,N) * MAX( 1.0_fp-fracNoHg0Dep, 0.0_fp )
+             ENDIF
+          ENDIF
+
+          ! Free species database pointer
+          ThisSpc => NULL()
+       ENDDO
+
+       !=====================================================================
+       ! Convert DFLX from 1/s to kg/m2/s
+       !
+       ! If applicable, add PARANOX loss to this term. The PARANOX
+       ! loss term is already in kg/m2/s. PARANOX loss (deposition) is
+       ! calculated for O3 and HNO3 by the PARANOX module, and data is
+       ! exchanged via the HEMCO diagnostics.  The data pointers PNOXLOSS_O3
+       ! and PNOXLOSS_HNO3 have been linked to these diagnostics at the
+       ! beginning of this routine (ckeller, 4/10/15).
+       !=====================================================================
+       dflx(I,J,:) = dflx(I,J,:) * State_Met%AD(I,J,1)                        &
+                                 / State_Grid%Area_M2(I,J)
+
+       IF ( ASSOCIATED( PNOxLoss_O3 ) .AND. id_O3 > 0 ) THEN
+          dflx(I,J,id_O3) = dflx(I,J,id_O3) + PNOxLoss_O3(I,J)
+       ENDIF
+
+       IF ( ASSOCIATED( PNOXLOSS_HNO3 ) .AND. id_HNO3 > 0 ) THEN
+          dflx(I,J,id_HNO3) = dflx(I,J,id_HNO3) + PNOxLOss_HNO3(I,J)
+       ENDIF
+
+       !=====================================================================
+       ! Surface flux (SFLX) = emissions (EFLX) - dry deposition (DFLX)
+       !
+       ! SFLX is what we need to pass into routine VDIFF
+       !=====================================================================
+       State_Chm%SurfaceFlux(I,J,:) = eflx(I,J,:) - dflx(I,J,:) ! kg/m2/s
+
+       !=====================================================================
+       ! Archive Hg deposition for surface reservoirs (cdh, 08/28/09)
+       !=====================================================================
+       IF ( Input_Opt%ITS_A_MERCURY_SIM ) THEN
+
+          ! Loop over only the drydep species
+          ! If drydep is turned off, nDryDep=0 and the loop won't execute
+          DO ND = 1, State_Chm%nDryDep
+
+             ! Get the species ID from the drydep ID
+             N = State_Chm%Map_DryDep(ND)
+
+             ! Point to the Species Database entry for tracer N
+             ThisSpc => State_Chm%SpcData(N)%Info
+
+             ! Deposition mass, kg
+             dep = dflx(I,J,N) * State_Grid%Area_M2(I,J) * GET_TS_CONV()
+
+             IF ( ThisSpc%Is_Hg2 ) THEN
+
+                ! Get the category number for this Hg2 tracer
+                Hg_Cat = ThisSpc%Hg_Cat
+
+                ! Archive dry-deposited Hg2
+                CALL ADD_Hg2_DD      ( I, J, Hg_Cat, dep                    )
+                CALL ADD_Hg2_SNOWPACK( I, J, Hg_Cat, dep,                    &
+                                       State_Met, State_Chm, State_Diag     )
+
+             ELSE IF ( ThisSpc%Is_HgP ) THEN
+
+                ! Get the category number for this HgP tracer
+                Hg_Cat = ThisSpc%Hg_Cat
+
+                ! Archive dry-deposited HgP
+                CALL ADD_HgP_DD      ( I, J, Hg_Cat, dep                    )
+                CALL ADD_Hg2_SNOWPACK( I, J, Hg_Cat, dep,                    &
+                                       State_Met, State_Chm, State_Diag     )
+
+             ENDIF
+
+             ! Free pointer
+             ThisSpc => NULL()
+          ENDDO
+       ENDIF
+
+    ENDDO
+    ENDDO
+    !$OMP END PARALLEL DO
+
+    !### Uncomment for debug output
+    !WRITE( 6, '(a)' ) 'eflx and dflx values HEMCO [kg/m2/s]'
+    !DO NA = 1, State_Chm%nAdvect
+    !   WRITE(6,*) 'eflx TRACER ', NA, ': ', SUM(eflx(:,:,NA))
+    !   WRITE(6,*) 'dflx TRACER ', NA, ': ', SUM(dflx(:,:,NA))
+    !   WRITE(6,*) 'sflx TRACER ', NA, ': ', SUM(State_Chm%SurfaceFlux(:,:,NA))
+    !ENDDO
+
+    !=======================================================================
+    ! DIAGNOSTICS: Compute drydep flux loss due to mixing [molec/cm2/s]
+    !
+    ! NOTE: Dry deposition of "tagged" species (e.g. in tagO3, tagCO, tagHg
+    ! specialty simulations) are accounted for in species 1..nDrydep,
+    ! so we don't need to do any further special handling.
+    !=======================================================================
+    IF ( Input_Opt%LGTMM              .or. Input_Opt%LSOILNOX          .or.  &
+         State_Diag%Archive_DryDepMix .or. State_Diag%Archive_DryDep ) THEN
+
+       ! Loop over only the drydep species
+       ! If drydep is turned off, nDryDep=0 and the loop won't execute
+       !$OMP PARALLEL DO                                                     &
+       !$OMP DEFAULT( SHARED                                                )&
+       !$OMP PRIVATE( ND, N, ThisSpc, EmMw_kg, tmpFlx                       )
+       DO ND = 1, State_Chm%nDryDep
+
+          ! Get the species ID from the drydep ID
+          N = State_Chm%Map_DryDep(ND)
+
+          ! Skip if not a valid species
+          IF ( N <= 0 ) CYCLE
+
+          ! Point to the Species Database entry for this tracer
+          ! NOTE: Assumes a 1:1 tracer index to species index mapping
+          ThisSpc => State_Chm%SpcData(N)%Info
+
+          ! Get the (emitted) molecular weight of the species in kg
+          EmMW_kg = ThisSpc%emMW_g * 1.e-3_fp
+
+          !-----------------------------------------------------------------
+          ! HISTORY: Update dry deposition flux loss [molec/cm2/s]
+          !
+          ! DFLX is in kg/m2/s.  We convert to molec/cm2/s by:
+          !
+          ! (1) multiplying by 1e-4 cm2/m2        => kg/cm2/s
+          ! (2) multiplying by ( AVO / EmMW_KG )  => molec/cm2/s
+          !
+          ! The term AVO/EmMW_kg = (molec/mol) / (kg/mol) = molec/kg
+          !
+          ! NOTE: we don't need to multiply by the ratio of TS_CONV /
+          ! TS_CHEM, as the updating frequency for HISTORY is determined
+          ! by the "frequency" setting in the "HISTORY.rc"input file.
+          ! The old bpch diagnostics archived the drydep due to chemistry
+          ! every chemistry timestep = 2X the dynamic timestep.  So in
+          ! order to avoid double-counting the drydep flux from mixing,
+          ! you had to multiply by TS_CONV / TS_CHEM.
+          !
+          ! ALSO NOTE: When comparing History output to bpch output,
+          ! you must use an updating frequency equal to the dynamic
+          ! timestep so that the drydep fluxes due to mixing will
+          ! be equivalent w/ the bpch output.  It is also recommended to
+          ! turn off chemistry so as to be able to compare the drydep
+          ! fluxes due to mixing in bpch vs. History as an "apples-to-
+          ! apples" comparison.
+          !
+          !    -- Bob Yantosca (yantosca@seas.harvard.edu)
+          !-----------------------------------------------------------------
+          IF ( State_Diag%Archive_DryDepMix   .or.                           &
+               State_Diag%Archive_DryDep    ) THEN
+             State_Diag%DryDepMix(:,:,ND) = Dflx(:,:,N)                      &
+                                            * 1.0e-4_fp                      &
+                                            * ( AVO / EmMW_kg  )
+          ENDIF
+
+          !-----------------------------------------------------------------
+          ! If Soil NOx is turned on, then call SOIL_DRYDEP to
+          ! archive dry deposition fluxes for nitrogen species
+          ! (SOIL_DRYDEP will exit if it can't find a match.
+          !
+          ! Locate position of each tracer in DEPSAV
+          ! (get tracer id)
+          ! NOTE: trc_id was previously NN and drydep id D
+          ! was previously N. This is changed for convention consistency
+          ! within subroutine (ewl, 1/25/16)
+          !-----------------------------------------------------------------
+          IF ( Input_Opt%LSOILNOX ) THEN
+             tmpFlx = 0.0_fp
+             DO J = 1, State_Grid%NY
+             DO I = 1, State_Grid%NX
+                tmpFlx = dflx(I,J,N)                                         &
+                 / EmMW_kg                                             &
+                       * AVO           * 1.e-4_fp                            &
+                       * GET_TS_CONV() / GET_TS_EMIS()
+
+                CALL Soil_DryDep( I, J, 1, N, tmpFlx, State_Chm )
+             ENDDO
+             ENDDO
+          ENDIF
+
+          ! Free species database pointer
+          ThisSpc => NULL()
+       ENDDO
+       !$OMP END PARALLEL DO
+    ENDIF
+
+    !=======================================================================
+    ! Unit conversion #2: Convert back to the original units
+    !=======================================================================
+    CALL Convert_Spc_Units( Input_Opt, State_Chm, State_Grid,                &
+                            State_Met, OrigUnit,  RC                        )
+
+    ! Trap potential errors
+    IF ( RC /= GC_SUCCESS ) THEN
+       ErrMsg = 'Error encountred in "Convert_Spc_Units" (from v/v dry)!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+
+  END SUBROUTINE Compute_Sflx_For_Vdiff
+!EOC
 END MODULE Hco_Interface_GC_Mod

--- a/GeosCore/hco_state_gc_mod.F90
+++ b/GeosCore/hco_state_gc_mod.F90
@@ -16,14 +16,20 @@ MODULE HCO_State_GC_Mod
 !
   USE HCOX_State_Mod, ONLY : Ext_State
   USE HCO_State_Mod,  ONLY : HCO_State
+  USE State_Grid_Mod, ONLY : GrdState
   IMPLICIT NONE
   PRIVATE
 !
 ! !REMARKS:
-!  Exists to avoid circular dependencies.
+!  Exists to avoid circular dependencies. Also holds the HEMCO intermediate grid
+!  description, State\_Grid\_HCO, for GC-Classic.
+!
+!  The intermediate grid descriptor uses GrdState to avoid code duplication. It will
+!  be initialized by HCO\_Interface\_GC\_Mod.
 !
 ! !REVISION HISTORY:
 !  13 Mar 2020 - H.P. Lin    - Initial version.
+!  04 Jun 2020 - H.P. Lin    - Now holding HEMCO intermediate grid object.
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -39,5 +45,12 @@ MODULE HCO_State_GC_Mod
 
   ! HEMCO extensions state
   TYPE(Ext_State), POINTER, PUBLIC :: ExtState => NULL()
+
+#if defined ( MODEL_CLASSIC )
+  !--------------------------
+  ! %%% HEMCO Intermediate Grid %%%
+  !--------------------------
+  TYPE(GrdState), PUBLIC           :: State_Grid_HCO
+#endif
 !EOC
 END MODULE HCO_State_GC_Mod

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -108,9 +108,9 @@ MODULE HCO_Utilities_GC_Mod
   REAL(f4), POINTER                    :: TMP_MDL_r4b(:,:,:)
   REAL(f4), POINTER                    :: TMP_HCO_r4 (:,:,:)
 
-  CHARACTER(LEN=255)                   :: LAST_TMP_REGRID_M2H       ! Last regridded container name
-  CHARACTER(LEN=255)                   :: LAST_TMP_REGRID_H2M       ! ... HEMCO to Model
-  CHARACTER(LEN=255)                   :: LAST_TMP_REGRID_H2Mb      ! ... HEMCO to Model (alt bfr)
+  CHARACTER(LEN=90)                    :: LAST_TMP_REGRID_M2H       ! Last regridded container name
+  CHARACTER(LEN=90)                    :: LAST_TMP_REGRID_H2M       ! ... HEMCO to Model
+  CHARACTER(LEN=90)                    :: LAST_TMP_REGRID_H2Mb      ! ... HEMCO to Model (alt bfr)
   INTEGER                              :: LAST_TMP_MDL_ZBND         ! Last z-boundary for TMP_MDL_r4 ptr
 
   ! Temporaries for Map_A2A shadow input variables.
@@ -246,6 +246,10 @@ CONTAINS
         IF ( AltBuffer ) THEN
           TMP_AltBuffer = .true.
         ENDIF
+      ELSE
+        ! This fallover else is not needed logically, but is necessary
+        ! due to a compiler bug in ifort 19 (hplin, 6/25/20)
+        TMP_AltBuffer = .false.
       ENDIF
 
       IF ( TMP_AltBuffer ) THEN 
@@ -269,7 +273,7 @@ CONTAINS
         ! Do not use GetHcoVal: load the entire chunk into memory
         ! Note: TrcID matches HcoID here. If not, remap the tracer ID to HEMCO ID below.
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValEmis/ImGrid: Attempting to load", TMP_TrcIDFldName, "was", LAST_TMP_REGRID_H2M, LAST_TMP_REGRID_H2Mb, TMP_AltBuffer
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValEmis/ImGrid: Attempting to load", TMP_TrcIDFldName, "was", LAST_TMP_REGRID_H2M, LAST_TMP_REGRID_H2Mb, TMP_AltBuffer
 
         IF ( TrcID > 0 ) THEN
           IF ( ASSOCIATED(HcoState%Spc(TrcID)%Emis%Val) ) THEN  ! Present! Read in the data
@@ -285,7 +289,7 @@ CONTAINS
             TMP_HCO = 0.0_fp ! Clear the output first
             TMP_HCO(:,:,1:ZBND) = HcoState%Spc(TrcID)%Emis%Val(:,:,1:ZBND)
 
-            IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValEmis/ImGrid: Read from HEMCO"
+            ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValEmis/ImGrid: Read from HEMCO"
 
             ! Now perform the on-demand regrid
             CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, TMP_MDL_target, ZBND )
@@ -301,7 +305,7 @@ CONTAINS
               LAST_TMP_REGRID_H2Mb = TMP_TrcIDFldName
             ENDIF
 
-            IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValEmis/ImGrid: Regrid OK return"
+            IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValEmis/ImGrid: Regrid OK return", TMP_TrcIDFldName
           ENDIF ! Associated
         ENDIF ! TrcID > 0
       ELSE ! Already in buffer! Just read the pointer data
@@ -400,7 +404,7 @@ CONTAINS
       IF( TMP_TrcIDFldName /= LAST_TMP_REGRID_H2Mb ) THEN   ! Not already in buffer
         ! Do not use GetHcoVal: load the entire chunk into memory
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValDep/ImGrid: Attempting to load", TMP_TrcIDFldName, "was", LAST_TMP_REGRID_H2Mb
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValDep/ImGrid: Attempting to load", TMP_TrcIDFldName, "was", LAST_TMP_REGRID_H2Mb
         ! Note: TrcID matches HcoID here. If not, remap the tracer ID to HEMCO ID below.
         IF ( TrcID > 0 ) THEN
           IF ( ASSOCIATED(HcoState%Spc(TrcID)%Depv%Val) ) THEN  ! Present! Read in the data
@@ -412,7 +416,7 @@ CONTAINS
             TMP_HCO = 0.0_fp ! Clear the output first
             TMP_HCO(:,:,1) = HcoState%Spc(TrcID)%Depv%Val(:,:)
 
-            IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValDep/ImGrid: Read from HEMCO"
+            ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValDep/ImGrid: Read from HEMCO"
 
             ! Now perform the on-demand regrid
             ! Note deposition is surface layer, so L is always 1. Read ZBND = 1
@@ -424,7 +428,7 @@ CONTAINS
             Dep = TMP_MDLb(I,J,1)
             LAST_TMP_REGRID_H2Mb = TMP_TrcIDFldName
 
-            IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValDep/ImGrid: Regrid OK return"
+            IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValDep/ImGrid: Regrid OK return", TMP_TrcIDFldName
           ENDIF
         ENDIF
       ELSE ! Already in buffer! Just read the pointer data
@@ -525,7 +529,7 @@ CONTAINS
 
       ! Check if cName is existing in the regrid buffer. If not, regrid on-the-fly
       IF ( cName /= LAST_TMP_REGRID_H2M ) THEN
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Last regrid not equal, looking up field ", cName
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Last regrid not equal, looking up field ", cName
 
         ! Now retrieve data into the HEMCO temporary!
         ! The bdy is a slice to ensure safety
@@ -535,7 +539,7 @@ CONTAINS
         ! be able to propagate the error above.
         IF ( RC /= GC_SUCCESS ) RETURN
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Lookup complete", cName, FND
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Lookup complete", cName, FND
 
         IF ( FND ) THEN
 
@@ -547,7 +551,7 @@ CONTAINS
           ! ( Input_Opt, State_Grid, State_Grid_HCO, PtrIn, PtrOut, ZBND )
           CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, Arr3D, ZBND )
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Regrid complete, z-boundary", ZBND
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Regrid complete, ", cName, " z-boundary", ZBND
 
           ! The output should be in Arr3D and ready to go.
           LAST_TMP_REGRID_H2M = cName
@@ -559,7 +563,7 @@ CONTAINS
         Arr3D(:,:,1:ZBND) = TMP_MDL(:,:,1:ZBND)
         FND = .true.
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Last regrid equal, reading from buffer"
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Last regrid equal, reading from buffer"
       ENDIF
     ELSE
       ! Not within the intermediate grid code path
@@ -651,7 +655,7 @@ CONTAINS
 
       ! Check if cName is existing in the regrid buffer. If not, regrid on-the-fly
       IF ( cName /= LAST_TMP_REGRID_H2M ) THEN
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Last regrid not equal, looking up field ", cName
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Last regrid not equal, looking up field ", cName
 
         ! Now retrieve data into the HEMCO temporary!
         ! The bdy is a slice to ensure safety
@@ -661,21 +665,10 @@ CONTAINS
         ! be able to propagate the error above.
         IF ( RC /= GC_SUCCESS ) RETURN
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Lookup complete", cName, FND
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Lookup complete", cName, FND
         
         ! If not found, return
         IF ( FND ) THEN
-
-          ! IF ( cName == "LANDTYPE02" ) THEN
-          !   WRITE(6,*) "====================================="
-          !   WRITE(6,*) "hplin debug EvalFld_2D: BEFORE REGRID field", cName
-          !   WRITE(6,*) "Grid sizes: GridNXNY, GridHCONXNY", State_Grid%NX, State_Grid%NY, State_Grid_HCO%NX, State_Grid_HCO%NY
-          !   DO II = 1, State_Grid_HCO%NX
-          !     WRITE(6,*) "I(HCOGrid) = ", II
-          !     WRITE(6,*) "Field(I,:)", TMP_HCO(II,:,1)
-          !   ENDDO
-          !   WRITE(6,*) "====================================="
-          ! ENDIF
 
           ! For safety, overwrite the temporary
           LAST_TMP_REGRID_H2M = "_HCO_Eval2D_TBD"
@@ -685,18 +678,7 @@ CONTAINS
           ! Z-boundary is 1 because 2-D field.
           CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, TMP_MDL, 1 )
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Regrid complete"
-
-          ! IF ( cName == "LANDTYPE02" ) THEN
-          !   WRITE(6,*) "====================================="
-          !   WRITE(6,*) "hplin debug EvalFld_2D: AFTER REGRID field", cName
-          !   WRITE(6,*) "Grid sizes: GridNXNY, GridHCONXNY", State_Grid%NX, State_Grid%NY, State_Grid_HCO%NX, State_Grid_HCO%NY
-          !   DO II = 1, State_Grid%NX
-          !     WRITE(6,*) "I(MDLGrid) = ", II
-          !     WRITE(6,*) "Field(I,:)", TMP_MDL(II,:,1)
-          !   ENDDO
-          !   WRITE(6,*) "====================================="
-          ! ENDIF
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Regrid", cName, " complete"
 
           ! Note that we cannot pass Arr2D to call above directly because it accepts a
           ! 3-D argument. So we regrid to the target dummy and copy
@@ -711,7 +693,7 @@ CONTAINS
         Arr2D(:,:) = TMP_MDL(:,:,1)
         FND = .true.
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Last regrid equal, reading from buffer"
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Last regrid equal, reading from buffer"
       ENDIF
     ELSE
       ! Not within the intermediate grid code path
@@ -825,7 +807,7 @@ CONTAINS
 
       ! Check if is existing in the regrid buffer. If not, regrid on-the-fly
       IF ( TMP_GetPtrFldName /= LAST_TMP_REGRID_H2M ) THEN
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Last regrid not equal, looking up field ", TMP_GetPtrFldName
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Last regrid not equal, looking up field ", TMP_GetPtrFldName
 
         ! For safety, overwrite the temporary
         LAST_TMP_REGRID_H2M = "_HCO_Ptr2D_TBD"
@@ -840,46 +822,22 @@ CONTAINS
         ! If not found, return
         IF ( iFOUND .and. iFILLED ) THEN
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Lookup complete", TMP_GetPtrFldName, iFOUND
+          ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Lookup complete", TMP_GetPtrFldName, iFOUND
 
           ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Dim Debug", SIZE(TMP_HCO, 1), SIZE(TMP_HCO, 2), SIZE(TMP_Ptr2D, 1), SIZE(TMP_Ptr2D, 2)
 
           ! Copy data to the temporary
           TMP_HCO(:,:,1) = TMP_Ptr2D(:,:)
 
-          ! hplin debug PS
-          ! IF ( DctName == "TO3" ) THEN
-          !   WRITE(6,*) "====================================="
-          !   WRITE(6,*) "hplin debug GetPtr_2D: BEFORE REGRID field", DctName, iTIDX, SIZE(TMP_Ptr2D, 1), SIZE(TMP_Ptr2D, 2)
-          !   WRITE(6,*) "Grid sizes: GridNXNY, GridHCONXNY", State_Grid%NX, State_Grid%NY, State_Grid_HCO%NX, State_Grid_HCO%NY
-          !   DO II = 1, State_Grid_HCO%NX
-          !     WRITE(6,*) "I(HCOGrid) = ", II
-          !     WRITE(6,*) "Field(I,:)", TMP_Ptr2D(II,:)
-          !   ENDDO
-          !   WRITE(6,*) "====================================="
-          ! ENDIF
-
           ! Regrid the buffer appropriately. We do not use TMP_MDL here in EvalFld,
           ! because the field target is given.
           ! Z-boundary is 1 because 2-D field.
           CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, TMP_MDL, 1 )
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Regrid complete"
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Regrid", TMP_GetPtrFldName, "complete"
 
           ! Free the pointer
           TMP_Ptr2D => NULL()
-
-          ! hplin debug PS
-          ! IF ( DctName == "TO3" ) THEN
-          !   WRITE(6,*) "====================================="
-          !   WRITE(6,*) "hplin debug GetPtr_2D: AFTER REGRID field", DctName
-          !   WRITE(6,*) "Grid sizes: GridNXNY, GridHCONXNY", State_Grid%NX, State_Grid%NY, State_Grid_HCO%NX, State_Grid_HCO%NY
-          !   DO II = 1, State_Grid%NX
-          !     WRITE(6,*) "I(Grid) = ", II
-          !     WRITE(6,*) "Field_MDL(I,:,1)", TMP_MDL(II,:,1)
-          !   ENDDO
-          !   WRITE(6,*) "====================================="
-          ! ENDIF
 
           ! Copy to the r4 so you can downgrade the precision for GetPtr calls
           ! for backwards compatibility
@@ -898,24 +856,13 @@ CONTAINS
         iFOUND = .true.
         iFILLED = .true.
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Last regrid equal, pointing to buffer"
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Last regrid equal, pointing to buffer"
       ENDIF
     ELSE
       ! Not within the intermediate grid code path
 #endif
       ! In which case, we just pass the call through
       CALL HCO_GetPtr( HcoState, DctName, Ptr2D, RC, iTIDX, iFOUND, iFILLED )
-
-      ! IF ( DctName == "TO3" ) THEN
-      !     WRITE(6,*) "====================================="
-      !     WRITE(6,*) "hplin debug GetPtr_2D: no REGRID field", DctName, iTIDX, SIZE(Ptr2D, 1), SIZE(Ptr2D, 2)
-      !     WRITE(6,*) "Grid sizes: GridNXNY", State_Grid%NX, State_Grid%NY
-      !     DO II = 1, State_Grid%NX
-      !       WRITE(6,*) "I(MdlGrid) = ", II
-      !       WRITE(6,*) "Field(I,:)", Ptr2D(II,:)
-      !     ENDDO
-      !     WRITE(6,*) "====================================="
-      !   ENDIF
 #ifdef MODEL_CLASSIC
     ENDIF
 #endif
@@ -1025,7 +972,7 @@ CONTAINS
 
       ! Check if is existing in the regrid buffer. If not, regrid on-the-fly
       IF ( TMP_GetPtrFldName /= LAST_TMP_REGRID_H2M ) THEN
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Last regrid not equal, looking up field ", TMP_GetPtrFldName
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Last regrid not equal, looking up field ", TMP_GetPtrFldName
 
         ! For safety, overwrite the temporary
         LAST_TMP_REGRID_H2M = "_HCO_Ptr3D_TBD"
@@ -1043,7 +990,7 @@ CONTAINS
           ! Get z-boundary
           ZBND = MAX(1, SIZE(TMP_Ptr3D, 3))
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Lookup complete", TMP_GetPtrFldName, iFOUND, ZBND
+          ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Lookup complete", TMP_GetPtrFldName, iFOUND, ZBND
 
           ! Copy data to the temporary
           TMP_HCO(:,:,1:ZBND) = TMP_Ptr3D(:,:,1:ZBND)
@@ -1053,7 +1000,7 @@ CONTAINS
           ! Z-boundary is 1 because 2-D field.
           CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, TMP_MDL, ZBND )
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Regrid complete"
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Regrid", TMP_GetPtrFldName, "complete"
 
           ! Free the pointer
           TMP_Ptr3D => NULL()
@@ -1076,7 +1023,7 @@ CONTAINS
         iFOUND = .true.
         iFILLED = .true.
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Last regrid equal, pointing to buffer"
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Last regrid equal, pointing to buffer"
       ENDIF
     ELSE
       ! Not within the intermediate grid code path
@@ -1185,6 +1132,7 @@ CONTAINS
     ENDIF
 
     TMP_MDL_target => NULL()
+    TMP_Ptr3D => NULL()
 
     IF ( Input_Opt%LIMGRID ) THEN
       ! The below section must be OMP CRITICAL because it is stateful.
@@ -1195,6 +1143,10 @@ CONTAINS
         IF ( AltBuffer ) THEN
           TMP_AltBuffer = .true.
         ENDIF
+      ELSE
+        ! This fallover else is not needed logically, but is necessary
+        ! due to a compiler bug in ifort 19 (hplin, 6/25/20)
+        TMP_AltBuffer = .false.
       ENDIF
 
       IF ( TMP_AltBuffer ) THEN 
@@ -1210,10 +1162,7 @@ CONTAINS
       IF( .not. ( (.not. TMP_AltBuffer .and. TMP_DiagnFldName == LAST_TMP_REGRID_H2M) .or. &
                   (      TMP_AltBuffer .and. TMP_DiagnFldName == LAST_TMP_REGRID_H2Mb) ) ) THEN   ! Not already in buffer
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_3D: Last regrid not equal, looking up field ", TMP_DiagnFldName
-
-        ! For safety, overwrite the temporary
-        LAST_TMP_REGRID_H2M = "_HCO_Dgn3D_TBD"
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_3D: Last regrid not equal, looking up field ", TMP_DiagnFldName
 
         ! Now retrieve data into the HEMCO temporary!
         ! Note that the data is in sp and has to be promoted for regridding,
@@ -1228,17 +1177,20 @@ CONTAINS
         ! If not found, return
         IF ( ASSOCIATED( TMP_Ptr3D ) ) THEN
 
+          ! For safety, overwrite the temporary
+          LAST_TMP_REGRID_H2M = "_HCO_Dgn3D_TBD"
+
           ! Get z-boundary
           ZBND = MAX(1, SIZE(TMP_Ptr3D, 3))
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_3D: Lookup complete", TMP_DiagnFldName, ZBND
+          ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_3D: Lookup complete", TMP_DiagnFldName, ZBND
 
           ! Copy data to the temporary
           TMP_HCO(:,:,1:ZBND) = TMP_Ptr3D(:,:,1:ZBND)
 
           CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, TMP_MDL, ZBND )
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_3D: Regrid complete"
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_3D: Regrid", TMP_DiagnFldName, "complete"
 
           ! Free the pointer
           TMP_Ptr3D => NULL()
@@ -1347,6 +1299,7 @@ CONTAINS
     REAL(sp), POINTER  :: TMP_Ptr2D(:,:)
 
     TMP_MDL_target => NULL()
+    TMP_Ptr2D => NULL()
 
     iCOL = HcoState%Diagn%HcoDiagnIDManual
     IF ( PRESENT(COL) ) THEN
@@ -1382,10 +1335,7 @@ CONTAINS
       IF( .not. ( (.not. TMP_AltBuffer .and. TMP_DiagnFldName == LAST_TMP_REGRID_H2M) .or. &
                   (      TMP_AltBuffer .and. TMP_DiagnFldName == LAST_TMP_REGRID_H2Mb) ) ) THEN   ! Not already in buffer
 
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_2D: Last regrid not equal, looking up field ", TMP_DiagnFldName
-
-        ! For safety, overwrite the temporary
-        LAST_TMP_REGRID_H2M = "_HCO_Dgn2D_TBD"
+        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_2D: Last regrid not equal, looking up field ", TMP_DiagnFldName
 
         ! Now retrieve data into the HEMCO temporary!
         ! Note that the data is in sp and has to be promoted for regridding,
@@ -1400,14 +1350,17 @@ CONTAINS
         ! If not found, return
         IF ( ASSOCIATED( TMP_Ptr2D ) ) THEN
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_2D: Lookup complete", TMP_DiagnFldName
+          ! For safety, overwrite the temporary
+          LAST_TMP_REGRID_H2M = "_HCO_Dgn2D_TBD"
+
+          ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_2D: Lookup complete", TMP_DiagnFldName
 
           ! Copy data to the temporary
           TMP_HCO(:,:,1) = TMP_Ptr2D(:,:)
 
           CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, TMP_MDL, 1 )
 
-          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_2D: Regrid complete"
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_2D: Regrid", TMP_DiagnFldName, "complete"
 
           ! Free the pointer
           TMP_Ptr2D => NULL()
@@ -2768,6 +2721,12 @@ CONTAINS
        ErrMsg = 'Error encountered in allocating model and HEMCO temporaries!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
     ENDIF
+
+    ! Initialize defaults
+    LAST_TMP_REGRID_M2H = ''
+    LAST_TMP_REGRID_H2M = ''
+    LAST_TMP_REGRID_H2Mb = ''
+    LAST_TMP_MDL_ZBND = 1
 
   END SUBROUTINE Init_IMGrid
 !EOC

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -38,6 +38,7 @@ MODULE HCO_Utilities_GC_Mod
   PUBLIC   :: GetHcoValDep
   PUBLIC   :: HCO_GC_EvalFld                ! Shim interface for HCO_EvalFld
   PUBLIC   :: HCO_GC_GetPtr                 ! Shim interface for HCO_GetPtr
+  PUBLIC   :: HCO_GC_GetDiagn               ! Shim interface for GetHcoDiagn
 
 #if defined( MODEL_CLASSIC )
   !=========================================================================
@@ -46,7 +47,7 @@ MODULE HCO_Utilities_GC_Mod
   !=========================================================================
   PUBLIC   :: Regrid_MDL2HCO
   PUBLIC   :: Regrid_HCO2MDL
-  PRIVATE  :: Init_IMGrid
+  PUBLIC   :: Init_IMGrid
 
   !=========================================================================
   ! These are only needed for GEOS-Chem "Classic"
@@ -72,7 +73,12 @@ MODULE HCO_Utilities_GC_Mod
   INTERFACE HCO_GC_GetPtr
     MODULE PROCEDURE HCO_GC_GetPtr_2D
     MODULE PROCEDURE HCO_GC_GetPtr_3D
-  END INTERFACE HCO_Gc_GetPtr
+  END INTERFACE HCO_GC_GetPtr
+
+  INTERFACE HCO_GC_GetDiagn
+    MODULE PROCEDURE HCO_GC_GetDiagn_2D
+    MODULE PROCEDURE HCO_GC_GetDiagn_3D
+  END INTERFACE HCO_GC_GetDiagn
 !
 ! !PRIVATE TYPES:
 !
@@ -98,8 +104,9 @@ MODULE HCO_Utilities_GC_Mod
 
   ! f4 variant temporaries.
   ! not directly used for regrid, used for pointing and downgrading data
-  REAL(f4), POINTER                    :: TMP_MDL_r4(:,:,:)
-  REAL(f4), POINTER                    :: TMP_HCO_r4(:,:,:)
+  REAL(f4), POINTER                    :: TMP_MDL_r4 (:,:,:)
+  REAL(f4), POINTER                    :: TMP_MDL_r4b(:,:,:)
+  REAL(f4), POINTER                    :: TMP_HCO_r4 (:,:,:)
 
   CHARACTER(LEN=255)                   :: LAST_TMP_REGRID_M2H       ! Last regridded container name
   CHARACTER(LEN=255)                   :: LAST_TMP_REGRID_H2M       ! ... HEMCO to Model
@@ -235,15 +242,6 @@ CONTAINS
     TMP_MDL_target => NULL()
 
     IF ( Input_Opt%LIMGRID ) THEN
-      ! The below section must be OMP CRITICAL because it is stateful.
-      ! The first call to the critical section will update the container!!
-      !$OMP CRITICAL
-
-      ! Initialize shadow regridding handles if they are not ready
-      IF ( .not. ASSOCIATED( LonEdgeM ) ) THEN
-        CALL Init_IMGrid ( Input_Opt, State_Grid, State_Grid_HCO )
-      ENDIF
-
       IF ( PRESENT(AltBuffer) ) THEN
         IF ( AltBuffer ) THEN
           TMP_AltBuffer = .true.
@@ -258,16 +256,23 @@ CONTAINS
 
       ! ... on-demand intermediate regridding. Check if we already have this field
       Found = .false.
-      WRITE(TMP_TrcIDFldName, '(a,i4)') "_HCO_Trc_", TrcID
-      IF( (.not. TMP_AltBuffer .and. TMP_TrcIDFldName /= LAST_TMP_REGRID_H2M) .and. &
-          (      TMP_AltBuffer .and. TMP_TrcIDFldName /= LAST_TMP_REGRID_H2Mb) ) THEN   ! Not already in buffer
 
+      ! Check if we have to load the data.
+      IF ( TrcID > 0 .and. (.not. ASSOCIATED(HcoState%Spc(TrcID)%Emis%Val)) ) RETURN
+
+      ! The below section must be OMP CRITICAL because it is stateful.
+      ! The first call to the critical section will update the container!!
+      !$OMP CRITICAL
+      WRITE(TMP_TrcIDFldName, '(a,i4)') "_HCO_Trc_", TrcID
+      IF( .not. ( (.not. TMP_AltBuffer .and. TMP_TrcIDFldName == LAST_TMP_REGRID_H2M) .or. &
+                  (      TMP_AltBuffer .and. TMP_TrcIDFldName == LAST_TMP_REGRID_H2Mb) ) ) THEN   ! Not already in buffer
         ! Do not use GetHcoVal: load the entire chunk into memory
         ! Note: TrcID matches HcoID here. If not, remap the tracer ID to HEMCO ID below.
+
+        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValEmis/ImGrid: Attempting to load", TMP_TrcIDFldName, "was", LAST_TMP_REGRID_H2M, LAST_TMP_REGRID_H2Mb, TMP_AltBuffer
+
         IF ( TrcID > 0 ) THEN
           IF ( ASSOCIATED(HcoState%Spc(TrcID)%Emis%Val) ) THEN  ! Present! Read in the data
-            IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValEmis/ImGrid: Attempting to load", TMP_TrcIDFldName, "was", LAST_TMP_REGRID_H2M, LAST_TMP_REGRID_H2Mb, TMP_AltBuffer
-
             ! Retrieve data into the HEMCO temporary!
             ! First, clear the buffer name. We are not sure if this was found yet.
             IF (.not. TMP_AltBuffer) THEN
@@ -297,8 +302,8 @@ CONTAINS
             ENDIF
 
             IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValEmis/ImGrid: Regrid OK return"
-          ENDIF
-        ENDIF
+          ENDIF ! Associated
+        ENDIF ! TrcID > 0
       ELSE ! Already in buffer! Just read the pointer data
         Found = .true.
         Emis  = TMP_MDL_target(I,J,L)
@@ -382,24 +387,23 @@ CONTAINS
     CHARACTER(LEN=32)  :: TMP_TrcIDFldName            ! Temporary tracer field name _HCO_TrcD_<id>
 
     IF ( Input_Opt%LIMGRID ) THEN
-      ! The below section must be OMP CRITICAL because it is stateful.
-      ! The first call to the critical section will update the container!
-      !$OMP CRITICAL
-
-      ! Initialize shadow regridding handles if they are not ready
-      IF ( .not. ASSOCIATED( LonEdgeM ) ) THEN
-        CALL Init_IMGrid ( Input_Opt, State_Grid, State_Grid_HCO )
-      ENDIF
-
       ! ... on-demand intermediate regridding. Check if we already have this field
       Found = .false.
       WRITE(TMP_TrcIDFldName, '(a,i4)') "_HCO_TrcD_", TrcID
+
+      ! Check if we have to load the data.
+      IF ( TrcID > 0 .and. (.not. ASSOCIATED(HcoState%Spc(TrcID)%Depv%Val)) ) RETURN
+
+      ! The below section must be OMP CRITICAL because it is stateful.
+      ! The first call to the critical section will update the container!
+      !$OMP CRITICAL
       IF( TMP_TrcIDFldName /= LAST_TMP_REGRID_H2Mb ) THEN   ! Not already in buffer
         ! Do not use GetHcoVal: load the entire chunk into memory
+
+        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValDep/ImGrid: Attempting to load", TMP_TrcIDFldName, "was", LAST_TMP_REGRID_H2Mb
         ! Note: TrcID matches HcoID here. If not, remap the tracer ID to HEMCO ID below.
         IF ( TrcID > 0 ) THEN
           IF ( ASSOCIATED(HcoState%Spc(TrcID)%Depv%Val) ) THEN  ! Present! Read in the data
-            IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# GetHcoValDep/ImGrid: Attempting to load", TMP_TrcIDFldName, "was", LAST_TMP_REGRID_H2Mb
 
             ! Retrieve data into the HEMCO temporary!
             ! First, clear the buffer name. We are not sure if this was found yet.
@@ -503,11 +507,6 @@ CONTAINS
 
 #ifdef MODEL_CLASSIC
     IF ( Input_Opt%LIMGRID ) THEN
-
-      ! Initialize shadow regridding handles if they are not ready
-      IF ( .not. ASSOCIATED( LonEdgeM ) ) THEN
-        CALL Init_IMGrid ( Input_Opt, State_Grid, State_Grid_HCO )
-      ENDIF
 
       ! Sanity check - output array must be sized correctly for MODEL grid 
       IF ( SIZE(Arr3D, 1) /= State_Grid%NX .or. SIZE(Arr3D, 2) /= State_Grid%NY ) THEN
@@ -642,11 +641,6 @@ CONTAINS
 
 #ifdef MODEL_CLASSIC
     IF ( Input_Opt%LIMGRID ) THEN
-
-      ! Initialize shadow regridding handles if they are not ready
-      IF ( .not. ASSOCIATED( LonEdgeM ) ) THEN
-        CALL Init_IMGrid ( Input_Opt, State_Grid, State_Grid_HCO )
-      ENDIF
 
       ! Sanity check - output array must be sized correctly for MODEL grid 
       IF ( SIZE(Arr2D, 1) /= State_Grid%NX .or. SIZE(Arr2D, 2) /= State_Grid%NY ) THEN
@@ -807,7 +801,7 @@ CONTAINS
 
     CHARACTER(LEN=255)               :: ThisLoc
     CHARACTER(LEN=512)               :: ErrMsg
-    CHARACTER(LEN=255)               :: TMP_GetPtrFldName
+    CHARACTER(LEN=80)                :: TMP_GetPtrFldName
 
     ! Pointers
     REAL(sp), POINTER                :: TMP_Ptr2D(:,:)
@@ -825,12 +819,6 @@ CONTAINS
 
 #ifdef MODEL_CLASSIC
     IF ( Input_Opt%LIMGRID ) THEN
-
-      ! Initialize shadow regridding handles if they are not ready
-      IF ( .not. ASSOCIATED( LonEdgeM ) ) THEN
-        CALL Init_IMGrid ( Input_Opt, State_Grid, State_Grid_HCO )
-      ENDIF
-
       ! Build the name which requires a unique recognition of the time index,
       ! in case they are read sequentially
       write(TMP_GetPtrFldName, '(a,i4)') DctName, iTIDX
@@ -840,7 +828,7 @@ CONTAINS
         IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Last regrid not equal, looking up field ", TMP_GetPtrFldName
 
         ! For safety, overwrite the temporary
-        LAST_TMP_REGRID_H2M = "_HCO_Eval2D_TBD"
+        LAST_TMP_REGRID_H2M = "_HCO_Ptr2D_TBD"
 
         ! Now retrieve data into the HEMCO temporary!
         CALL HCO_GetPtr( HcoState, DctName, TMP_Ptr2D, RC, iTIDX, iFOUND, iFILLED )
@@ -848,17 +836,19 @@ CONTAINS
         ! If failure, return up the chain. The calls to this function will
         ! be able to propagate the error above.
         IF ( RC /= GC_SUCCESS ) RETURN
-
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Lookup complete", TMP_GetPtrFldName, iFOUND
         
         ! If not found, return
         IF ( iFOUND .and. iFILLED ) THEN
+
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Lookup complete", TMP_GetPtrFldName, iFOUND
+
+          ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Dim Debug", SIZE(TMP_HCO, 1), SIZE(TMP_HCO, 2), SIZE(TMP_Ptr2D, 1), SIZE(TMP_Ptr2D, 2)
 
           ! Copy data to the temporary
           TMP_HCO(:,:,1) = TMP_Ptr2D(:,:)
 
           ! hplin debug PS
-          ! IF ( DctName == "USTAR" ) THEN
+          ! IF ( DctName == "TO3" ) THEN
           !   WRITE(6,*) "====================================="
           !   WRITE(6,*) "hplin debug GetPtr_2D: BEFORE REGRID field", DctName, iTIDX, SIZE(TMP_Ptr2D, 1), SIZE(TMP_Ptr2D, 2)
           !   WRITE(6,*) "Grid sizes: GridNXNY, GridHCONXNY", State_Grid%NX, State_Grid%NY, State_Grid_HCO%NX, State_Grid_HCO%NY
@@ -876,8 +866,11 @@ CONTAINS
 
           IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_2D: Regrid complete"
 
+          ! Free the pointer
+          TMP_Ptr2D => NULL()
+
           ! hplin debug PS
-          ! IF ( DctName == "USTAR" ) THEN
+          ! IF ( DctName == "TO3" ) THEN
           !   WRITE(6,*) "====================================="
           !   WRITE(6,*) "hplin debug GetPtr_2D: AFTER REGRID field", DctName
           !   WRITE(6,*) "Grid sizes: GridNXNY, GridHCONXNY", State_Grid%NX, State_Grid%NY, State_Grid_HCO%NX, State_Grid_HCO%NY
@@ -912,6 +905,17 @@ CONTAINS
 #endif
       ! In which case, we just pass the call through
       CALL HCO_GetPtr( HcoState, DctName, Ptr2D, RC, iTIDX, iFOUND, iFILLED )
+
+      ! IF ( DctName == "TO3" ) THEN
+      !     WRITE(6,*) "====================================="
+      !     WRITE(6,*) "hplin debug GetPtr_2D: no REGRID field", DctName, iTIDX, SIZE(Ptr2D, 1), SIZE(Ptr2D, 2)
+      !     WRITE(6,*) "Grid sizes: GridNXNY", State_Grid%NX, State_Grid%NY
+      !     DO II = 1, State_Grid%NX
+      !       WRITE(6,*) "I(MdlGrid) = ", II
+      !       WRITE(6,*) "Field(I,:)", Ptr2D(II,:)
+      !     ENDDO
+      !     WRITE(6,*) "====================================="
+      !   ENDIF
 #ifdef MODEL_CLASSIC
     ENDIF
 #endif
@@ -996,7 +1000,7 @@ CONTAINS
 
     CHARACTER(LEN=255)               :: ThisLoc
     CHARACTER(LEN=512)               :: ErrMsg
-    CHARACTER(LEN=255)               :: TMP_GetPtrFldName
+    CHARACTER(LEN=80)                :: TMP_GetPtrFldName
 
     ! Pointers
     REAL(sp), POINTER                :: TMP_Ptr3D(:,:,:)
@@ -1015,11 +1019,6 @@ CONTAINS
 #ifdef MODEL_CLASSIC
     IF ( Input_Opt%LIMGRID ) THEN
 
-      ! Initialize shadow regridding handles if they are not ready
-      IF ( .not. ASSOCIATED( LonEdgeM ) ) THEN
-        CALL Init_IMGrid ( Input_Opt, State_Grid, State_Grid_HCO )
-      ENDIF
-
       ! Build the name which requires a unique recognition of the time index,
       ! in case they are read sequentially
       write(TMP_GetPtrFldName, '(a,i4)') DctName, iTIDX
@@ -1029,7 +1028,7 @@ CONTAINS
         IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Last regrid not equal, looking up field ", TMP_GetPtrFldName
 
         ! For safety, overwrite the temporary
-        LAST_TMP_REGRID_H2M = "_HCO_Eval3D_TBD"
+        LAST_TMP_REGRID_H2M = "_HCO_Ptr3D_TBD"
 
         ! Now retrieve data into the HEMCO temporary!
         CALL HCO_GetPtr( HcoState, DctName, TMP_Ptr3D, RC, iTIDX, iFOUND, iFILLED )
@@ -1037,14 +1036,14 @@ CONTAINS
         ! If failure, return up the chain. The calls to this function will
         ! be able to propagate the error above.
         IF ( RC /= GC_SUCCESS ) RETURN
-
-        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Lookup complete", TMP_GetPtrFldName, iFOUND, ZBND
         
         ! If not found, return
         IF ( iFOUND .and. iFILLED ) THEN
 
           ! Get z-boundary
           ZBND = MAX(1, SIZE(TMP_Ptr3D, 3))
+
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Lookup complete", TMP_GetPtrFldName, iFOUND, ZBND
 
           ! Copy data to the temporary
           TMP_HCO(:,:,1:ZBND) = TMP_Ptr3D(:,:,1:ZBND)
@@ -1055,6 +1054,9 @@ CONTAINS
           CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, TMP_MDL, ZBND )
 
           IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetPtr_3D: Regrid complete"
+
+          ! Free the pointer
+          TMP_Ptr3D => NULL()
 
           ! Copy to the r4 so you can downgrade the precision for GetPtr calls
           ! for backwards compatibility
@@ -1100,6 +1102,348 @@ CONTAINS
     ENDIF
 
   END SUBROUTINE HCO_GC_GetPtr_3D
+!EOC
+!------------------------------------------------------------------------------
+!                    Harmonized Emissions Component (HEMCO)                   !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: HCO_GC_GetDiagn_3D
+!
+! !DESCRIPTION: Subroutine HCO_GC_GetDiagn is a shim for the original GetHcoDiagn.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE HCO_GC_GetDiagn_3D ( Input_Opt,      State_Grid, DiagnName, &
+                                  StopIfNotFound, RC,         Ptr3D,     &
+                                  COL,            AutoFill,   AltBuffer )
+!
+! !USES:
+!
+    USE HCO_Interface_Common, ONLY : GetHcoDiagn
+    USE HCO_State_GC_Mod,     ONLY : ExtState
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Grid_Mod,       ONLY : GrdState
+#ifdef MODEL_CLASSIC
+    USE HCO_State_GC_Mod,     ONLY : State_Grid_HCO
+#endif
+!
+! !INPUT ARGUMENTS:
+!
+    TYPE(OptInput),     INTENT(IN   )  :: Input_Opt  ! Input options
+    TYPE(GrdState),     INTENT(IN   )  :: State_Grid ! Grid State
+    CHARACTER(LEN=*),   INTENT(IN   )  :: DiagnName  ! Name of diagnostics
+    LOGICAL,            INTENT(IN   )  :: StopIfNotFound
+
+    INTEGER, OPTIONAL,  INTENT(IN   )  :: COL        ! Collection Nr.
+    INTEGER, OPTIONAL,  INTENT(IN   )  :: AutoFill   ! Autofill diagnostics only?
+
+    LOGICAL, OPTIONAL,  INTENT(IN   )  :: AltBuffer  ! Alternate buffer? (Use B)
+!
+! !OUTPUT ARGUMENTS:
+!
+    REAL(sp),           POINTER        :: Ptr3D(:,:,:)
+    INTEGER,            INTENT(INOUT)  :: RC
+!
+! !REMARKS:
+!  See GetPtr. Note that this allows an alternative buffer to be used to
+!  avoid conflict in reading the cached pointer.
+!
+!  FOR SAFETY SAKE, DESTROY THE POINTER READ FROM THIS ROUTINE BEFORE THE NEXT
+!  CALL TO HCO_GC_GetDiagn OR YOU WILL HAVE WRONG DATA FED TO YOU!
+!
+! !REVISION HISTORY:
+!  21 Jun 2020 - H.P. Lin  - Initial version
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+#ifdef MODEL_CLASSIC
+!
+! !LOCAL VARIABLES:
+!
+    CHARACTER(LEN=90)  :: TMP_DiagnFldName            ! Temporary diagnostic fld name
+    INTEGER            :: ZBND
+    LOGICAL            :: TMP_AltBuffer = .false.     ! Use buffer A or B?
+    REAL(hp), POINTER  :: TMP_MDL_target(:,:,:)       ! Pointer to ease switcheroo of the model target buffer
+    REAL(sp), POINTER  :: TMP_MDL_target4(:,:,:)      ! Pointer to ease switcheroo of the model target buffer
+
+    ! Subroutine call temporaries
+    INTEGER            :: iCOL, iAF
+    REAL(sp), POINTER  :: TMP_Ptr3D(:,:,:)
+
+    iCOL = HcoState%Diagn%HcoDiagnIDManual
+    IF ( PRESENT(COL) ) THEN
+      iCOL = COL
+    ENDIF
+
+    iAF = -1
+    IF ( PRESENT(AutoFill) ) THEN
+      iAF = AutoFill
+    ENDIF
+
+    TMP_MDL_target => NULL()
+
+    IF ( Input_Opt%LIMGRID ) THEN
+      ! The below section must be OMP CRITICAL because it is stateful.
+      ! The first call to the critical section will update the container!!
+      !$OMP CRITICAL
+
+      IF ( PRESENT(AltBuffer) ) THEN
+        IF ( AltBuffer ) THEN
+          TMP_AltBuffer = .true.
+        ENDIF
+      ENDIF
+
+      IF ( TMP_AltBuffer ) THEN 
+        TMP_MDL_target => TMP_MDLb
+        TMP_MDL_target4 => TMP_MDL_r4b
+      ELSE
+        TMP_MDL_target => TMP_MDL
+        TMP_MDL_target4 => TMP_MDL_r4
+      ENDIF
+
+      ! ... on-demand intermediate regridding. Check if we already have this field
+      WRITE(TMP_DiagnFldName, *) "_Dgn_", DiagnName
+      IF( .not. ( (.not. TMP_AltBuffer .and. TMP_DiagnFldName == LAST_TMP_REGRID_H2M) .or. &
+                  (      TMP_AltBuffer .and. TMP_DiagnFldName == LAST_TMP_REGRID_H2Mb) ) ) THEN   ! Not already in buffer
+
+        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_3D: Last regrid not equal, looking up field ", TMP_DiagnFldName
+
+        ! For safety, overwrite the temporary
+        LAST_TMP_REGRID_H2M = "_HCO_Dgn3D_TBD"
+
+        ! Now retrieve data into the HEMCO temporary!
+        ! Note that the data is in sp and has to be promoted for regridding,
+        ! then demoted again for output.
+        CALL GetHcoDiagn( HcoState, ExtState, DiagnName, StopIfNotFound, RC, &
+                          Ptr3D=TMP_Ptr3D,    COL=iCOL,  AutoFill=iAF )
+
+        ! If failure, return up the chain. The calls to this function will
+        ! be able to propagate the error above.
+        IF ( RC /= GC_SUCCESS ) RETURN
+        
+        ! If not found, return
+        IF ( ASSOCIATED( TMP_Ptr3D ) ) THEN
+
+          ! Get z-boundary
+          ZBND = MAX(1, SIZE(TMP_Ptr3D, 3))
+
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_3D: Lookup complete", TMP_DiagnFldName, ZBND
+
+          ! Copy data to the temporary
+          TMP_HCO(:,:,1:ZBND) = TMP_Ptr3D(:,:,1:ZBND)
+
+          CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, TMP_MDL, ZBND )
+
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_3D: Regrid complete"
+
+          ! Free the pointer
+          TMP_Ptr3D => NULL()
+
+          ! Copy to the r4 so you can downgrade the precision for GetPtr calls
+          ! for backwards compatibility
+          TMP_MDL_target4(:,:,1:ZBND) = TMP_MDL(:,:,1:ZBND)
+
+          ! Point to target dummy
+          Ptr3D => TMP_MDL_target4(:,:,1:ZBND)
+
+          ! The output should be pointing to Ptr2D (in TMP_MDL:,:,1) and ready to go.
+          LAST_TMP_REGRID_H2M = TMP_DiagnFldName
+          LAST_TMP_MDL_ZBND   = ZBND ! Remember the z-boundary ... will be used later
+
+        ENDIF
+
+      ELSE ! Already in buffer! Just read the pointer data
+        Ptr3D => TMP_MDL_target4(:,:,1:LAST_TMP_MDL_ZBND)
+        ! ... fill the ptr
+      ENDIF
+      !$OMP END CRITICAL
+      ! End of LIMGRID OMP Critical section
+    ELSE
+#endif
+      ! Not GC-Classic or not on-demand intermediate grid, just shim around calls
+      CALL GetHcoDiagn( HcoState, ExtState, DiagnName, StopIfNotFound, RC, &
+                        Ptr3D=Ptr3D,        COL=iCOL,  AutoFill=iAF )
+#ifdef MODEL_CLASSIC
+    ENDIF
+
+    TMP_MDL_target => NULL()
+    TMP_MDL_target4 => NULL()
+#endif
+
+  END SUBROUTINE HCO_GC_GetDiagn_3D
+!EOC
+!------------------------------------------------------------------------------
+!                    Harmonized Emissions Component (HEMCO)                   !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: HCO_GC_GetDiagn_2D
+!
+! !DESCRIPTION: Subroutine HCO_GC_GetDiagn is a shim for the original GetHcoDiagn.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE HCO_GC_GetDiagn_2D ( Input_Opt,      State_Grid, DiagnName, &
+                                  StopIfNotFound, RC,         Ptr2D,     &
+                                  COL,            AutoFill,   AltBuffer )
+!
+! !USES:
+!
+    USE HCO_Interface_Common, ONLY : GetHcoDiagn
+    USE HCO_State_GC_Mod,     ONLY : ExtState
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Grid_Mod,       ONLY : GrdState
+#ifdef MODEL_CLASSIC
+    USE HCO_State_GC_Mod,     ONLY : State_Grid_HCO
+#endif
+!
+! !INPUT ARGUMENTS:
+!
+    TYPE(OptInput),     INTENT(IN   )  :: Input_Opt  ! Input options
+    TYPE(GrdState),     INTENT(IN   )  :: State_Grid ! Grid State
+    CHARACTER(LEN=*),   INTENT(IN   )  :: DiagnName  ! Name of diagnostics
+    LOGICAL,            INTENT(IN   )  :: StopIfNotFound
+
+    INTEGER, OPTIONAL,  INTENT(IN   )  :: COL        ! Collection Nr.
+    INTEGER, OPTIONAL,  INTENT(IN   )  :: AutoFill   ! Autofill diagnostics only?
+
+    LOGICAL, OPTIONAL,  INTENT(IN   )  :: AltBuffer  ! Alternate buffer? (Use B)
+!
+! !OUTPUT ARGUMENTS:
+!
+    REAL(sp),           POINTER        :: Ptr2D(:,:)
+    INTEGER,            INTENT(INOUT)  :: RC
+!
+! !REMARKS:
+!  See GetPtr. Note that this allows an alternative buffer to be used to
+!  avoid conflict in reading the cached pointer.
+!
+!  FOR SAFETY SAKE, DESTROY THE POINTER READ FROM THIS ROUTINE BEFORE THE NEXT
+!  CALL TO HCO_GC_GetDiagn OR YOU WILL HAVE WRONG DATA FED TO YOU!
+!
+! !REVISION HISTORY:
+!  21 Jun 2020 - H.P. Lin  - Initial version
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+#ifdef MODEL_CLASSIC
+!
+! !LOCAL VARIABLES:
+!
+    CHARACTER(LEN=90)  :: TMP_DiagnFldName            ! Temporary diagnostic fld name
+    LOGICAL            :: TMP_AltBuffer = .false.     ! Use buffer A or B?
+    REAL(hp), POINTER  :: TMP_MDL_target(:,:,:)       ! Pointer to ease switcheroo of the model target buffer
+    REAL(sp), POINTER  :: TMP_MDL_target4(:,:,:)      ! Pointer to ease switcheroo of the model target buffer
+
+    ! Subroutine call temporaries
+    INTEGER            :: iCOL, iAF
+    REAL(sp), POINTER  :: TMP_Ptr2D(:,:)
+
+    TMP_MDL_target => NULL()
+
+    iCOL = HcoState%Diagn%HcoDiagnIDManual
+    IF ( PRESENT(COL) ) THEN
+      iCOL = COL
+    ENDIF
+
+    iAF = -1
+    IF ( PRESENT(AutoFill) ) THEN
+      iAF = AutoFill
+    ENDIF
+
+    IF ( Input_Opt%LIMGRID ) THEN
+      ! The below section must be OMP CRITICAL because it is stateful.
+      ! The first call to the critical section will update the container!!
+      !$OMP CRITICAL
+
+      IF ( PRESENT(AltBuffer) ) THEN
+        IF ( AltBuffer ) THEN
+          TMP_AltBuffer = .true.
+        ENDIF
+      ENDIF
+
+      IF ( TMP_AltBuffer ) THEN 
+        TMP_MDL_target => TMP_MDLb
+        TMP_MDL_target4 => TMP_MDL_r4b
+      ELSE
+        TMP_MDL_target => TMP_MDL
+        TMP_MDL_target4 => TMP_MDL_r4
+      ENDIF
+
+      ! ... on-demand intermediate regridding. Check if we already have this field
+      WRITE(TMP_DiagnFldName, *) "_Dgn_", DiagnName
+      IF( .not. ( (.not. TMP_AltBuffer .and. TMP_DiagnFldName == LAST_TMP_REGRID_H2M) .or. &
+                  (      TMP_AltBuffer .and. TMP_DiagnFldName == LAST_TMP_REGRID_H2Mb) ) ) THEN   ! Not already in buffer
+
+        IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_2D: Last regrid not equal, looking up field ", TMP_DiagnFldName
+
+        ! For safety, overwrite the temporary
+        LAST_TMP_REGRID_H2M = "_HCO_Dgn2D_TBD"
+
+        ! Now retrieve data into the HEMCO temporary!
+        ! Note that the data is in sp and has to be promoted for regridding,
+        ! then demoted again for output.
+        CALL GetHcoDiagn( HcoState, ExtState, DiagnName, StopIfNotFound, RC, &
+                          Ptr2D=TMP_Ptr2D,    COL=iCOL,  AutoFill=iAF )
+
+        ! If failure, return up the chain. The calls to this function will
+        ! be able to propagate the error above.
+        IF ( RC /= GC_SUCCESS ) RETURN
+        
+        ! If not found, return
+        IF ( ASSOCIATED( TMP_Ptr2D ) ) THEN
+
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_2D: Lookup complete", TMP_DiagnFldName
+
+          ! Copy data to the temporary
+          TMP_HCO(:,:,1) = TMP_Ptr2D(:,:)
+
+          CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, TMP_MDL, 1 )
+
+          IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_GetDiagn_2D: Regrid complete"
+
+          ! Free the pointer
+          TMP_Ptr2D => NULL()
+
+          ! Copy to the r4 so you can downgrade the precision for GetDgn calls
+          ! for backwards compatibility
+          TMP_MDL_target4(:,:,1) = TMP_MDL(:,:,1)
+
+          ! Point to target dummy
+          Ptr2D => TMP_MDL_target4(:,:,1)
+
+          ! The output should be pointing to Ptr2D (in TMP_MDL:,:,1) and ready to go.
+          LAST_TMP_REGRID_H2M = TMP_DiagnFldName
+          LAST_TMP_MDL_ZBND   = 1 ! Remember the z-boundary ... will be used later
+
+        ENDIF
+
+      ELSE ! Already in buffer! Just read the pointer data
+        Ptr2D => TMP_MDL_target4(:,:,1)
+        ! ... fill the ptr
+      ENDIF
+      !$OMP END CRITICAL
+      ! End of LIMGRID OMP Critical section
+    ELSE
+#endif
+      ! Not GC-Classic or not on-demand intermediate grid, just shim around calls
+      CALL GetHcoDiagn( HcoState, ExtState, DiagnName, StopIfNotFound, RC, &
+                        Ptr2D=Ptr2D,        COL=iCOL,  AutoFill=iAF )
+#ifdef MODEL_CLASSIC
+    ENDIF
+
+    TMP_MDL_target => NULL()
+    TMP_MDL_target4 => NULL()
+#endif
+
+  END SUBROUTINE HCO_GC_GetDiagn_2D
 !EOC
 #if defined ( MODEL_CLASSIC )
 !------------------------------------------------------------------------------
@@ -1684,7 +2028,7 @@ CONTAINS
 210         FORMAT( 12x, ' STATE_PSC: Min = ', es15.9, ', Max = ', es15.9 )
          ENDIF
       ELSE
-         IF ( Input_OPt%amIRoot ) THEN
+         IF ( Input_Opt%amIRoot ) THEN
 #ifdef ESMF_
             ! ExtData and HEMCO behave ambiguously - if the file was found
             ! but was full of zeros throughout the domain of interest, it
@@ -2065,9 +2409,10 @@ CONTAINS
          State_Chm%BoundaryCond(:,:,:,N) = Ptr3D(:,:,:) * MW_g / AIRMW
 
          ! Debug
-!         Print*, 'BCs found for ', TRIM( SpcInfo%Name ), &
-!                 MINVAL(State_Chm%BoundaryCond(:,:,:,N)), &
-!                 MAXVAL(State_Chm%BoundaryCond(:,:,:,N))
+         ! Print*, 'BCs found for ', TRIM( SpcInfo%Name ), &
+         !         MINVAL(State_Chm%BoundaryCond(:,:,:,N)), &
+         !         MAXVAL(State_Chm%BoundaryCond(:,:,:,N)), &
+         !         SUM(State_Chm%BoundaryCond(:,:,:,N))
 
          ! Loop over grid boxes and apply BCs to the specified buffer zone
 !$OMP PARALLEL DO                                                       &
@@ -2381,6 +2726,9 @@ CONTAINS
     ! Intermediate grid functionality?
     IF ( .not. Input_Opt%LIMGRID ) RETURN
 
+    ! Are we allocated?
+    IF ( ASSOCIATED(LonEdgeM) ) RETURN
+
     ! TMP_MDL, TMP_HCO 3D IJK, TMP_MDLb (alternate model buffer)
     ! LAST_TMP_REGRID_M2H, LAST_TMP_REGRID_H2M, H2Mb
     ! LonEdgeH, LatEdgeH (actually SIN), LonEdgeM, LatEdgeM (actually SIN) -- NX+1, NY+1
@@ -2412,8 +2760,9 @@ CONTAINS
     ALLOCATE(TMP_MDLb(State_Grid    %NX, State_Grid    %NY, State_Grid%NZ+1), STAT=RC)
     ALLOCATE(TMP_HCO (State_Grid_HCO%NX, State_Grid_HCO%NY, State_Grid%NZ+1), STAT=RC)
 
-    ALLOCATE(TMP_MDL_r4(State_Grid    %NX, State_Grid    %NY, State_Grid%NZ+1), STAT=RC)
-    ALLOCATE(TMP_HCO_r4(State_Grid_HCO%NX, State_Grid_HCO%NY, State_Grid%NZ+1), STAT=RC)
+    ALLOCATE(TMP_MDL_r4 (State_Grid    %NX, State_Grid    %NY, State_Grid%NZ+1), STAT=RC)
+    ALLOCATE(TMP_MDL_r4b(State_Grid    %NX, State_Grid    %NY, State_Grid%NZ+1), STAT=RC)
+    ALLOCATE(TMP_HCO_r4 (State_Grid_HCO%NX, State_Grid_HCO%NY, State_Grid%NZ+1), STAT=RC)
 
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered in allocating model and HEMCO temporaries!'

--- a/GeosCore/isorropiaII_mod.F90
+++ b/GeosCore/isorropiaII_mod.F90
@@ -121,8 +121,7 @@ CONTAINS
     USE ERROR_MOD,            ONLY : DEBUG_MSG
     USE ERROR_MOD,            ONLY : ERROR_STOP
     USE ERROR_MOD,            ONLY : SAFE_DIV
-    USE HCO_State_GC_Mod,     ONLY : HcoState
-    USE HCO_Calc_Mod,         ONLY : HCO_EvalFld
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
     USE Input_Opt_Mod,        ONLY : OptInput
     USE PhysConstants,        ONLY : AIRMW
     USE State_Chm_Mod,        ONLY : ChmState
@@ -343,7 +342,7 @@ CONTAINS
     ! Evaluate offline global HNO3 from HEMCO is using. Doing this every
     ! timestep allows usage of HEMCO's scaling and masking functionality
     IF ( USE_HNO3_FROM_HEMCO ) THEN
-       CALL HCO_EvalFld( HcoState, 'GLOBAL_HNO3', OFFLINE_HNO3, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_HNO3', OFFLINE_HNO3, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'GLOBAL_HNO3 not found in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/land_mercury_mod.F90
+++ b/GeosCore/land_mercury_mod.F90
@@ -172,7 +172,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE BIOMASSHG( Input_Opt, EHg0_bb, RC )
+  SUBROUTINE BIOMASSHG( Input_Opt, State_Grid, EHg0_bb, RC )
 !
 ! !USES:
 !
@@ -181,11 +181,14 @@ CONTAINS
     USE HCO_STATE_MOD,        ONLY : HCO_STATE
     USE HCO_State_GC_Mod,     ONLY : HcoState, ExtState
     USE HCO_Interface_Common, ONLY : GetHcoDiagn
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetDiagn
     USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Grid_Mod,       ONLY : GrdState
 !
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput),           INTENT(IN)  :: Input_Opt   ! Input Options
+    TYPE(GrdState),           INTENT(IN)  :: State_Grid
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -248,7 +251,7 @@ CONTAINS
        ! by HEMCO automatically. Output unit is as specified when
        ! defining diagnostics (kg/m2/s).
        DgnName = 'BIOMASS_HG0'
-       CALL GetHcoDiagn( HcoState, ExtState, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
+       CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not find HEMCO field ' // TRIM( DgnName )
           CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/main.F90
+++ b/GeosCore/main.F90
@@ -1251,7 +1251,7 @@ PROGRAM GEOS_Chem
 
              ! Copy UV Albedo data (for photolysis) into the
              ! State_Met%UVALBEDO field. (bmy, 3/20/15)
-             CALL Get_UvAlbedo( Input_Opt, State_Met, RC )
+             CALL Get_UvAlbedo( Input_Opt, State_Grid, State_Met, RC )
 
              ! Trap potential errors
              IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/main.F90
+++ b/GeosCore/main.F90
@@ -773,7 +773,7 @@ PROGRAM GEOS_Chem
   IF ( notDryRun ) THEN
 
      ! Populate the State_Met%LandTypeFrac field with data from HEMCO
-     CALL Init_LandTypeFrac( Input_Opt, State_Met, RC )
+     CALL Init_LandTypeFrac( Input_Opt, State_Grid, State_Met, RC )
      IF ( RC /= GC_SUCCESS ) THEN
         ErrMsg = 'Error encountered in "Init_LandTypeFrac"!'
         CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1139,7 +1139,7 @@ PROGRAM GEOS_Chem
        IF ( ITS_A_NEW_DAY() .and. notDryRun ) THEN
 
           ! Initialize the State_Met%XLAI_NATIVE field from HEMCO
-          CALL Get_XlaiNative_from_HEMCO( Input_Opt, State_Met, RC )
+          CALL Get_XlaiNative_from_HEMCO( Input_Opt, State_Grid, State_Met, RC )
 
           ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/main.F90
+++ b/GeosCore/main.F90
@@ -1534,6 +1534,8 @@ PROGRAM GEOS_Chem
              ENDIF
           ENDIF
 
+          IF ( prtDebug ) CALL Debug_Msg( '### MAIN: a Compute_Sflx_For_Vdiff' )
+
           ! Note: mixing routine expects tracers in v/v
           ! DO_MIXING applies the tracer tendencies (dry deposition,
           ! emission rates) to the tracer arrays and performs PBL

--- a/GeosCore/mercury_mod.F90
+++ b/GeosCore/mercury_mod.F90
@@ -2443,7 +2443,7 @@ CONTAINS
        ENDIF
 
        ! Read anthro, ocean, land emissions of Hg from disk
-       CALL MERCURY_READYR( Input_Opt, RC )
+       CALL MERCURY_READYR( Input_Opt, State_Grid, RC )
 
        ! Trap potential errors
        IF ( RC /= GC_SUCCESS ) THEN
@@ -2523,7 +2523,7 @@ CONTAINS
                                 State_Grid, State_Met )
     IF ( prtDebug ) CALL DEBUG_MSG( '### EMISSMERCURY: a SNOW_FLUX' )
 
-    CALL BIOMASSHG( Input_Opt, EHg0_bb, RC )
+    CALL BIOMASSHG( Input_Opt, State_Grid, EHg0_bb, RC )
     IF ( prtDebug ) CALL DEBUG_MSG( '### EMISSMERCURY: a BIOMASS' )
 
     IF ( LnoUSAemis ) THEN
@@ -4004,20 +4004,21 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE MERCURY_READYR( Input_Opt, RC )
+  SUBROUTINE MERCURY_READYR( Input_Opt, State_Grid, RC )
 !
 ! !USES:
 !
     USE ErrCode_Mod
     USE HCO_ERROR_MOD
-    USE HCO_State_GC_Mod,     ONLY : HcoState, ExtState
-    USE HCO_EMISLIST_MOD,     ONLY : HCO_GetPtr
-    USE HCO_Interface_Common, ONLY : GetHcoDiagn
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetDiagn, HCO_GC_GetPtr
     USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Grid_Mod,       ONLY : GrdState
 !
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+    TYPE(GrdState), INTENT(IN)    :: State_Grid
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -4112,7 +4113,7 @@ CONTAINS
 
        ! Anthropogenic emissions
        DgnName = 'HG0_ANTHRO'
-       CALL GetHcoDiagn( HcoState, ExtState, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
+       CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not get HEMCO field ' // TRIM( DgnName )
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -4123,7 +4124,7 @@ CONTAINS
 
        ! Artisanal emissions
        DgnName = 'HG0_ARTISANAL'
-       CALL GetHcoDiagn( HcoState, ExtState, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
+       CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not get HEMCO field ' // TRIM( DgnName )
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -4139,7 +4140,7 @@ CONTAINS
 
        ! Anthropogenic emissions
        DgnName = 'HG2_ANTHRO'
-       CALL GetHcoDiagn( HcoState, ExtState, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
+       CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
        IF ( RC /= HCO_SUCCESS ) THEN
           ErrMsg = 'Could not get HEMCO field ' // TRIM( DgnName )
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -4152,7 +4153,7 @@ CONTAINS
 
     ! Natural emissions
     DgnName = 'HG0_NATURAL'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .TRUE., RC, Ptr2D=Ptr2D )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Could not get HEMCO field ' // TRIM( DgnName )
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -4162,7 +4163,7 @@ CONTAINS
     Ptr2D    => NULL()
 
     ! Soil distribution
-    CALL HCO_GetPtr( HcoState, 'HG0_SOILDIST', Ptr2D, RC )
+    CALL HCO_GC_GetPtr( Input_Opt, State_Grid, 'HG0_SOILDIST', Ptr2D, RC )
     IF ( RC /= HCO_SUCCESS ) THEN
        ErrMsg = 'Could not get pointer to HEMCO field HG0_SOILDIST!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -218,6 +218,7 @@ CONTAINS
     USE GET_NDEP_MOD,         ONLY : SOIL_DRYDEP
     USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetDiagn
     USE HCO_Utilities_GC_Mod, ONLY : GetHcoValEmis, GetHcoValDep, InquireHco
+    USE HCO_Utilities_GC_Mod, ONLY : LoadHcoValEmis, LoadHcoValDep
     USE Input_Opt_Mod,        ONLY : OptInput
     USE PhysConstants,        ONLY : AVO
     USE Species_Mod,          ONLY : Species
@@ -228,6 +229,9 @@ CONTAINS
     USE State_Met_Mod,        ONLY : MetState
     USE TIME_MOD,             ONLY : GET_TS_DYN, GET_TS_CONV, GET_TS_CHEM
     USE UnitConv_Mod,         ONLY : Convert_Spc_Units
+
+    use timers_mod
+    use hco_utilities_gc_mod, only: TMP_MDL ! danger
 !
 ! !INPUT PARAMETERS:
 !
@@ -524,6 +528,17 @@ CONTAINS
           EmisSpec = .FALSE.
        ENDIF
 
+       ! If there is emissions for this species, it must be loaded into memory first.
+       ! This is achieved by attempting to retrieve a grid box while NOT in a parallel
+       ! loop. Failure to load this will result in severe performance issues!! (hplin, 9/27/20)
+       IF ( EmisSpec ) THEN
+          CALL LoadHcoValEmis ( Input_Opt, State_Grid, N )
+       ENDIF
+
+       IF ( DryDepSpec ) THEN
+          CALL LoadHcoValDep ( Input_Opt, State_Grid, N )
+       ENDIF
+
        !--------------------------------------------------------------------
        ! Can go to next species if this species does not have
        ! dry deposition and/or emissions
@@ -704,7 +719,19 @@ CONTAINS
              IF ( EmisSpec .AND. ( L <= EMIS_TOP ) ) THEN
 
                 ! Get HEMCO emissions. Units are [kg/m2/s].
-                CALL GetHcoValEmis ( Input_Opt, State_Grid, N, I, J, L, FND, TMP )
+                ! Fix hplin: for intermediate grid, pass SkipCheck in a tight loop. Note that this assumes that adjacent
+                ! calls to GetHcoValEmis are from the same species ID, or there will be big trouble. (hplin, 10/10/20)
+
+#ifdef MODEL_CLASSIC
+                IF ( Input_Opt%LIMGRID ) THEN
+                  FND = .true.
+                  TMP = TMP_MDL(I,J,L) ! this is a kludge for the tight loop optimization
+                ELSE
+#endif
+                  CALL GetHcoValEmis ( Input_Opt, State_Grid, N, I, J, L, FND, TMP, SkipCheck=.true. )
+#ifdef MODEL_CLASSIC
+                ENDIF
+#endif          
 
                 ! Add emissions (if any)
                 ! Bug fix: allow negative fluxes. (ckeller, 4/12/17)
@@ -767,7 +794,6 @@ CONTAINS
        SpcInfo  => NULL()
 
     ENDDO !N
-
     !--------------------------------------------------------------
     ! Special handling for tagged CH4 simulations
     !--------------------------------------------------------------

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -218,7 +218,7 @@ CONTAINS
     USE GET_NDEP_MOD,         ONLY : SOIL_DRYDEP
     USE HCO_Interface_Common, ONLY : GetHcoDiagn
     USE HCO_State_GC_Mod,     ONLY : HcoState, ExtState
-    USE HCO_Utilities_GC_Mod, ONLY : GetHcoValEmis, GetHcoValDep
+    USE HCO_Utilities_GC_Mod, ONLY : GetHcoValEmis, GetHcoValDep, InquireHco
     USE Input_Opt_Mod,        ONLY : OptInput
     USE PhysConstants,        ONLY : AVO
     USE Species_Mod,          ONLY : Species
@@ -409,6 +409,23 @@ CONTAINS
     !=======================================================================
     ! Do for every advected species and grid box
     !=======================================================================
+
+    ! Note: For GEOS-Chem Classic HEMCO "Intermediate Grid" feature,
+    ! where HEMCO is running on a distinct grid from the model, the
+    ! on-demand regridding is most optimized when contiguous accesses
+    ! to GetHcoValEmis and GetHcoValDep are performed for the given species.
+    ! Therefore, it is most optimal to call in the following fashion (IJKN)
+    !    Emis(1,1,1,1) -> Emis(1,1,2,1) -> ... -> Dep(1,1,1,1) -> Dep(1,1,2,1)
+    ! By switching emis/dep or the species # LAST, as either of these changing
+    ! WILL trigger a new regrid and thrashing of the old buffer.
+    !
+    ! Therefore, the loop below has been adjusted to two grid loops to
+    ! balance memory and performance:
+    !  By NA = 1, nAdvect
+    !     By I, J ... for emissions ...
+    !     By I, J ... for dry dep and everything else ...
+    ! (hplin, 6/13/20)
+
 !$OMP PARALLEL DO                                                           &
 !$OMP DEFAULT( SHARED                                                     ) &
 !$OMP PRIVATE( I,        J,            L,          L1,       L2           ) &
@@ -443,7 +460,7 @@ CONTAINS
           ! Check if this is a HEMCO drydep species
           DryDepSpec = ( DryDepId > 0 )
           IF ( .NOT. DryDepSpec ) THEN
-             CALL GetHcoValDep ( Input_Opt, State_Grid, N, 1, 1, 1, DryDepSpec, TMP )
+             CALL InquireHco ( N, Dep=DryDepSpec )
           ENDIF
 
           ! Special case for O3 or HNO3: include PARANOX loss
@@ -457,12 +474,7 @@ CONTAINS
        ! Check if we need to do emissions for this species
        !--------------------------------------------------------------------
        IF ( LEMIS ) THEN
-          ! FIXME hplin: This is rather inefficient in the HEMCO intermediate grid
-          ! implementation, as it will trigger a on-demand regrid while
-          ! this is just an INQUIRY to whether this EmisSpec exists.
-          ! It should be optimized into another subroutine in the future.
-          ! (hplin, 6/6/20)
-          CALL GetHcoValEmis ( Input_Opt, State_Grid, N, 1, 1, 1, EmisSpec, TMP )
+          CALL InquireHco ( N, Emis=EmisSpec )
        ELSE
           EmisSpec = .FALSE.
        ENDIF

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -443,7 +443,7 @@ CONTAINS
           ! Check if this is a HEMCO drydep species
           DryDepSpec = ( DryDepId > 0 )
           IF ( .NOT. DryDepSpec ) THEN
-             CALL GetHcoValDep ( N, 1, 1, 1, DryDepSpec, TMP )
+             CALL GetHcoValDep ( Input_Opt, State_Grid, N, 1, 1, 1, DryDepSpec, TMP )
           ENDIF
 
           ! Special case for O3 or HNO3: include PARANOX loss
@@ -457,7 +457,12 @@ CONTAINS
        ! Check if we need to do emissions for this species
        !--------------------------------------------------------------------
        IF ( LEMIS ) THEN
-          CALL GetHcoValEmis ( N, 1, 1, 1, EmisSpec, TMP )
+          ! FIXME hplin: This is rather inefficient in the HEMCO intermediate grid
+          ! implementation, as it will trigger a on-demand regrid while
+          ! this is just an INQUIRY to whether this EmisSpec exists.
+          ! It should be optimized into another subroutine in the future.
+          ! (hplin, 6/6/20)
+          CALL GetHcoValEmis ( Input_Opt, State_Grid, N, 1, 1, 1, EmisSpec, TMP )
        ELSE
           EmisSpec = .FALSE.
        ENDIF
@@ -569,7 +574,7 @@ CONTAINS
                 ! dry deposition frequencies for air-sea exchange and
                 ! from ship NOx plume parameterization (PARANOx). The
                 ! units are [s-1].
-                CALL GetHcoValDep ( N, I, J, 1, FND, TMP )
+                CALL GetHcoValDep ( Input_Opt, State_Grid, N, I, J, 1, FND, TMP )
 
                 ! Add to dry dep frequency from drydep_mod.F90
                 IF ( FND ) FRQ = FRQ + TMP
@@ -673,7 +678,7 @@ CONTAINS
              IF ( EmisSpec .AND. ( L <= EMIS_TOP ) ) THEN
 
                 ! Get HEMCO emissions. Units are [kg/m2/s].
-                CALL GetHcoValEmis ( N, I, J, L, FND, TMP )
+                CALL GetHcoValEmis ( Input_Opt, State_Grid, N, I, J, L, FND, TMP )
 
                 ! Add emissions (if any)
                 ! Bug fix: allow negative fluxes. (ckeller, 4/12/17)
@@ -705,7 +710,7 @@ CONTAINS
 
                       ! Get soil absorption from HEMCO. Units are [kg/m2/s].
                       ! CH4_SAB is species #15
-                      CALL GetHcoValEmis ( 15, I, J, L, FND, TMP )
+                      CALL GetHcoValEmis ( Input_Opt, State_Grid, 15, I, J, L, FND, TMP )
 
                       ! Remove soil absorption from total CH4 emissions
                       IF ( FND ) THEN

--- a/GeosCore/olson_landmap_mod.F90
+++ b/GeosCore/olson_landmap_mod.F90
@@ -330,16 +330,16 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Init_LandTypeFrac( Input_Opt, State_Met, RC )
+  SUBROUTINE Init_LandTypeFrac( Input_Opt, State_Grid, State_Met, RC )
 !
 ! !USES:
 !
-    USE CMN_SIZE_Mod,      ONLY : NSURFTYPE
+    USE CMN_SIZE_Mod,         ONLY : NSURFTYPE
     USE ErrCode_Mod
-    USE HCO_State_GC_Mod,  ONLY : HcoState
-    USE Hco_EmisList_Mod,  ONLY : Hco_GetPtr
-    USE Input_Opt_Mod,     ONLY : OptInput
-    USE State_Met_Mod,     ONLY : MetState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Met_Mod,        ONLY : MetState
+    USE State_Grid_Mod,       ONLY : GrdState
 !
 ! !INPUT PARAMETERS:
 !
@@ -347,6 +347,7 @@ CONTAINS
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
+    TYPE(GrdState), INTENT(INOUT) :: State_Grid
     TYPE(MetState), INTENT(INOUT) :: State_Met   ! Meteorology State object
 !
 ! !OUTPUT PARAMETERS:
@@ -368,13 +369,11 @@ CONTAINS
 !
     ! Scalars
     INTEGER            :: T
+    LOGICAL            :: FND
 
     ! Strings
     CHARACTER(LEN=10)  :: Name
     CHARACTER(LEN=255) :: ErrMsg, ThisLoc
-
-    ! Pointers
-    REAL(f4), POINTER  :: Ptr2D(:,:)
 
     !=======================================================================
     ! Init_LandTypeFrac begins here!
@@ -386,9 +385,6 @@ CONTAINS
     ThisLoc = &
       ' -> at Init_LandTypeFrac (in module "GeosCore/olson_landmap_mod.F90'
 
-    ! Free pointer
-    Ptr2D => NULL()
-
     ! Loop over the number of Olson land types
     DO T = 1, NSURFTYPE
 
@@ -396,20 +392,14 @@ CONTAINS
        ! (variable names are LANDTYPE00, LANDTYPE01 .. LANDTYPE72)
        WRITE( Name, 100 ) T-1
  100   FORMAT( 'LANDTYPE', i2.2 )
-       CALL HCO_GetPtr( HcoState, Name, Ptr2D, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, Name, State_Met%LandTypeFrac(:,:,T), RC, FOUND=FND )
 
        ! Trap potential errors
-       IF ( RC /= GC_SUCCESS ) THEN
-          ErrMsg = 'Could not get pointer to HEMCO field: ' // TRIM( Name )
+       IF ( RC /= GC_SUCCESS .or. .not. FND ) THEN
+          ErrMsg = 'Could not read HEMCO field: ' // TRIM( Name )
           CALL GC_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
-
-       ! Copy into State_Met%LandTypeFrac
-       State_Met%LandTypeFrac(:,:,T) = Ptr2D
-
-       ! Free pointer
-       Ptr2D => NULL()
 
     ENDDO
 

--- a/GeosCore/rpmares_mod.F90
+++ b/GeosCore/rpmares_mod.F90
@@ -61,18 +61,17 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE ERROR_MOD,          ONLY : ERROR_STOP
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE PhysConstants,      ONLY : AIRMW
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Chm_Mod,      ONLY : Ind_
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE State_Met_Mod,      ONLY : MetState
-    USE TIME_MOD,           ONLY : GET_MONTH
-    USE TIME_MOD,           ONLY : ITS_A_NEW_MONTH
-    USE TIME_MOD,           ONLY : GET_ELAPSED_SEC
+    USE ERROR_MOD,            ONLY : ERROR_STOP
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE PhysConstants,        ONLY : AIRMW
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Chm_Mod,        ONLY : Ind_
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
+    USE TIME_MOD,             ONLY : GET_MONTH
+    USE TIME_MOD,             ONLY : ITS_A_NEW_MONTH
+    USE TIME_MOD,             ONLY : GET_ELAPSED_SEC
 !
 ! !INPUT PARAMETERS:
 !
@@ -179,7 +178,7 @@ CONTAINS
     ! Evaluate offline global HNO3 from HEMCO is using. Doing this every
     ! timestep allows usage of HEMCO's scaling and masking functionality
     IF ( USE_HNO3_FROM_HEMCO ) THEN
-       CALL HCO_EvalFld( HcoState, 'GLOBAL_HNO3', HCO_HNO3, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_HNO3', HCO_HNO3, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'GLOBAL_HNO3 not found in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, 'rpmares_mod.F90: Do_rpmares' )

--- a/GeosCore/set_global_ch4_mod.F90
+++ b/GeosCore/set_global_ch4_mod.F90
@@ -52,8 +52,7 @@ CONTAINS
 !
     USE ErrCode_Mod
     USE ERROR_MOD
-    USE HCO_State_GC_Mod,  ONLY : HcoState
-    USE HCO_Calc_Mod,      ONLY : HCO_EvalFld
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
     USE Input_Opt_Mod,     ONLY : OptInput
     USE State_Chm_Mod,     ONLY : ChmState, Ind_
     USE State_Diag_Mod,    ONLY : DgnState
@@ -131,13 +130,13 @@ CONTAINS
     id_CH4 = Ind_( 'CH4' )
 
     ! Use the NOAA spatially resolved data where available
-    CALL HCO_EvalFld( HcoState, 'NOAA_GMD_CH4', State_Chm%SFC_CH4, RC, &
-                      FOUND=FOUND )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'NOAA_GMD_CH4', State_Chm%SFC_CH4, RC, &
+                         FOUND=FOUND )
     IF (.NOT. FOUND ) THEN
        FOUND = .TRUE.
        ! Use the CMIP6 data from Meinshausen et al. 2017, GMD
        ! https://doi.org/10.5194/gmd-10-2057-2017a
-       CALL HCO_EvalFld( HcoState, 'CMIP6_Sfc_CH4', State_Chm%SFC_CH4, RC, &
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'CMIP6_Sfc_CH4', State_Chm%SFC_CH4, RC, &
                          FOUND=FOUND )
     ENDIF
     IF (.NOT. FOUND ) THEN

--- a/GeosCore/sfcvmr_mod.F90
+++ b/GeosCore/sfcvmr_mod.F90
@@ -88,13 +88,12 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE State_Met_Mod,      ONLY : MetState
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE Species_Mod,        ONLY : Species
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Met_Mod,        ONLY : MetState
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE Species_Mod,          ONLY : Species
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
 !
 ! !INPUT PARAMETERS:
 !
@@ -162,7 +161,7 @@ CONTAINS
 
        ! Check if file exists
        FldName = TRIM( Prefix ) // TRIM( SpcInfo%Name )
-       CALL HCO_EvalFld( HcoState, TRIM(FldName), Arr2D, RC, FOUND=FOUND )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, TRIM(FldName), Arr2D, RC, FOUND=FOUND )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find field : ' // TRIM( FldName )
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -229,15 +228,14 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE State_Met_Mod,      ONLY : MetState
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE State_Chm_Mod,      ONLY : Ind_
-    USE Species_Mod,        ONLY : Species
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : Hco_EvalFld
-    USE TIME_MOD,           ONLY : Get_Month
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Met_Mod,        ONLY : MetState
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Chm_Mod,        ONLY : Ind_
+    USE Species_Mod,          ONLY : Species
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE TIME_MOD,             ONLY : Get_Month
 
     ! Needed for the new CHxCly boundary condition
     Use PhysConstants,      Only : AirMW
@@ -311,7 +309,7 @@ CONTAINS
     DO WHILE( ASSOCIATED( iObj ) )
 
        ! Get concentration for this species
-       CALL HCO_EvalFld( HcoState, Trim(iObj%FldName), Arr2D, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, Trim(iObj%FldName), Arr2D, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not get surface VMR for species: '//               &
                    TRIM( iObj%FldName ) // '!'

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -206,7 +206,7 @@ CONTAINS
     USE ErrCode_Mod
     USE ERROR_MOD
     USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
     USE Input_Opt_Mod,      ONLY : OptInput
     USE State_Chm_Mod,      ONLY : ChmState
     USE State_Chm_Mod,      ONLY : Ind_
@@ -298,7 +298,7 @@ CONTAINS
     IF ( Input_Opt%ITS_AN_AEROSOL_SIM ) THEN
 
        ! Evaluate offline global OH from HEMCO
-       CALL HCO_EvalFld( HcoState, 'GLOBAL_OH', GLOBAL_OH, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_OH', GLOBAL_OH, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Cannot get data for GLOBAL_OH from HEMCO!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -306,7 +306,7 @@ CONTAINS
        ENDIF
 
        ! Evaluate offline global HNO3 from HEMCO
-       CALL HCO_EvalFld( HcoState, 'GLOBAL_HNO3', GLOBAL_HNO3, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_HNO3', GLOBAL_HNO3, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Cannot get data for GLOBAL_HNO3 from HEMCO!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -1778,8 +1778,7 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE HCO_State_GC_Mod,   ONLY : HcoState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
     USE Input_Opt_Mod,      ONLY : OptInput
     USE State_Chm_Mod,      ONLY : ChmState
     USE State_Diag_Mod,     ONLY : DgnState
@@ -1890,7 +1889,7 @@ CONTAINS
     f           = 1000.e+0_fp / AIRMW * AVO * 1.e-6_fp
 
     ! Evaluate offline global NO3 from HEMCO
-    CALL HCO_EvalFld( HcoState, 'GLOBAL_NO3', GLOBAL_NO3, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_NO3', GLOBAL_NO3, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get data for GLOBAL_NO3 from HEMCO!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -2098,16 +2097,15 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Diag_Mod,     ONLY : DgnState
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE State_Met_Mod,      ONLY : MetState
-    USE TIME_MOD,           ONLY : GET_MONTH
-    USE TIME_MOD,           ONLY : GET_TS_CHEM
-    USE TIME_MOD,           ONLY : ITS_A_NEW_MONTH
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
+    USE TIME_MOD,             ONLY : GET_MONTH
+    USE TIME_MOD,             ONLY : GET_TS_CHEM
+    USE TIME_MOD,             ONLY : ITS_A_NEW_MONTH
 !
 ! !INPUT PARAMETERS:
 !
@@ -2176,7 +2174,7 @@ CONTAINS
     F         = 1000.e+0_fp / AIRMW * AVO * 1.e-6_fp
 
     ! Evaluate offline fields from HEMCO for P(H2O2)
-    CALL HCO_EvalFld( HcoState, 'PH2O2', PH2O2m, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'PH2O2', PH2O2m, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get data for PH2O2 from HEMCO!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -2184,7 +2182,7 @@ CONTAINS
     ENDIF
 
     ! Evaluate offline fields from HEMCO for J(H2O2)
-    CALL HCO_EvalFld( HcoState, 'JH2O2', JH2O2, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'JH2O2', JH2O2, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get data for JH2O2 from HEMCO!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -2290,7 +2288,7 @@ CONTAINS
     USE TIME_MOD,             ONLY : ITS_A_NEW_MONTH
     USE HCO_State_GC_Mod,     ONLY : HcoState, ExtState
     USE HCO_Interface_Common, ONLY : GetHcoDiagn
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
 #ifdef APM
     USE APM_DRIV_MOD,       ONLY : PSO4GAS
     USE APM_DRIV_MOD,       ONLY : XO3
@@ -2501,7 +2499,7 @@ CONTAINS
 
     ! If offline aerosol simulation, evaluate offline oxidant fields from HEMCO
     IF ( Input_Opt%ITS_AN_AEROSOL_SIM ) THEN
-       CALL HCO_EvalFld( HcoState, 'O3', O3m, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'O3', O3m, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Cannot get data for O3 from HEMCO!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -6879,7 +6877,7 @@ CONTAINS
        ! Get ALK1 and ALK2 surface emissions from HEMCO. These are in
        ! kg/m2/s.
        CALL GetHcoValEmis( Input_Opt, State_Grid, id_SALA, I, J, 1, FOUND, ALK1 )
-       CALL GetHcoValEmis( Input_Opt, State_Grid, id_SALC, I, J, 1, FOUND, ALK2 )
+       CALL GetHcoValEmis( Input_Opt, State_Grid, id_SALC, I, J, 1, FOUND, ALK2, AltBuffer=.true. )
 
        ! kg/m2/s --> kg. Weight by fraction of PBL
        ALK1 = MAX(ALK1,0.0e+0_fp) * State_Grid%Area_M2(I,J) * TS_EMIS * FEMIS

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -2288,7 +2288,7 @@ CONTAINS
     USE TIME_MOD,             ONLY : GET_TS_CHEM, GET_MONTH
     USE TIME_MOD,             ONLY : ITS_A_NEW_MONTH
     USE HCO_State_GC_Mod,     ONLY : HcoState
-    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld, HCO_GC_GetDiagn
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld, HCO_GC_GetDiagn, LoadHcoValEmis
 #ifdef APM
     USE APM_DRIV_MOD,       ONLY : PSO4GAS
     USE APM_DRIV_MOD,       ONLY : XO3
@@ -2523,6 +2523,11 @@ CONTAINS
           RETURN
        ENDIF
     ENDIF
+
+    ! Load emissions into buffer first for ALK1, ALK2 
+    ! BEFORE entering loop (hplin, 9/27/20)
+    CALL LoadHcoValEmis ( Input_Opt, State_Grid, id_SALA )
+    CALL LoadHcoValEmis ( Input_Opt, State_Grid, id_SALC, AltBuffer=.true. )
 
     ! Loop over chemistry grid boxes
     !$OMP PARALLEL DO       &

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -844,8 +844,9 @@ CONTAINS
     USE TOMAS_MOD,            ONLY : Xk
     USE TOMAS_MOD,            ONLY : SUBGRIDCOAG, MNFIX
     USE TOMAS_MOD,            ONLY : SRTSO4, SRTNH4,  DEBUGPRINT
-    USE HCO_State_GC_Mod,     ONLY : HcoState, ExtState
-    USE HCO_Interface_Common, ONLY : GetHcoDiagn
+
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_GetDiagn
+    USE HCO_State_GC_Mod,     ONLY : HcoState
 !
 ! !INPUT PARAMETERS:
 !
@@ -992,7 +993,7 @@ CONTAINS
     ! READ IN HEMCO EMISSIONS
     !================================================================
     DgnName = 'SO4_ANTH'
-    CALL GetHcoDiagn( HcoState, ExtState, DgnName, .FALSE., ERR, Ptr3D=Ptr3D )
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, DgnName, .FALSE., ERR, Ptr3D=Ptr3D )
     IF ( .NOT. ASSOCIATED(Ptr3D) ) THEN
        CALL HCO_WARNING('Not found: '//TRIM(DgnName),ERR,THISLOC=LOC)
     ELSE
@@ -2286,9 +2287,8 @@ CONTAINS
     USE State_Met_Mod,        ONLY : MetState
     USE TIME_MOD,             ONLY : GET_TS_CHEM, GET_MONTH
     USE TIME_MOD,             ONLY : ITS_A_NEW_MONTH
-    USE HCO_State_GC_Mod,     ONLY : HcoState, ExtState
-    USE HCO_Interface_Common, ONLY : GetHcoDiagn
-    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld, HCO_GC_GetDiagn
 #ifdef APM
     USE APM_DRIV_MOD,       ONLY : PSO4GAS
     USE APM_DRIV_MOD,       ONLY : XO3
@@ -2410,6 +2410,7 @@ CONTAINS
     REAL(fp), POINTER     :: SSAlk(:,:,:,:)
     REAL(fp), POINTER     :: H2O2s(:,:,:)
     REAL(fp), POINTER     :: SO2s(:,:,:)
+    REAL(f4), POINTER     :: Ptr2D(:,:) => NULL()
 
     ! For HEMCO update
     LOGICAL, SAVE         :: FIRST = .TRUE.
@@ -2469,30 +2470,46 @@ CONTAINS
     ! disabled), the passed pointers NDENS_SALA and NDENS_SALC
     ! will stay nullified. Values of zero will be used in this
     ! case! (ckeller, 01/12/2015)
+
+    ! Now retrieve the pointer data on every call for the HEMCO on-demand
+    ! regridding in GC-Classic (hplin, 6/25/20)
+
+    ! Sea salt density, fine mode
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, 'SEASALT_DENS_FINE', &
+                      StopIfNotFound=.FALSE., RC=RC, Ptr2D=Ptr2D )
+
+    ! Trap potential errors
+    IF ( RC /= HCO_SUCCESS ) THEN
+       ErrMsg = 'Cannot get HEMCO field SEASALT_DENS_FINE!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+
+    IF ( ASSOCIATED( Ptr2D ) ) THEN
+      ALLOCATE( NDENS_SALA( State_Grid%NX, State_Grid%NY ), STAT=RC )
+      NDENS_SALA(:,:) = Ptr2D(:,:)
+    ENDIF
+    Ptr2D => NULL()
+
+    ! Sea salt density, coarse mode
+    CALL HCO_GC_GetDiagn( Input_Opt, State_Grid, 'SEASALT_DENS_COARSE', &
+                      StopIfNotFound=.FALSE., RC=RC, Ptr2D=Ptr2D )
+
+    ! Trap potential errors
+    IF ( RC /= HCO_SUCCESS ) THEN
+       ErrMsg = 'Cannot get HEMCO field SEASALT_DENS_COARSE!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+
+    IF ( ASSOCIATED( Ptr2D ) ) THEN
+      ALLOCATE( NDENS_SALC( State_Grid%NX, State_Grid%NY ), STAT=RC )
+      NDENS_SALC(:,:) = Ptr2D(:,:)
+    ENDIF
+    Ptr2D => NULL()
+
+
     IF ( FIRST ) THEN
-
-       ! Sea salt density, fine mode
-       CALL GetHcoDiagn( HcoState, ExtState, 'SEASALT_DENS_FINE', &
-                         StopIfNotFound=.FALSE., RC=RC, Ptr2D=NDENS_SALA )
-
-       ! Trap potential errors
-       IF ( RC /= HCO_SUCCESS ) THEN
-          ErrMsg = 'Cannot get HEMCO field SEASALT_DENS_FINE!'
-          CALL GC_Error( ErrMsg, RC, ThisLoc )
-          RETURN
-       ENDIF
-
-       ! Sea salt density, coarse mode
-       CALL GetHcoDiagn( HcoState, ExtState, 'SEASALT_DENS_COARSE', &
-                         StopIfNotFound=.FALSE., RC=RC, Ptr2D=NDENS_SALC )
-
-       ! Trap potential errors
-       IF ( RC /= HCO_SUCCESS ) THEN
-          ErrMsg = 'Cannot get HEMCO field SEASALT_DENS_COARSE!'
-          CALL GC_Error( ErrMsg, RC, ThisLoc )
-          RETURN
-       ENDIF
-
        ! Adjust first flag
        FIRST = .FALSE.
     ENDIF
@@ -3664,6 +3681,10 @@ CONTAINS
     ENDDO
     !$OMP END PARALLEL DO
 
+    ! Deallocate if allocated
+    IF ( ASSOCIATED( NDENS_SALA ) ) DEALLOCATE ( NDENS_SALA )
+    IF ( ASSOCIATED( NDENS_SALC ) ) DEALLOCATE ( NDENS_SALC )
+
     ! Free pointers
     Spc     => NULL()
     pHCloud => NULL()
@@ -3671,6 +3692,8 @@ CONTAINS
     SSAlk   => NULL()
     H2O2s   => NULL()
     SO2s    => NULL()
+    NDENS_SALA => NULL()
+    NDENS_SALC => NULL()
 
   END SUBROUTINE CHEM_SO2
 !EOC

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -6878,8 +6878,8 @@ CONTAINS
 
        ! Get ALK1 and ALK2 surface emissions from HEMCO. These are in
        ! kg/m2/s.
-       CALL GetHcoValEmis( id_SALA, I, J, 1, FOUND, ALK1 )
-       CALL GetHcoValEmis( id_SALC, I, J, 1, FOUND, ALK2 )
+       CALL GetHcoValEmis( Input_Opt, State_Grid, id_SALA, I, J, 1, FOUND, ALK1 )
+       CALL GetHcoValEmis( Input_Opt, State_Grid, id_SALC, I, J, 1, FOUND, ALK2 )
 
        ! kg/m2/s --> kg. Weight by fraction of PBL
        ALK1 = MAX(ALK1,0.0e+0_fp) * State_Grid%Area_M2(I,J) * TS_EMIS * FEMIS

--- a/GeosCore/tagged_co_mod.F90
+++ b/GeosCore/tagged_co_mod.F90
@@ -89,19 +89,19 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE ERROR_MOD,          ONLY : CHECK_VALUE
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_State_Mod,      ONLY : HCO_GetHcoId
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE PhysConstants,      ONLY : AVO
-    USE State_Chm_Mod,      ONLY : ChmState, Ind_
-    USE State_Diag_Mod,     ONLY : DgnState
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE State_Met_Mod,      ONLY : MetState
-    USE TIME_MOD,           ONLY : GET_TS_CHEM,     GET_TS_EMIS
-    USE TIME_MOD,           ONLY : GET_MONTH,       GET_YEAR
-    USE TIME_MOD,           ONLY : ITS_A_NEW_MONTH, ITS_A_NEW_YEAR
+    USE ERROR_MOD,            ONLY : CHECK_VALUE
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE HCO_State_Mod,        ONLY : HCO_GetHcoId
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE PhysConstants,        ONLY : AVO
+    USE State_Chm_Mod,        ONLY : ChmState, Ind_
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
+    USE TIME_MOD,             ONLY : GET_TS_CHEM,     GET_TS_EMIS
+    USE TIME_MOD,             ONLY : GET_MONTH,       GET_YEAR
+    USE TIME_MOD,             ONLY : ITS_A_NEW_MONTH, ITS_A_NEW_YEAR
 !
 ! !INPUT PARAMETERS:
 !
@@ -284,7 +284,7 @@ CONTAINS
     ENDIF
 
     ! Evaluate global OH from HEMCO
-    CALL HCO_EvalFld( HcoState, 'GLOBAL_OH', GLOBAL_OH,   RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GLOBAL_OH', GLOBAL_OH,   RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot retrieve data for GLOBAL_OH from HEMCO!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -292,7 +292,7 @@ CONTAINS
     ENDIF
 
     ! Evaluate strat P(CO) from GMI from HEMCO
-    CALL HCO_EvalFld( HcoState, 'GMI_PROD_CO', GMI_PROD_CO, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GMI_PROD_CO', GMI_PROD_CO, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot retrieve data for GMI_PROD_CO from HEMCO!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -300,7 +300,7 @@ CONTAINS
     ENDIF
 
     ! Evaluate strat L(CO) from GMI from HEMCO
-    CALL HCO_EvalFld( HcoState, 'GMI_LOSS_CO', GMI_LOSS_CO, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GMI_LOSS_CO', GMI_LOSS_CO, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot retrieve data for GMI_LOSS_CO from HEMCO!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -308,7 +308,7 @@ CONTAINS
     ENDIF
 
     ! Evaluate surface CH4 data from HEMCO
-    CALL HCO_EvalFld( HcoState, 'NOAA_GMD_CH4', SFC_CH4, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'NOAA_GMD_CH4', SFC_CH4, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot retrieve data for NOAA_GMD_CH4 from HEMCO!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -317,7 +317,7 @@ CONTAINS
 
     ! Evaluate trop P(CO) from CH4 in HEMCO if needed
     IF ( LPCO_CH4 ) THEN
-       CALL HCO_EvalFld( HcoState, 'PCO_CH4', PCO_CH4, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'PCO_CH4', PCO_CH4, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Cannot retrieve data for PCO_CH4 from HEMCO!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -327,7 +327,7 @@ CONTAINS
 
     ! Evaluate trop P(CO) from NMVOC in HEMCO if needed
     IF ( LPCO_NMVOC ) THEN
-       CALL HCO_EvalFld( HcoState, 'PCO_NMVOC', PCO_NMVOC, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'PCO_NMVOC', PCO_NMVOC, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Cannot retrieve data for PCO_NMVOC from HEMCO!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/tagged_o3_mod.F90
+++ b/GeosCore/tagged_o3_mod.F90
@@ -336,15 +336,15 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE ERROR_MOD,          ONLY : GEOS_CHEM_STOP
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE State_Chm_Mod,      ONLY : ChmState
-    USE State_Diag_Mod,     ONLY : DgnState
-    USE State_Grid_Mod,     ONLY : GrdState
-    USE State_Met_Mod,      ONLY : MetState
-    USE TIME_MOD,           ONLY : GET_TS_CHEM
+    USE ERROR_MOD,            ONLY : GEOS_CHEM_STOP
+    USE HCO_State_GC_Mod,     ONLY : HcoState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Chm_Mod,        ONLY : ChmState
+    USE State_Diag_Mod,       ONLY : DgnState
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Met_Mod,        ONLY : MetState
+    USE TIME_MOD,             ONLY : GET_TS_CHEM
 
     IMPLICIT NONE
 !
@@ -454,7 +454,7 @@ CONTAINS
     CALL GC_CheckVar( 'tagged_o3_mod.F: P24H', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     P24H = 0.0_fp
-    CALL HCO_EvalFld( HcoState, 'O3_PROD', P24H, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'O3_PROD', P24H, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get pointer to O3_PROD!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -469,7 +469,7 @@ CONTAINS
     CALL GC_CheckVar( 'tagged_o3_mod.F: L24H', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     L24H = 0.0_fp
-    CALL HCO_EvalFld( HcoState, 'O3_LOSS', L24H, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'O3_LOSS', L24H, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Cannot get pointer to O3_LOSS!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/toms_mod.F90
+++ b/GeosCore/toms_mod.F90
@@ -93,11 +93,10 @@ CONTAINS
 !
 ! !USES:
 !
-    USE HCO_Calc_Mod,      ONLY : Hco_EvalFld
-    USE HCO_State_GC_Mod,  ONLY : HcoState
-    USE Input_Opt_Mod,     ONLY : OptInput
-    USE State_Grid_Mod,    ONLY : GrdState
-    USE State_Chm_Mod,     ONLY : ChmState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Grid_Mod,       ONLY : GrdState
+    USE State_Chm_Mod,        ONLY : ChmState
 !
 ! !INPUT PARAMETERS:
 !
@@ -220,7 +219,7 @@ CONTAINS
     ELSE
 
        ! Evalulate the first day TOMS O3 columns from HEMCO
-       CALL HCO_EvalFld( HcoState, 'TOMS1_O3_COL', State_Chm%TOMS1, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'TOMS1_O3_COL', State_Chm%TOMS1, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find TOMS1_O3_COL in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, 'toms_mod.F' )
@@ -228,7 +227,7 @@ CONTAINS
        ENDIF
        
        ! Evalulate the last day TOMS O3 columns from HEMCO
-       CALL HCO_EvalFld( HcoState, 'TOMS2_O3_COL', State_Chm%TOMS2, RC )
+       CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'TOMS2_O3_COL', State_Chm%TOMS2, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Could not find TOMS2_O3_COL in HEMCO data list!'
           CALL GC_Error( ErrMsg, RC, 'toms_mod.F' )

--- a/GeosCore/uvalbedo_mod.F90
+++ b/GeosCore/uvalbedo_mod.F90
@@ -52,20 +52,21 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Get_UValbedo( Input_Opt, State_Met, RC )
+  SUBROUTINE Get_UValbedo( Input_Opt, State_Grid, State_Met, RC )
 !
 ! !USES:
 !
     USE ErrCode_Mod
-    USE HCO_State_GC_Mod,   ONLY : HcoState
-    USE HCO_Calc_Mod,       ONLY : HCO_EvalFld
-    USE Input_Opt_Mod,      ONLY : OptInput
-    USE State_Met_Mod,      ONLY : MetState
+    USE HCO_Utilities_GC_Mod, ONLY : HCO_GC_EvalFld
+    USE Input_Opt_Mod,        ONLY : OptInput
+    USE State_Met_Mod,        ONLY : MetState
+    USE State_Grid_Mod,       ONLY : GrdState
 !
 !
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+    TYPE(GrdState), INTENT(IN)    :: State_Grid
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -104,7 +105,7 @@ CONTAINS
     ENDIF
 
     ! Evalulate the UV albedo from HEMCO
-    CALL HCO_EvalFld( HcoState, 'UV_ALBEDO', State_Met%UVALBEDO, RC )
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'UV_ALBEDO', State_Met%UVALBEDO, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Could not find UV_ALBEDO in HEMCO data list!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/vdiff_mod.F90
+++ b/GeosCore/vdiff_mod.F90
@@ -1820,11 +1820,6 @@ CONTAINS
     USE OCEAN_MERCURY_MOD,  ONLY : OMMFP => Fp
     USE OCEAN_MERCURY_MOD,  ONLY : LHg2HalfAerosol !cdh
 
-    ! HEMCO update
-    USE HCO_State_GC_Mod,     ONLY : HcoState, ExtState
-    USE HCO_Interface_Common, ONLY : GetHcoDiagn
-    USE HCO_Utilities_GC_Mod, ONLY : GetHcoValEmis, GetHcoValDep
-
     implicit none
 !
 ! !INPUT PARAMETERS:

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -147,6 +147,9 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: LCH4SBC
      LOGICAL                     :: LSETH2O
 
+     ! For HEMCO "intermediate" grid (hplin, 6/2/20)
+     LOGICAL                     :: LIMGRID    ! Use different grid resolution for HEMCO?
+
      !----------------------------------------
      ! CO MENU fields
      !----------------------------------------
@@ -632,6 +635,7 @@ CONTAINS
     Input_Opt%LCH4EMIS               = .FALSE.
     Input_Opt%LCH4SBC                = .FALSE.
     Input_Opt%LSETH2O                = .FALSE.
+    Input_Opt%LIMGRID                = .FALSE.
 
     !----------------------------------------
     ! CO MENU fields

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -149,6 +149,8 @@ MODULE Input_Opt_Mod
 
      ! For HEMCO "intermediate" grid (hplin, 6/2/20)
      LOGICAL                     :: LIMGRID    ! Use different grid resolution for HEMCO?
+     INTEGER                     :: IMGRID_XSCALE
+     INTEGER                     :: IMGRID_YSCALE
 
      !----------------------------------------
      ! CO MENU fields
@@ -636,6 +638,8 @@ CONTAINS
     Input_Opt%LCH4SBC                = .FALSE.
     Input_Opt%LSETH2O                = .FALSE.
     Input_Opt%LIMGRID                = .FALSE.
+    Input_Opt%IMGRID_XSCALE          = 1
+    Input_Opt%IMGRID_YSCALE          = 1
 
     !----------------------------------------
     ! CO MENU fields

--- a/Headers/state_grid_mod.F90
+++ b/Headers/state_grid_mod.F90
@@ -199,7 +199,7 @@ CONTAINS
 !
 ! !IROUTINE: Allocate_State_Grid
 !
-! !DESCRIPTION: Subroutine ALLOCATE\_STATE\_GRID initializes variables and!
+! !DESCRIPTION: Subroutine ALLOCATE\_STATE\_GRID initializes variables and
 !  allocates module arrays.
 !\\
 !\\


### PR DESCRIPTION
Hi GCST,

This update includes the HEMCO 3.0 planned feature, the "HEMCO Intermediate Grid", which allows HEMCO to operate on a different grid than the GC-Classic simulation, at runtime. The update is rather hefty and here goes a quick summary of what's happening under the hood:

## Changes summary
* The intermediate grid feature is controlled by three new input options, `Input_Opt%IMGRID_XSCALE`, `Input_Opt%IMGRID_YSCALE`, which defines the refinement scale for the HEMCO grid (setting them to 2, 2 means that HEMCO works on 1x1.25 on a 2x2.5 simulation). This number is **hardcoded** as 1, 1 (= do nothing) under `hco_interface_gc_mod.F90` right now because the feature requires testing and validation and its best kept hidden for now. If any of the scales are not equal to 1, then `Input_Opt%LIMGRID` is enabled, which enables the intermediate grid feature. In the future these should be switches in `input.geos` but they are not implemented yet as the feature has not passed scientific validation.

* The HEMCO grid is described in `State_Grid_HCO` stored in `hco_state_gc_mod.F90`. It reuses the `GrdState` nicely. Generation of a "refined"/scaled grid is using the new subroutine `gc_grid_mod.F90 : Compute_Scaled_Grid`.

* The main idea: Data is stored in HEMCO resolution in `HcoState` as usual, and only regridded on-demand. The regridded data lies in **a single buffer** (actually, two.) (`TMP_MDL` in `hco_utilities_gc_mod.F90`) which is updated when a new field is requested via the new `HCO_GC_*` subroutines below...

* **Everything** intermediate-grid related is wrapped in `MODEL_CLASSIC` and `IF ( Input_Opt%LIMGRID )` checks. There are minor changes to the code that affect all simulations, though:
  * All calls to `HCO_GetPtr` should now be `HCO_GC_GetPtr`, implemented in `hco_utilities_gc_mod.F90`.
  * All calls to `HCO_EvalFld` should now be `HCO_GC_EvalFld`.
  * All calls to `GetHcoDiagn` should now be `HCO_GC_GetDiagn`.
  * The above calls redirect to their in-HEMCO counterparts when intermediate grid is disabled. Nothing new happens.
  * `Compute_Sflx_For_Vdiff` has been moved to `hco_interface_gc_mod.F90` due to circular dependency.
  * Loop orders in `mixing_mod.F90 : DO_TEND` and `hco_interface_gc_mod.F90 : Compute_Sflx_For_Vdiff` have been switched slightly: the species loop must be outermost, as HEMCO intermediate grid only stores up to one species in the "regridded" memory buffer, so species must be read contiguously before moving on to the next.
  * **The changes above have been validated to minimal differences, attributed to switch of some precisions from f4 to fp, and optimization changes due to change of loop orders.** See attached log below.

* When intermediate grid is enabled, the above `HCO_GC_*` calls retrieves data from HEMCO, **compares it against the buffer**, and regrids as necessary, discarding old data in the buffer. Why a buffer? Because some calls to `HCO_GetPtr` expect a `POINTER` and do their own data copying. To maximize compatibility, they're given the temporary buffer to point to. **Care should be taken to "update" these pointers at every time step now, as they won't be pointing to the right things if the data wasn't copied from them before the next `HCO_GC_*` call.** I've checked **all** the places in G-C that do this and changed everywhere, **except** `strat_chem_mod.F90`, pending decision on tropchem.

* Detailed list of changes below. I've also fixed some debug messages as I went probing through the entire GC source.

## List of changes made to the code in all commits
### Structural changes (validated to "zero" diff, see below, when IMGrid is not enabled):
- Implements a new Input_Opt field LIMGRID to indicate intermediate grid functionality.
- Reads HEMCO extension met fields from HEMCO state when possible
- Remove `FRAC_OF_PBL` duplicate and read through `State_Met`.
- Add `IMGRID_XSCALE`, `IMGRID_YSCALE` HEMCO grid scaling (refinement) factors to `Input_Opt`.
- Move `SUMCOSZA` to `State_Met%SUNCOSsum`.
- Move `Calc_SUMCOSZA` to `Calc_Met_Mod`.
- Move Read_Met_Fields to HCO_Interface_GC_Mod to avoid circular dependencies.
- Add `State_Grid_HCO` to store HEMCO grid state in `HCO_State_GC_Mod`.
- Modified method signatures in a few subroutines to accept Input_Opt, State_Grid.
- Add `InquireHco` subroutine in `HCO_GC_Utilities_Mod` for checking if given species has Deposition/Emissions, instead of calling with I,J,L=1 to retrieve data for probing.
- Now use `EmisSpec`, `DepSpec` in `Compute_Sflx_For_Vdiff` which retrieves a species is emis/dep enabled or not from the `InquireHco` subroutine, to save CPU.
- Moved `Compute_Sflx_For_Vdiff` from `HCO_Utilities_GC_Mod` to `HCO_Interface_GC_Mod` to avoid a circular dependence issue (the subroutine depends on Global_CH4 and Global_Br)
- Now read `PNOXLOSS_O3` and `PNOXLOSS_HNO3` diagnostics in `MIXING_MOD` and `COMPUTE_SFLX_FOR_VDIFF` at every time step, in preparation of HEMCO changes.
- Add `HCO_GC_GetDiagn` interface in HCO_Utilities_GC_Mod. It is a shim for `GetHcoDiagn` in `HCO_Interface_Common`, performing on-demand regrid when IMGrid is enabled.
- Add a secondary R4 buffer for model regridded data.
- Fixed wrong output type and added extra out variables for N_/L2_L2-cutoff error in `FAST_JX_Mod`.
- Add a debug message for `Compute_Sflx_for_Vdiff` in `MAIN.F90`

### Functionality changes, all MODEL_CLASSIC:
- Add intermediate grid assignment in `HCOI_GC_Init`.
- Add intermediate grid variables and allocation in `HCO_Interface_GC_Mod`.
- Add `Compute_Scaled_Grid` to compute refined grid based on State_Grid in `GC_Grid_Mod`.
- Add on-demand regridding functionality for `GetHcoValDep`, `GetHcoValEmis` in `HCO_Utilities_GC_Mod`.
- Add on-demand regridding shim HCO_GC_GetPtr in HCO_Utilities_GC_Mod.
- Add on-demand regridding shim HCO_GC_EvalFld in HCO_Utilities_GC_Mod.
- Use on-demand regridding for reading met fields in FlexGrid and HCO modules.
- Use on-demand regridding in a variety of modules that used HCO_GetPtr.
- Use on-demand regridding for various modules (TOMS_MOD, TAGGED_O3, TAGGED_CO, Sulfate_Mod, SfcVmr_Mod)
- Use on-demand regridding for various modules (RPMARES_Mod, ISORROPIAII_Mod, Global_CH4_Mod, Global_Br_Mod)
- Use on-demand regridding for various modules (Aerosol_Mod, Carbon_Mod)
- Use `HCO_GC_EvalFld` for OLSON_LANDMAP_MOD and MODIS_LAI_MOD.
- Use on-demand regridding for Global_CH4_Mod::EmissCH4, Land_Mercury_Mod::BIOMASSHg, Mercury_Mod
- Use on-demand regridding for Sulfate_Mod HEMCO diagnostics


## Difference test output
Only nonzero species attached.
Comparison was made against **GEOS-Chem Classic "Wrapper"**, with GEOS-Chem Classic commit `28aa0358` in `dev/13.0.0`.

```
Variable               Ref=geosfp_2x25_standard Dev=dev_geosfp_2x25_standard Dev-Ref
SpeciesConc_Br2      : 1.3926416e-07          | 1.3926413e-07          | -2.842170943040401e-14
SpeciesConc_HI       : 5.0519042e-09          | 5.0519047e-09          | 4.440892098500626e-16
SpeciesConc_HNO3     : 0.0009782148           | 0.0009782154           | 5.820766091346741e-10
SpeciesConc_IHN4     : 1.115168e-09           | 1.1151681e-09          | 1.1102230246251565e-16
SpeciesConc_INPB     : 4.9958273e-09          | 4.995828e-09           | 8.881784197001252e-16
SpeciesConc_LVOC     : 2.276081e-10           | 2.2760828e-10          | 1.8041124150158794e-16
SpeciesConc_NH3      : 2.5541443e-05          | 2.5541423e-05          | -2.000888343900442e-11
SpeciesConc_NIT      : 9.795141e-06           | 9.7945585e-06          | -5.820766091346741e-10
```

Please feel free to squash the commits and let me know of any questions regarding this implementation... Apologies in advance for a 6,000 line commit in one PR. Hopefully there aren't *too many* merge conflicts. All changes are under the hood if the functionality isn't enabled at code level in `hco_interface_gc_mod.F90` to set the `XSCALE`/`YSCALE` to non-1 value, so afterwards GEOS-Chem should look and work like GEOS-Chem as usual. 

Have a nice day 😄
Haipeng 