### PR TITLE
[PULL REQUEST] FlexChem performance with OpenMP collapse

### DIFF
--- a/GeosCore/flexchem_mod.F90
+++ b/GeosCore/flexchem_mod.F90
@@ -594,7 +594,7 @@ CONTAINS
     !$OMP PRIVATE  ( OHreact                                                )&
     !$OMP PRIVATE  ( LCH4,     PCO_TOT,  PCO_CH4, PCO_NMVOC                 )&
     !$OMP SCHEDULE ( DYNAMIC,  1                                            )&
-    !$OMP COLLAPSE ( 2 )
+    !$OMP COLLAPSE ( 3 )
     DO L = 1, State_Grid%NZ
     DO J = 1, State_Grid%NY
     DO I = 1, State_Grid%NX

--- a/GeosCore/flexchem_mod.F90
+++ b/GeosCore/flexchem_mod.F90
@@ -593,7 +593,8 @@ CONTAINS
     !$OMP PRIVATE  ( Vloc,     Aout,     Thread,  RC                        )&
     !$OMP PRIVATE  ( OHreact                                                )&
     !$OMP PRIVATE  ( LCH4,     PCO_TOT,  PCO_CH4, PCO_NMVOC                 )&
-    !$OMP SCHEDULE ( DYNAMIC,  1                                            )
+    !$OMP SCHEDULE ( DYNAMIC,  1                                            )&
+    !$OMP COLLAPSE ( 2 )
     DO L = 1, State_Grid%NZ
     DO J = 1, State_Grid%NY
     DO I = 1, State_Grid%NX


### PR DESCRIPTION
Add OpenMP collapse ( 2 ) directive to flexchem.

Previously only the outer L loop was parallel, so there were nLev work blocks.
With collapse ( 2 ), both L and J loops execute in parallel, giving nLev * nLat work blocks.

The larger number of work blocks allow more even
distribution of the work across CPUs, improving runtime.
FlexChem performance improvement (median of 3 trials):
12% faster with 20 OpenMP threads
32% faster with 50 OpenMP threads

Collapse ( 3 ) (i.e. parallelizing over all I,J,L loops)
was 1% faster than collapse ( 2 ) in tests with 50 threads.
Since benefits will be smaller with fewer threads, collapse ( 2 )
currently seems to be a good balance between performance and overhead.

Other loops within GEOS-Chem may similarly benefit from collapse directives.

Signed-off-by: Christopher Holmes <cdholmes@fsu.edu>