### PR TITLE
[PULL REQUEST] Bug fixes for GEOS-Chem Classic dry-run simulations

### DIFF
--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -49,7 +49,6 @@ MODULE UCX_MOD
 !
 ! !PUBLIC DATA MEMBERS:
 !
-  PUBLIC :: NOON_FILE_ROOT ! Directory for noontime data
   PUBLIC :: T_STS          ! Max temperature of STS formation (K)
   PUBLIC :: NDENS_AER      ! See below
 !
@@ -144,7 +143,6 @@ MODULE UCX_MOD
   !=================================================================
 
   ! Scalars
-  CHARACTER(LEN=255)   :: NOON_FILE_ROOT
   REAL(fp)             :: SLA_VA
   REAL(fp)             :: SLA_RR
   REAL(fp)             :: SLA_VR
@@ -3926,6 +3924,8 @@ CONTAINS
     CHARACTER(LEN=255) :: TARG_TRAC
     CHARACTER(LEN=255) :: DBGMSG
     CHARACTER(LEN=255) :: FileMsg
+    CHARACTER(LEN=255) :: GridSpec
+    CHARACTER(LEN=255) :: NOON_FILE_ROOT
 
     !=================================================================
     ! NOXCOEFF_INIT begins here!
@@ -3933,6 +3933,27 @@ CONTAINS
 
     ! Copy fields from INPUT_OPT
     prtDebug = ( Input_Opt%LPRT .and. Input_Opt%amIRoot )
+
+    ! --------------------------------------------------------------
+    ! Input data sources
+    ! --------------------------------------------------------------
+
+    ! For ASCII input, use 2x25 grid for all other grids than 4x5.
+    ! This is ok for the NOx coeffs which can be regridded on the fly
+    ! from 2x25 onto any other grid. This won't work for the 2D
+    ! boundary conditions, but those have been checked in the logical
+    ! check above (USE2DDATA).
+    IF ( TRIM(State_Grid%GridRes) == '4.0x5.0' ) THEN
+       GRIDSPEC = 'Grid4x5/InitCFC_'
+    ELSE
+       GRIDSPEC = 'Grid2x25/InitCFC_'
+    ENDIF
+    WRITE(   NOON_FILE_ROOT,'(a,a,a)') TRIM(Input_Opt%CHEM_INPUTS_DIR), &
+#ifdef MODEL_GEOS
+         'UCX_201902/NoonTime/', TRIM(GRIDSPEC)
+#else
+         'UCX_201403/NoonTime/', TRIM(GRIDSPEC)
+#endif
 
     !=================================================================
     ! In dry-run mode, print file paths to dryrun log and exit.

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -4274,46 +4274,10 @@ CONTAINS
        WRITE( 6,'(a)') REPEAT( '=', 79 )
     ENDIF
 
-    ! --------------------------------------------------------------
-    ! Input data sources
-    ! --------------------------------------------------------------
-
-    ! For ASCII input, use 2x25 grid for all other grids than 4x5.
-    ! This is ok for the NOx coeffs which can be regridded on the fly
-    ! from 2x25 onto any other grid. This won't work for the 2D
-    ! boundary conditions, but those have been checked in the logical
-    ! check above (USE2DDATA).
-    IF ( TRIM(State_Grid%GridRes) == '4.0x5.0' ) THEN
-       GRIDSPEC = 'Grid4x5/InitCFC_'
-    ELSE
-       GRIDSPEC = 'Grid2x25/InitCFC_'
-    ENDIF
-    WRITE(   NOON_FILE_ROOT,'(a,a,a)') TRIM(Input_Opt%CHEM_INPUTS_DIR), &
-#ifdef MODEL_GEOS
-         'UCX_201902/NoonTime/', TRIM(GRIDSPEC)
-#else
-         'UCX_201403/NoonTime/', TRIM(GRIDSPEC)
-#endif
-
     !=================================================================
     ! In dry-run mode, print file path to dryrun log and return.
     !=================================================================
     IF ( Input_Opt%DryRun ) THEN
-
-       ! Test if the file exists and define an output string
-       FileName = Noon_File_Root
-       INQUIRE( FILE=TRIM( FileName ), EXIST=FileExists )
-       IF ( FileExists ) THEN
-          FileMsg = 'UCX (SFCMR_READ): Opening'
-       ELSE
-          FileMsg = 'UCX (SFCMR_READ): REQUIRED FILE NOT FOUND'
-       ENDIF
-
-       ! Write to stdout for the dry-run simulation
-       IF ( Input_Opt%amIRoot ) THEN
-          WRITE( 6, 300 ) TRIM( FileMsg ), TRIM( FileName )
-300       FORMAT( a, ' ', a )
-       ENDIF
 
        ! Get dry-run output from NOXCOEFF_INIT as well
        CALL NOXCOEFF_INIT( Input_Opt, State_Grid )
@@ -4323,25 +4287,8 @@ CONTAINS
     ENDIF
 
     !=================================================================
-    ! For regular simulations, read data from files
+    ! For regular simulations, allocate arrays
     !=================================================================
-
-    ! Write the status of Noon_File_Root to stdout
-    INQUIRE( FILE=TRIM( Noon_File_Root ), EXIST=FileExists )
-    IF ( FileExists ) THEN
-       FileMsg = 'UCX (SFCMR_READ): Opening'
-    ELSE
-       FileMsg = 'UCX (SFCMR_READ): REQUIRED FILE NOT FOUND'
-    ENDIF
-    IF ( Input_Opt%amIRoot ) THEN
-       WRITE( 6, 300 ) TRIM( FileMsg ), TRIM( Noon_File_Root )
-    ENDIF
-
-    IF ( prtDebug ) THEN
-       WRITE(DBGMSG,'(a,a)') '### UCX: Reading O1D/O3P from ', &
-            TRIM(NOON_FILE_ROOT)
-       CALL DEBUG_MSG( TRIM(DBGMSG) )
-    ENDIF
 
     ! Allocate arrays of input pressure levels and lat edges
     ALLOCATE( UCX_PLEVS( UCX_NLEVS ), STAT=AS )

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -434,6 +434,9 @@ CONTAINS
     State_Chm%nSpecies          =  0
     State_Chm%nWetDep           =  0
 
+    ! Indices for HetChem
+    State_Chm%HetInfo           => NULL()
+
     ! Mapping vectors
     State_Chm%Map_Advect        => NULL()
     State_Chm%Map_Aero          => NULL()

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -1080,6 +1080,7 @@ CONTAINS
     State_Diag%Archive_SpeciesRst                  = .FALSE.
 
     State_Diag%SpeciesBC                           => NULL()
+    State_Diag%Map_SpeciesBC                       => NULL()
     State_Diag%Archive_SpeciesBC                   = .FALSE.
 
     State_Diag%SpeciesConc                         => NULL()

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -731,20 +731,32 @@ if [[ "x${sim_name}" == "xfullchem" ]]; then
 	sample_rst=${rst_root}/GC_13.0.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
     fi
 
-elif [[ ${sim_name} = "TransportTracers" ]]; then
+elif [[ "x${sim_name}" == "xaerosol" ]]; then
+
+    # Aerosol-only simulations can use the fullchem r start
+    # as all of the aerosol species are included
+    sample_rst=${rst_root}/GC_13.0.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
+
+elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
 
     # For TransportTracers, use restart from latest 1-year benchmark
     sample_rst=${rst_root}/GC_13.0.0/GEOSChem.Restart.TransportTracers.20190101_0000z.nc4
 
+elif [[ "x${sim_name}" == "xPOPs" ]]; then
+
+    # For POPs, the extra option is in the restart file name
+    sample_rst=${rst_root}/v2020-02/initial_GEOSChem_rst.2x25_${sim_name}_${sim_extra_option}.nc
+
 else
 
     # For other specialty simulations, use previoiusly saved restarts
-    sample_rst=${rst_root}/v2018-11/initial_GEOSChem_rst.${grid_res}_${sim_name}.nc
+    # that have 2019 dates.  We only need the 2x25 restarts.
+    sample_rst=${rst_root}/v2020-02/initial_GEOSChem_rst.2x25_${sim_name}.nc
 fi
 
 # Copy the restart file to the run directory (for AWS or on a local server)
 if [[ "x${is_aws}" != "x" ]]; then
-    ${s3_cp} ${sample_rst} ${rundir}/GEOSChem.Restart.${startdate}_0000z.nc4
+    ${s3_cp} ${sample_rst} ${rundir}/GEOSChem.Restart.${startdate}_0000z.nc4 2>/dev/null
 elif [[ -f ${sample_rst} ]]; then
     cp ${sample_rst} ${rundir}/GEOSChem.Restart.${startdate}_0000z.nc4
 else


### PR DESCRIPTION
### Overview

This PR fixes several issues in the GEOS-Chem "Classic" dry-run simulation, namely:

  1. Routine `INIT_UCX` in (`GeosCore/ucx_mod.F90`), was printing incorrect dry-run output to the log file, which caused dry-run simulations to hang.  This has now been corrected.
  
  2. The `run/GCClassic/createRunDir.sh` script has the following updates:
    a.  Aerosol simulations now use the fullchem restart file
    b.  POPs simulation now looks for an initial restart file w/ the extra option (BaP, PYR, PHE) in` ExtData/GEOSCHEM_RESTARTS/v2020-02`.  
    c. All other specialty simulations use restart files in `GEOSCHEM_RESTARTS/v2020-02` on the remote server
    d. Send error output from `aws s3 cp` to `dev/null`

  3. The `run/shared/download_data.py` script has the following updates:
    a. Look for NK15 and NK40 in input.geos to decide if we need to download data files for TOMAS15 and TOMAS40 simulations
    b. Use the fullchem restart file (Jan 2019) for the aerosol simulation
    c. Look for specialty simulation restart files in `GEOSCHEM_RESTARTS/v2020-02`
    d. When downloading data from ComputeCanada, first download it to the local `GEOSCHEM_RESTARTS` directory tree, then copy it to the run directory.
    e. AWS restart files should now be placed in the run directory by `createRunDir.sh`.  But if a restart file is missing, running
       `download_data.py` with `-aws` will restore it.
  4. In `state_chm_mod.F90`, we now nullify the `State_Chm%HetInfo` and `State_Chm%Map_SpeciesBC` fields in routine `Init_State_Chm`.  Explicitly setting these fields to `NULL()` will make them be recognized as unallocated by the compiler, which can prevent seg faults during finalization, at least with the later GNU Fortran compilers.

  5. Also note: 2 x 2.5 specialty simulation restart files have been copied to `ExtData/GEOSCHEM_RESTARTS/v2020-02`.  The reference time of these restart files has been edited to either 2019-01-01 or 2019-07-01.

### Testing

The dry-run capability was tested on the AWS cloud.  The proper restart files are now being placed into the run directories.

CAVEAT: There may be still some issues with the POPS simulation, since there are 3 separate restart files.  But since the POPs simulation is basically unused, I think we can address any user-reported issues that come up on a case-by-case basis.