### PR TITLE
Allow RRTMG to be off even if compiled

### DIFF
--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -2713,13 +2713,7 @@ CONTAINS
     !=================================================================
 
     ! Use of RRTMG necessitates recompilation
-#ifdef RRTMG
-    IF ( .not. Input_Opt%LRAD ) THEN
-       ErrMsg = 'LRAD=F but RRTMG is defined at compile time!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc )
-       RETURN
-    ENDIF
-#else
+#if !defined( RRTMG )
     IF ( Input_Opt%LRAD ) THEN
        ErrMsg = 'LRAD=T but RRTMG is not defined at compile time!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )


### PR DESCRIPTION
GEOS-Chem currently chokes if RRTMG is turned off but the binary is compiled with it enabled. This is unnecessary
as RRTMG only provides diagnostic output. This fix will allow a simulation to continue with `LRAD=F` even if
the binary was compiled with RRTMG.