### PR TITLE
Quality-of-life improvements for createRunDir.sh

### DIFF
--- a/run/GCHPctm/createRunDir.sh
+++ b/run/GCHPctm/createRunDir.sh
@@ -46,7 +46,7 @@ if [[ -z "${GC_DATA_ROOT}" ]]; then
     valid_path=0
     while [ "$valid_path" -eq 0 ]
     do
-	read extdata
+	read -e extdata
 	if [[ ${extdata} = "q" ]]; then
 	    printf "\nExiting.\n"
 	    exit 1
@@ -172,7 +172,17 @@ printf "\nEnter path where the run directory will be created:\n"
 valid_path=0
 while [ "$valid_path" -eq 0 ]
 do
-    read rundir_path
+    read -e rundir_path
+    # If this is just a new directory within an existing one, give the user the option to proceed
+    if [[ ! -d ${rundir_path} ]]; then
+        if [[ -d $( dirname ${rundir_path} ) ]]; then
+            printf "\nWarning: ${rundir_path} does not exist, but the parent directory does.\nWould you like to make this directory? (y/n)\n"
+            read mk_rundir
+            if [[ ${mk_rundir} == "y" ]]; then
+                mkdir $rundir_path
+            fi
+        fi
+    fi
     if [[ ${rundir_path} = "q" ]]; then
 	printf "\nExiting.\n"
 	exit 1


### PR DESCRIPTION
Creating run directories in createRunDir.sh now allows:
1. Tab-completion (using `read -e`) when the run directory (or ExtData) is requested
2. If the run directory does not exist but its parent does, the user can opt to create it

This should help to reduce some frustration around run directory creation without risking users accidentally creating monster paths because of the combination of `mkdir -p` and a typo early in the directory path.