### PR TITLE
Ecophysiology module that simulates stomatal resistance, plant productivity and isoprene emission

### DIFF
--- a/GeosCore/CMakeLists.txt
+++ b/GeosCore/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(GeosCore
   diag53_mod.F90
   drydep_mod.F90
   dust_mod.F90
+	ecophy_mod.F90
   emissions_mod.F90
   fast_jx_mod.F90
   flexchem_mod.F90

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -231,6 +231,7 @@ CONTAINS
 !
     USE Input_Opt_Mod,    ONLY : OptInput
     USE State_Diag_Mod,   ONLY : DgnState
+    USE Time_Mod,         ONLY : ITS_TIME_FOR_EMIS
 !
 ! !INPUT PARAMETERS:
 !
@@ -307,6 +308,50 @@ CONTAINS
        ! up to that height, so we need to zero these out.)
        IF ( State_Diag%Archive_DryDepMix .or. State_Diag%Archive_DryDep ) THEN
           State_Diag%DryDepMix = 0.0_f4
+       ENDIF
+    ENDIF
+
+    ! Zero diagnostics here
+    IF ( ITS_TIME_FOR_EMIS() ) THEN
+       ! Zero diagnostics here
+       IF ( State_Diag%Archive_EcophyGCan ) THEN
+          State_Diag%EcophyGCan ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyACan ) THEN
+          State_Diag%EcophyACan ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyRespCan ) THEN
+          State_Diag%EcophyRespCan ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyCO2Leaf ) THEN
+          State_Diag%EcophyCO2Leaf ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyFluxO3Can   ) THEN
+          State_Diag%EcophyFluxO3Can   ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyO3DmgFac ) THEN
+          State_Diag%EcophyO3DmgFac ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophySoilStress ) THEN
+          State_Diag%EcophySoilStress ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyVCMax ) THEN
+          State_Diag%EcophyVCMax ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyLightLmtRate ) THEN
+          State_Diag%EcophyLightLmtRate ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyRubisLmtRate ) THEN
+          State_Diag%EcophyRubisLmtRate ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyProdLmtRate ) THEN
+          State_Diag%EcophyProdLmtRate ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyAGrossLeaf ) THEN
+          State_Diag%EcophyAGrossLeaf ( :,:,: ) = 0.0_f4
+       ENDIF
+       IF ( State_Diag%Archive_EcophyIsopEmisPFT ) THEN
+          State_Diag%EcophyIsopEmisPFT ( :,:,: ) = 0.0_f4
        ENDIF
     ENDIF
 

--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -405,7 +405,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER            :: I,   J,   L,   D,   N,  NDVZ,  A, S
+    INTEGER            :: I,   J,   L,   D,   N,  NDVZ,  A, S, PFT
     REAL(f8)           :: DVZ, THIK
     CHARACTER(LEN=255) :: ErrMsg,  ThisLoc
 
@@ -1349,12 +1349,6 @@ CONTAINS
 
     ! Initialize State_Chm%DryDepVel
     State_Chm%DryDepVel = 0.0e+0_f8
-
-    ! Initialize if PFT-specific dry dep velocity is enabled 
-    ! (Joey Lam, 28 Aug 2019)
-    IF ( State_Diag%Archive_DryDepVel_anyPFT ) THEN
-       State_Diag%DryDepVelPFT = 0.e+0_fp
-    ENDIF
 
 #ifdef MODEL_GEOS
     ! Logical flag for Ra (ckeller, 12/29/17)
@@ -2320,11 +2314,11 @@ CONTAINS
              VK(K) = VD(K)
              VD(K) = VK(K) +.001D0* DBLE( IUSE(I,J,LDT) )/C1X(K)
                ! PFT-specific dry deposition velocity (Joey Lam, 22 Aug 2019)
-               IF ( State_Diag%Archive_DryDepVel_anyPFT 
-     &              .and. PFT .NE. 0 ) THEN
+               IF ( State_Diag%Archive_DryDepVel_anyPFT .and. &
+                    PFT .NE. 0 ) THEN
                   VK(K) = VD_PFT(K,PFT) 
-                  VD_PFT(K,PFT) = VK(K) + DBLE( IUSE(I,J,LDT) )/C1X(K)
-     &                                    / DBLE( IUSE_PFT(PFT) )
+                  VD_PFT(K,PFT) = VK(K) + DBLE( IUSE(I,J,LDT) )/C1X(K) &
+                                        / DBLE( IUSE_PFT(PFT) )
                ENDIF
 400       CONTINUE
 

--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -53,6 +53,8 @@ MODULE DRYDEP_MOD
 #if defined( MODEL_CESM )
   PUBLIC :: NDVZIND
 #endif
+  ! For ecophysiology (Joey Lam, 21 Mar 2019)  
+  PUBLIC :: IPFT ! index of Plant functional types (PFT)
 !
 ! !REMARKS:
 !  References:
@@ -161,6 +163,7 @@ MODULE DRYDEP_MOD
   INTEGER                        :: id_MENO3, id_ETNO3
   INTEGER                        :: id_NK1
   INTEGER                        :: id_HNO3,  id_PAN,   id_IHN1
+  INTEGER                        :: id_ISOPND
 
   ! Arrays for Baldocchi drydep polynomial coefficients
   REAL(fp), TARGET               :: DRYCOEFF(NPOLY    )
@@ -170,6 +173,7 @@ MODULE DRYDEP_MOD
   INTEGER                        :: IDEP    (NSURFTYPE )
   INTEGER                        :: IZO     (NSURFTYPE )
   INTEGER                        :: IWATER  (NSURFTYPE )
+  INTEGER                        :: IPFT    (NSURFTYPE )
 
   ! Arrays that hold information for each of the 11 drydep land types
   INTEGER                        :: IDRYDEP (NDRYDTYPE)
@@ -292,6 +296,7 @@ CONTAINS
     REAL(f8) :: AZO   (State_Grid%NX,State_Grid%NY) ! Z0, per (I,J) square
     REAL(f8) :: SUNCOS_MID(State_Grid%NX,State_Grid%NY) ! COS(SZA) @ midt of
                                                         ! current chem timestep
+
     !=================================================================
     ! DO_DRYDEP begins here!
     !=================================================================
@@ -592,6 +597,91 @@ CONTAINS
              IF ( A > 0 ) THEN
                 State_Diag%DryDepVelForALT1(I,J,A) = DVZ
              ENDIF
+          ENDIF
+
+          !-----------------------------------------------------------
+          ! PFT-specific dry deposition velocity (Joey Lam, 22 Aug 2019)
+          ! Remarks: Cannot register an array with dimensions 
+          !          (I,J,nDryDep,PFT) in either State_Chm or State_Diag,
+          !          so save to State_Diag%DryDepVel_PFT[1-5] separately.
+          !----------------------------------------------------------
+          IF ( State_Diag%Archive_DryDepVel_anyPFT ) THEN
+          DO PFT = 1, MAXVAL(IPFT)
+
+             ! Keep the calculations of vd of specific species as-is
+             ! Dry deposition velocity [cm/s]
+             SELECT CASE ( PFT )
+             CASE( 1 )
+                IF ( State_Diag%Archive_DryDepVelPFT1 ) THEN
+                   DVZ = State_Diag%DryDepVelPFT1(I,J,NDVZ) * 100.e+0_f8
+                ENDIF
+             CASE( 2 )
+                IF ( State_Diag%Archive_DryDepVelPFT2 ) THEN
+                   DVZ = State_Diag%DryDepVelPFT2(I,J,NDVZ) * 100.e+0_f8
+                ENDIF
+             CASE( 3 )
+                IF ( State_Diag%Archive_DryDepVelPFT3 ) THEN
+                   DVZ = State_Diag%DryDepVelPFT3(I,J,NDVZ) * 100.e+0_f8
+                ENDIF
+             CASE( 4 )
+                IF ( State_Diag%Archive_DryDepVelPFT4 ) THEN
+                   DVZ = State_Diag%DryDepVelPFT4(I,J,NDVZ) * 100.e+0_f8
+                ENDIF
+             CASE( 5 )
+                IF ( State_Diag%Archive_DryDepVelPFT5 ) THEN
+                   DVZ = State_Diag%DryDepVelPFT5(I,J,NDVZ) * 100.e+0_f8
+                ENDIF
+             CASE DEFAULT
+                ! Do nothing (ignore vd for PFT=0: non-vegetated land)
+             END SELECT 
+
+             ! Scale relative to specified species (krt, 3/1/15)
+             IF ( FLAG(D) .eq. 1 )  THEN
+
+                ! Scale species to HNO3 
+                DVZ = DVZ * sqrt(State_Chm%SpcData(id_HNO3)%Info%MW_g)   &
+                          / sqrt(SpcInfo%MW_g)
+
+             ELSE IF ( FLAG(D) .eq. 2 ) THEN
+
+                ! Scale species to PAN
+                DVZ = DVZ * sqrt(State_Chm%SpcData(id_PAN)%Info%MW_g)    &
+                          / sqrt(SpcInfo%MW_g)         
+
+             ELSE IF ( FLAG(D) .eq. 3 ) THEN
+
+                ! Scale species to ISOPN
+                DVZ = DVZ * sqrt(State_Chm%SpcData(id_IHN1)%Info%MW_g) &
+                          / sqrt(SpcInfo%MW_g)            
+
+             ENDIF
+
+             ! Output PFT-specific vd (in cm/s)
+             SELECT CASE ( PFT )
+             CASE( 1 )
+                IF ( State_Diag%Archive_DryDepVelPFT1 ) THEN
+                   State_Diag%DryDepVelPFT1(I,J,NDVZ) = DVZ
+                ENDIF
+             CASE( 2 )
+                IF ( State_Diag%Archive_DryDepVelPFT2 ) THEN
+                   State_Diag%DryDepVelPFT2(I,J,NDVZ) = DVZ
+                ENDIF
+             CASE( 3 )
+                IF ( State_Diag%Archive_DryDepVelPFT3 ) THEN
+                   State_Diag%DryDepVelPFT3(I,J,NDVZ) = DVZ
+                ENDIF
+             CASE( 4 )
+                IF ( State_Diag%Archive_DryDepVelPFT4 ) THEN
+                   State_Diag%DryDepVelPFT4(I,J,NDVZ) = DVZ
+                ENDIF
+             CASE( 5 )
+                IF ( State_Diag%Archive_DryDepVelPFT5 ) THEN
+                   State_Diag%DryDepVelPFT5(I,J,NDVZ) = DVZ
+                ENDIF
+             CASE DEFAULT
+                ! Do nothing (ignore vd for PFT=0: non-vegetated land)
+             END SELECT 
+          ENDDO
           ENDIF
 
           ! Free pointer
@@ -957,10 +1047,11 @@ CONTAINS
 #endif
     USE Input_Opt_Mod,      ONLY : OptInput
     USE Species_Mod,        ONLY : Species
-    USE State_Chm_Mod,      ONLY : ChmState
+    USE State_Chm_Mod,      ONLY : ChmState, Ind_
     USE State_Diag_Mod,     ONLY : DgnState
     USE State_Grid_Mod,     ONLY : GrdState
     USE State_Met_Mod,      ONLY : MetState
+    USE Ecophy_Mod,         ONLY : Do_Ecophy
 #ifdef APM
     USE APM_INIT_MOD,       ONLY : APMIDS
     USE APM_INIT_MOD,       ONLY : RDRY, RSALT, RDST, DENDST
@@ -1167,6 +1258,25 @@ CONTAINS
     !LOGICAL           :: WriteRa10m
 #endif
 
+    ! Turn on ecophysiology module? (Joey Lam, 01 Apr 2019)
+    LOGICAL           :: LECOPHY  ! Turn on ecophysiology
+    INTEGER           :: PFT      ! mapping indices for PFT
+    INTEGER           :: id_O3    ! species index of O3 in State_Chm
+    REAL(fp)          :: RS       ! Bulk stomatal resistance
+    REAL(fp)          :: XMWO3    ! Molecular weight of O3 
+    REAL(fp)          :: RB_O3    ! Boundary layer resistance for O3
+    REAL(fp)          :: SumLAI_PFT( MAXVAL(IPFT) ) ! leaf area of the PFT 
+    INTEGER           :: IUSE_PFT  ( MAXVAL(IPFT) ) ! fraction of grid box
+                                                    ! occupied by the PFT
+    ! PFT-specific diagnostics (Joey Lam, 22 Aug 2019)
+    REAL(fp)          :: VD_PFT( NUMDEP, MAXVAL(IPFT) )
+    REAL(fp)          :: Tmp
+
+    ! Turn on photosynthesis-dependent isoprene emission? (Joey Lam, 28 Oct 2020)
+    LOGICAL           :: LIsop_from_Ecophy       ! Turn on online isoprene emission
+    REAL(fp), POINTER :: Isop_from_Ecophy(:,:)   ! Pointer to StateChm
+    REAL(fp)          :: Isop_PFT                ! temporary variable 
+
     ! For the species database
     INTEGER                :: SpcId
     TYPE(Species), POINTER :: SpcInfo
@@ -1207,6 +1317,15 @@ CONTAINS
     ! Is this a POPs simmulation?
     IS_POPS = Input_Opt%ITS_A_POPS_SIM  ! clf, 1/3/2011
 
+    ! Turn on ecophysiology module? (Joey Lam, 2/26/2019)
+    LECOPHY = Input_Opt%LECOPHY
+
+    ! Turn on online isoprene emission from ecophysiology module? 
+    ! (Joey Lam, 28 Oct 2020)
+    LIsop_from_Ecophy = Input_Opt%LIsop_from_Ecophy
+    Isop_from_Ecophy => State_Chm%Isop_from_Ecophy
+    Isop_from_Ecophy = 0.e+0_fp   ! Initialize value
+
     ! Size of drycoeff (ckeller, 05/19/14)
     NN = SIZE(DRYCOEFF)
 
@@ -1230,6 +1349,12 @@ CONTAINS
 
     ! Initialize State_Chm%DryDepVel
     State_Chm%DryDepVel = 0.0e+0_f8
+
+    ! Initialize if PFT-specific dry dep velocity is enabled 
+    ! (Joey Lam, 28 Aug 2019)
+    IF ( State_Diag%Archive_DryDepVel_anyPFT ) THEN
+       State_Diag%DryDepVelPFT = 0.e+0_fp
+    ENDIF
 
 #ifdef MODEL_GEOS
     ! Logical flag for Ra (ckeller, 12/29/17)
@@ -1255,6 +1380,7 @@ CONTAINS
           LDEP(K) = .FALSE.
        ENDIF
     ENDDO
+
 
     !***********************************************************************
     !*
@@ -1295,6 +1421,8 @@ CONTAINS
     !$OMP PRIVATE( C1X,     VK,      I,       J,      IW                ) &
     !$OMP PRIVATE( DIAM,    DEN,     XLAI_FP, SUNCOS_FP,       CFRAC_FP ) &
     !$OMP PRIVATE( N_SPC,   alpha,   DEPVw                              ) &
+    !$OMP PRIVATE( SumLAI_PFT,       IUSE_PFT,        RS,      PFT      ) &
+    !$OMP PRIVATE( id_O3,   RB_O3,   VD_PFT,  Isop_PFT                  ) &
 #ifdef MODEL_GEOS
     !$OMP PRIVATE( RA2M,    Z0OBK2M, RA10M, Z0OBK10M                    ) &
 #endif
@@ -1326,6 +1454,16 @@ CONTAINS
           END DO
        END DO
 
+       ! Initialize if PFT-specific dry dep velocity is enabled 
+       ! (Joey Lam, 28 Aug 2019)
+       IF ( State_Diag%Archive_DryDepVel_anyPFT ) THEN
+          DO K = 1,NUMDEP
+             DO PFT = 1,MAXVAL(IPFT)
+                VD_PFT(K,PFT) = 0.e+0_fp
+             ENDDO
+          ENDDO
+       ENDIF
+
        !** Calculate the kinematic viscosity XNU (m2 s-1) of air
        !** as a function of temperature.
        !** The kinematic viscosity is used to calculate the roughness heights
@@ -1347,401 +1485,33 @@ CONTAINS
        !*        RT = 1000.0*EXP(-(TEMPC-4.0))
        RT = 1000.0e+0_f8*EXP(-TEMPC-4.0e+0_f8)
        !*
-       !    Get surface resistances - loop over land types LDT
-       !***********************************************************************
-       !* The land types within each grid square are defined using the Olson
-       !* land-type database.  Each of the Olson land types is assigned a
-       !* corresponding "deposition land type" with characteristic values of
-       !* surface resistance components.  There are 74 Olson land-types but only
-       !* 11 deposition land-types (i.e., many of the Olson land types share the
-       !* same deposition characteristics).  Surface resistance components for
-       !* the "deposition land types" are from Wesely [1989] except for tropical
-       !* forests [Jacob and Wofsy, 1990] and for tundra [Jacob et al., 1992].
-       !* All surface resistance components are normalized to a leaf area index
-       !* of unity.
-       !*
-       !* Olson land types, deposition land types, and surface resistance
-       !* components are read from file 'drydep.table'; check that file for
-       !* further details.
-       !***********************************************************************
 
-       ! Loop over the # of Olson land types in this grid box (I,J)
-       DO 170 LDT = 1, IREG(I,J)
+       ! Calculate fraction of grid occupied by each PFT and its LAI
+       ! (Joey Lam, 11 Jun 2019)
+       SumLAI_PFT( : ) = 0
+       IUSE_PFT  ( : ) = 0
+       DO LDT = 1,NTYPE
+          ! Skip if land type is absent
+          IF ( IUSE(I,J,LDT) == 0 ) CYCLE
+          IOLSON = ILAND( I,J,LDT ) + 1
+          PFT = IPFT(IOLSON)
+          IF ( PFT /= 0 ) THEN
+             SumLAI_PFT( PFT ) = SumLAI_PFT( PFT ) &
+                      + DBLE( IUSE( I,J,LDT ) ) * XLAI ( I,J,LDT )
+             IUSE_PFT( PFT ) = IUSE_PFT( PFT ) + IUSE( I,J,LDT )
+          END IF
+       END DO
 
-          ! If the land type is not represented in grid
-          ! box  (I,J), then skip to the next land type
-          IF ( IUSE(I,J,LDT) == 0 ) GOTO 170
-
-          ! Olson land type index + 1
-          IOLSON = ILAND(I,J,LDT)+1
-
-          ! Dry deposition land type index
-          II     = IDEP(IOLSON)
-          !
-          !** If the surface to be snow or ice;
-          !** set II to 1 instead.
-          !
-          IF(State_Met%isSnow(I,J)) II=1
-
-          !* Read the internal resistance RI (minimum stomatal resistance for
-          !* water vapor,per unit area of leaf) from the IRI array; a '9999'
-          !* value means no deposition to stomata so we impose a very large
-          !* value for RI.
-          RI(LDT) = DBLE(IRI(II))
-          IF (RI(LDT)   .GE. 9999.e+0_f8) RI(LDT)   = 1.e+12_f8
-
-          !** Cuticular resistances IRLU read in from 'drydep.table'
-          !** are per unit area of leaf;
-          !** divide them by the leaf area index to get a cuticular resistance
-          !** for the bulk canopy.  If IRLU is '9999' it means there are no
-          !** cuticular surfaces on which to deposit so we impose a very large
-          !** value for RLU.
-          IF ( IRLU(II) >= 9999 .or. XLAI(I,J,LDT) <= 0.e+0_f8 ) THEN
-             RLU(LDT) = 1.e+6_f8
-          ELSE
-             RLU(LDT) = DBLE( IRLU(II) ) / XLAI(I,J,LDT)
-             ! Additional resistance at low temperatures.
-             ! Limit increase to a factor of 2.
-             ! V. Shah 23 Oct 18
-             ! Ref Jaegle et al. 2018
-             RLU(LDT) = MIN( RLU(LDT) + RT, 2.e+0_f8 * RLU(LDT) )
-          ENDIF
-          !** The following are the remaining resistances for the Wesely
-          !** resistance-in-series model for a surface canopy
-          !** (see Atmos. Environ. paper, Fig.1).
-          RAC(LDT)  = MAX(DBLE(IRAC(II)), 1.e+0_f8)
-          IF (RAC(LDT)  .GE. 9999.e+0_f8) RAC(LDT)  = 1.e+12_f8
-          RGSS(LDT) = MAX(DBLE(IRGSS(II)), 1.e+0_f8)
-          ! Additional resistance at low temperatures.
-          ! Limit increase of RGSS, RGSO, RCLS, & RCLO to a factor of 2.
-          ! V. Shah 23 Oct 18
-          ! Ref Jaegle et al. 2018
-          RGSS(LDT) = MIN( RGSS(LDT) + RT, 2.e+0_f8 * RGSS(LDT) )
-          IF (RGSS(LDT) .GE. 9999.e+0_f8) RGSS(LDT) = 1.e12_f8
-          RGSO(LDT) = MAX(DBLE(IRGSO(II)) ,1.e+0_f8)
-          RGSO(LDT) = MIN( RGSO(LDT) + RT, 2.e+0_f8 * RGSO(LDT) )
-          IF (RGSO(LDT) .GE. 9999.e+0_f8) RGSO(LDT) = 1.e+12_f8
-          RCLS(LDT) = DBLE(IRCLS(II))
-          RCLS(LDT) = MIN( RCLS(LDT) + RT, 2.e+0_f8 * RCLS(LDT) )
-          IF (RCLS(LDT) .GE. 9999.e+0_f8) RCLS(LDT) = 1.e+12_f8
-          RCLO(LDT) = DBLE(IRCLO(II))
-          RCLO(LDT) = MIN( RCLO(LDT) + RT, 2.e+0_f8 * RCLO(LDT) )
-          IF (RCLO(LDT) .GE. 9999.e+0_f8) RCLO(LDT) = 1.e+12_f8
-          !********************************************************************
-          !*
-          !*    Adjust stomatal resistances for insolation and temperature:
-          !*
-          !*     Temperature adjustment is from Wesely [1989], equation (3).
-          !*
-          !*     Light adjustment by the function BIOFIT is described by Wang
-          !*     [1996]. It combines
-          !*       - Local dependence of stomal resistance on the intensity I
-          !*         of light impinging the leaf; this is expressed as a
-          !*         mutliplicative factor I/(I+b) to the stomatal resistance
-          !*         where b = 50 W m-2 (equation (7) of Baldocchi et al.[1987])
-          !*       - radiative transfer of direct and diffuse radiation in the
-          !*         canopy using equations (12)-(16) from Guenther et al.[1995]
-          !*       - separate accounting of sunlit and shaded leaves using
-          !*         equation (12) of Guenther et al. [1995]
-          !*       - partitioning of the radiation at the top of the canopy into
-          !*         direct and diffuse components using a parameterization to
-          !*         results from an atmospheric radiative transfer model
-          !*         [Wang, 1996]
-          !*     The dependent variables of the function BIOFIT are the leaf
-          !*     area index (XYLAI), the cosine of zenith angle (SUNCOS) and
-          !*     the fractional cloud cover (CFRAC).  The factor GFACI
-          !*     integrates the light dependence over the canopy depth; sp even
-          !*     though RI is input per unit area of leaf it need not be scaled
-          !*     by LAI to yield a bulk canopy value because that's already
-          !*     done in the GFACI formulation.
-          !********************************************************************
-          RAD0 = RADIAT(I,J)
-          RIX = RI(LDT)
-          IF (RIX .GE. 9999.e+0_f8) GO TO 150
-          GFACT = 100.0e+0_f8
-          IF (TEMPC .GT. 0.e+0_f8 .AND. TEMPC .LT. 40.e+0_f8) &
-              GFACT = 400.e+0_f8/TEMPC/(40.0e+0_f8-TEMPC)
-          GFACI = 100.e+0_f8
-          IF ( RAD0 > 0.e+0_f8 .and. XLAI(I,J,LDT) > 0.e+0_f8 ) THEN
-             ! Now make sure all inputs to BIOFIT are flexible precision
-             ! so that the code will compile properly (bmy, 12/18/14)
-             XLAI_FP   = XLAI(I,J,LDT)
-             SUNCOS_FP = SUNCOS(I,J)
-             CFRAC_FP  = CFRAC(I,J)
-             GFACI     = 1.e+0_f8 / BIOFIT( DRYCOEFF,  XLAI_FP, &
-                                            SUNCOS_FP, CFRAC_FP, NN )
-          ENDIF
-
-          RIX = RIX*GFACT*GFACI
-
-          ! Apply scaling factor to RIX when CO2 effect is turned on
-          ! (ayhwong, 6/25/19)
-          IF (Input_Opt%CO2_EFFECT) THEN
-             RIX = RIX*Input_Opt%RS_SCALE
-          ENDIF
-
-150       CONTINUE
-          !*
-          !*    Compute aerodynamic resistance to lower elements in lower part
-          !*    of the canopy or structure, assuming level terrain -
-          !*    equation (5) of Wesely [1989].
-          !*
-          RDC = 100.e+0_f8*(1.0e+0_f8+1000.0e+0_f8/(RAD0+10.e+0_f8))
-          !*
-          !*    Loop over species; species-dependent corrections to resistances
-          !*    are from equations (6)-(9) of Wesely [1989].
-          !*
-          DO 160  K = 1,NUMDEP
-
-             !** exit for non-depositing species or aerosols.
-             IF (.NOT. LDEP(K) .OR. AIROSOL(K)) GOTO 155
-
-             ! Test for special treatment for O3 drydep to ocean
-             N_SPC = State_Chm%Map_DryDep(K)
-             IF ((N_SPC .EQ. ID_O3) .AND. (II .EQ. 11)) THEN
-
-                IF (State_Chm%SALINITY(I,J) .GT. 20.0_f8) THEN
-
-                   ! Now apply the Luhar et al. [2018] equations for the
-                   ! special treatment of O3 dry deposition to the ocean
-                   ! surface 
-                   CALL OCEANO3(State_Met%TSKIN(I,J),USTAR(I,J),&
-                                State_Chm%IODIDE(I,J),I,J,DEPVw)
-
-                   ! Now convert to the new rc value(s) can probably tidy
-                   ! this up a bit
-                   alpha = 10.0_f8**(-0.25-0.013*( &
-                                     State_Met%TSKIN(I,J)-273.16_f8))
-                   RSURFC(K,LDT) = 1.0_f8/(alpha*DEPVw)
-
-                ELSE
-
-                   ! It's not 'ocean' so we instead don't change it from
-                   ! 'default' rc
-                   RSURFC(K,LDT) = 2000.0_f8
-
-                ENDIF
-
-             ELSE
-
-                !XMWH2O = 18.e-3_f8 ! Use global H2OMW (ewl, 1/6/16)
-                XMWH2O = H2OMW * 1.e-3_f8
-                RIXX = RIX*DIFFG(TEMPK,PRESSU(I,J),XMWH2O)/ &
-                     DIFFG(TEMPK,PRESSU(I,J),XMW(K)) &
-                     + 1.e+0_f8/(HSTAR(K)/3000.e+0_f8+100.e+0_f8*F0(K))
-                RLUXX = 1.e+12_f8
-                IF (RLU(LDT).LT.9999.e+0_f8) &
-                     RLUXX = RLU(LDT)/(HSTAR(K)/1.0e+05_f8 + F0(K))
-
-                ! If POPs simulation, scale cuticular resistances with octanol-
-                ! air partition coefficient (Koa) instead of HSTAR 
-                ! (clf, 1/3/2011)
-                IF (IS_POPS) &
-                     RLUXX = RLU(LDT)/(KOA(K)/1.0e+05_f8 + F0(K))
-
-                !*
-                !* To prevent virtually zero resistance to species with huge
-                !* HSTAR, such as HNO3, a minimum value of RLUXX needs to be
-                !* set. The rationality of the existence of such a minimum is
-                !* demonstrated by the observed relationship between Vd(NOy-NOx)
-                !* and Ustar in Munger et al.[1996];
-                !* Vd(HNO3) never exceeds 2 cm s-1 in observations. The
-                !* corresponding minimum resistance is 50 s m-1. This correction
-                !* was introduced by J.Y. Liang on 7/9/95.
-                !*
-                RGSX = 1.e+0_f8/(HSTAR(K)/1.0e+05_f8/RGSS(LDT) + &
-                       F0(K)/RGSO(LDT))
-                RCLX = 1.e+0_f8/(HSTAR(K)/1.0e+05_f8/RCLS(LDT) + &
-                       F0(K)/RCLO(LDT))
-                !*
-                !** Get the bulk surface resistance of the canopy, RSURFC, from
-                !** the network of resistances in parallel and in series (Fig. 1
-                !** of Wesely [1989])
-                DTMP1=1.e+0_f8/RIXX
-                DTMP2=1.e+0_f8/RLUXX
-                DTMP3=1.e+0_f8/(RAC(LDT)+RGSX)
-                DTMP4=1.e+0_f8/(RDC+RCLX)
-                RSURFC(K,LDT) = 1.e+0_f8/(DTMP1 + DTMP2 + DTMP3 + DTMP4)
-
-             ENDIF
-
-             !** get surface deposition velocity for aerosols if needed;
-             !** equations (15)-(17) of Walcek et al. [1986]
-155          IF (.NOT. AIROSOL(K)) GOTO 160
-
-             ! Get information about this species from the database
-             SpcId   =  NTRAIND(K)
-             SpcInfo => State_Chm%SpcData(SpcId)%Info
-
-             IF ( SpcInfo%DD_AeroDryDep ) THEN
-
-                !=====================================================
-                ! Use size-resolved dry deposition calculations for
-                ! seasalt aerosols.  We need to account for the
-                ! hygroscopic growth of the aerosol particles.
-                !=====================================================
-
-                ! [Zhang et al., 2001]
-                RSURFC(K,LDT) = AERO_SFCRSII( K,                   &
-                                              II,                  &
-                                              PRESSU(I,J)*1e-3_f8, &
-                                              TEMPK,               &
-                                              USTAR(I,J),          &
-                                              RHB(I,J),            &
-                                              W10(I,J),            &
-                                              Input_Opt )
-
-             ELSE IF ( SpcInfo%DD_DustDryDep ) THEN
-
-                !=====================================================
-                ! Use size-resolved dry deposition calculations for
-                ! dust aerosols only.  Do not account for hygroscopic
-                ! growth of the dust aerosol particles.
-                !=====================================================  
-#ifdef TOMAS
-                !-------------------------------
-                !%%% TOMAS SIMULATIONS %%%
-                !-------------------------------
-                IF ( TRIM(SpcInfo%Name) == 'DST1' .or. &
-                     TRIM(SpcInfo%Name) == 'DST2' .or. &
-                     TRIM(SpcInfo%Name) == 'DST3' .or. &
-                     TRIM(SpcInfo%Name) == 'DST4' ) THEN
-
-                   ! Particle diameter, convert [m] -> [um]
-                   DIAM  = A_RADI(K) * 2.e+0_f8
-
-                   ! Particle density [kg/m3]
-                   DEN   = A_DEN(K)
-
-                ELSE
-
-                   ! Get current aerosol diameter and density
-                   ! NOTE: In TOMAS the aerosol diameter and density
-                   ! evolves with time.  We have to save these in the
-                   ! DIAM and DEN variables so that we can hold these
-                   ! PRIVATE for the parallel loop.
-                   BIN  = NTRAIND(K) - id_NK1 + 1
-                   DIAM = SIZ_DIA( I, J, BIN )     ! Diameter [m]
-                   DEN  = SIZ_DEN( I, J, BIN )     ! Density  [kg/m3]
-
-                ENDIF
-#else
-                !-------------------------------
-                !%%% NON-TOMAS SIMULATIONS %%%
-                !-------------------------------
-
-                ! Particle diameter, convert [m] -> [um]
-                DIAM  = A_RADI(K) * 2.e+0_f8
-
-                ! Particle density [kg/m3]
-                DEN   = A_DEN(K)
-#endif
-
-#ifdef APM
-                IF(SpcInfo%Name(1:8)=='APMSPBIN')THEN
-                   DIAM = RDRY(SpcId-APMIDS%id_SO4BIN1+1)* &
-                        GFTOT3D(I,J,1,1)*2.D0
-                   DEN = DENWET3D(I,J,1,1)*1.D3
-                ENDIF
-                IF(SpcInfo%Name(1:9)=='APMSEABIN')THEN
-                   DIAM = RSALT(SpcId-APMIDS%id_SEABIN1+1)* &
-                        GFTOT3D(I,J,1,2)*2.D0
-                   DEN = DENWET3D(I,J,1,2)*1.D3
-                ENDIF
-                IF(SpcInfo%Name(1:9)=='APMDSTBIN')THEN
-                   DIAM = RDST(SpcId-APMIDS%id_DSTBIN1+1)*2.D0
-                   DEN = DENDST(SpcId-APMIDS%id_DSTBIN1+1)*1.D3
-                ENDIF
-                IF(SpcInfo%Name(1:8)=='APMLVSOA')THEN
-                   DIAM = MWSIZE3D(I,J,1,1)*2.D0
-                   DEN = DENWET3D(I,J,1,1)*1.D3
-                ENDIF
-                IF(SpcInfo%Name(1:8)=='APMCTSEA')THEN
-                   DIAM = MWSIZE3D(I,J,1,2)*2.D0
-                   DEN = DENWET3D(I,J,1,2)*1.D3
-                ENDIF
-                IF(SpcInfo%Name(1:8)=='APMCTDST')THEN
-                   DIAM = MWSIZE3D(I,J,1,3)*2.D0
-                   DEN = DENDST(12)*1.D3
-                ENDIF
-#endif
-
-                ! [Zhang et al., 2001]
-                RSURFC(K,LDT) = DUST_SFCRSII( K,                   &
-                                              II,                  &
-                                              PRESSU(I,J)*1e-3_f8, &
-                                              TEMPK,               &
-                                              USTAR(I,J),          &
-                                              DIAM,                &
-                                              DEN )
-
-             ELSE
-
-                !=====================================================
-                ! Replace original code to statement 160 here: only
-                ! do this for non-size-resolved species where
-                ! AIROSOL(K)=T. (rjp, tdf, bec, bmy, 4/20/04)
-                !=====================================================
-                !! use Zhang et al for all aerosols (hotp 10/26/07)
-                !VDS = 0.002D0*USTAR(I,J)
-                !IF (OBK(I,J) .LT. 0.0D0) THEN
-                !   VDS = VDS*(1.D0+(-300.D0/OBK(I,J))**0.6667D0)
-                !ENDIF
-                !
-                !IF ( OBK(I,J) .EQ. 0.0D0 ) &
-                !    WRITE(6,156) OBK(I,J),I,J,LDT
-                ! 156 FORMAT(1X,'OBK(I,J)=',E11.2,1X,' I,J =',2I4, 1X,'LDT=',I3/)
-                !CZH  = ZH(I,J)/OBK(I,J)
-                !IF (CZH.LT.-30.0D0) VDS = 0.0009D0*USTAR(I,J)* &
-                !   (-CZH)**0.6667D0
-
-                RSURFC(K, LDT) = ADUST_SFCRSII(K, II, PRESSU(I,J)*1e-3_f8, &
-                                            TEMPK, USTAR(I,J))
-
-                !*
-                !*    Set VDS to be less than VDSMAX (entry in input file
-                !*    divided by 1.D4) VDSMAX is taken from Table 2 of Walcek
-                !*    et al. [1986]. Invert to get corresponding R
-
-                !RSURFC(K,LDT) = 1.D0/MIN(VDS, DBLE(IVSMAX(II))/1.D4)
-             ENDIF
-
-             ! Free pointer
-             SpcInfo => NULL()
-
-160       CONTINUE
-             !*
-170    CONTINUE
-       !*
-       !*    Set max and min values for bulk surface resistances
-       !*
-       DO 190 K = 1,NUMDEP
-          IF (.NOT.LDEP(K)) GOTO 190
-          DO 180 LDT = 1, IREG(I,J)
-             IF ( IUSE(I,J,LDT) == 0 ) GOTO 180
-             ! because of high resistance values, different rule applied for
-             ! ocean ozone               
-             N_SPC = State_Chm%Map_DryDep(K)
-             IF ((N_SPC .EQ. ID_O3) .AND. (II .EQ. 11)) THEN
-                RSURFC(K,LDT)= MAX(1.e+0_f8, MIN(RSURFC(K,LDT),999999.e+0_f8))
-             ELSE
-                RSURFC(K,LDT)= MAX(1.e+0_f8, MIN(RSURFC(K,LDT),9999.e+0_f8))
-             ENDIF
-             ! Set Rc for strong acids (HNO3,HCl,HBr) to 1 s/m
-             ! V. Shah (23 Oct 18)
-             ! Ref. Jaegle et al. 2018, cf. Erisman,van Pul,Ayers 1994
-             IF ( HSTAR(K) .gt. 1.e+10_f8 ) THEN
-                RSURFC(K,LDT)= 1.e+0_f8
-             ENDIF
-180       CONTINUE
-190    CONTINUE
        !*
        !*    Loop through the different landuse types present in 
        !*    the grid square
        !*
+       ! Loop over the # of Olson land types in this grid box (I,J)
        DO 500 LDT = 1, IREG(I,J)
+
+          ! If the land type is not represented in grid
+          ! box  (I,J), then skip to the next land type
           IF ( IUSE(I,J,LDT) == 0 ) GOTO 500
-          IOLSON = ILAND(I,J,LDT) + 1
 
           !***** Get aerodynamic resistances Ra and Rb. ***********
           !   The aerodynamic resistance Ra is integrated from altitude z0+d up
@@ -2079,6 +1849,435 @@ CONTAINS
           ENDIF
 
 1001      FORMAT('WARNING: RA < 0 IN SUBROUTINE DEPVEL',2I4,4(1X,E12.5))
+
+       !    Get surface resistances - loop over land types LDT
+       !***********************************************************************
+       !* The land types within each grid square are defined using the Olson
+       !* land-type database.  Each of the Olson land types is assigned a
+       !* corresponding "deposition land type" with characteristic values of
+       !* surface resistance components.  There are 74 Olson land-types but only
+       !* 11 deposition land-types (i.e., many of the Olson land types share the
+       !* same deposition characteristics).  Surface resistance components for
+       !* the "deposition land types" are from Wesely [1989] except for tropical
+       !* forests [Jacob and Wofsy, 1990] and for tundra [Jacob et al., 1992].
+       !* All surface resistance components are normalized to a leaf area index
+       !* of unity.
+       !*
+       !* Olson land types, deposition land types, and surface resistance
+       !* components are read from file 'drydep.table'; check that file for
+       !* further details.
+       !***********************************************************************
+
+          ! Olson land type index + 1
+          IOLSON = ILAND(I,J,LDT)+1
+
+          ! Dry deposition land type index
+          II     = IDEP(IOLSON)
+          !
+          !** If the surface to be snow or ice;
+          !** set II to 1 instead.
+          !
+          IF(State_Met%isSnow(I,J)) II=1
+
+          ! PFT index, mapped from Olson land type index
+          PFT    = IPFT(IOLSON)   ! for ecophysiology and PFT-specific outputs
+                                  ! (Joey Lam, 22 Aug 2019)
+
+          !* Read the internal resistance RI (minimum stomatal resistance for
+          !* water vapor,per unit area of leaf) from the IRI array; a '9999'
+          !* value means no deposition to stomata so we impose a very large
+          !* value for RI.
+          RI(LDT) = DBLE(IRI(II))
+          IF (RI(LDT)   .GE. 9999.e+0_f8) RI(LDT)   = 1.e+12_f8
+
+          !** Cuticular resistances IRLU read in from 'drydep.table'
+          !** are per unit area of leaf;
+          !** divide them by the leaf area index to get a cuticular resistance
+          !** for the bulk canopy.  If IRLU is '9999' it means there are no
+          !** cuticular surfaces on which to deposit so we impose a very large
+          !** value for RLU.
+          IF ( IRLU(II) >= 9999 .or. XLAI(I,J,LDT) <= 0.e+0_f8 ) THEN
+             RLU(LDT) = 1.e+6_f8
+          ELSE
+             RLU(LDT) = DBLE( IRLU(II) ) / XLAI(I,J,LDT)
+             ! Additional resistance at low temperatures.
+             ! Limit increase to a factor of 2.
+             ! V. Shah 23 Oct 18
+             ! Ref Jaegle et al. 2018
+             RLU(LDT) = MIN( RLU(LDT) + RT, 2.e+0_f8 * RLU(LDT) )
+          ENDIF
+          !** The following are the remaining resistances for the Wesely
+          !** resistance-in-series model for a surface canopy
+          !** (see Atmos. Environ. paper, Fig.1).
+          RAC(LDT)  = MAX(DBLE(IRAC(II)), 1.e+0_f8)
+          IF (RAC(LDT)  .GE. 9999.e+0_f8) RAC(LDT)  = 1.e+12_f8
+          RGSS(LDT) = MAX(DBLE(IRGSS(II)), 1.e+0_f8)
+          ! Additional resistance at low temperatures.
+          ! Limit increase of RGSS, RGSO, RCLS, & RCLO to a factor of 2.
+          ! V. Shah 23 Oct 18
+          ! Ref Jaegle et al. 2018
+          RGSS(LDT) = MIN( RGSS(LDT) + RT, 2.e+0_f8 * RGSS(LDT) )
+          IF (RGSS(LDT) .GE. 9999.e+0_f8) RGSS(LDT) = 1.e12_f8
+          RGSO(LDT) = MAX(DBLE(IRGSO(II)) ,1.e+0_f8)
+          RGSO(LDT) = MIN( RGSO(LDT) + RT, 2.e+0_f8 * RGSO(LDT) )
+          IF (RGSO(LDT) .GE. 9999.e+0_f8) RGSO(LDT) = 1.e+12_f8
+          RCLS(LDT) = DBLE(IRCLS(II))
+          RCLS(LDT) = MIN( RCLS(LDT) + RT, 2.e+0_f8 * RCLS(LDT) )
+          IF (RCLS(LDT) .GE. 9999.e+0_f8) RCLS(LDT) = 1.e+12_f8
+          RCLO(LDT) = DBLE(IRCLO(II))
+          RCLO(LDT) = MIN( RCLO(LDT) + RT, 2.e+0_f8 * RCLO(LDT) )
+          IF (RCLO(LDT) .GE. 9999.e+0_f8) RCLO(LDT) = 1.e+12_f8
+          !********************************************************************
+          !*
+          !*    Adjust stomatal resistances for insolation and temperature:
+          !*
+          !*     Temperature adjustment is from Wesely [1989], equation (3).
+          !*
+          !*     Light adjustment by the function BIOFIT is described by Wang
+          !*     [1996]. It combines
+          !*       - Local dependence of stomal resistance on the intensity I
+          !*         of light impinging the leaf; this is expressed as a
+          !*         mutliplicative factor I/(I+b) to the stomatal resistance
+          !*         where b = 50 W m-2 (equation (7) of Baldocchi et al.[1987])
+          !*       - radiative transfer of direct and diffuse radiation in the
+          !*         canopy using equations (12)-(16) from Guenther et al.[1995]
+          !*       - separate accounting of sunlit and shaded leaves using
+          !*         equation (12) of Guenther et al. [1995]
+          !*       - partitioning of the radiation at the top of the canopy into
+          !*         direct and diffuse components using a parameterization to
+          !*         results from an atmospheric radiative transfer model
+          !*         [Wang, 1996]
+          !*     The dependent variables of the function BIOFIT are the leaf
+          !*     area index (XYLAI), the cosine of zenith angle (SUNCOS) and
+          !*     the fractional cloud cover (CFRAC).  The factor GFACI
+          !*     integrates the light dependence over the canopy depth; sp even
+          !*     though RI is input per unit area of leaf it need not be scaled
+          !*     by LAI to yield a bulk canopy value because that's already
+          !*     done in the GFACI formulation.
+          !********************************************************************
+          RAD0 = RADIAT(I,J)
+
+          !-----------------------------------------------------------------
+          ! In order to include ecophysiology module as an option, the 
+          ! orders of calculation of surface resistance and aerodynamic 
+          ! resistance are interchanged. (Joey Lam, 26 Feb 2019)
+          !-----------------------------------------------------------------
+          ! Use default Wesely scheme values for non-vegetated grid boxes
+          ! or if ecophysiology module is turned off
+          IF ( LECOPHY .AND. PFT .NE. 0 ) THEN
+
+             ! Get boundary layer resistance Rb for ozone in order to 
+             ! implement ozone damage scheme in ecophysiology module
+             !** DAIR is the thermal diffusivity of air; value of 0.2*1.E-4 m2 s-1 
+             !** cited on p. 16,476 of Jacob et al. [1992]
+             DAIR  = 0.2e0_f8*1.e-4_f8
+             id_O3 = IND_( 'O3' )
+             XMWO3 = State_Chm%SpcData( id_O3 )%Info%MW_g*1.e-3_fp
+             RB_O3 = (2.e+0_f8/CKUSTR)* &
+                     (DAIR/DIFFG(TEMPK,PRESSU(I,J),XMWO3)) &
+                     **0.667e+0_f8
+
+             ! Call from ecophysiology module to get RIX 
+             CALL DO_ECOPHY ( Input_Opt, State_Met,              & 
+                              State_Chm, State_Diag, RC,         &
+                              I, J,      LDT, PFT,   RA, RB_O3,  &
+                              PRESSU(I,J), Isop_PFT,             &
+                              RS,        SumLAI_PFT(PFT),        & 
+                              IUSE_PFT(PFT)                     )
+             ! If we use online isoprene emission from ecophysiology
+             IF ( Input_Opt%LIsop_from_Ecophy ) THEN 
+                ! The value of Isop_PFT is in kg C m-2 grid s-1
+                ! Sum over different land types to get a grid total
+                Isop_from_Ecophy( I,J ) = Isop_from_Ecophy( I,J ) + Isop_PFT
+             END IF
+             RIX = RS
+          ELSE
+             RIX = RI(LDT)
+             IF (RIX .GE. 9999.e+0_f8) GO TO 150
+             GFACT = 100.0e+0_f8
+             IF (TEMPC .GT. 0.e+0_f8 .AND. TEMPC .LT. 40.e+0_f8) &
+                 GFACT = 400.e+0_f8/TEMPC/(40.0e+0_f8-TEMPC)
+             GFACI = 100.e+0_f8
+             IF ( RAD0 > 0.e+0_f8 .and. XLAI(I,J,LDT) > 0.e+0_f8 ) THEN
+                ! Now make sure all inputs to BIOFIT are flexible precision
+                ! so that the code will compile properly (bmy, 12/18/14)
+                XLAI_FP   = XLAI(I,J,LDT)
+                SUNCOS_FP = SUNCOS(I,J)
+                CFRAC_FP  = CFRAC(I,J)
+                GFACI     = 1.e+0_f8 / BIOFIT( DRYCOEFF,  XLAI_FP, &
+                                               SUNCOS_FP, CFRAC_FP, NN )
+             ENDIF
+
+             RIX = RIX*GFACT*GFACI
+
+             ! Apply scaling factor to RIX when CO2 effect is turned on
+             ! (ayhwong, 6/25/19)
+             IF (Input_Opt%CO2_EFFECT) THEN
+                RIX = RIX*Input_Opt%RS_SCALE
+             ENDIF
+
+150          CONTINUE
+          ENDIF
+
+          ! Archive stomatal conductance for ecophysiology module 
+          ! (Joey Lam, 09 Apr 2019)
+          IF ( State_Diag%Archive_EcophyGCan .AND. PFT /= 0  &
+               .AND. IUSE_PFT(PFT) /= 0 ) THEN
+             Tmp = State_Diag%EcophyGCan ( I,J,PFT )
+             State_Diag%EcophyGCan ( I,J,PFT ) = Tmp         &
+                   + DBLE( IUSE(I,J,LDT) ) / RIX / IUSE_PFT(PFT)
+          END IF
+
+          !*
+          !*    Compute aerodynamic resistance to lower elements in lower part
+          !*    of the canopy or structure, assuming level terrain -
+          !*    equation (5) of Wesely [1989].
+          !*
+          RDC = 100.e+0_f8*(1.0e+0_f8+1000.0e+0_f8/(RAD0+10.e+0_f8))
+          !*
+          !*    Loop over species; species-dependent corrections to resistances
+          !*    are from equations (6)-(9) of Wesely [1989].
+          !*
+          DO 160  K = 1,NUMDEP
+
+             !** exit for non-depositing species or aerosols.
+             IF (.NOT. LDEP(K) .OR. AIROSOL(K)) GOTO 155
+
+             ! Test for special treatment for O3 drydep to ocean
+             N_SPC = State_Chm%Map_DryDep(K)
+             IF ((N_SPC .EQ. ID_O3) .AND. (II .EQ. 11)) THEN
+
+                IF (State_Chm%SALINITY(I,J) .GT. 20.0_f8) THEN
+
+                   ! Now apply the Luhar et al. [2018] equations for the
+                   ! special treatment of O3 dry deposition to the ocean
+                   ! surface 
+                   CALL OCEANO3(State_Met%TSKIN(I,J),USTAR(I,J),&
+                                State_Chm%IODIDE(I,J),I,J,DEPVw)
+
+                   ! Now convert to the new rc value(s) can probably tidy
+                   ! this up a bit
+                   alpha = 10.0_f8**(-0.25-0.013*( &
+                                     State_Met%TSKIN(I,J)-273.16_f8))
+                   RSURFC(K,LDT) = 1.0_f8/(alpha*DEPVw)
+
+                ELSE
+
+                   ! It's not 'ocean' so we instead don't change it from
+                   ! 'default' rc
+                   RSURFC(K,LDT) = 2000.0_f8
+
+                ENDIF
+
+             ELSE
+
+                !XMWH2O = 18.e-3_f8 ! Use global H2OMW (ewl, 1/6/16)
+                XMWH2O = H2OMW * 1.e-3_f8
+                RIXX = RIX*DIFFG(TEMPK,PRESSU(I,J),XMWH2O)/ &
+                     DIFFG(TEMPK,PRESSU(I,J),XMW(K)) &
+                     + 1.e+0_f8/(HSTAR(K)/3000.e+0_f8+100.e+0_f8*F0(K))
+                RLUXX = 1.e+12_f8
+                IF (RLU(LDT).LT.9999.e+0_f8) &
+                     RLUXX = RLU(LDT)/(HSTAR(K)/1.0e+05_f8 + F0(K))
+
+                ! If POPs simulation, scale cuticular resistances with octanol-
+                ! air partition coefficient (Koa) instead of HSTAR 
+                ! (clf, 1/3/2011)
+                IF (IS_POPS) &
+                     RLUXX = RLU(LDT)/(KOA(K)/1.0e+05_f8 + F0(K))
+
+                !*
+                !* To prevent virtually zero resistance to species with huge
+                !* HSTAR, such as HNO3, a minimum value of RLUXX needs to be
+                !* set. The rationality of the existence of such a minimum is
+                !* demonstrated by the observed relationship between Vd(NOy-NOx)
+                !* and Ustar in Munger et al.[1996];
+                !* Vd(HNO3) never exceeds 2 cm s-1 in observations. The
+                !* corresponding minimum resistance is 50 s m-1. This correction
+                !* was introduced by J.Y. Liang on 7/9/95.
+                !*
+                RGSX = 1.e+0_f8/(HSTAR(K)/1.0e+05_f8/RGSS(LDT) + &
+                       F0(K)/RGSO(LDT))
+                RCLX = 1.e+0_f8/(HSTAR(K)/1.0e+05_f8/RCLS(LDT) + &
+                       F0(K)/RCLO(LDT))
+                !*
+                !** Get the bulk surface resistance of the canopy, RSURFC, from
+                !** the network of resistances in parallel and in series (Fig. 1
+                !** of Wesely [1989])
+                DTMP1=1.e+0_f8/RIXX
+                DTMP2=1.e+0_f8/RLUXX
+                DTMP3=1.e+0_f8/(RAC(LDT)+RGSX)
+                DTMP4=1.e+0_f8/(RDC+RCLX)
+                RSURFC(K,LDT) = 1.e+0_f8/(DTMP1 + DTMP2 + DTMP3 + DTMP4)
+
+             ENDIF
+
+             !** get surface deposition velocity for aerosols if needed;
+             !** equations (15)-(17) of Walcek et al. [1986]
+155          IF (.NOT. AIROSOL(K)) GOTO 160
+
+             ! Get information about this species from the database
+             SpcId   =  NTRAIND(K)
+             SpcInfo => State_Chm%SpcData(SpcId)%Info
+
+             IF ( SpcInfo%DD_AeroDryDep ) THEN
+
+                !=====================================================
+                ! Use size-resolved dry deposition calculations for
+                ! seasalt aerosols.  We need to account for the
+                ! hygroscopic growth of the aerosol particles.
+                !=====================================================
+
+                ! [Zhang et al., 2001]
+                RSURFC(K,LDT) = AERO_SFCRSII( K,                   &
+                                              II,                  &
+                                              PRESSU(I,J)*1e-3_f8, &
+                                              TEMPK,               &
+                                              USTAR(I,J),          &
+                                              RHB(I,J),            &
+                                              W10(I,J),            &
+                                              Input_Opt )
+
+             ELSE IF ( SpcInfo%DD_DustDryDep ) THEN
+
+                !=====================================================
+                ! Use size-resolved dry deposition calculations for
+                ! dust aerosols only.  Do not account for hygroscopic
+                ! growth of the dust aerosol particles.
+                !=====================================================  
+#ifdef TOMAS
+                !-------------------------------
+                !%%% TOMAS SIMULATIONS %%%
+                !-------------------------------
+                IF ( TRIM(SpcInfo%Name) == 'DST1' .or. &
+                     TRIM(SpcInfo%Name) == 'DST2' .or. &
+                     TRIM(SpcInfo%Name) == 'DST3' .or. &
+                     TRIM(SpcInfo%Name) == 'DST4' ) THEN
+
+                   ! Particle diameter, convert [m] -> [um]
+                   DIAM  = A_RADI(K) * 2.e+0_f8
+
+                   ! Particle density [kg/m3]
+                   DEN   = A_DEN(K)
+
+                ELSE
+
+                   ! Get current aerosol diameter and density
+                   ! NOTE: In TOMAS the aerosol diameter and density
+                   ! evolves with time.  We have to save these in the
+                   ! DIAM and DEN variables so that we can hold these
+                   ! PRIVATE for the parallel loop.
+                   BIN  = NTRAIND(K) - id_NK1 + 1
+                   DIAM = SIZ_DIA( I, J, BIN )     ! Diameter [m]
+                   DEN  = SIZ_DEN( I, J, BIN )     ! Density  [kg/m3]
+
+                ENDIF
+#else
+                !-------------------------------
+                !%%% NON-TOMAS SIMULATIONS %%%
+                !-------------------------------
+
+                ! Particle diameter, convert [m] -> [um]
+                DIAM  = A_RADI(K) * 2.e+0_f8
+
+                ! Particle density [kg/m3]
+                DEN   = A_DEN(K)
+#endif
+
+#ifdef APM
+                IF(SpcInfo%Name(1:8)=='APMSPBIN')THEN
+                   DIAM = RDRY(SpcId-APMIDS%id_SO4BIN1+1)* &
+                        GFTOT3D(I,J,1,1)*2.D0
+                   DEN = DENWET3D(I,J,1,1)*1.D3
+                ENDIF
+                IF(SpcInfo%Name(1:9)=='APMSEABIN')THEN
+                   DIAM = RSALT(SpcId-APMIDS%id_SEABIN1+1)* &
+                        GFTOT3D(I,J,1,2)*2.D0
+                   DEN = DENWET3D(I,J,1,2)*1.D3
+                ENDIF
+                IF(SpcInfo%Name(1:9)=='APMDSTBIN')THEN
+                   DIAM = RDST(SpcId-APMIDS%id_DSTBIN1+1)*2.D0
+                   DEN = DENDST(SpcId-APMIDS%id_DSTBIN1+1)*1.D3
+                ENDIF
+                IF(SpcInfo%Name(1:8)=='APMLVSOA')THEN
+                   DIAM = MWSIZE3D(I,J,1,1)*2.D0
+                   DEN = DENWET3D(I,J,1,1)*1.D3
+                ENDIF
+                IF(SpcInfo%Name(1:8)=='APMCTSEA')THEN
+                   DIAM = MWSIZE3D(I,J,1,2)*2.D0
+                   DEN = DENWET3D(I,J,1,2)*1.D3
+                ENDIF
+                IF(SpcInfo%Name(1:8)=='APMCTDST')THEN
+                   DIAM = MWSIZE3D(I,J,1,3)*2.D0
+                   DEN = DENDST(12)*1.D3
+                ENDIF
+#endif
+
+                ! [Zhang et al., 2001]
+                RSURFC(K,LDT) = DUST_SFCRSII( K,                   &
+                                              II,                  &
+                                              PRESSU(I,J)*1e-3_f8, &
+                                              TEMPK,               &
+                                              USTAR(I,J),          &
+                                              DIAM,                &
+                                              DEN )
+
+             ELSE
+
+                !=====================================================
+                ! Replace original code to statement 160 here: only
+                ! do this for non-size-resolved species where
+                ! AIROSOL(K)=T. (rjp, tdf, bec, bmy, 4/20/04)
+                !=====================================================
+                !! use Zhang et al for all aerosols (hotp 10/26/07)
+                !VDS = 0.002D0*USTAR(I,J)
+                !IF (OBK(I,J) .LT. 0.0D0) THEN
+                !   VDS = VDS*(1.D0+(-300.D0/OBK(I,J))**0.6667D0)
+                !ENDIF
+                !
+                !IF ( OBK(I,J) .EQ. 0.0D0 ) &
+                !    WRITE(6,156) OBK(I,J),I,J,LDT
+                ! 156 FORMAT(1X,'OBK(I,J)=',E11.2,1X,' I,J =',2I4, 1X,'LDT=',I3/)
+                !CZH  = ZH(I,J)/OBK(I,J)
+                !IF (CZH.LT.-30.0D0) VDS = 0.0009D0*USTAR(I,J)* &
+                !   (-CZH)**0.6667D0
+
+                RSURFC(K, LDT) = ADUST_SFCRSII(K, II, PRESSU(I,J)*1e-3_f8, &
+                                            TEMPK, USTAR(I,J))
+
+                !*
+                !*    Set VDS to be less than VDSMAX (entry in input file
+                !*    divided by 1.D4) VDSMAX is taken from Table 2 of Walcek
+                !*    et al. [1986]. Invert to get corresponding R
+
+                !RSURFC(K,LDT) = 1.D0/MIN(VDS, DBLE(IVSMAX(II))/1.D4)
+             ENDIF
+
+             ! Free pointer
+             SpcInfo => NULL()
+
+160       CONTINUE
+
+       !*
+       !*    Set max and min values for bulk surface resistances
+       !*
+       DO 190 K = 1,NUMDEP
+          IF (.NOT.LDEP(K)) GOTO 190
+             ! because of high resistance values, different rule applied for
+             ! ocean ozone               
+             N_SPC = State_Chm%Map_DryDep(K)
+             IF ((N_SPC .EQ. ID_O3) .AND. (II .EQ. 11)) THEN
+                RSURFC(K,LDT)= MAX(1.e+0_f8, MIN(RSURFC(K,LDT),999999.e+0_f8))
+             ELSE
+                RSURFC(K,LDT)= MAX(1.e+0_f8, MIN(RSURFC(K,LDT),9999.e+0_f8))
+             ENDIF
+             ! Set Rc for strong acids (HNO3,HCl,HBr) to 1 s/m
+             ! V. Shah (23 Oct 18)
+             ! Ref. Jaegle et al. 2018, cf. Erisman,van Pul,Ayers 1994
+             IF ( HSTAR(K) .gt. 1.e+10_f8 ) THEN
+                RSURFC(K,LDT)= 1.e+0_f8
+             ENDIF
+190    CONTINUE
           !* Get total resistance for deposition
           !* loop over species.
           DO 215 K = 1,NUMDEP
@@ -2120,7 +2319,16 @@ CONTAINS
              IF (.NOT.LDEP(K)) GOTO 400
              VK(K) = VD(K)
              VD(K) = VK(K) +.001D0* DBLE( IUSE(I,J,LDT) )/C1X(K)
+               ! PFT-specific dry deposition velocity (Joey Lam, 22 Aug 2019)
+               IF ( State_Diag%Archive_DryDepVel_anyPFT 
+     &              .and. PFT .NE. 0 ) THEN
+                  VK(K) = VD_PFT(K,PFT) 
+                  VD_PFT(K,PFT) = VK(K) + DBLE( IUSE(I,J,LDT) )/C1X(K)
+     &                                    / DBLE( IUSE_PFT(PFT) )
+               ENDIF
 400       CONTINUE
+
+
 
 #ifdef MODEL_GEOS
           !--- Eventually archive aerodynamic resistance.
@@ -2143,6 +2351,39 @@ CONTAINS
        DO 550 K=1,NUMDEP
           IF (.NOT.LDEP(K)) GOTO 550
           State_Chm%DryDepVel(I,J,K) = VD(K)
+
+       !-----------------------------------------------------------
+       ! PFT-specific dry deposition velocity (Joey Lam, 22 Aug 2019)
+       ! Remarks: Cannot register an array with dimensions 
+       !          (I,J,nDryDep,PFT) in either State_Chm or State_Diag,
+       !          so save to State_Diag%DryDepVel_PFT[1-5] separately.
+       !----------------------------------------------------------
+          DO PFT = 1, MAXVAL(IPFT)
+             SELECT CASE ( PFT ) 
+             CASE( 1 )
+                IF ( State_Diag%Archive_DryDepVelPFT1 ) THEN
+                   State_Diag%DryDepVelPFT1(I,J,K) = VD_PFT(K,PFT)
+                ENDIF
+             CASE( 2 )
+                IF ( State_Diag%Archive_DryDepVelPFT2 ) THEN
+                   State_Diag%DryDepVelPFT2(I,J,K) = VD_PFT(K,PFT)
+                ENDIF
+             CASE( 3 )
+                IF ( State_Diag%Archive_DryDepVelPFT3 ) THEN
+                   State_Diag%DryDepVelPFT3(I,J,K) = VD_PFT(K,PFT)
+                ENDIF
+             CASE( 4 )
+                IF ( State_Diag%Archive_DryDepVelPFT4 ) THEN
+                   State_Diag%DryDepVelPFT4(I,J,K) = VD_PFT(K,PFT)
+                ENDIF
+             CASE( 5 )
+                IF ( State_Diag%Archive_DryDepVelPFT5 ) THEN
+                   State_Diag%DryDepVelPFT5(I,J,K) = VD_PFT(K,PFT)
+                ENDIF
+             CASE DEFAULT
+                ! Do nothing (ignore vd for PFT=0: non-vegetated land)
+             END SELECT 
+          ENDDO
 
           ! Now check for negative deposition velocity before returning to
           ! calling program (bmy, 4/16/00)
@@ -2312,7 +2553,7 @@ CONTAINS
                                  IDRYDEP,   IRI,      IRLU,   &
                                  IRAC,      IRGSS,    IRGSO,  &
                                  IRCLS,     IRCLO,    IVSMAX, &
-                                 RC )
+                                 IPFT,      RC )
 !
 ! !USES:
 !
@@ -2359,6 +2600,7 @@ CONTAINS
     ! IRCLS    : RCLS resistance for drydep
     ! IRCLO    : RCLO resistance for drydep
     ! IVSMAX   : Max drydep velocity (for aerosol) perr drydep land type
+    ! IPFT     : Mapping: Olson ==> PFT ID
     !-----------------------------------------------------------------------
     REAL(fp), INTENT(OUT) :: DRYCOEFF(NPOLY    )
     INTEGER,  INTENT(OUT) :: IOLSON  (NSURFTYPE)
@@ -2375,6 +2617,7 @@ CONTAINS
     INTEGER,  INTENT(OUT) :: IRCLS   (NDRYDTYPE)
     INTEGER,  INTENT(OUT) :: IRCLO   (NDRYDTYPE)
     INTEGER,  INTENT(OUT) :: IVSMAX  (NDRYDTYPE)
+    INTEGER,  INTENT(OUT) :: IPFT    (NSURFTYPE)
 
     ! Success or failure flag
     INTEGER,  INTENT(OUT) :: RC
@@ -2437,7 +2680,8 @@ CONTAINS
     ThisLoc = ' -> at READ_DRYDEP_INPUTS (in module GeosCore/drydep_mod.F90)'
 
     ! Input file for Olson 2001
-    nc_file = 'Olson_2001_Drydep_Inputs.nc'
+    ! nc_file = 'Olson_2001_Drydep_Inputs.nc'
+    nc_file = 'Olson_2001_Drydep_Inputs_edited_20191104.nc' 
 
     ! Open file for reading (construct full data path)
     nc_dir  = TRIM( Input_Opt%CHEM_INPUTS_DIR ) // &
@@ -2889,6 +3133,27 @@ CONTAINS
     a_name = "units"
     CALL NcGet_Var_Attributes( fId,TRIM(v_name),TRIM(a_name),a_val )
 #endif
+
+    ! Echo info to stdout
+    IF ( Input_Opt%amIRoot ) THEN
+       WRITE( 6, 130 ) TRIM(v_name), TRIM(a_val)
+    ENDIF
+
+    !----------------------------------------
+    ! VARIABLE: IPFT
+    !----------------------------------------
+
+    ! Variable name
+    v_name = "IPFT"
+
+    ! Read IDEP from file
+    st1d   = (/ 1         /)
+    ct1d   = (/ NSURFTYPE /)
+    CALL NcRd( IPFT, fId, TRIM(v_name), st1d, ct1d )
+
+    ! Read the IDEP:units attribute
+    a_name = "units"
+    CALL NcGet_Var_Attributes( fId,TRIM(v_name),TRIM(a_name),a_val )
 
     ! Echo info to stdout
     IF ( Input_Opt%amIRoot ) THEN
@@ -4290,7 +4555,7 @@ CONTAINS
                              IDRYDEP,   IRI,      IRLU,   &
                              IRAC,      IRGSS,    IRGSO,  &
                              IRCLS,     IRCLO,    IVSMAX, &
-                             RC )
+                             IPFT,      RC )
 
     ! Trap potential errors
     IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/ecophy_mod.F90
+++ b/GeosCore/ecophy_mod.F90
@@ -1,0 +1,1748 @@
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !MODULE: ecophy_mod.F90
+!
+! !DESCRIPTION: Module ECOPHY\_MOD contains variables and routines for the
+!  GEOS-Chem ecophysiology scheme. It modifies the bulk canopy stomatal
+!  resistance RIX in the dry deposition scheme.
+!\\
+!\\
+! !INTERFACE:
+!
+      MODULE ECOPHY_MOD
+!
+! !USES:
+!
+      USE PhysConstants, ONLY: RSTARG, AIRMW    ! Physical constants
+      USE PRECISION_MOD                         ! For GEOS-Chem Precision (fp)
+      IMPLICIT NONE
+      PRIVATE
+!
+! !PUBLIC MEMBER FUNCTIONS:
+!
+      PUBLIC :: DO_ECOPHY
+      PUBLIC :: INIT_ECOPHY
+      PUBLIC :: CLEANUP_ECOPHY
+!
+! !REVISION HISTORY:
+!
+! !REMARKS:
+!  References:
+!  ============================================================================
+!  (1 ) Clark, D. B., et al., "The Joint UK Land Environment Simulator (JULES), 
+!        model description – Part 2: Carbon fluxes and vegetation dynamics", 
+!        Geosci. Model Dev., 4, 701–722, 
+!        https://doi.org/10.5194/gmd-4-701-2011, 2011.
+!  (2 ) Best, M. J., et al. "The Joint UK Land Environment Simulator (JULES), 
+!        model description – Part 1: Energy and water fluxes", 
+!        Geosci. Model Dev., 4, 677–699, 
+!        https://doi.org/10.5194/gmd-4-677-2011, 2011.
+!  (3 ) P.M Cox, C Huntingford, R.J Harding, "A canopy conductance and 
+!        photosynthesis model for use in a GCM land surface scheme",
+!        Journal of Hydrology, Volumes 212–213, Pages 79-94, ISSN 0022-1694,
+!        https://doi.org/10.1016/S0022-1694(98)00203-0, 1998.
+!  (4 ) Raoult, N. M., "Land-surface parameter optimisation using data 
+!        assimilation techniques: the adJULES system V1.0",
+!        Geosci. Model Dev., 9, 2833–2852, 
+!        https://doi.org/10.5194/gmd-9-2833-2016, 2016.
+!  (5 ) Pacifico, F., et al., "Photosynthesis-based biogenic isoprene emission 
+!        scheme in JULES",
+!        Atmos. Chem. Phys., 11, 4371–4389, 2011
+!        https://doi.org/10.5194/acp-11-4371-2011, 2011
+!  ============================================================================
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !PRIVATE DATA MEMBERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! NUMPFT        : Total number of PFTs                              []
+      ! MAX_ITER      : Maximum number of iterations                      []
+      ! IS_C3_PLANT   : IS_C3_PLANT = 1 for C3 plants, else 0             []
+      ! ALPHA         : Quantum efficiency of photosynthesis              [mol CO2 mol^-1 PAR]
+      ! V_CMAX25      : V_CMAX at 25 deg C                                [mol CO2 m^-2 s^-1]
+      ! T_UPP         : PFT-specific parameter for V_CMAX                 [deg C]
+      ! T_LOW         : PFT-specific parameter for V_CMAX                 [deg C]
+      ! F_DARKRESP    : Dark respiration coefficient                      []
+      ! D_STAR        : PFT-specific parameter for closure eq.            [kg H2O / kg air]
+      ! f0            : PFT-specific parameter for closure eq.            []
+      ! G_LEAF_MIN    : PFT-specific min leaf conductance for closure eq. [m s^-1]
+      ! K_EXTINCT     : Light extinction coefficient                      []
+      ! PARAM_A_LOW   : PFT-specific parameter for low sensitivity   
+      !                 ozone damage scheme                               [m^2 s nmol^-1]
+      ! PARAM_A_HI    : PFT-specific parameter for high sensitivity 
+      !                 ozone damage scheme                               [m^2 s nmol^-1]
+      ! FLUXO3_CRIT   : PFT-specific threshold for ozone uptake           [nmol m^-2 s^-1]
+      ! THRESHOLD     : Threshold of relative error                       []
+      ! CO2_O2_RATIO  : Ratio of diffusivity of CO2 compared to H2O       []
+      ! Leaf_density  : Specific leaf density                             [kg C m^-2 leaf]
+      ! IEF           : Isoprene Emission Factors under standard cond.    [ug C g^-1 (dry weight) hr^-1]
+      ! TEMP_st       : Standard conditions (temperature)                 [K]
+      ! PAR_st        : Standard conditions (PAR)                         []
+      !---------------------------------------------------------------------------------------
+      INTEGER,  PARAMETER   :: NUMPFT                 = 5 
+      INTEGER,  PARAMETER   :: MAX_ITER               = 1
+      INTEGER,  PARAMETER   :: IS_C3_PLANT   (NUMPFT) = (/ 1,1,1,0,1 /)
+      ! REAL(fp), PARAMETER   :: ALPHA         (NUMPFT) = (/ 0.08, 0.08, 0.12, 0.06, 0.08 /)
+      ! REAL(fp), PARAMETER   :: V_CMAX25      (NUMPFT) = (/ 0.046, 0.033, 0.073, 0.060, 0.060 /) * &
+      !                                                   (/ 0.0008, 0.0008, 0.0008, 0.0004, 0.0008 /)
+      ! REAL(fp), PARAMETER   :: T_UPP         (NUMPFT) = (/ 36.0, 26.0, 36.0, 45.0, 36.0 /)
+      ! REAL(fp), PARAMETER   :: T_LOW         (NUMPFT) = (/ 0.0, -10.0, 0.0,  13.0, 0.0  /)
+      REAL(fp), PARAMETER   :: F_DARKRESP    (NUMPFT) = (/ .015, .015, .015, .025, .015 /)
+      ! REAL(fp), PARAMETER   :: D_STAR        (NUMPFT) = (/ 0.09, 0.06, 0.1,  .075, 0.1  /)
+      ! REAL(fp), PARAMETER   :: f0            (NUMPFT) = (/ .875, .875, 0.9,  0.8,  0.9  /)
+      REAL(fp), PARAMETER   :: G_LEAF_MIN    (NUMPFT) = 1.0e-4                                ! gives RS ~ 9999
+      REAL(fp), PARAMETER   :: K_EXTINCT     (NUMPFT) = 0.5
+      REAL(fp), PARAMETER   :: PARAM_A_LOW   (NUMPFT) = (/ 0.04, 0.02, 0.25, 0.13, 0.03 /)    ! low sensitivity
+      REAL(fp), PARAMETER   :: PARAM_A_HI    (NUMPFT) = (/ 0.15, 0.075, 1.40, 0.735, 0.10 /)  ! high sensistivity
+      REAL(fp), PARAMETER   :: FLUXO3_CRIT   (NUMPFT) = (/ 1.6,  1.6,  5.0,  5.0,  1.6  /)
+      REAL(fp), PARAMETER   :: THRESHOLD              = 1.0e-3
+      ! Second set of optimized parameters (from Raoult et al. 2016)
+      REAL(fp), PARAMETER   :: ALPHA         (NUMPFT) = (/ 0.131, 0.096, 0.179, 0.118, 0.102 /)
+      REAL(fp), PARAMETER   :: V_CMAX25      (NUMPFT) = (/ 0.061, 0.065, 0.070, 0.051, 0.041 /) * &
+                                                        (/ 0.0008, 0.0008, 0.0008, 0.0004, 0.0008 /)
+      REAL(fp), PARAMETER   :: T_UPP         (NUMPFT) = (/ 38.578, 34.721, 36.242, 44.897, 35.385 /)
+      REAL(fp), PARAMETER   :: T_LOW         (NUMPFT) = (/ 1.203, -8.698, -1.985, 11.37, -5.208 /)
+      REAL(fp), PARAMETER   :: D_STAR        (NUMPFT) = (/ 0.048, 0.036, 0.086, 0.046, 0.077 /)
+      REAL(fp), PARAMETER   :: f0            (NUMPFT) = (/ 0.765, 0.737, 0.817, 0.765, 0.782 /)  
+      REAL(fp), PARAMETER   :: CO2_O2_RATIO = 1.6
+
+      ! Parameters for photosynthesis-dependent isoprene emission
+      REAL(fp), PARAMETER   :: Leaf_density  (NUMPFT) = (/ 0.0375, 0.1000, 0.0250, 0.0500, 0.0500 /) 
+      REAL(fp), PARAMETER   :: IEF           (NUMPFT) = (/ 35.0, 12.0, 16.0, 8.0,  20.0 /)
+      REAL(fp), PARAMETER   :: Dry_fraction           = 0.4
+      REAL(fp), PARAMETER   :: TEMPK_st               = 303.15e+0_fp
+
+!
+! MODULE VARIABLES:
+!
+      !=========================================================================================
+      ! SATU          : Soil moisture at saturation point                 [m^3 water / m^3 soil]
+      ! CRIT          : Soil moisture at critical point                   [m^3 water / m^3 soil]
+      ! WILT          : Soil moisture at wilting point                    [m^3 water / m^3 soil]
+      ! O3dmg_opt     : Control switch for ozone damage scheme            [hi/low/off]
+      ! A_NET_st      : Leaf photosynthesis rate under standard cond.     [mol CO2 m^-2 leaf s^-1]
+      ! RESP_st       : Leaf respiration rate under standard cond.        [mol CO2 m^-2 leaf s^-1]
+      ! CO2_IN_st     : Leaf CO2 partial pressure under standard cond.    [Pa]
+      !=========================================================================================
+      REAL(fp)              :: SATU
+      REAL(fp)              :: CRIT
+      REAL(fp)              :: WILT
+      CHARACTER(len=3)      :: O3dmg_opt 
+      REAL(fp)              :: A_NET_st      (NUMPFT)
+      REAL(fp)              :: RESP_st       (NUMPFT)
+      REAL(fp)              :: CO2_IN_st     (NUMPFT)
+
+      !=================================================================
+      ! MODULE ROUTINES -- follow below the "CONTAINS" statement
+      !=================================================================
+      CONTAINS
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: do_ecophy
+!
+! !DESCRIPTION: Subroutine DO\_ECOPHY is the interface between dry
+!  deposition module and the ecophysiology module. It computes the
+!  bulk canopy stomatal resistance r_s according to meterological inputs,
+!  plant functional types, and soil types.
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE DO_ECOPHY ( Input_Opt, State_Met,             &
+                             State_Chm, State_Diag, RC,        &
+                             I, J,      LDT, PFT,   RA, RB_O3, &
+                             PRESSU,    Isop_from_Ecophy,      &
+                             RS,        SumLAI_PFT, IUSE_PFT   )
+!
+! !USES:
+!
+      USE ErrCode_Mod
+      USE Input_Opt_Mod,      ONLY : OptInput
+      USE Species_Mod,        ONLY : Species
+      USE State_Chm_Mod,      ONLY : ChmState
+      USE State_Met_Mod,      ONLY : MetState
+      USE State_Diag_Mod,     ONLY : DgnState
+!
+! !INPUT PARAMETERS:
+!
+      INTEGER,        INTENT(IN)    :: I           ! longitude index
+      INTEGER,        INTENT(IN)    :: J           ! latitude index
+      INTEGER,        INTENT(IN)    :: PFT         ! PFT index
+      INTEGER,        INTENT(IN)    :: LDT         ! Land type index (for archiving)
+      TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+      TYPE(MetState), INTENT(IN)    :: State_Met   ! Meteorology State object
+      REAL(fp),       INTENT(IN)    :: RA          ! Aerodynamic resistance 
+      REAL(fp),       INTENT(IN)    :: RB_O3       ! Boundary layer resistance
+      REAL(fp),       INTENT(IN)    :: PRESSU      ! Surface Pressure (Pa)
+      REAL(fp),       INTENT(IN)    :: SumLAI_PFT  ! leaf area of the PFT
+      INTEGER,        INTENT(IN)    :: IUSE_PFT    ! fraction of grid box 
+                                                   ! occupied by the PFT
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+      TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
+      TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
+!
+! !OUTPUT PARAMETERS:
+!
+      INTEGER,        INTENT(OUT)   :: RC          ! Success or failure
+      REAL(fp),       INTENT(OUT)   :: RS          ! Bulk canopy stomatal resistance
+      REAL(fp),       INTENT(OUT)   :: Isop_from_Ecophy  ! Isoprene emission
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+      ! Scalars
+      CHARACTER(LEN=255) :: ErrMsg, ThisLoc
+
+      !  Note: Read subroutine DO_PHOTOSYNTHESIS for descriptions of variables.
+      REAL(fp)   :: TEMPK
+      REAL(fp)   :: QV2M
+      REAL(fp)   :: APAR
+      ! REAL(fp)   :: PRESSURE
+      REAL(fp)   :: CO2
+      REAL(fp)   :: O2
+      REAL(fp)   :: O3
+      REAL(fp)   :: SOIL_WETNESS
+      REAL(fp)   :: G_CAN_OUT
+      REAL(fp)   :: G_LEAF_OUT
+      REAL(fp)   :: CO2_IN
+      REAL(fp)   :: A_CAN_OUT
+      REAL(fp)   :: A_NET_OUT
+      REAL(fp)   :: RESP_CAN_OUT
+      REAL(fp)   :: RESP_OUT
+      REAL(fp)   :: FLUXO3_CAN
+      REAL(fp)   :: FLUXO3
+      REAL(fp)   :: FACTOR_O3
+      REAL(fp)   :: BETA
+      REAL(fp)   :: V_CMAX
+      REAL(fp)   :: RATE_LIGHT
+      REAL(fp)   :: RATE_RUBISCO
+      REAL(fp)   :: RATE_PRODUCT
+      REAL(fp)   :: A_GROSS
+      REAL(fp)   :: LAI
+      REAL(fp)   :: ISOP_EMIS
+      INTEGER    :: IOLSON
+      INTEGER    :: IUSE
+
+      !=================================================================
+      ! DO_ECOPHY begins here!
+      !=================================================================
+      ! Assume success
+      RC = GC_SUCCESS
+
+      ! Initialize
+      ErrMsg  = ''
+      ThisLoc = &
+      ' -> at Do_ECOPHY (in module GeosCore/ecophysiology.F90)'
+
+      ! get inputs for the module
+      CALL GET_ECOPHY_INPUTS( State_Met,    State_Chm, Input_Opt,&
+                              I, J, LDT,                         &
+                              TEMPK,        QV2M,                &
+                              APAR,         CO2,                 &
+                              O2,           LAI,       O3,       &
+                              SOIL_WETNESS, IUSE                 &
+                              )
+
+      ! simulate plant processes
+      CALL DO_PHOTOSYNTHESIS( LAI, PFT,     PRESSU,      APAR,         &
+                              CO2, O2,      TEMPK,       G_CAN_OUT,    &
+                              G_LEAF_OUT,   CO2_IN,      A_CAN_OUT,    &
+                              A_NET_OUT,    RESP_CAN_OUT, RESP_OUT,    &
+                              FLUXO3_CAN,   FLUXO3,      FACTOR_O3,    &
+                              BETA,         V_CMAX,      RATE_LIGHT,   &
+                              RATE_RUBISCO, RATE_PRODUCT, A_GROSS, RC, &
+                              QV2M=QV2M,    RA=RA,       RB_O3=RB_O3,  &
+                              O3=O3,        SOIL_WETNESS=SOIL_WETNESS  &
+                              )
+
+      IF ( Input_Opt%LIsop_from_Ecophy ) THEN
+         ! calculate isoprene emission from photosynthesis 
+         CALL DO_ISOP_EMIS( A_CAN_OUT, RESP_CAN_OUT,  &
+                            TEMPK, CO2_IN,            &
+                            LAI, PFT,                 &
+                            ISOP_EMIS                 )
+      ENDIF
+
+      ! Trap potential errors
+      IF ( RC /= GC_SUCCESS ) THEN
+         ErrMsg = 'Error encountered in call to "GET_ECOPHY_INPUTS!'
+         CALL GC_Error( ErrMsg, RC, ThisLoc )
+         RETURN
+      ENDIF
+
+      ! Output bulk stomatal resistance to dry deposition module
+      RS = 1.0 / G_CAN_OUT
+
+      ! Output isoprene emission rate to dry deposition module
+      ! Convert from kg C m-2 land s-1 to kg C m-2 grid s-1 
+      ! IUSE / 1000 is the the fraction of the grid for that land type
+      Isop_from_Ecophy = ISOP_EMIS * DBLE( IUSE ) / 1.e+3_fp
+
+      ! Send output to State_Diag
+      CALL Ecophy_Diagn( I, J,         LDT,        PFT,          &
+                         IUSE,         LAI,        SumLAI_PFT,   &
+                         IUSE_PFT,     RA,         RB_O3,        &
+                         G_CAN_OUT,    A_CAN_OUT,  RESP_CAN_OUT, &
+                         CO2_IN,       FLUXO3_CAN,               &
+                         FACTOR_O3,    BETA,       V_CMAX,       &
+                         RATE_LIGHT,   RATE_RUBISCO,             &
+                         RATE_PRODUCT, A_GROSS,    ISOP_EMIS,    &
+                         State_Met,    State_Diag, RC            &
+                       )
+      ! Trap potential errors
+      IF ( RC /= GC_SUCCESS ) THEN
+         ErrMsg = 'Error encountered in call to "GET_ECOPHY_INPUTS!'
+         CALL GC_Error( ErrMsg, RC, ThisLoc )
+         RETURN
+      ENDIF
+
+      ! Return to calling program
+      END SUBROUTINE DO_ECOPHY
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: do_photosynthesis
+!
+! !DESCRIPTION: Subroutine DO\_PHOTOSYNTHESIS is the main driver of this
+!  module.
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE DO_PHOTOSYNTHESIS( LAI, PFT,     PRESSURE,    APAR,         &
+                                    CO2, O2,      TEMPK,       G_CAN_OUT,    &
+                                    G_LEAF_OUT,   CO2_IN,      A_CAN_OUT,    &
+                                    A_NET_OUT,    RESP_CAN_OUT, RESP_OUT,    &
+                                    FLUXO3_CAN,   FLUXO3,      FACTOR_O3,    &
+                                    BETA,         V_CMAX,      RATE_LIGHT,   &
+                                    RATE_RUBISCO, RATE_PRODUCT, A_GROSS, RC, &
+                                    V_CMAX_IN,    QV2M,        DEFICIT_Q_IN, &
+                                    RA, RB_O3,    O3,          FACTOR_O3_IN, &
+                                    SOIL_WETNESS, BETA_IN                    &
+                                    )
+!
+! !USES:
+!
+      USE ErrCode_Mod
+!
+!INPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! LAI           : Leaf area index for the PFT                       [m^2 m^-2]
+      ! PFT           : Index for PFT                                     []
+      ! APAR          : Absorbed PAR                                      [mol photon m^-2 s^-1]
+      ! PRESSURE      : Atmospheric Pressure in canopy layer              [Pa]
+      ! CO2           : Ambient CO2 mole fraction                         [mol/mol air]
+      ! O2            : Ambient O2 mole fraction                          [mol/mol air]
+      ! TEMPK         : Leaf temperature in Kelvin                        [K]
+      ! QV2M          : Specific humidity in canopy layer                 [kg H2O / kg air]
+      ! DEFICIT_Q_IN  : Alternative input of specific humidity deficit    [kg H2O / kg air]
+      ! V_CMAX_IN     : Alternative input of V_CMAX                       [mol CO2 m^-2 s^-1]
+      ! RA            : Aerodynamic resistance                            [s m^-1]
+      ! RB_O3         : Boundary layer resistance                         [s m^-1]
+      ! O3            : Ozone mole fraction in canopy layer               [mol/mol air]
+      ! FACTOR_O3_IN  : Alternative input of ozone damage factor          []
+      ! SOIL_WETNESS  : Fraction of moisture in soil pores                []
+      ! BETA_IN       : Alternative input of soil moisture stress factor  []
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(IN)             :: LAI
+      INTEGER,  INTENT(IN)             :: PFT
+      REAL(fp), INTENT(IN)             :: PRESSURE
+      REAL(fp), INTENT(IN)             :: APAR
+      REAL(fp), INTENT(IN)             :: CO2
+      REAL(fp), INTENT(IN)             :: O2
+      REAL(fp), INTENT(IN)             :: TEMPK
+
+      ! If V_CMAX_IN is provided, it will be used and the module will not 
+      ! calculate V_CMAX according to leaf temperature.
+      REAL(fp), INTENT(IN), OPTIONAL   :: V_CMAX_IN
+
+      ! Parameters for calculating specific humidity deficit
+      ! If DEFICIT_Q_IN is provided, it will be used and the module will not 
+      ! calculate DEFICIT_Q according to QV2M and leaf temperature.
+      REAL(fp), INTENT(IN), OPTIONAL   :: QV2M
+      REAL(fp), INTENT(IN), OPTIONAL   :: DEFICIT_Q_IN
+
+      ! Parameters for ozone damage scheme
+      ! If FACTOR_O3_IN is provided, it will be used as the ozone damage factor
+      ! and the module will not calculate FACTOR_O3 according to 
+      ! RA, RB and O3 from other modules.
+      REAL(fp), INTENT(IN), OPTIONAL   :: RA
+      REAL(fp), INTENT(IN), OPTIONAL   :: RB_O3
+      REAL(fp), INTENT(IN), OPTIONAL   :: O3
+      REAL(fp), INTENT(IN), OPTIONAL   :: FACTOR_O3_IN
+
+      ! Parameters for soil moisture stress factor
+      ! If BETA_IN is provided, it will be used as the soil moisture stress factor
+      ! and the module will not calculate BETA according to SOIL_WETNESS from 
+      ! input meteorology data.
+      REAL(fp), INTENT(IN), OPTIONAL   :: SOIL_WETNESS
+      REAL(fp), INTENT(IN), OPTIONAL   :: BETA_IN
+!
+!OUTPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! G_CAN_OUT     : Canopy conductance for H2O (output)               [m s^-1]
+      ! G_LEAF_OUT    : Leaf level stomatal conductance for H2O (output)  [m s^-1]
+      ! CO2_IN        : Leaf internal partial pressure of CO2             [Pa]
+      ! A_CAN_OUT     : Canopy net photosynthetic rate (output)           [mol CO2 m^-2 s^-1]
+      ! A_NET_OUT     : Leaf level net photosynthetic rate (output)       [mol CO2 m^-2 s^-1]
+      ! RESP_CAN_OUT  : Canopy dark respiration (output)                  [mol CO2 m^-2 s^-1]
+      ! RESP_OUT      : Leaf level dark respiration (output)              [mol CO2 m^-2 s^-1]
+      ! FLUXO3_CAN    : Canopy ozone uptake                               [nmol m^-2 s^-1]
+      ! FLUXO3        : Stomatal ozone uptake                             [nmol m^-2 s^-1]
+      ! FACTOR_O3     : Ozone damage factor                               []
+      ! BETA          : Soil moisture stress factor                       []
+      ! V_CMAX        : Max Rubisco carboxylation rate                    [mol CO2 m^-2 s^-1]
+      ! RATE_LIGHT    : Light-limited rate                                [mol CO2 m^-2 s^-1]
+      ! RATE_PRODUCT  : Product-limited rate                              [mol CO2 m^-2 s^-1]
+      ! RATE_RUBISCO  : Rubisco-limited rate                              [mol CO2 m^-2 s^-1]
+      ! A_GROSS       : Leaf level gross photosynthesis                   [mol CO2 m^-2 s^-1]
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(OUT) :: G_CAN_OUT
+      REAL(fp), INTENT(OUT) :: G_LEAF_OUT
+      REAL(fp), INTENT(OUT) :: CO2_IN
+      REAL(fp), INTENT(OUT) :: A_CAN_OUT
+      REAL(fp), INTENT(OUT) :: A_NET_OUT
+      REAL(fp), INTENT(OUT) :: RESP_CAN_OUT
+      REAL(fp), INTENT(OUT) :: RESP_OUT
+      REAL(fp), INTENT(OUT) :: FLUXO3_CAN
+      REAL(fp), INTENT(OUT) :: FLUXO3
+      REAL(fp), INTENT(OUT) :: FACTOR_O3
+      REAL(fp), INTENT(OUT) :: BETA
+      REAL(fp), INTENT(OUT) :: V_CMAX
+      REAL(fp), INTENT(OUT) :: RATE_LIGHT
+      REAL(fp), INTENT(OUT) :: RATE_RUBISCO
+      REAL(fp), INTENT(OUT) :: RATE_PRODUCT
+      REAL(fp), INTENT(OUT) :: A_GROSS
+      INTEGER,  INTENT(OUT) :: RC
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+!LOCAL VARIABLES:
+!
+      !---------------------------------------------------------------------------------------
+      ! TEMPC         : Leaf temperature in degree Celsius                [deg C]
+      ! SPHU_SAT      : Saturation specific humidity in canopy layer      [kg H2O / kg air]
+      ! DEFICIT_Q     : Specific humidity deficit at leaf surface         [kg H2O / kg air]
+      ! CO2_AMBIENT   : Ambient CO2 partial pressure                      [Pa]
+      ! O3_CONC       : Ozone concentration in canopy layer               [nmol m^-3]
+      ! BIGLEAFSCALE  : Scaling with Big-leaf approach                    []
+      ! G_CAN         : Canopy conductance for H2O                        [m s^-1]
+      ! G_LEAF        : Leaf level stomatal conductance for H2O           [m s^-1]
+      ! G_LEAF_PREV   : G_LEAF in previous iteration                      [m s^-1]
+      ! CO2_IN_PREV   : CO2_IN in previous iteration                      [Pa]
+      ! A_NET         : Leaf level net photosynthetic rate                [mol CO2 m^-2 s^-1]
+      ! RESP          : Leaf level dark respiration                       [mol CO2 m^-2 s^-1]
+      ! A_NET_PREV    : A_NET in previous iteration                       [mol CO2 m^-2 s^-1]
+      ! V_CMAX        : Max Rubisco carboxylation rate                    [mol CO2 m^-2 s^-1]
+      ! CO2_GAMMA     : CO2 Compensation point                            [Pa]
+      ! RATE_LIGHT    : Light-limited rate                                [mol CO2 m^-2 s^-1]
+      ! RATE_PRODUCT  : Product-limited rate                              [mol CO2 m^-2 s^-1]
+      ! RATE_RUBISCO  : Rubisco-limited rate                              [mol CO2 m^-2 s^-1]
+      ! A_GROSS       : Leaf level gross photosynthesis                   [mol CO2 m^-2 s^-1]
+      ! TAU           : Rubisco specificity for CO2 to O2                 []
+      ! DENOM         : Denominator for calculating V_CMAX                []
+      ! ITER          : No. of iterations in calculating conductance      []
+      ! ERR1          : Relative change for G_LEAF between iterations     []
+      ! ERR2          : Relative change for CO2_IN between iterations     []
+      ! ERR3          : Relative change for A_NET between iterations      []
+      ! DELTA         : Maximum of the 3 relative changes                 []
+      ! RAB           : Aerodynamic and boundary layer resistance         [s m^-1]
+      !---------------------------------------------------------------------------------------
+      REAL(fp)    :: TEMPC
+      REAL(fp)    :: SPHU_SAT
+      REAL(fp)    :: DEFICIT_Q
+      REAL(fp)    :: CO2_AMBIENT
+      REAL(fp)    :: O3_CONC
+      REAL(fp)    :: BIGLEAFSCALE
+      REAL(fp)    :: G_CAN
+      REAL(fp)    :: G_LEAF
+      ! REAL(fp)    :: G_LEAF_PREV
+      ! REAL(fp)    :: CO2_IN_PREV
+      REAL(fp)    :: A_NET
+      REAL(fp)    :: RESP
+      ! REAL(fp)    :: A_NET_PREV
+      ! REAL(fp)    :: V_CMAX
+      REAL(fp)    :: CO2_GAMMA
+      ! REAL(fp)    :: RATE_LIGHT
+      ! REAL(fp)    :: RATE_PRODUCT
+      ! REAL(fp)    :: RATE_RUBISCO
+      ! REAL(fp)    :: A_GROSS
+      REAL(fp)    :: TAU
+      REAL(fp)    :: DENOM
+      INTEGER     :: ITER
+      ! REAL(fp)    :: ERR1
+      ! REAL(fp)    :: ERR2
+      ! REAL(fp)    :: ERR3
+      REAL(fp)    :: DELTA
+      REAL(fp)    :: RAB
+      ! Strings
+      CHARACTER(LEN=255) :: ErrMsg, ThisLoc
+
+      !=================================================================
+      ! DO_PHOTOSYNTHESIS begins here!
+      !=================================================================
+      ! Initialize output variables
+      G_CAN_OUT      = 0.e+0_fp
+      A_CAN_OUT      = 0.e+0_fp
+      RESP_CAN_OUT   = 0.e+0_fp
+      G_LEAF_OUT     = 0.e+0_fp
+      CO2_IN         = 0.e+0_fp
+      A_NET_OUT      = 0.e+0_fp
+      RESP_OUT       = 0.e+0_fp
+      FLUXO3_CAN     = 0.e+0_fp
+      FLUXO3         = 0.e+0_fp
+      FACTOR_O3      = 1.e+0_fp
+      BETA           = 1.e+0_fp
+      V_CMAX         = 0.e+0_fp
+      RATE_LIGHT     = 0.e+0_fp
+      RATE_RUBISCO   = 0.e+0_fp
+      RATE_PRODUCT   = 0.e+0_fp
+      A_GROSS        = 0.e+0_fp
+
+      ! Initialize local variables
+      TEMPC          = 0.e+0_fp
+      SPHU_SAT       = 0.e+0_fp
+      DEFICIT_Q      = 0.e+0_fp
+      CO2_AMBIENT    = 0.e+0_fp
+      O3_CONC        = 0.e+0_fp
+      BIGLEAFSCALE   = 0.e+0_fp
+      G_CAN          = 0.e+0_fp
+      G_LEAF         = 0.e+0_fp
+      A_NET          = 0.e+0_fp
+      RESP           = 0.e+0_fp 
+      CO2_GAMMA      = 0.e+0_fp
+      TAU            = 0.e+0_fp
+      DENOM          = 0.e+0_fp
+      DELTA          = 0.e+0_fp
+
+      ! Initialize
+      RC         = GC_SUCCESS
+      ErrMsg     = ''
+      ThisLoc    = ' -> at DO_PHOTOSYNTHESIS (in GeosCore/ecophy_mod.F90)'
+
+      ! Calculations start.
+      TEMPC          = TEMPK - 273.15e+0_fp
+      ! Calculate V_CMAX if V_CMAX_IN is not provided
+      IF ( PRESENT( V_CMAX_IN ) ) THEN
+         V_CMAX = V_CMAX_IN 
+      ELSE 
+         ! Calculate V_CMAX and respiration which depends on V_CMAX only
+         DENOM          = ( 1.e+0_fp + EXP( 0.3e+0_fp*( TEMPC - T_UPP(PFT) ) ) ) &
+                        * ( 1.e+0_fp + EXP( 0.3e+0_fp*( T_LOW(PFT) - TEMPC ) ) )
+         V_CMAX         = V_CMAX25(PFT) * FACTOR_Q10( 2.e+0_fp, TEMPC ) / DENOM
+      END IF
+      RESP           = F_DARKRESP(PFT) * V_CMAX
+
+      ! Calculate CO2 compensation point
+      TAU            = 2.6e+3_fp * FACTOR_Q10( 0.57e+0_fp, TEMPC )    ! CO2/O2 Specificity Ratio
+      CO2_GAMMA      = IS_C3_PLANT(PFT) / ( 2.e+0_fp * TAU ) &
+                     * PRESSURE * O2
+
+      ! Calculate canopy scaling factor
+      BIGLEAFSCALE   = MAX( ( 1.e+0_fp - EXP( - K_EXTINCT(PFT) * LAI ) ) / K_EXTINCT(PFT), 0.e+0_fp )
+
+      ! Calculate CO2 partial pressure in ambient air
+      CO2_AMBIENT    = PRESSURE * CO2
+
+      ! Calculate inputs for ozone damage scheme if FACTOR_O3_IN is not provided
+      IF ( .NOT. PRESENT( FACTOR_O3_IN ) ) THEN
+         IF ( .NOT. PRESENT( RA    ) ) RETURN
+         IF ( .NOT. PRESENT( RB_O3 ) ) RETURN
+         IF ( .NOT. PRESENT( O3    ) ) RETURN
+         ! Calculate O3 molar concentration in canopy layer
+         O3_CONC        = O3 * PRESSURE / RSTARG / TEMPK * 1.e+9_fp
+         ! Calculate aerodynamic and boundary layer resistance for ozone damage 
+         RAB            = RA + RB_O3
+      END IF
+
+      ! Calculate soil moisture stress factor if BETA_IN is not provided.
+      IF ( PRESENT( BETA_IN ) ) THEN
+         BETA = BETA_IN
+      ELSE
+         IF ( .NOT. PRESENT( SOIL_WETNESS ) ) RETURN
+         ! To modify net photosynthesis rate by soil moisture stress later
+         ! Not needed to be inside the loop
+         CALL MOIST_STRESS( SOIL_WETNESS, BETA )
+      END IF
+
+      ! Iterate to find a self-consistent set of photosynthesis,
+      ! stomatal conductance and leaf internal CO2 concentration
+      ! Initial guess: G_LEAF = 0 and other initializations
+      ITER           = 1
+      G_LEAF         = 0.e+0_fp
+      G_CAN          = 0.e+0_fp
+      ! CO2_IN_PREV    = 0.e+0_fp
+      ! A_NET_PREV     = 0.e+0_fp
+      ! G_LEAF_PREV    = 0.e+0_fp
+      ! ERR1           = 1.e+0_fp
+      ! ERR2           = 1.e+0_fp
+      ! ERR3           = 1.e+0_fp
+      DELTA          = 1.e+0_fp
+      DO WHILE ( DELTA >= THRESHOLD .AND. ITER <= MAX_ITER )
+         ! Step 1: Calculate internal CO2 partial pressure from 
+         !         the closure condition by Jacobs (1994)
+         SPHU_SAT    = 0.622e+0_fp * E_SAT( TEMPC ) / PRESSURE
+         G_CAN       = G_LEAF * BIGLEAFSCALE
+         ! Calculate specific humidity deficit if DEFICIT_Q_IN is not provided
+         ! Remark: Consider moving this out of the (potential) loop. Currently 
+         ! the total iteration of the loop is set to 1 only.
+         IF ( PRESENT( DEFICIT_Q_IN ) ) THEN
+            DEFICIT_Q = DEFICIT_Q_IN
+         ELSE 
+            IF ( .NOT. PRESENT( QV2M ) ) RETURN
+            DEFICIT_Q   = MAX( SPHU_SAT - QV2M, 0.e+0_fp )
+         END IF
+         CO2_IN      = CO2_GAMMA + f0(PFT)*( 1 - DEFICIT_Q / D_STAR(PFT) ) &
+                     * ( CO2_AMBIENT - CO2_GAMMA )
+         IF ( BETA <= 0.e+0_fp .OR. DEFICIT_Q >= D_STAR(PFT) & 
+                               .OR. APAR <= 0.e+0_fp ) THEN
+            ! Close stomata if the above conditions are satisfied
+            A_NET_OUT   = - RESP * BETA
+            RESP_OUT    = RESP
+            G_LEAF_OUT  = G_LEAF_MIN(PFT)
+            EXIT
+         ELSE
+            ! Step 2: Photosynthesis model by Collatz et al. (1991) and
+            !         Collatz et al. (1992)
+            CALL PHOTOSYNTHESIS_LIMITS( CO2_IN,       CO2_GAMMA,    &
+                                        O2, APAR,     PRESSURE,     &
+                                        TEMPC,        V_CMAX,       &
+                                        PFT,          RATE_LIGHT,   &
+                                        RATE_PRODUCT, RATE_RUBISCO  )
+            CALL SOLVE_COLIMIT( RATE_LIGHT,   RATE_PRODUCT, &
+                                RATE_RUBISCO, A_GROSS      )
+            ! Calculate net photosynthesis
+            A_NET    = ( A_GROSS - RESP ) * BETA
+
+            ! Step 3: Calculate leaf-level stomatal conductance by 
+            !         considering diffusive CO2 flux thru open stomata
+            CALL LEAF_CONDUCTANCE( A_NET, CO2_AMBIENT, CO2_IN,  &
+                                   TEMPK, G_LEAF                )
+            ! Close stomata if net photosynthesis <= 0 or
+            ! stomatal conductance is too small
+            IF ( A_NET <= 0.e+0_fp .OR. G_LEAF <= G_LEAF_MIN(PFT) ) THEN
+               A_NET_OUT   = - RESP * BETA
+               RESP_OUT    = RESP
+               G_LEAF_OUT  = G_LEAF_MIN(PFT)
+               EXIT
+            END IF
+
+            ! Calculate ozone damage if FACTOR_O3_IN is not provided
+            IF ( PRESENT ( FACTOR_O3_IN ) ) THEN 
+               FACTOR_O3   = FACTOR_O3_IN 
+               A_NET_OUT   = FACTOR_O3 * A_NET
+               RESP_OUT    = FACTOR_O3 * RESP
+               G_LEAF_OUT  = FACTOR_O3 * G_LEAF
+                  ! Close stomata if net photosynthesis <= 0 or
+                  ! stomatal conductance is too small
+                  IF ( A_NET_OUT <= 0.e+0_fp .OR. G_LEAF_OUT <= G_LEAF_MIN(PFT) ) THEN
+                     A_NET_OUT   = - RESP * BETA
+                     RESP_OUT    = RESP
+                     G_LEAF_OUT  = G_LEAF_MIN(PFT)
+                     EXIT
+                  END IF
+            ELSE 
+               ! Apply ozone damage scheme by Sitch et al. (2007)
+               SELECT CASE( O3dmg_opt )
+               CASE( 'LOW', 'HI' )
+                  CALL OZONE_DAMAGE ( O3_CONC,   RAB,         &
+                                      G_LEAF,    PFT,         &
+                                      FLUXO3,    FACTOR_O3,   &
+                                      O3dmg_opt, RC           )
+                  A_NET_OUT   = FACTOR_O3 * A_NET
+                  RESP_OUT    = FACTOR_O3 * RESP
+                  G_LEAF_OUT  = FACTOR_O3 * G_LEAF
+                     ! Close stomata if net photosynthesis <= 0 or
+                     ! stomatal conductance is too small
+                     IF ( A_NET_OUT <= 0.e+0_fp .OR. G_LEAF_OUT <= G_LEAF_MIN(PFT) ) THEN
+                        A_NET_OUT   = - RESP * BETA
+                        RESP_OUT    = RESP
+                        G_LEAF_OUT  = G_LEAF_MIN(PFT)
+                        EXIT
+                     END IF
+               CASE( 'OFF' )
+                  A_NET_OUT   = A_NET
+                  RESP_OUT    = RESP
+                  G_LEAF_OUT  = G_LEAF
+               CASE DEFAULT 
+                  ErrMsg = 'No ozone damage option chosen. Please ' // &
+                           'choose from HI, LOW or OFF.'
+                  CALL GC_Error( ErrMsg, RC, ThisLoc )
+                  RETURN               
+               END SELECT   ! O3 damage
+            END IF   ! FACTOR_O3_IN is present 
+         END IF      ! Open or closed stomata
+         ! IF ( ITER >= 2 ) THEN
+         ! ! calculate error from step 2 onwards
+         !    ERR1  = REL_ERR( G_LEAF, G_LEAF_PREV )
+         !    ERR2  = REL_ERR( CO2_IN, CO2_IN_PREV )
+         !    ERR3  = REL_ERR( A_NET,  A_NET_PREV  )
+         !    DELTA = ABS( MAX( ERR1, ERR2, ERR3 ) )
+         ! END IF
+         ! CO2_IN_PREV  = CO2_IN
+         ! A_NET_PREV   = A_NET
+         ! G_LEAF_PREV  = G_LEAF
+         ITER = ITER + 1
+      END DO  ! Do while loop
+
+      ! Canopy scaling: scale leaf-level net photosynthesis, 
+      !                 bulk stomatal conductance, repiration and 
+      !                 stomatal ozone flux to canopy-level
+      A_CAN_OUT      = BIGLEAFSCALE * A_NET_OUT
+      G_CAN_OUT      = BIGLEAFSCALE * G_LEAF_OUT
+      RESP_CAN_OUT   = BIGLEAFSCALE * RESP_OUT
+      FLUXO3_CAN     = BIGLEAFSCALE * FLUXO3
+
+      ! Return to calling program
+      END SUBROUTINE DO_PHOTOSYNTHESIS
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: do_isop_emis
+!
+! !DESCRIPTION: Subroutine DO\_ISOP\_EMIS calculates the photosyntheis-
+!  dependent isoprene emission based on Pacifico et al. (2011) 
+!  Atm. Chem. Phys.
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE DO_ISOP_EMIS( A_CAN_OUT, RESP_CAN_OUT,  &
+                               TEMPK, CO2_IN,            &
+                               LAI, PFT,                 &
+                               ISOP_EMIS                 )
+!
+! !INPUT PARAMETERS: 
+!
+      !---------------------------------------------------------------------------------------
+      ! A_CAN_OUT     : Canopy net photosynthetic rate      [mol CO2 m^-2 s^-1]
+      ! RESP_CAN_OUT  : Canopy dark respiration             [mol CO2 m^-2 s^-1]
+      ! TEMPK         : Leaf temperature in Kelvin          [K]
+      ! CO2_IN        : Leaf partial pressure of CO2        [Pa]
+      ! LAI           : Leaf area index for the PFT         [m^2 m^-2]
+      ! PFT           : Index for PFT                       []
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(IN)    :: A_CAN_OUT
+      REAL(fp), INTENT(IN)    :: RESP_CAN_OUT
+      REAL(fp), INTENT(IN)    :: TEMPK
+      REAL(fp), INTENT(IN)    :: CO2_IN
+      REAL(fp), INTENT(IN)    :: LAI
+      INTEGER,  INTENT(IN)    :: PFT
+!
+! !OUTPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! ISOP_EMIS     : Rate of isoprene emission           [kg C m-2 land s-1]
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(OUT)    :: ISOP_EMIS
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+!
+! !LOCAL VARIABLES:
+!
+      !---------------------------------------------------------------------------------------
+      ! FACTOR_CO2    : CO2 factor for online isoprene emission           [] 
+      ! FACTOR_TEMP   : Temparture factor for online isoprene emission    [] 
+      ! Dry_weight    : Dry weight of leaf per leaf area                  [g dry weight m-2 leaf]
+      !---------------------------------------------------------------------------------------
+      REAL(fp)    :: FACTOR_CO2
+      REAL(fp)    :: FACTOR_TEMP
+      REAL(fp)    :: Dry_weight
+      
+      !=================================================================
+      ! DO_ISOP_EMIS begins here!
+      !=================================================================
+      ! Initialize local variables
+      FACTOR_CO2     = 0.e+0_fp
+      FACTOR_TEMP    = 0.e+0_fp
+
+      ! Calculate CO2 and temperature factors for photosynthesis-dependent 
+      ! isoprene Emission
+      FACTOR_CO2     = CO2_IN_st(PFT) / CO2_IN 
+      FACTOR_TEMP    = MIN( 2.3e+0_fp , EXP( 0.1e+0_fp * (TEMPK - TEMPK_st) ) )
+      
+      ! Calculate dry weight of leaf per leaf area (g dry weight m-2 leaf)
+      Dry_weight     = Leaf_density(PFT) * 1.e+3_fp / Dry_fraction 
+
+      ! Calculate isoprene emission (kg C m-2 land s-1)
+      ISOP_EMIS      = IEF(PFT) * Dry_weight * 1.e-9_fp / 3.6e+3_fp  &
+                     * ( A_CAN_OUT + RESP_CAN_OUT )                  &
+                     / ( A_NET_st(PFT) + RESP_st (PFT) )             &
+                     * FACTOR_CO2 * FACTOR_TEMP   
+      ISOP_EMIS      = MAX( 0.e+0_fp, ISOP_EMIS )
+
+      ! Return to calling program
+      END SUBROUTINE DO_ISOP_EMIS
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: photosynthesis_limits
+!
+! !DESCRIPTION: Subroutine PHOTOSYNTHESIS\_LIMITES determines potential 
+!  leaf-level photosynthesis, according to C3 and C4 photosynthesis
+!  model from Collatz et al. (1991) and Collatz et al. (1992)
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE PHOTOSYNTHESIS_LIMITS( CO2_IN,       CO2_GAMMA,    &
+                                        O2, APAR,     PRESSURE,     &
+                                        TEMPC,        V_CMAX,       &
+                                        PFT,          RATE_LIGHT,   &
+                                        RATE_PRODUCT, RATE_RUBISCO  )
+!
+! !INPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! CO2_IN        : Leaf internal partial pressure of CO2              [Pa]
+      ! CO2_GAMMA     : CO2 Compensation point                             [Pa]
+      ! O2            : Ambient O2 mole fraction                           [mol/mol air]
+      ! APAR          : Absorbed photosynthetically active radiation (PAR) [mol photon m^-2 s^-1]
+      ! PRESSURE      : Surface air pressure                               [Pa]
+      ! TEMPC         : Temperature                                        [deg C]
+      ! V_CMAX        : Maximum rate of carboxylation of Rubisco           [mol CO2 m^-2 s^-1]
+      ! PFT           : Index for PFT                                      []
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(IN)  :: CO2_IN
+      REAL(fp), INTENT(IN)  :: CO2_GAMMA
+      REAL(fp), INTENT(IN)  :: O2
+      REAL(fp), INTENT(IN)  :: APAR
+      REAL(fp), INTENT(IN)  :: PRESSURE
+      REAL(fp), INTENT(IN)  :: TEMPC
+      REAL(fp), INTENT(IN)  :: V_CMAX
+      INTEGER,  INTENT(IN)  :: PFT
+!
+! !OUTPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! RATE_LIGHT         : Light-limited rate                            [mol CO2 m^-2 s^-1]
+      ! RATE_PRODUCT       : Product-limited rate                          [mol CO2 m^-2 s^-1]
+      ! RATE_RUBISCO       : Rubisco-limited rate                          [mol CO2 m^-2 s^-1]
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(OUT) :: RATE_LIGHT
+      REAL(fp), INTENT(OUT) :: RATE_PRODUCT
+      REAL(fp), INTENT(OUT) :: RATE_RUBISCO
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+      ! Michaelis-Menten parameters for CO2 and O2 respectively
+      REAL(fp)              :: K_C
+      REAL(fp)              :: K_O
+
+      !=================================================================
+      ! PHOTOSYNTHESIS_LIMITS begins here!
+      !=================================================================
+      K_C               = 3.e+1_fp * FACTOR_Q10( 2.1e+0_fp, TEMPC )
+      K_O               = 3.e+4_fp * FACTOR_Q10( 1.2e+0_fp, TEMPC )
+      ! For C4 plants
+      IF ( IS_C3_PLANT(PFT) == 0 ) THEN
+         RATE_RUBISCO   = V_CMAX
+         RATE_LIGHT     = ALPHA(PFT) * APAR
+         RATE_PRODUCT   = 2.e+4_fp * V_CMAX * CO2_IN / PRESSURE
+      ELSE    ! For C3 plants
+         RATE_RUBISCO   = V_CMAX * ( CO2_IN - CO2_GAMMA )  &
+                        / ( CO2_IN + K_C * ( 1.e+0_fp + PRESSURE * O2 / K_O ) )
+         RATE_LIGHT     = ALPHA(PFT) * APAR           &
+                        * ( CO2_IN - CO2_GAMMA )      &
+                        / ( CO2_IN + CO2_GAMMA * 2.e+0_fp )
+         RATE_RUBISCO   = MAX( RATE_RUBISCO, 0.e+0_fp )
+         RATE_LIGHT     = MAX( RATE_LIGHT, 0.e+0_fp )
+         RATE_PRODUCT   = 0.5e+0_fp * V_CMAX
+      END IF
+
+      ! Return to calling program
+      END SUBROUTINE PHOTOSYNTHESIS_LIMITS
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: solve_colimit
+!
+! !DESCRIPTION: Subroutine SOLVE\_COLIMIT determines gross leaf-level 
+!  photosynthesis from the three unstressed photosynthesis rates, 
+!  according to the co-limiting regime in C3 and C4 photosynthesis
+!  model from Collatz et al. (1991) and Collatz et al. (1992)
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE SOLVE_COLIMIT( RATE_LIGHT,   RATE_PRODUCT, &
+                                RATE_RUBISCO, A_GROSS       )
+!
+! !INPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! RATE_LIGHT         : Light-limited rate [mol CO2 m^-2 s^-1]
+      ! RATE_PRODUCT       : Product-limited rate [mol CO2 m^-2 s^-1]
+      ! RATE_RUBISCO       : Rubisco-limited rate [mol CO2 m^-2 s^-1]
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(IN)  :: RATE_LIGHT
+      REAL(fp), INTENT(IN)  :: RATE_PRODUCT
+      REAL(fp), INTENT(IN)  :: RATE_RUBISCO
+!
+! !OUTPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! A_GROSS            : Gross rate of photosynthesis [mol CO2 m^-2 s^-1]
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(OUT) :: A_GROSS
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+      REAL(fp), PARAMETER   :: BETA1 = 0.83e+0_fp
+      REAL(fp), PARAMETER   :: BETA2 = 0.93e+0_fp
+      REAL(fp)              :: TEMP
+      REAL(fp)              :: B
+      REAL(fp)              :: C
+
+      !=================================================================
+      ! SOLVE_COLIMIT begins here!
+      !=================================================================
+      ! 1st quadratic
+      B = -( RATE_RUBISCO + RATE_LIGHT ) / BETA1
+      C = RATE_RUBISCO * RATE_LIGHT / BETA1
+      ! Note that C > 0, SQRT( B^2 - 4*C ) < ABS(B)
+      ! Take smaller root
+      TEMP = 0.5e+0_fp * ( - B - SQRT( B * B - 4.e+0_fp * C ) )
+
+      ! 2nd quadratic
+      B = - ( TEMP + RATE_PRODUCT ) / BETA2
+      C = TEMP * RATE_PRODUCT / BETA2
+      ! Note that C > 0, SQRT( B^2 - 4*C ) < ABS(B)
+      ! Take smaller root
+      A_GROSS  = 0.5e+0_fp * ( - B - SQRT( B * B - 4.e+0_fp * C ) )
+
+      ! Return to calling program
+      END SUBROUTINE SOLVE_COLIMIT
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: moist_stress
+!
+! !DESCRIPTION: Subroutine MOIST\_STRESS determines a soil moisutre 
+!  stress factor that reduces photosynthesis rate and stomatal 
+!  conductance. It is currently a linear function of soil moisture.
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE MOIST_STRESS( SOIL_WETNESS, BETA )
+!
+! !INPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! SOIL_WETNESS    : Volumetric mean moisture concentration in root zone divided by porosity
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(IN)  :: SOIL_WETNESS
+!
+! !OUTPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! BETA            : Moisture stress factor
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(OUT) :: BETA
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES: (Declared as module variables)
+!
+      !---------------------------------------------------------------------------------------
+      ! SATU            : Volumetric soil moisture at saturation (= porosity)
+      ! CRIT            : Volumetric soil moisture at critical point (above which
+      !                   plants are no longer stressed by soil moisture)
+      ! WILT            : Volumetric soil moisture at wilting point (below which
+      !                   photosynthesis is stopped by limited soil moisture)
+      !---------------------------------------------------------------------------------------
+
+      !=================================================================
+      ! MOIST_STRESS begins here!
+      !=================================================================
+      BETA =  ( SOIL_WETNESS*SATU - WILT ) / ( CRIT - WILT )
+      BETA = MIN( MAX( 0.e+0_fp, BETA ), 1.e+0_fp ) 
+
+      ! Return to calling program
+      END SUBROUTINE MOIST_STRESS
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: leaf_conductance
+!
+! !DESCRIPTION: Subroutine LEAF_CONDUCTANCE determines leaf-level stomatal 
+!  conductance by considering the diffusive CO2 exchange through stomatal 
+!  exchange.
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE LEAF_CONDUCTANCE( A_NET, CO2_AMBIENT, CO2_IN,  &
+                                   TEMPK, G_LEAF                )
+!
+! !INPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! A_NET             : Net photosynthesis                      [mol CO2 m^-2 s^-1]
+      ! CO2_AMBIENT       : Ambient CO2 partial pressure            [Pa]
+      ! CO2_IN            : Leaf internal CO2 partial pressure      [Pa]
+      ! TEMPK             : Leaf temperature                        [K]
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(IN)    :: A_NET
+      REAL(fp), INTENT(IN)    :: CO2_AMBIENT
+      REAL(fp), INTENT(IN)    :: CO2_IN
+      REAL(fp), INTENT(IN)    :: TEMPK
+!
+! !OUTPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! G_LEAF            : Leaf conductance for H2O                [m s^-1]
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(OUT)   :: G_LEAF
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC     
+
+      !=================================================================
+      ! LEAF_CONDUCTANCE begins here!
+      !=================================================================
+      G_LEAF = CO2_O2_RATIO * RSTARG * TEMPK  &
+             * A_NET / ( CO2_AMBIENT - CO2_IN )
+
+      ! Return to calling program
+      END SUBROUTINE LEAF_CONDUCTANCE
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: ozone_damage
+!
+! !DESCRIPTION: Subroutine MOIST\_STRESS determines an ozone damage 
+!  factor that reduces photosynthesis rate and stomatal conductance, 
+!  based on Sitch et al. (2007).
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE OZONE_DAMAGE ( O3_CONC,   RAB,       &
+                                G_LEAF,    PFT,       &
+                                FLUXO3,    FACTOR_O3, &
+                                O3dmg_opt, RC         )
+!
+! !USES:
+!
+      USE ErrCode_Mod
+!
+! !INPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! O3_CONC         : Ozone concentration in canopy layer                     [nmol m^-3]
+      ! RAB             : Aerodynamic and boundary resistance                     [s m^-1]
+      ! G_LEAF          : Leaf conductance for H2O in the absence of O3 effects   [m s^-1]
+      ! PFT             : Index for PFT                                           []
+      ! O3dmg_opt       : Control switch for ozone damage scheme                  [HI/LOW/OFF]
+      !---------------------------------------------------------------------------------------
+      REAL(fp),         INTENT(IN)  :: O3_CONC
+      REAL(fp),         INTENT(IN)  :: RAB
+      REAL(fp),         INTENT(IN)  :: G_LEAF
+      INTEGER,          INTENT(IN)  :: PFT
+      CHARACTER(LEN=3), INTENT(IN)  :: O3dmg_opt
+!
+! !OUTPUT PARAMETERS:
+!  
+      !---------------------------------------------------------------------------------------
+      ! FLUXO3          : Leaf uptake of O3                                       [nmol m^-2 s^-1]
+      ! FACTOR_O3       : Ozone damage factor                                     []
+      ! RC              : Return Code                                             []
+      !---------------------------------------------------------------------------------------
+      REAL(fp),         INTENT(OUT) :: FLUXO3
+      REAL(fp),         INTENT(OUT) :: FACTOR_O3
+      INTEGER,          INTENT(OUT) :: RC
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!    
+      REAL(fp) :: B       ! Second coefficient in quadratic equation
+      REAL(fp) :: C       ! Constant in quadratic equation
+      REAL(fp) :: TEMP1
+      REAL(fp) :: TEMP2
+      REAL(fp) :: F
+      REAL(fp) :: PARAM_A
+      ! Strings
+      CHARACTER(LEN=255) :: ErrMsg,    ThisLoc
+
+      !=================================================================
+      ! OZONE_DAMAGE begins here!
+      !=================================================================
+      ! Initialize
+      RC         = GC_SUCCESS
+      ErrMsg     = ''
+      ThisLoc    = ' -> at OZONE_DAMAGE (in GeosCore/ecophy_mod.F90)'
+      ! Choose ozone damage parameters based on sensistivity
+      SELECT CASE( O3dmg_opt )
+         CASE( 'HI' )
+            PARAM_A = PARAM_A_HI( PFT )
+         CASE( 'LOW' )
+            PARAM_A = PARAM_A_LOW( PFT )
+         CASE DEFAULT
+            PARAM_A = 0
+            ErrMsg = 'Any O3dmg_opt other than "HI" or "LOW" should ' // &
+                     'not have reached this subroutine.'
+            CALL GC_Error( ErrMsg, RC, ThisLoc )
+            RETURN
+      END SELECT
+      TEMP1       = 1.e+0_fp + PARAM_A * FLUXO3_CRIT(PFT)
+      TEMP2       = 1.61e+0_fp / G_LEAF
+
+      ! Solve for ozone damage factor
+      ! Calculate coefficients for quadratic equation F^2 + B*F + C = 0
+      IF ( ABS(RAB) < EPSILON(1.e+0_fp) ) THEN
+         ! RAB        = 0.0
+         FACTOR_O3 = TEMP1 / ( 1.e+0_fp + PARAM_A * O3_CONC / TEMP2 )
+      ELSE
+         B         = TEMP2 / RAB - TEMP1 + PARAM_A * O3_CONC / RAB
+         C         = - TEMP1 * TEMP2 / RAB
+         ! Note that C < 0, SQRT( B^2 - 4*C ) > ABS(B)
+         ! Take positive root
+         F         = 0.5e+0_fp * ( SQRT( B * B - 4.e+0_fp * C ) - B )
+         FACTOR_O3 = MIN( MAX( F, 0.e+0_fp ), 1.e+0_fp )
+      END IF
+
+      ! Calculate stomatal ozone flux
+      FLUXO3      = O3_CONC / ( RAB + TEMP2 / FACTOR_O3 )
+
+      ! Return to calling program
+      END SUBROUTINE OZONE_DAMAGE
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: factor_q10
+!
+! !DESCRIPTION: Function FACTOR\_Q10 determines the q10 temperature 
+!  sensitivity factor that scales the maximum rubisco carboxylation rate
+!  at 25 degree Celsius to other temperatures.
+!\\
+!\\
+! !INTERFACE:
+!
+      FUNCTION FACTOR_Q10( Q10, TEMPC ) RESULT( FACTOR )
+!
+! !INPUT PARAMETERS:
+!
+      REAL(fp), INTENT(IN)    :: Q10         ! Coefficient
+      REAL(fp), INTENT(IN)    :: TEMPC       ! Temperature [deg C]
+!
+! !RETURN VALUE:
+!   
+      REAL(fp)                :: FACTOR
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+      
+
+      !=================================================================
+      ! FACTOR_Q10 begins here!
+      !=================================================================
+      FACTOR = Q10**( 0.1e+0_fp * ( TEMPC - 25.e+0_fp ) )
+
+      ! Return to calling program
+      END FUNCTION FACTOR_Q10
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: rel_err
+!
+! !DESCRIPTION: Function REL\_ERR calculates the relative error of a 
+!  quantity between two iterations.
+!\\
+!\\
+! !INTERFACE:
+!
+      FUNCTION REL_ERR( ITEM, ITEM_PREV ) RESULT( ERROR )
+!
+! !INPUT PARAMETERS:
+!
+      REAL(fp), INTENT(IN)    :: ITEM
+      REAL(fp), INTENT(IN)    :: ITEM_PREV
+!
+! !RETURN VALUE:
+!
+      REAL(fp)                :: ERROR
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+
+      !=================================================================
+      ! REL_ERR begins here!
+      !=================================================================
+      ERROR = ABS( ITEM - ITEM_PREV ) / ABS( ITEM_PREV )
+
+      !Return to calling program
+      END FUNCTION REL_ERR
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: e_sat
+!
+! !DESCRIPTION: Function E\_SAT calculates the saturation vapour 
+!  pressure (in Pa) using the empirical formula by Lowe and Ficke (1974)
+!\\
+!\\
+! !INTERFACE:
+!
+      FUNCTION E_SAT( TEMPC ) RESULT ( Esat )
+!
+! !INPUT PARAMETERS:
+!
+      REAL(fp), INTENT(IN)  :: TEMPC
+!
+! !RETURN VALUE:
+!
+      REAL(fp)              :: Esat
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+      REAL(fp), PARAMETER   :: a0 = 6.107799961e+0_fp
+      REAL(fp), PARAMETER   :: a1 = 4.436518521e-1_fp
+      REAL(fp), PARAMETER   :: a2 = 1.428945805e-2_fp
+      REAL(fp), PARAMETER   :: a3 = 2.650648471e-4_fp
+      REAL(fp), PARAMETER   :: a4 = 3.031240396e-6_fp
+      REAL(fp), PARAMETER   :: a5 = 2.034080948e-8_fp
+      REAL(fp), PARAMETER   :: a6 = 6.136820929e-11_fp
+
+      !=================================================================
+      ! E_SAT begins here!
+      !=================================================================
+      Esat = 1.e+2_fp * ( a0 + TEMPC * ( a1 + TEMPC * ( a2 + TEMPC   &
+                      * ( a3 + TEMPC * ( a4 + TEMPC * ( a5 + TEMPC * a6 ) ) ) ) ) )
+
+      ! Return to calling program
+      END FUNCTION E_SAT
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: get_ecophy_inputs
+!
+! !DESCRIPTION: Subroutine GET\_ECOPHY_INPUTS get inputs
+!  from Met and Chem State objects and Input Options.
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE GET_ECOPHY_INPUTS( State_Met,    State_Chm, Input_Opt,&
+                                    I, J, LDT,                         &
+                                    TEMPK,        QV2M,                &
+                                    PAR_ABSORBED, CO2,                 &
+                                    O2,           LAI,       O3,       &
+                                    SOIL_WETNESS, IUSE                 &
+                                    )
+!
+! !USES:
+!
+      USE State_Chm_Mod,      ONLY : ChmState, Ind_
+      USE State_Met_Mod,      ONLY : MetState
+      USE Input_Opt_Mod,      ONLY : OptInput
+!
+! !INPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! State_Met     : Meteorology State Object
+      ! State_Chm     : Chemistry State Object
+      ! Input_Opt.    : Input Options Object
+      ! I             : Current lon index
+      ! J             : Current lat index
+      ! LDT           : Land type index
+      !---------------------------------------------------------------------------------------
+      Type(MetState), INTENT(IN)  :: State_Met
+      Type(ChmState), INTENT(IN)  :: State_Chm
+      TYPE(OptInput), INTENT(IN)  :: Input_Opt 
+      INTEGER,        INTENT(IN)  :: I
+      INTEGER,        INTENT(IN)  :: J
+      INTEGER,        INTENT(IN)  :: LDT
+!
+! !OUTPUT PARAMETERS:
+!
+      !---------------------------------------------------------------------------------------
+      ! TEMPK         : Temperature in Kelvin                             [K]
+      ! QV2M          : Specific humidity in canopy layer                 [kg H2O / kg air]
+      ! PAR_ABSORBED  : Absorbed PAR                                      [mol photon m^-2 s^-1]
+      ! PRESSURE      : Atmospheric Pressure in canopy layer              [Pa]
+      ! CO2           : Ambient CO2 mole fraction                         [kg / kg dry]
+      ! O2            : Ambient O2 mole fraction                          [kg / kg dry]
+      ! O3            : Ozone mole fraction in canopy layer               [kg / kg dry]
+      ! LAI           : Leaf area index for the PFT                       [m^2 m^-2]
+      ! SOIL_WETNESS  : Fraction of moisture in soil pores                []
+      ! IUSE          : Fraction(*1000) of grid occupied by land type LDT []
+      !---------------------------------------------------------------------------------------
+      REAL(fp), INTENT(OUT) :: TEMPK
+      REAL(fp), INTENT(OUT) :: QV2M
+      REAL(fp), INTENT(OUT) :: PAR_ABSORBED
+      ! REAL(fp), INTENT(OUT) :: PRESSURE
+      REAL(fp), INTENT(OUT) :: CO2
+      REAL(fp), INTENT(OUT) :: O2
+      REAL(fp), INTENT(OUT) :: O3
+      REAL(fp), INTENT(OUT) :: LAI
+      REAL(fp), INTENT(OUT) :: SOIL_WETNESS
+      INTEGER,  INTENT(OUT) :: IUSE
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+      REAL(fp) :: PARDR, PARDF, ALBD
+      ! INTEGER :: I, J
+      INTEGER  :: id_O2, id_O3
+
+      !=================================================================
+      ! get_ecophy_inputs begins here!
+      !=================================================================
+      ! Find tracer indices with function the Ind_() function
+      id_O2     = IND_( 'O2'  )
+      id_O3     = IND_( 'O3'  )
+
+      ! ! Loop over surface grid boxes
+      ! DO J = 1, JJPAR
+      ! DO I = 1, IIPAR
+      ! Surface temperature [K]
+      TEMPK         = State_Met%TS( I,J )
+      ! Specific humidity [kg/kg]
+      QV2M          = State_Met%QV2M( I,J )
+      ! Photosynthetically active radiation absorbed [W m^-2]
+      PARDR         = State_Met%PARDR( I,J )
+      PARDF         = State_Met%PARDF( I,J )
+      ALBD          = State_Met%ALBD ( I,J )
+      PAR_ABSORBED  = ( 1 - ALBD ) * ( PARDR + PARDF ) * 4.6e-6_fp
+      ! ! Pressure [Pa]
+      ! PRESSURE      = State_Met%SLP( I,J ) * 1.e+2_fp
+      ! CO2 mole fraction [mol/mol]
+      ! CO2           = State_Chm%Species( I,J,1,id_CO2 ) * AIRMW &
+      !               / State_Chm%SpcData( id_CO2 )%Info%MW_g
+      CO2           = Input_Opt%Ecophy_CO2 * 1.e-6_fp
+      ! O2 mole fraction [mol/mol]
+      O2            = State_Chm%Species( I,J,1,id_O2  ) * AIRMW &
+                    / State_Chm%SpcData( id_O2  )%Info%MW_g
+      ! O3 mole fraction [mol/mol]
+      O3            = State_Chm%Species( I,J,1,id_O3  ) * AIRMW &
+                    / State_Chm%SpcData( id_O3  )%Info%MW_g
+      ! LAI [m^2 m^-2]
+      LAI           = State_Met%XLAI( I,J,LDT )
+      ! Root zone soil wetness
+      SOIL_WETNESS  = State_Met%GWETROOT( I,J )
+      ! Soil moisture at saturation
+      SATU          = State_Met%THETA_SATU( I,J )
+      ! Soil moisture at critical point
+      CRIT          = State_Met%THETA_CRIT( I,J )
+      ! Soil moisture at wilting point
+      WILT          = State_Met%THETA_WILT( I,J )
+      ! NOTE: Leave possibility to call soil matric potentials instead
+      !       of soil moistures
+      ! Fraction(*1000) of grid occupied by land type LDT 
+      ! IUSE=500 => 50% of the grid 
+      IUSE          = State_Met%IUSE( I,J,LDT )
+       ! END DO
+       ! END DO
+
+      ! Return to calling program
+      END SUBROUTINE GET_ECOPHY_INPUTS
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: ecophy_diagn
+!
+! !DESCRIPTION: Subroutine ECOPHY\_DIAGN deals with saving ecophysiology
+!  module outputs (per land type) to State_Diag arrays (per PFT)
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE Ecophy_Diagn( I, J,         LDT,        PFT,          &
+                               IUSE,         LAI,        SumLAI_PFT,   &
+                               IUSE_PFT,     RA,         RB_O3,        &
+                               G_CAN_OUT,    A_CAN_OUT,  RESP_CAN_OUT, &
+                               CO2_IN,       FLUXO3_CAN,               &
+                               FACTOR_O3,    BETA,       V_CMAX,       &
+                               RATE_LIGHT,   RATE_RUBISCO,             &
+                               RATE_PRODUCT, A_GROSS,    ISOP_EMIS,    &
+                               State_Met,    State_Diag, RC            &
+                             )
+!
+! !USES:
+!
+      USE ErrCode_Mod
+      USE State_Met_Mod,  ONLY : MetState
+      USE State_Diag_Mod, ONLY : DgnState
+!
+! !INPUT PARAMETERS:
+!
+      INTEGER,        INTENT(IN)    :: I, J, LDT, PFT
+      INTEGER,        INTENT(IN)    :: IUSE
+      REAL(fp),       INTENT(IN)    :: LAI
+      REAL(fp),       INTENT(IN)    :: SumLAI_PFT
+      INTEGER,        INTENT(IN)    :: IUSE_PFT
+      REAL(fp),       INTENT(IN)    :: RA
+      REAL(fp),       INTENT(IN)    :: RB_O3
+      REAL(fp),       INTENT(IN)    :: G_CAN_OUT
+      REAL(fp),       INTENT(IN)    :: A_CAN_OUT
+      REAL(fp),       INTENT(IN)    :: RESP_CAN_OUT
+      REAL(fp),       INTENT(IN)    :: CO2_IN
+      REAL(fp),       INTENT(IN)    :: FLUXO3_CAN 
+      REAL(fp),       INTENT(IN)    :: FACTOR_O3
+      REAL(fp),       INTENT(IN)    :: BETA
+      REAL(fp),       INTENT(IN)    :: V_CMAX
+      REAL(fp),       INTENT(IN)    :: RATE_LIGHT
+      REAL(fp),       INTENT(IN)    :: RATE_RUBISCO
+      REAL(fp),       INTENT(IN)    :: RATE_PRODUCT
+      REAL(fp),       INTENT(IN)    :: A_GROSS
+      REAL(fp),       INTENT(IN)    :: ISOP_EMIS
+      Type(MetState), INTENT(IN)    :: State_Met   ! Met State object
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+      TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
+!
+! !OUTPUT PARAMETERS:
+!
+      INTEGER,        INTENT(OUT)   :: RC          ! Success or failure
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+      INTEGER                :: IOLSON
+      REAL(fp)               :: Tmp
+      ! Strings
+      CHARACTER(LEN=255)     :: Msg, ErrMsg, ThisLoc
+
+      !=================================================================
+      ! Ecophy_Diagn begins here!
+      !=================================================================
+      ! Initialize
+      RC        = GC_SUCCESS
+      ErrMsg    = ''
+      ThisLoc   = ' -> at Ecophy_Diagn (in module GeosCore/ecophysiology.F90)'
+
+      ! send to diagnostics outputs
+      IF ( State_Diag%Archive_EcophyPFTFrac      .AND. SumLAI_PFT /= 0 ) THEN
+         State_Diag%EcophyPFTFrac      ( I,J,PFT ) = DBLE( IUSE_PFT ) 
+      END IF
+      IF ( State_Diag%Archive_EcophyLAI          .AND. IUSE_PFT /= 0 ) THEN
+         State_Diag%EcophyLAI          ( I,J,PFT ) = SumLAI_PFT / DBLE( IUSE_PFT )
+      END IF
+      IF ( State_Diag%Archive_EcophyRa           .AND. SumLAI_PFT /= 0 ) THEN
+         State_Diag%EcophyRa     ( I,J ) = RA
+      END IF
+      IF ( State_Diag%Archive_EcophyRbO3        .AND. SumLAI_PFT /= 0 ) THEN
+         State_Diag%EcophyRbO3  ( I,J ) = RB_O3
+      END IF
+      !-----------------------------------------------------------------
+      ! Canopy-level diagnostics: weight by land area occupied by the PFT
+      !-----------------------------------------------------------------
+      ! G_CAN_OUT is archived in drydep_mod.F instead of here.
+      IF ( State_Diag%Archive_EcophyACan    .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyACan    ( I,J,PFT )
+         State_Diag%EcophyACan    ( I,J,PFT ) = Tmp    &
+            + A_CAN_OUT    * DBLE( IUSE ) / DBLE( IUSE_PFT )
+      END IF
+      IF ( State_Diag%Archive_EcophyRespCan .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyRespCan ( I,J,PFT )
+         State_Diag%EcophyRespCan ( I,J,PFT ) = Tmp    &
+            + RESP_CAN_OUT * DBLE( IUSE ) / DBLE( IUSE_PFT )
+      END IF
+      IF ( State_Diag%Archive_EcophyFluxO3Can   .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyFluxO3Can   ( I,J,PFT )
+         State_Diag%EcophyFluxO3Can   ( I,J,PFT ) = Tmp    &
+            + FLUXO3_CAN   * DBLE( IUSE ) / DBLE( IUSE_PFT )
+      END IF
+      IF ( State_Diag%Archive_EcophyIsopEmisPFT    .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyIsopEmisPFT    ( I,J,PFT )
+         State_Diag%EcophyIsopEmisPFT    ( I,J,PFT ) = Tmp    &
+            + ISOP_EMIS    * DBLE( IUSE ) / DBLE( IUSE_PFT )
+      END IF
+      !-----------------------------------------------------------------
+      ! Leaf-level diagnostics: weight by leaf area
+      !-----------------------------------------------------------------
+      IF ( State_Diag%Archive_EcophyCO2Leaf       .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyCO2Leaf       ( I,J,PFT )
+         State_Diag%EcophyCO2Leaf       ( I,J,PFT ) = Tmp    &
+            + CO2_IN       * DBLE( IUSE ) * LAI / SumLAI_PFT
+      END IF
+      IF ( State_Diag%Archive_EcophyO3DmgFac    .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyO3DmgFac    ( I,J,PFT )
+         State_Diag%EcophyO3DmgFac    ( I,J,PFT ) = Tmp    &
+            + FACTOR_O3    * DBLE( IUSE ) * LAI / SumLAI_PFT
+      END IF
+      IF ( State_Diag%Archive_EcophySoilStress   .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophySoilStress   ( I,J,PFT )
+         State_Diag%EcophySoilStress   ( I,J,PFT ) = Tmp    &
+            + BETA         * DBLE( IUSE ) * LAI / SumLAI_PFT
+      END IF
+      IF ( State_Diag%Archive_EcophyVCMax       .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyVCMax       ( I,J,PFT )
+         State_Diag%EcophyVCMax       ( I,J,PFT ) = Tmp    &
+            + V_CMAX       * DBLE( IUSE ) * LAI / SumLAI_PFT
+      END IF
+      IF ( State_Diag%Archive_EcophyLightLmtRate   .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyLightLmtRate   ( I,J,PFT )
+         State_Diag%EcophyLightLmtRate   ( I,J,PFT ) = Tmp    &
+            + RATE_LIGHT   * DBLE( IUSE ) * LAI / SumLAI_PFT
+      END IF
+      IF ( State_Diag%Archive_EcophyRubisLmtRate .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyRubisLmtRate ( I,J,PFT )
+         State_Diag%EcophyRubisLmtRate ( I,J,PFT ) = Tmp    &
+            + RATE_RUBISCO * DBLE( IUSE ) * LAI / SumLAI_PFT
+      END IF
+      IF ( State_Diag%Archive_EcophyProdLmtRate .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyProdLmtRate ( I,J,PFT )
+         State_Diag%EcophyProdLmtRate ( I,J,PFT ) = Tmp    &
+            + RATE_PRODUCT * DBLE( IUSE ) * LAI / SumLAI_PFT
+      END IF
+      IF ( State_Diag%Archive_EcophyAGrossLeaf      .AND. SumLAI_PFT /= 0 ) THEN
+         Tmp = State_Diag%EcophyAGrossLeaf      ( I,J,PFT )
+         State_Diag%EcophyAGrossLeaf      ( I,J,PFT ) = Tmp    &
+            + A_GROSS      * DBLE( IUSE ) * LAI / SumLAI_PFT
+      END IF
+
+      ! Return to calling program 
+      END SUBROUTINE Ecophy_Diagn
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: init_ecophy
+!
+! !DESCRIPTION: Subroutine INIT\_ECOPHY initializes certain variables for the
+!  GEOS-CHEM ecophysiology subroutines and calculates the photosynthesis under 
+!  standard conditions.
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE INIT_ECOPHY( Input_Opt, RC )
+!
+! !USES:
+!
+      USE ErrCode_Mod
+      USE Charpak_Mod,    ONLY : To_UpperCase
+      USE Input_Opt_Mod,  ONLY : OptInput
+!
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+      TYPE(OptInput), INTENT(INOUT) :: Input_Opt   ! Input Options object
+!
+! !OUTPUT PARAMETERS:
+!
+      INTEGER,        INTENT(OUT)   :: RC          ! Success or failure
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+      INTEGER  :: PFT
+      REAL(fp) :: LAI            = 1.e+0_fp
+      ! Standard conditions 
+      REAL(fp) :: PRESSURE       = 1.01325e+5_fp
+      REAL(fp) :: APAR           = 1000.e-6_fp
+      REAL(fp) :: CO2            = 370.e-6_fp
+      REAL(fp) :: O2             = 0.209e+0_fp
+      REAL(fp) :: TEMPK          = 303.15e+0_fp 
+      REAL(fp) :: DEFICIT_Q_IN   = 0.e+0_fp
+      REAL(fp) :: FACTOR_O3_IN   = 1.e+0_fp
+      REAL(fp) :: BETA_IN        = 1.e+0_fp
+      REAL(fp) :: G_CAN_OUT
+      REAL(fp) :: G_LEAF_OUT
+      REAL(fp) :: CO2_IN
+      REAL(fp) :: A_CAN_OUT
+      REAL(fp) :: A_NET_OUT
+      REAL(fp) :: RESP_CAN_OUT
+      REAL(fp) :: RESP_OUT
+      REAL(fp) :: FLUXO3_CAN
+      REAL(fp) :: FLUXO3
+      REAL(fp) :: FACTOR_O3
+      REAL(fp) :: BETA
+      REAL(fp) :: V_CMAX
+      REAL(fp) :: RATE_LIGHT
+      REAL(fp) :: RATE_RUBISCO
+      REAL(fp) :: RATE_PRODUCT
+      REAL(fp) :: A_GROSS
+
+      ! Strings
+      CHARACTER(LEN=255)     :: Msg, ErrMsg, ThisLoc
+
+      !=================================================================
+      ! INIT_ECOPHY begins here!
+      !=================================================================
+
+      ! Initialize
+      RC        = GC_SUCCESS
+      O3dmg_opt = To_Uppercase( TRIM( Input_Opt%O3dmg_opt ) )
+      ErrMsg    = ''
+      ThisLoc   = ' -> at Init_Ecophy (in module GeosCore/ecophysiology.F90)'
+
+      IF ( Input_Opt%LIsop_from_Ecophy ) THEN
+         DO PFT = 1,5
+            ! simulate plant processes under standard conditions
+            CALL DO_PHOTOSYNTHESIS( LAI, PFT,     PRESSURE,     APAR,         &
+                                    CO2, O2,      TEMPK,        G_CAN_OUT,    &
+                                    G_LEAF_OUT,   CO2_IN,       A_CAN_OUT,    &
+                                    A_NET_OUT,    RESP_CAN_OUT, RESP_OUT,     &
+                                    FLUXO3_CAN,   FLUXO3,       FACTOR_O3,    &
+                                    BETA,         V_CMAX,       RATE_LIGHT,   &
+                                    RATE_RUBISCO, RATE_PRODUCT, A_GROSS, RC,  &
+                                    DEFICIT_Q_IN=DEFICIT_Q_IN,                &
+                                    FACTOR_O3_IN=FACTOR_O3_IN,                &
+                                    BETA_IN=BETA_IN                           &
+                                    )
+            A_NET_st    (PFT)  = A_NET_OUT
+            RESP_st     (PFT)  = RESP_OUT
+            CO2_IN_st   (PFT)  = CO2_IN
+         END DO
+         WRITE( 6, *   ) 'Ecophysiology variables under standard conditions'
+         WRITE( 6, *   ) 'A_NET_st :   Canopy Photosynthesis (mol CO2 m^-2 s^-1) '
+         WRITE( 6, *   ) 'RESP_st  :   Canopy Respiration    (mol CO2 m^-2 s^-1) '
+         WRITE( 6, *   ) 'CO2_IN_st:   Leaf CO2 Pressure     (Pa)                '
+         WRITE( 6, *   ) 'A_NET_st,      RESP_st,       CO2_IN_st                '
+         DO PFT = 1,5
+            WRITE( 6, 100 ) A_NET_st(PFT), RESP_st (PFT), CO2_IN_st(PFT)
+         END DO 
+ 100     FORMAT( ES15.4E4, 3X, ES15.4E4, 3X, ES15.4E4 )
+      END IF
+
+      END SUBROUTINE INIT_ECOPHY
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: CLEANUP\_ECOPHY
+!
+! !DESCRIPTION: Subroutine CLEANUP_ECOPHY deallocates all module arrays.
+!\\
+!\\
+! !INTERFACE:
+!
+      SUBROUTINE CLEANUP_ECOPHY()
+!
+! !REVISION HISTORY:
+!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+
+      !=================================================================
+      ! CLEANUP_ECOPHY begins here!
+      !=================================================================
+
+      ! Return to calling program
+      END SUBROUTINE CLEANUP_ECOPHY
+!EOC
+      END MODULE ECOPHY_MOD

--- a/GeosCore/flexgrid_read_mod.F90
+++ b/GeosCore/flexgrid_read_mod.F90
@@ -132,6 +132,25 @@ CONTAINS
     CALL Get_Met_2D( State_Grid, Q, TRIM(v_name) )
     State_Met%PHIS = Q
 
+    ! Read extra soil variables if ecophysiology module is used 
+    ! (Joey Lam, 26 Feb 2019)
+    IF ( Input_Opt%LECOPHY ) THEN
+       ! Read THETA_WILT
+       v_name = "THETA_WILT"
+       CALL Get_Met_2D( State_Grid, Q, TRIM(v_name) )
+       State_Met%THETA_WILT = Q
+
+       ! Read THETA_CRIT
+       v_name = "THETA_CRIT"
+       CALL Get_Met_2D( State_Grid, Q, TRIM(v_name) )
+       State_Met%THETA_CRIT = Q
+
+       ! Read THETA_SATU
+       v_name = "THETA_SATU"
+       CALL Get_Met_2D( State_Grid, Q, TRIM(v_name) )
+       State_Met%THETA_SATU = Q
+    ENDIF
+
     ! Echo info
     stamp = TimeStamp_String( 20110101, 000000 )
     WRITE( 6, 10 ) stamp
@@ -386,13 +405,11 @@ CONTAINS
     CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%PRECTOT = Q
 
-    !-----------------------------------------------------------------------
-    ! Comment this out for now, this field isn't needed (bmy, 2/2/12)
-    !! Read QV2M
-    !v_name = "QV2M"
-    !CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
-    !State_Met%QV2M = Q
-    !-----------------------------------------------------------------------
+    ! Uncommented for ecophysiology module (Joey Lam, 26 Feb 2019)
+    ! Read QV2M
+    v_name = "QV2M"
+    CALL Get_Met_2D( State_Grid, Q, TRIM(v_name), t_index=t_index )
+    State_Met%QV2M = Q
 
     ! Read SEAICE00
     v_name = "SEAICE00"

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -426,6 +426,7 @@ CONTAINS
     USE DiagList_Mod,       ONLY : DgnList
     USE Drydep_Mod,         ONLY : Init_Drydep
     USE Dust_Mod,           ONLY : Init_Dust
+    USE Ecophy_Mod,         ONLY : Init_Ecophy
     USE ErrCode_Mod
     USE Error_Mod,          ONLY : Debug_Msg
     USE Get_Ndep_Mod,       ONLY : Init_Get_Ndep
@@ -536,6 +537,22 @@ CONTAINS
           ErrMsg = 'Error encountered in "Init_Drydep"!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
           RETURN
+       ENDIF
+
+       !--------------------------------------------------------------
+       ! Call setup routines for ecophysiology (Joey Lam, 26 Feb 2019)
+       ! Note: No need to initialize ecophysiology module if dry
+       !       deposition is turned off.
+       !--------------------------------------------------------------
+       IF ( Input_Opt%LECOPHY ) THEN
+
+          ! Initialize for ecophysiology module
+          CALL Init_Ecophy( Input_Opt, RC )
+          IF ( RC /= GC_SUCCESS ) THEN
+             ErrMsg = 'Error encountered in "Init_Ecophy"!'
+             CALL GC_Error( ErrMsg, RC, ThisLoc )
+             RETURN
+          ENDIF
        ENDIF
 
        ! Print extra info message for Hg simulation

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -1561,6 +1561,7 @@ CONTAINS
     LOGICAL, SAVE           :: first    = .TRUE.
     INTEGER, SAVE           :: id_O3    = -1
     INTEGER, SAVE           :: id_HNO3  = -1
+    INTEGER, SAVE           :: id_ISOP  = -1
 
     ! Scalars
     LOGICAL                 :: found,   zeroHg0Dep
@@ -1631,7 +1632,7 @@ CONTAINS
        ! Get species IDs
        id_O3   = Ind_('O3'  )
        id_HNO3 = Ind_('HNO3')
-       is_ISOP = Ind_('ISOP')
+       id_ISOP = Ind_('ISOP')
 
 #if !defined( MODEL_CESM )
        IF ( id_O3 > 0 ) THEN

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -1631,6 +1631,7 @@ CONTAINS
        ! Get species IDs
        id_O3   = Ind_('O3'  )
        id_HNO3 = Ind_('HNO3')
+       is_ISOP = Ind_('ISOP')
 
 #if !defined( MODEL_CESM )
        IF ( id_O3 > 0 ) THEN
@@ -1727,6 +1728,17 @@ CONTAINS
              DO L = 1, topMix
                 CALL GetHcoValEmis( NA, I, J, L, found, emis )
                 IF ( .NOT. found ) EXIT
+                ! Add an option to use simulated isoprene emission
+                ! from ecophysiology module (Joey Lam, 1 Feb 2021)
+                IF ( NA == id_ISOP ) THEN
+                   IF ( State_Diag%Archive_HEMCOIsopEmis ) THEN
+                      State_Diag%HEMCOIsopEmis( I,J,L ) = emis
+                   ENDIF
+                   ! replace HEMCO values by simulated isoprene emission
+                   IF ( L == 1 .AND. Input_Opt%LIsop_from_Ecophy ) THEN
+                      emis = State_Chm%Isop_from_Ecophy( I,J )
+                   ENDIF
+                ENDIF
                 tmpFlx = tmpFlx + emis
              ENDDO
              eflx(I,J,NA) = eflx(I,J,NA) + tmpFlx

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -3203,6 +3203,38 @@ CONTAINS
     ENDIF
     READ( SUBSTRS(1:N), * ) Input_Opt%RA_Alt_Above_Sfc
 
+    ! Turn on ecophysiology?
+    CALL SPLIT_ONE_LINE( SUBSTRS, N, 1, 'LECOPHY', RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+    READ( SUBSTRS(1:N), * ) Input_Opt%LECOPHY
+
+    ! Sitch ozone damage scheme option (HI/LOW/OFF)
+    CALL SPLIT_ONE_LINE( SUBSTRS, N, 1, 'O3dmg_opt', RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+    READ( SUBSTRS(1:N), * ) Input_Opt%O3dmg_opt
+
+    ! CO2 concentration in ppmv for ecophysiology module
+    CALL SPLIT_ONE_LINE( SUBSTRS, N, 1, 'Ecophy_CO2', RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+    READ( SUBSTRS(1:N), * ) Input_Opt%Ecophy_CO2
+
+    ! Turn on photosynthesis-dependent isoprene emission?
+    CALL SPLIT_ONE_LINE( SUBSTRS, N, 1, 'LIsop_from_Ecophy', RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+    READ( SUBSTRS(1:N), * ) Input_Opt%LIsop_from_Ecophy
+
     ! Separator line
     CALL SPLIT_ONE_LINE( SUBSTRS, N, 1, 'separator', RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -3221,6 +3253,15 @@ CONTAINS
     IF ( Input_Opt%ITS_A_TAGO3_SIM   ) Input_Opt%LWETD = .FALSE.
     IF ( Input_Opt%ITS_A_TAGCO_SIM   ) Input_Opt%LWETD = .FALSE.
     IF ( Input_Opt%ITS_A_CH4_SIM     ) Input_Opt%LWETD = .FALSE.
+
+    ! Turn off ecophysiology for simulations that don't need it
+    IF ( .NOT. Input_Opt%LDRYD     ) Input_Opt%LECOPHY = .FALSE.
+
+    ! Turn off ozone damage scheme for simulations that don't need it
+    IF ( .NOT. Input_Opt%LECOPHY ) Input_Opt%O3dmg_opt = 'OFF'
+
+    ! Turn off online isoprene emission scheme for simulations that don't need it
+    IF ( .NOT. Input_Opt%LECOPHY ) Input_Opt%LIsop_from_Ecophy = .FALSE.
 
     ! Set the PBL drydep flag. This determines if dry deposition is
     ! applied (and drydep frequencies are calculated) over the entire
@@ -3263,11 +3304,20 @@ CONTAINS
                             Input_Opt%CO2_REF
        WRITE( 6, 110     ) 'RIX scaling factor          : ', &
                             Input_Opt%RS_SCALE
+       WRITE( 6, 100     ) 'Turn on ecophysiology?      : ', &
+                            Input_Opt%LECOPHY
+       WRITE( 6, 130     ) ' => O3 damage (Sitch)?      : ', &
+                            Input_Opt%O3dmg_opt
+       WRITE( 6, 110     ) ' => CO2 conc. (ppmv)        : ', &
+                            Input_Opt%Ecophy_CO2
+       WRITE( 6, 100     ) ' => Online isoprene emis?   : ', &
+                            Input_Opt%LIsop_from_Ecophy
     ENDIF
 
     ! FORMAT statements
 100 FORMAT( A, L5 )
 110 FORMAT( A, f6.2 )
+130 FORMAT( A, A  )
 
   END SUBROUTINE READ_DEPOSITION_MENU
 !EOC

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -268,7 +268,7 @@ CONTAINS
     INTEGER,           SAVE :: id_ALK4,  id_C2H6,  id_C3H8, id_CH2O
     INTEGER,           SAVE :: id_PRPE,  id_O3,    id_HNO3, id_BrO
     INTEGER,           SAVE :: id_Br2,   id_Br,    id_HOBr, id_HBr
-    INTEGER,           SAVE :: id_BrNO3
+    INTEGER,           SAVE :: id_BrNO3, id_ISOP
 
     ! Pointers and objects
     TYPE(Species), POINTER  :: SpcInfo
@@ -381,6 +381,7 @@ CONTAINS
        id_HOBr = Ind_('HOBr' )
        id_HBr  = Ind_('HBr'  )
        id_BrNO3= Ind_('BrNO3')
+       id_ISOP = Ind_('ISOP' )
 
        ! On first call, get pointers to the PARANOX loss fluxes. These are
        ! stored in diagnostics 'PARANOX_O3_DEPOSITION_FLUX' and

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -268,7 +268,7 @@ CONTAINS
     INTEGER,           SAVE :: id_ALK4,  id_C2H6,  id_C3H8, id_CH2O
     INTEGER,           SAVE :: id_PRPE,  id_O3,    id_HNO3, id_BrO
     INTEGER,           SAVE :: id_Br2,   id_Br,    id_HOBr, id_HBr
-    INTEGER,           SAVE :: id_BrNO3, id_ISOP
+    INTEGER,           SAVE :: id_BrNO3
 
     ! Pointers and objects
     TYPE(Species), POINTER  :: SpcInfo
@@ -381,7 +381,6 @@ CONTAINS
        id_HOBr = Ind_('HOBr' )
        id_HBr  = Ind_('HBr'  )
        id_BrNO3= Ind_('BrNO3')
-       id_ISOP = Ind_('ISOP' )
 
        ! On first call, get pointers to the PARANOX loss fluxes. These are
        ! stored in diagnostics 'PARANOX_O3_DEPOSITION_FLUX' and

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -241,6 +241,10 @@ MODULE Input_Opt_Mod
      REAL(fp)                    :: CO2_REF
      REAL(fp)                    :: RS_SCALE
      INTEGER                     :: RA_Alt_Above_Sfc
+     LOGICAL                     :: LECOPHY
+     CHARACTER(LEN=3)            :: O3dmg_opt 
+     REAL(fp)                    :: Ecophy_CO2
+     LOGICAL                     :: LIsop_from_Ecophy
 
      !----------------------------------------
      ! GAMAP MENU fields
@@ -760,7 +764,10 @@ CONTAINS
     Input_Opt%CO2_EFFECT             = .FALSE.
     Input_Opt%RS_SCALE               = 1.0_fp
     Input_Opt%RA_Alt_Above_Sfc       = 10       ! default height
-
+    Input_Opt%LECOPHY                = .FALSE.
+    Input_Opt%O3dmg_opt              = 'OFF'
+    Input_Opt%Ecophy_CO2             = 390.0
+    Input_Opt%LIsop_from_Ecophy      = .FALSE.
 
     !----------------------------------------
     ! GAMAP_MENU fields

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -214,6 +214,86 @@ MODULE State_Diag_Mod
      TYPE(DgnMap),       POINTER :: Map_DryDepVel
      LOGICAL                     :: Archive_DryDepVel
 
+     REAL(f4),           POINTER :: DryDepVelPFT1(:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_DryDepVelPFT1
+     LOGICAL                     :: Archive_DryDepVelPFT1
+
+     REAL(f4),           POINTER :: DryDepVelPFT2(:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_DryDepVelPFT2
+     LOGICAL                     :: Archive_DryDepVelPFT2
+
+     REAL(f4),           POINTER :: DryDepVelPFT3(:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_DryDepVelPFT3
+     LOGICAL                     :: Archive_DryDepVelPFT3
+
+     REAL(f4),           POINTER :: DryDepVelPFT4(:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_DryDepVelPFT4
+     LOGICAL                     :: Archive_DryDepVelPFT4
+
+     REAL(f4),           POINTER :: DryDepVelPFT5(:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_DryDepVelPFT5
+     LOGICAL                     :: Archive_DryDepVelPFT5
+     LOGICAL                     :: Archive_DryDepVel_anyPFT
+
+     !%%%%% Ecophysiology %%%%%
+
+     REAL(f4),           POINTER :: EcophyPFTFrac(:,:,:)
+     LOGICAL                     :: Archive_EcophyPFTFrac
+
+     REAL(f4),           POINTER :: EcophyLAI(:,:,:)
+     LOGICAL                     :: Archive_EcophyLAI
+
+     REAL(f4),           POINTER :: EcophyRa(:,:)
+     LOGICAL                     :: Archive_EcophyRa
+
+     REAL(f4),           POINTER :: EcophyRbO3(:,:)
+     LOGICAL                     :: Archive_EcophyRbO3
+
+     REAL(f4),           POINTER :: EcophyGCan(:,:,:)
+     LOGICAL                     :: Archive_EcophyGCan
+
+     REAL(f4),           POINTER :: EcophyACan(:,:,:)
+     LOGICAL                     :: Archive_EcophyACan
+
+     REAL(f4),           POINTER :: EcophyRespCan(:,:,:)
+     LOGICAL                     :: Archive_EcophyRespCan
+
+     REAL(f4),           POINTER :: EcophyCO2Leaf(:,:,:)
+     LOGICAL                     :: Archive_EcophyCO2Leaf
+
+     REAL(f4),           POINTER :: EcophyRespLeaf(:,:,:)
+     LOGICAL                     :: Archive_EcophyRespLeaf
+
+     REAL(f4),           POINTER :: EcophyFluxO3Can(:,:,:)
+     LOGICAL                     :: Archive_EcophyFluxO3Can
+
+     REAL(f4),           POINTER :: EcophyO3DmgFac(:,:,:)
+     LOGICAL                     :: Archive_EcophyO3DmgFac
+
+     REAL(f4),           POINTER :: EcophySoilStress(:,:,:)
+     LOGICAL                     :: Archive_EcophySoilStress
+
+     REAL(f4),           POINTER :: EcophyVCMax(:,:,:)
+     LOGICAL                     :: Archive_EcophyVCMax
+
+     REAL(f4),           POINTER :: EcophyLightLmtRate(:,:,:)
+     LOGICAL                     :: Archive_EcophyLightLmtRate
+
+     REAL(f4),           POINTER :: EcophyRubisLmtRate(:,:,:)
+     LOGICAL                     :: Archive_EcophyRubisLmtRate
+
+     REAL(f4),           POINTER :: EcophyProdLmtRate(:,:,:)
+     LOGICAL                     :: Archive_EcophyProdLmtRate
+
+     REAL(f4),           POINTER :: EcophyAGrossLeaf(:,:,:)
+     LOGICAL                     :: Archive_EcophyAGrossLeaf
+
+     REAL(f4),           POINTER :: EcophyIsopEmisPFT(:,:,:)
+     LOGICAL                     :: Archive_EcophyIsopEmisPFT
+
+     REAL(f4),           POINTER :: HEMCOIsopEmis(:,:,:)
+     LOGICAL                     :: Archive_HEMCOIsopEmis
+
      !%%%%% Photolysis %%%%%
 
      REAL(f4),           POINTER :: Jval(:,:,:,:)
@@ -1189,6 +1269,86 @@ CONTAINS
     State_Diag%DryDepVel                           => NULL()
     State_Diag%Map_DryDepVel                       => NULL()
     State_Diag%Archive_DryDepVel                   = .FALSE.
+
+    State_Diag%DryDepVelPFT1                       => NULL()
+    State_Diag%Map_DryDepVelPFT1                   => NULL()
+    State_Diag%Archive_DryDepVelPFT1               = .FALSE.
+
+    State_Diag%DryDepVelPFT2                       => NULL()
+    State_Diag%Map_DryDepVelPFT2                   => NULL()
+    State_Diag%Archive_DryDepVelPFT2               = .FALSE.
+
+    State_Diag%DryDepVelPFT3                       => NULL()
+    State_Diag%Map_DryDepVelPFT3                   => NULL()
+    State_Diag%Archive_DryDepVelPFT3               = .FALSE.
+
+    State_Diag%DryDepVelPFT4                       => NULL()
+    State_Diag%Map_DryDepVelPFT4                   => NULL()
+    State_Diag%Archive_DryDepVelPFT4               = .FALSE.
+
+    State_Diag%DryDepVelPFT5                       => NULL()
+    State_Diag%Map_DryDepVelPFT5                   => NULL()
+    State_Diag%Archive_DryDepVelPFT5               = .FALSE.
+    State_Diag%Archive_DryDepVel_anyPFT            = .FALSE.
+
+    !%%%%% Ecophysiology diagnostics %%%%%
+
+    State_Diag%EcophyPFTFrac                       => NULL()
+    State_Diag%Archive_EcophyPFTFrac               = .FALSE.
+
+    State_Diag%EcophyLAI                           => NULL()
+    State_Diag%Archive_EcophyLAI                   = .FALSE.
+
+    State_Diag%EcophyRa                            => NULL()
+    State_Diag%Archive_EcophyRa                    = .FALSE.
+
+    State_Diag%EcophyRbO3                          => NULL()
+    State_Diag%Archive_EcophyRbO3                  = .FALSE.
+
+    State_Diag%EcophyGCan                          => NULL()
+    State_Diag%Archive_EcophyGCan                  = .FALSE.
+
+    State_Diag%EcophyACan                          => NULL()
+    State_Diag%Archive_EcophyACan                  = .FALSE.
+
+    State_Diag%EcophyRespCan                       => NULL()
+    State_Diag%Archive_EcophyRespCan               = .FALSE.
+
+    State_Diag%EcophyCO2Leaf                       => NULL()
+    State_Diag%Archive_EcophyCO2Leaf               = .FALSE.
+
+    State_Diag%EcophyRespLeaf                      => NULL()
+    State_Diag%Archive_EcophyRespLeaf              = .FALSE.
+
+    State_Diag%EcophyFluxO3Can                     => NULL()
+    State_Diag%Archive_EcophyFluxO3Can             = .FALSE.
+
+    State_Diag%EcophyO3DmgFac                      => NULL()
+    State_Diag%Archive_EcophyO3DmgFac              = .FALSE.
+
+    State_Diag%EcophySoilStress                    => NULL()
+    State_Diag%Archive_EcophySoilStress            = .FALSE.
+
+    State_Diag%EcophyVCMax                         => NULL()
+    State_Diag%Archive_EcophyVCMax                 = .FALSE.
+
+    State_Diag%EcophyLightLmtRate                  => NULL()
+    State_Diag%Archive_EcophyLightLmtRate          = .FALSE.
+
+    State_Diag%EcophyRubisLmtRate                  => NULL()
+    State_Diag%Archive_EcophyRubisLmtRate          = .FALSE.
+
+    State_Diag%EcophyProdLmtRate                   => NULL()
+    State_Diag%Archive_EcophyProdLmtRate           = .FALSE.
+
+    State_Diag%EcophyAGrossLeaf                    => NULL()
+    State_Diag%Archive_EcophyAGrossLeaf            = .FALSE.
+
+    State_Diag%EcophyIsopEmisPFT                   => NULL()
+    State_Diag%Archive_EcophyIsopEmisPFT           = .FALSE.
+
+    State_Diag%HEMCOIsopEmis                       => NULL()
+    State_Diag%Archive_HEMCOIsopEmis               = .FALSE.
 
     !%%%%% Chemistry, J-value, Prod/Loss diagnostics %%%%%
 
@@ -2690,6 +2850,522 @@ CONTAINS
        errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
        CALL GC_Error( errMsg, RC, thisLoc )
        RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Dry deposition velocity for broadleaf tree
+    !-----------------------------------------------------------------------
+    diagID  = 'DryDepVelPFT1'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%DryDepVelPFT1,                          &
+         archiveData    = State_Diag%Archive_DryDepVelPFT1,                  &
+         mapData        = State_Diag%Map_DryDepVelPFT1,                      &
+         diagId         = diagId,                                            &
+         diagFlag       = 'D',                                               &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Dry deposition velocity for needleleaf tree
+    !-----------------------------------------------------------------------
+    diagID  = 'DryDepVelPFT2'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%DryDepVelPFT2,                          &
+         archiveData    = State_Diag%Archive_DryDepVelPFT2,                  &
+         mapData        = State_Diag%Map_DryDepVelPFT2,                      &
+         diagId         = diagId,                                            &
+         diagFlag       = 'D',                                               &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Dry deposition velocity for C3 grass
+    !-----------------------------------------------------------------------
+    diagID  = 'DryDepVelPFT3'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%DryDepVelPFT3,                          &
+         archiveData    = State_Diag%Archive_DryDepVelPFT3,                  &
+         mapData        = State_Diag%Map_DryDepVelPFT3,                      &
+         diagId         = diagId,                                            &
+         diagFlag       = 'D',                                               &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Dry deposition velocity for C4 grass
+    !-----------------------------------------------------------------------
+    diagID  = 'DryDepVelPFT4'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%DryDepVelPFT4,                          &
+         archiveData    = State_Diag%Archive_DryDepVelPFT4,                  &
+         mapData        = State_Diag%Map_DryDepVelPFT4,                      &
+         diagId         = diagId,                                            &
+         diagFlag       = 'D',                                               &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Dry deposition velocity for Shrub
+    !-----------------------------------------------------------------------
+    diagID  = 'DryDepVelPFT5'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%DryDepVelPFT5,                          &
+         archiveData    = State_Diag%Archive_DryDepVelPFT5,                  &
+         mapData        = State_Diag%Map_DryDepVelPFT5,                      &
+         diagId         = diagId,                                            &
+         diagFlag       = 'D',                                               &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Fraction of grid box occupied by the PFT (per 1000)
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyPFTFrac'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyPFTFrac,                          &
+         archiveData    = State_Diag%Archive_EcophyPFTFrac,                  &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Leaf area index of the PFT
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyLAI'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyLAI,                              &
+         archiveData    = State_Diag%Archive_EcophyLAI,                      &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Aerodynamic resistance
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyRa'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyRa,                               &
+         archiveData    = State_Diag%Archive_EcophyRa,                       &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+ 
+    !-----------------------------------------------------------------------
+    ! Boundary layer resistance
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyRbO3'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyRbO3,                             &
+         archiveData    = State_Diag%Archive_EcophyRbO3,                     &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Bulk canopy stomatal conductance
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyGCan'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyGCan,                             &
+         archiveData    = State_Diag%Archive_EcophyGCan,                     &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Bulk canopy photosynthesis
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyACan'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyACan,                             &
+         archiveData    = State_Diag%Archive_EcophyACan,                     &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Bulk canopy respiration
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyRespCan'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyRespCan,                          &
+         archiveData    = State_Diag%Archive_EcophyRespCan,                  &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! CO2 internal partial pressure
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyCO2Leaf'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyCO2Leaf,                          &
+         archiveData    = State_Diag%Archive_EcophyCO2Leaf,                  &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Canopy ozone uptake flux
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyFluxO3Can'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyFluxO3Can,                        &
+         archiveData    = State_Diag%Archive_EcophyFluxO3Can,                &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Ozone damage factor
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyO3DmgFac'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyO3DmgFac,                         &
+         archiveData    = State_Diag%Archive_EcophyO3DmgFac,                 &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Soil moisture stress factor
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophySoilStress'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophySoilStress,                       &
+         archiveData    = State_Diag%Archive_EcophySoilStress,               &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Maximum photosynthetic capacity
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyVCMax'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyVCMax,                            &
+         archiveData    = State_Diag%Archive_EcophyVCMax,                    &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Light-limited photosynthetic rate
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyLightLmtRate'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyLightLmtRate,                     &
+         archiveData    = State_Diag%Archive_EcophyLightLmtRate,             &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Rubisco-limited photosynthetic rate
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyRubisLmtRate'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyRubisLmtRate,                     &
+         archiveData    = State_Diag%Archive_EcophyRubisLmtRate,             &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Product-limited photosynthetic rate 
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyProdLmtRate'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyProdLmtRate,                      &
+         archiveData    = State_Diag%Archive_EcophyProdLmtRate,              &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Leaf level gross photosynthesis
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyAGrossLeaf'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyAGrossLeaf,                       &
+         archiveData    = State_Diag%Archive_EcophyAGrossLeaf,               &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Isoprene Emission
+    !-----------------------------------------------------------------------
+    diagID  = 'EcophyIsopEmisPFT'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%EcophyIsopEmisPFT,                      &
+         archiveData    = State_Diag%Archive_EcophyIsopEmisPFT,              &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! HEMCO Isoprene Emission in vdiff_mod
+    !-----------------------------------------------------------------------
+    diagID  = 'HEMCOIsopEmis'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%HEMCOIsopEmis,                          &
+         archiveData    = State_Diag%Archive_HEMCOIsopEmis,                  &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+    
+    IF( RC /= GC_SUCCESS ) THEN
+      errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+      CALL GC_Error( errMsg, RC, thisLoc )
+      RETURN
     ENDIF
 
 #ifdef MODEL_GEOS
@@ -8260,6 +8936,13 @@ CONTAINS
          State_Diag%Archive_OHwgtByAirMassColumnFull                    .or. &
          State_Diag%Archive_OHwgtByAirMassColumnTrop                        )
 
+    State_Diag%Archive_DryDepVel_anyPFT = (                                  &
+         State_Diag%Archive_DryDepVelPFT1                               .or. &
+         State_Diag%Archive_DryDepVelPFT2                               .or. &
+         State_Diag%Archive_DryDepVelPFT3                               .or. &
+         State_Diag%Archive_DryDepVelPFT4                               .or. &
+         State_Diag%Archive_DryDepVelPFT5                                   )
+
     !========================================================================
     ! Work array used to to calculate budget diagnostics, if needed
     ! 4th dimension is column region: Full, Trop, PBL respectively
@@ -8483,6 +9166,126 @@ CONTAINS
     CALL Finalize( diagId   = 'DryDepVel',                                   &
                    Ptr2Data = State_Diag%DryDepVel,                          &
                    mapData  = State_Diag%Map_DryDepVel,                      &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'DryDepVelPFT1',                               &
+                   Ptr2Data = State_Diag%DryDepVelPFT1,                      &
+                   mapData  = State_Diag%Map_DryDepVelPFT1,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'DryDepVelPFT2',                               &
+                   Ptr2Data = State_Diag%DryDepVelPFT2,                      &
+                   mapData  = State_Diag%Map_DryDepVelPFT2,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'DryDepVelPFT3',                               &
+                   Ptr2Data = State_Diag%DryDepVelPFT3,                      &
+                   mapData  = State_Diag%Map_DryDepVelPFT3,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'DryDepVelPFT4',                               &
+                   Ptr2Data = State_Diag%DryDepVelPFT4,                      &
+                   mapData  = State_Diag%Map_DryDepVelPFT4,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'DryDepVelPFT5',                               &
+                   Ptr2Data = State_Diag%DryDepVelPFT5,                      &
+                   mapData  = State_Diag%Map_DryDepVelPFT5,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyLAI',                                   &
+                   Ptr2Data = State_Diag%EcophyLAI,                          &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyRa',                                    &
+                   Ptr2Data = State_Diag%EcophyRa,                           &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyRbO3',                                  &
+                   Ptr2Data = State_Diag%EcophyRbO3,                         &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyPFTFrac',                               &
+                   Ptr2Data = State_Diag%EcophyPFTFrac,                      &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyGCan',                                  &
+                   Ptr2Data = State_Diag%EcophyGCan,                         &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyACan',                                  &
+                   Ptr2Data = State_Diag%EcophyACan,                         &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyRespCan',                               &
+                   Ptr2Data = State_Diag%EcophyRespCan,                      &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyCO2Leaf',                               &
+                   Ptr2Data = State_Diag%EcophyCO2Leaf,                      &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyFluxO3Can',                             &
+                   Ptr2Data = State_Diag%EcophyFluxO3Can,                    &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyO3DmgFac',                              &
+                   Ptr2Data = State_Diag%EcophyO3DmgFac,                     &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophySoilStress',                            &
+                   Ptr2Data = State_Diag%EcophySoilStress,                   &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyVCMax',                                 &
+                   Ptr2Data = State_Diag%EcophyVCMax,                        &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyLightLmtRate',                          &
+                   Ptr2Data = State_Diag%EcophyLightLmtRate,                 &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyRubisLmtRate',                          &
+                   Ptr2Data = State_Diag%EcophyRubisLmtRate,                 &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyProdLmtRate',                           &
+                   Ptr2Data = State_Diag%EcophyProdLmtRate,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyAGrossLeaf',                            &
+                   Ptr2Data = State_Diag%EcophyAGrossLeaf,                   &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'EcophyIsopEmisPFT',                           &
+                   Ptr2Data = State_Diag%EcophyIsopEmisPFT,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'HEMCOIsopEmis',                               &
+                   Ptr2Data = State_Diag%HEMCOIsopEmis,                      &
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
@@ -9868,6 +10671,146 @@ CONTAINS
        IF ( isUnits   ) Units = 'cm s-1'
        IF ( isRank    ) Rank  = 2
        IF ( isTagged  ) TagId = 'DRY'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'DRYDEPVELPFT1' ) THEN
+       IF ( isDesc    ) Desc  = 'Dry deposition velocity of species' // &
+                                ' for broadleaf tree'
+       IF ( isUnits   ) Units = 'cm s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagId = 'DRY'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'DRYDEPVELPFT2' ) THEN
+       IF ( isDesc    ) Desc  = 'Dry deposition velocity of species' // &
+                                ' for needleleaf tree'
+       IF ( isUnits   ) Units = 'cm s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagId = 'DRY'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'DRYDEPVELPFT3' ) THEN
+       IF ( isDesc    ) Desc  = 'Dry deposition velocity of species' // &
+                                ' for C3 grass'
+       IF ( isUnits   ) Units = 'cm s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagId = 'DRY'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'DRYDEPVELPFT4' ) THEN
+       IF ( isDesc    ) Desc  = 'Dry deposition velocity of species' // &
+                                ' for C4 grass'
+       IF ( isUnits   ) Units = 'cm s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagId = 'DRY'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'DRYDEPVELPFT5' ) THEN
+       IF ( isDesc    ) Desc  = 'Dry deposition velocity of species' // &
+                                ' for shrub'
+       IF ( isUnits   ) Units = 'cm s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagId = 'DRY'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYPFTFRAC' ) THEN 
+       IF ( isDesc    ) Desc  = 'Fraction of grid box occupied by the PFT'
+       IF ( isUnits   ) Units = '1000'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYLAI' ) THEN 
+       IF ( isDesc    ) Desc  = 'Leaf area index of the PFT'
+       IF ( isUnits   ) Units = 'm2 m-2'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYRA' ) THEN 
+       IF ( isDesc    ) Desc  = 'Aerodynamic resistance'
+       IF ( isUnits   ) Units = 's m-1'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYRBO3' ) THEN 
+       IF ( isDesc    ) Desc  = 'Boundary layer resistance'
+       IF ( isUnits   ) Units = 's m-1'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYGCAN' ) THEN 
+       IF ( isDesc    ) Desc  = 'Bulk canopy stomatal conductance'
+       IF ( isUnits   ) Units = 'm s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYACAN' ) THEN 
+       IF ( isDesc    ) Desc  = 'Bulk canopy photosynthesis'
+       IF ( isUnits   ) Units = 'mol m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYRESPCAN' ) THEN 
+       IF ( isDesc    ) Desc  = 'Bulk canopy respiration'
+       IF ( isUnits   ) Units = 'mol m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYCO2LEAF' ) THEN 
+       IF ( isDesc    ) Desc  = 'CO2 internal partial pressure'
+       IF ( isUnits   ) Units = 'Pa'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYFLUXO3CAN' ) THEN 
+       IF ( isDesc    ) Desc  = 'Canopy ozone uptake flux'
+       IF ( isUnits   ) Units = 'nmol m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYO3DMGFAC' ) THEN 
+       IF ( isDesc    ) Desc  = 'Ozone damage factor'
+       IF ( isUnits   ) Units = '1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYSOILSTRESS' ) THEN 
+       IF ( isDesc    ) Desc  = 'Soil moisture stress factor'
+       IF ( isUnits   ) Units = '1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYVCMAX' ) THEN 
+       IF ( isDesc    ) Desc  = 'Maximum Rubisco Carboxylation rate'
+       IF ( isUnits   ) Units = 'mol m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYLIGHTLMTRATE' ) THEN 
+       IF ( isDesc    ) Desc  = 'Light-limited photosynthetic rate'
+       IF ( isUnits   ) Units = 'mol m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYRUBISLMTRATE' ) THEN 
+       IF ( isDesc    ) Desc  = 'Rubisco-limited photosynthetic rate'
+       IF ( isUnits   ) Units = 'mol m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYPRODLMTRATE' ) THEN 
+       IF ( isDesc    ) Desc  = 'Product-limited photosynthetic rate'
+       IF ( isUnits   ) Units = 'mol m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYAGROSSLEAF' ) THEN 
+       IF ( isDesc    ) Desc  = 'Leaf level gross photosynthesis'
+       IF ( isUnits   ) Units = 'mol m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'ECOPHYISOPEMISPFT' ) THEN 
+       IF ( isDesc    ) Desc  = 'Isoprene Emission'
+       IF ( isUnits   ) Units = 'kg C m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagID = 'PFT'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'HEMCOISOPEMIS' ) THEN
+       IF ( isDesc    ) Desc  = 'Isoprene Emission'
+       IF ( isUnits   ) Units = 'kg C m-2 s-1'
+       IF ( isRank    ) Rank  = 3
 
 #ifdef MODEL_GEOS
     ELSE IF ( TRIM( Name_AllCaps ) == 'MONINOBUKHOV' ) THEN
@@ -11262,6 +12205,8 @@ CONTAINS
           numTags = State_Chm%nKppVar
        CASE( 'WET',     'W' )
           numTags = State_Chm%nWetDep
+       CASE( 'PFT'          )
+          numTags = 5
        CASE DEFAULT
           ErrMsg = 'Handling of wildCard ' // TRIM( tagId ) // &
                    ' is not implemented for getting number of tags'
@@ -11378,7 +12323,7 @@ CONTAINS
     ! Get mapping index
     !=======================================================================
     SELECT CASE( TRIM( tagID ) )
-       CASE( 'ALL','ADV', 'DUSTBIN', 'PRD', 'LOS', 'RRTMG', 'UVFLX', 'RXN' )
+       CASE( 'ALL', 'ADV', 'DUSTBIN', 'PRD', 'LOS', 'RRTMG', 'UVFLX', 'RXN', 'PFT' )
           D = N
        CASE( 'AER'  )
           D = State_Chm%Map_Aero(N)
@@ -11469,6 +12414,11 @@ CONTAINS
              CALL GC_Error( errMsg, RC, thisLoc )
              RETURN
           ENDIF
+
+       ! Plant functional types implemented in drydep_mod.F90
+       CASE( 'PFT' )
+          WRITE ( Nstr, "(I1)" ) D
+          tagName = 'PFT' // TRIM(Nstr)
 
        ! Default tag name is the name in the species database
        CASE DEFAULT

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -203,6 +203,7 @@ PROGRAM GEOS_Chem
   LOGICAL                  :: LCONV
   LOGICAL                  :: LDRYD
   LOGICAL                  :: LDYNOCEAN
+  LOGICAL                  :: LECOPHY
   LOGICAL                  :: LEMIS
   LOGICAL                  :: LGTMM
   LOGICAL                  :: LLINOZ
@@ -457,6 +458,7 @@ PROGRAM GEOS_Chem
   LCONV               =  Input_Opt%LCONV
   LDRYD               =  Input_Opt%LDRYD
   LDYNOCEAN           =  Input_Opt%LDYNOCEAN
+  LECOPHY             =  Input_Opt%LECOPHY
   LEMIS               =  Input_Opt%LEMIS
   LGTMM               =  Input_Opt%LGTMM
   LLINOZ              =  Input_Opt%LLINOZ
@@ -954,7 +956,7 @@ PROGRAM GEOS_Chem
           ENDIF
        ENDIF
 
-       !=====================================================================
+       !==============================================================
        !       ***** R U N   H E M C O   P H A S E   1 *****
        !
        !    Phase 1 updates the HEMCO clock and the content of the

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -124,6 +124,7 @@ Warnings:                    1
     --> RRTMG                  :       false    # 2002
     --> SfcVMR                 :       true     # 1750-2014
     --> OCEAN_O3_DRYDEP        :       true     # 1985
+    --> SOIL_PARAMS            :       true     # const.
 # -----------------------------------------------------------------------------
 100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2/MENO3/ETNO3/MOH
@@ -2629,6 +2630,7 @@ Warnings:                    1
 * PRECLSC   $METDIR/$YYYY/$MM/$MET.$YYYY$MM$DD.A1.$RES.$NC     PRECLSC  1980-2021/1-12/1-31/*/+30minute EFY xy  1  * -  1 1
 * PRECSNO   $METDIR/$YYYY/$MM/$MET.$YYYY$MM$DD.A1.$RES.$NC     PRECSNO  1980-2021/1-12/1-31/*/+30minute EFY xy  1  * -  1 1
 * PRECTOT   $METDIR/$YYYY/$MM/$MET.$YYYY$MM$DD.A1.$RES.$NC     PRECTOT  1980-2021/1-12/1-31/*/+30minute EFY xy  1  * -  1 1
+* QV2M      $METDIR/$YYYY/$MM/$MET.$YYYY$MM$DD.A1.$RES.$NC     QV2M     1980-2021/1-12/1-31/*/+30minute EFY xy  1  * -  1 1
 * SEAICE00  $METDIR/$YYYY/$MM/$MET.$YYYY$MM$DD.A1.$RES.$NC     SEAICE00 1980-2021/1-12/1-31/*/+30minute EFY xy  1  * -  1 1
 * SEAICE10  $METDIR/$YYYY/$MM/$MET.$YYYY$MM$DD.A1.$RES.$NC     SEAICE10 1980-2021/1-12/1-31/*/+30minute EFY xy  1  * -  1 1
 * SEAICE20  $METDIR/$YYYY/$MM/$MET.$YYYY$MM$DD.A1.$RES.$NC     SEAICE20 1980-2021/1-12/1-31/*/+30minute EFY xy  1  * -  1 1
@@ -2700,6 +2702,15 @@ Warnings:                    1
 * FLASH_DENS $ROOT/OFFLINE_LIGHTNING/v2020-03/$MET/$YYYY/FLASH_CTH_$MET_{NATIVE_RES}_$YYYY_$MM.nc4  LDENS 1980-2021/1-12/1-31/0-23/+90minute RFY3 xy  1  * -  1 1
 * CONV_DEPTH $ROOT/OFFLINE_LIGHTNING/v2020-03/$MET/$YYYY/FLASH_CTH_$MET_{NATIVE_RES}_$YYYY_$MM.nc4  CTH   1980-2021/1-12/1-31/0-23/+90minute RFY3 xy  1  * -  1 1
 )))LightNOx
+
+#==============================================================================
+# --- Soil parameter fields used in ecophysiology module ---
+#==============================================================================
+(((SOIL_PARAMS
+* THETA_WILT     ./HadGEM2ES_Soil_Ancil_05x05.nc     sm_wilt         */1/1/0     C xy  1  * -  1 1
+* THETA_CRIT     ./HadGEM2ES_Soil_Ancil_05x05.nc     sm_crit         */1/1/0     C xy  1  * -  1 1
+* THETA_SATU     ./HadGEM2ES_Soil_Ancil_05x05.nc     sm_sat          */1/1/0     C xy  1  * -  1 1
+)))SOIL_PARAMS
 
 )))METEOROLOGY
 

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -49,6 +49,9 @@ COLLECTIONS: 'Restart',
              #'WetLossConv',
              #'WetLossLS',
              ##'BoundaryConditions',
+             'Ecophysiology',
+             'Ecophys_ave',
+             'Ecophys_const',
 ::
 ###############################################################################
 ### The rest of this file consists of collection definitions.               ###
@@ -363,6 +366,11 @@ COLLECTIONS: 'Restart',
                               ##'DryDepChm_?DRY?              ', 'GIGCchem',
                               ##'DryDepMix_?DRY?              ', 'GIGCchem',
                               'DryDep_?DRY?                  ', 'GIGCchem',
+                              'DryDepVelPFT1                 ', 'GIGCchem',
+                              'DryDepVelPFT2                 ', 'GIGCchem',
+                              'DryDepVelPFT3                 ', 'GIGCchem',
+                              'DryDepVelPFT4                 ', 'GIGCchem',
+                              'DryDepVelPFT5                 ', 'GIGCchem',
 ::
 #==============================================================================
 # %%%%% THE JValues COLLECTION %%%%%
@@ -717,4 +725,48 @@ COLLECTIONS: 'Restart',
   BoundaryConditions.duration:   00000001 000000
   BoundaryConditions.mode:       'instantaneous'
   BoundaryConditions.fields:     'SpeciesBC_?ADV?             ', 'GIGCchem',
+::
+#==============================================================================
+# %%%%% THE Ecophysiology COLLECTION %%%%%
+#
+# Ecophysiology module variable outputs
+#
+# Available for fullchem simulations
+#==============================================================================
+  Ecophysiology.template:     '%y4%m2%d2_%h2%n2z.nc4',
+  Ecophysiology.format:       'CFIO',
+  Ecophysiology.frequency:    {FREQUENCY}
+  Ecophysiology.duration:     {DURATION}
+  Ecophysiology.mode:         'instantaneous'
+  Ecophysiology.fields:       'EcophyLAI_?PFT?               ', 'GIGCchem',
+                              'EcophyRa                      ', 'GIGCchem',
+                              'EcophyRbO3                    ', 'GIGCchem',
+                              'EcophyGCan_?PFT?              ', 'GIGCchem',
+                              'EcophyACan_?PFT?              ', 'GIGCchem',
+                              'EcophyRespCan_?PFT?           ', 'GIGCchem',
+                              'EcophyCO2Leaf_?PFT?           ', 'GIGCchem',
+                              'EcophyFluxO3Can_?PFT?         ', 'GIGCchem',
+                              'EcophyO3DmgFac_?PFT?          ', 'GIGCchem',
+                              'EcophySoilStress_?PFT?        ', 'GIGCchem',
+                              'EcophyVCMax_?PFT?             ', 'GIGCchem',
+                              'EcophyLightLmtRate_?PFT?      ', 'GIGCchem',
+                              'EcophyRubisLmtRate_?PFT?      ', 'GIGCchem',
+                              'EcophyProdLmtRate_?PFT?       ', 'GIGCchem',
+                              'EcophyAGrossLeaf_?PFT?        ', 'GIGCchem',
+                              'EcophyIsopEmisPFT_?PFT?       ', 'GIGCchem',
+                              'HEMCOIsopEmis                 ', 'GIGCchem',
+::
+#==============================================================================
+# %%%%% THE Ecophysiology constant COLLECTION %%%%%
+#
+# Ecophysiology module constant outputs
+#
+# Available for fullchem simulations
+#==============================================================================
+  Ecophys_const.template:     '%y4%m2%d2_%h2%n2z.nc4',
+  Ecophys_const.format:       'CFIO',
+  Ecophys_const.frequency:    'end'
+  Ecophys_const.duration:     'end'
+  Ecophys_const.mode:         'instantaneous'
+  Ecophys_const.fields:       'EcophyPFTFrac_?PFT?           ', 'GIGCchem',
 ::

--- a/run/GCClassic/input.geos.templates/input.geos.fullchem
+++ b/run/GCClassic/input.geos.templates/input.geos.fullchem
@@ -281,6 +281,10 @@ Turn on CO2 Effect?     : F
 CO2 level               : 600.0
 Reference CO2 level     : 380.0
 Diag alt above sfc [m]  : 10
+Turn on Ecophysiology?  : F
+ => O3 damage (Sitch)?  : OFF
+ => CO2 conc. (ppmv)    : 390
+ => online isop. emis.? : T
 ------------------------+------------------------------------------------------
 %%% CHEMISTRY MENU %%%  :
 Turn on Chemistry?      : T


### PR DESCRIPTION
Hi support team, 

This PR is about incorporating the ecophysiology module into the GEOS-Chem. Details are described below. Please feel free to let me know if any additional information is required. Thank you!

## Summary

Ground-level ozone (O3) is a major air pollutant that adversely affects human health and agricultural productivity. Removal of air pollutants including tropospheric O3 from the atmosphere by vegetation is controlled mostly by the process of dry deposition in the form of plant stomatal uptake, which in turn causes damage to plant tissues with ramifications for ecosystem and crop health. The openness of plant stomata is generally represented by a bulk stomatal conductance, which is often semi-empirically parameterized in many atmospheric and land surface models, and highly fitted to historical observations. A lack of mechanistic linkage to ecophysiological processes such as photosynthesis may render models insufficient to represent plant-mediated responses of atmospheric chemistry to long-term changes in CO2, climate and short-lived air pollutant concentrations. A new ecophysiology module is developed to mechanistically simulate land−atmosphere exchange of important gas species in GEOS-Chem, a chemical transport model widely used in atmospheric chemistry studies. We adopted the formulations from the Joint UK Land Environmental Simulator (JULES) to couple photosynthesis rate, bulk stomatal conductance and isoprene emission rate dynamically. 

### Key results
1. Our estimated dry deposition velocity of O3 is close to SynFlux dry deposition velocity with root-mean-squared errors (RMSE) ranging from 0.1 to 0.2 cm s–1 across different plant functional types (PFTs), despite an overall positive bias in surface O3 concentration (by up to 16 ppbv). 
1. Estimated global O3 deposition flux is 864 Tg O3 yr–1 with GEOS-Chem v12.2.0, and the new module decreases this estimate by 92 Tg O3 yr–1. 
1. Estimated global gross primary product (GPP) is 119 Pg C yr–1, with an O3-induced damage of 4.2 Pg C yr–1 (3.5%). An elevated CO2 scenario (580 ppm) yields higher global GPP (+16.8%) and lower global O3 depositional sink (–3.3%). 
1. Global isoprene emission total simulated with a photosynthesis-based scheme is 317.9 Tg C yr–1, which is 31.2 Tg C yr−1 (−8.9%) less than the values calculated using the MEGAN emission inventory. 

## Code updates

The ecophysiology-related formulation is inside GeosCore/ecophy_mod.F90. Changes in drydep_mod.F, state_diag_mod.F90 and diagnostics_mod.F90 mainly deal with diagnostics. Updates in other files are mostly about enabling my module to work in GEOS-Chem. When the module is turned on, the dry deposition over vegetated land is generally lower and the resulting ozone concentration over land becomes higher.

```
 GeosCore/CMakeLists.txt                            |    1 +
 GeosCore/diagnostics_mod.F90                       |   45 +
 GeosCore/drydep_mod.F90                            | 1589 ++++++++++--------
 GeosCore/ecophy_mod.F90                            | 1748 ++++++++++++++++++++
 GeosCore/flexgrid_read_mod.F90                     |   31 +-
 GeosCore/gc_environment_mod.F90                    |   17 +
 GeosCore/hco_utilities_gc_mod.F90                  |   12 +
 GeosCore/input_mod.F90                             |   50 +
 GeosCore/mixing_mod.F90                            |    3 +-
 Headers/input_opt_mod.F90                          |    9 +-
 Headers/state_chm_mod.F90                          |   42 +
 Headers/state_diag_mod.F90                         |  952 ++++++++++-
 Headers/state_met_mod.F90                          |  138 ++
 Interfaces/GCClassic/main.F90                      |    4 +-
 .../HEMCO_Config.rc.fullchem                       |   11 +
 .../HISTORY.rc.templates/HISTORY.rc.fullchem       |   52 +
 .../input.geos.templates/input.geos.fullchem       |    4 +
```

### Model structure
Currently, my module is called inside the drydep_mod.F when the bulk canopy stomatal resistance is calculated. If ecophysiology is turned on, it replaces the default parameterization of the stomatal resistance in Wesely scheme.

### Clarifications on my changes in drydep_mod.F90
Most of those changes are involved to interchange the order of calculation of aerodynamic resistance RA and surface conductance RSURFC (which involves removing a DO loop) and include an IF-statement to call the ecophysiology module.

## Data file update

To enable the parameterizations in the ecophysiology module, I included a map of some soil parameters. It is read by HEMCO.

## References:
1. Lam, J. C. Y. and Tai, A. P. K., _Development of an ecophysiology module in the GEOS-Chem chemical transport model to represent biosphere−atmosphere fluxes_, In prep, 2021
1. Clark, D., Mercado, L., Sitch, S., Jones, C., Gedney, N., Best, M., Pryor, M., Rooney, G., Essery, R., Blyth, E., Boucher, O., Harding, R., Huntingford, C. and Cox, P., _The Joint UK Land Environment Simulator (JULES), model description - Part 2: Carbon fluxes and vegetation dynamics_, Geosci. Model Dev., 4, 701, doi:10.5194/gmd-4-701-2011, 2011. 
1. Best, M., Pryor, M., Clark, D., Rooney, G., Essery, R., Ménard, C., Edwards, J., Hendry, M., Porson, A., Gedney, N., Mercado, L., Sitch, S., Blyth, E., Boucher, O., Cox, P., Grimmond, C. and Harding, R., _The Joint UK Land Environment Simulator (JULES), model description - Part 1: Energy and water fluxes_, Geosci. Model Dev., 4, 677, doi:10.5194/gmd-4-677-2011, 2011.
1. Cox, P. M., Huntingford, C. and Harding, R. J., _A canopy conductance and photosynthesis model for use in a GCM land surface scheme_, J. Hydrol., 212, 79–94, doi:10.1016/S0022-1694(98)00203-0, 1998.
1. Raoult, N. M., Jupp, T. E., Cox, P. M. and Luke, C. M., _Land-surface parameter optimisation using data assimilation techniques: the adJULES system V1.0_, Geosci. Model Dev., 9, 2833, doi:10.5194/gmd-9-2833-2016, 2016.