### PR TITLE
[PULL REQUEST] Extraction of J-rates from KPP via planeflight diagnostic

### DIFF
--- a/GeosCore/planeflight_mod.F90
+++ b/GeosCore/planeflight_mod.F90
@@ -781,9 +781,8 @@ CONTAINS
            JPREAC(R) = -999
            P         = -999         ! GEOS-Chem photolyis species ID
 
-           !
+           ! Loop the reaciton branches and find the correct "P" index
            DO IK = 1, JVN_
-               WRITE(*,*) 'TMS debug 5.0:', NUM, IK, ( IK == NUM )
 
                ! GC photolysis species index
                P = GC_Photo_Id(NUM)
@@ -2131,7 +2130,7 @@ CONTAINS
              !!--------------------------
              !! Reaction rates
              !!--------------------------
-             !CASE ( 10000:99999 )
+             !CASE ( 10000:30000 )
              !
              !   ! Increment reaction count
              !   R = R + 1
@@ -2151,6 +2150,7 @@ CONTAINS
                NUM = JPREAC(R) - 30000
 
                ! Extract this reaction number from the state diag
+               ! NOTE: JValues collection must have been requested in HISTORY.rc
                VARI(V) = State_Diag%JVal(I,J,L, NUM )
 
              !--------------------------


### PR DESCRIPTION
J-rates listed in planeflight dat files in format `JVL_???` (where `???` is a reaction index from `FJX_j2j.dat`) are now extracted for locations requested (e.g. along a flight/cruise track). 

This code for extracting J-rates adds a feature raised by issues #412 and #132. However, it does not completely resolve #132 as it doesn't allow extraction of production/reaction rates too. This same approach as used here could be used to get reaction rates via (`State_Diag%RxnRate`) or production rates (via a `State_Diag%Prod...` container). 