### PR TITLE
[PULL REQUEST] Fix typo in call to HetIxCycleSSA (in KPP/fullchem/gckpp_HetRates.F90)

### DIFF
--- a/KPP/fullchem/gckpp_HetRates.F90
+++ b/KPP/fullchem/gckpp_HetRates.F90
@@ -1322,7 +1322,7 @@ MODULE GCKPP_HETRATES
       HET(ind_IONO2, 5) = kIIR1Ltd( spcVec, H%IONO2%mId, H%SALACL%mId,       &
                                     kITemp, HetMinLife                      )
 
-      kITemp            = HETIXCycleSSA( H%IONO2%MW_g, 0.01_fp, SSAlk, 3    )
+      kITemp            = HETIXCycleSSA( H%IONO2%MW_g, 0.01_fp, SSAlk, 4    )
       HET(ind_IONO2, 6) = kIIR1Ltd( spcVec, H%IONO2%mId, H%SALCCL%mId,       &
                                     kITemp, HetMinLife )
 


### PR DESCRIPTION
This function call in routine `SET_HET` (`KPP/fullchem/gckpp_HetRates.F90`)
```
  kITemp            = HETIXCycleSSA( H%IONO2%MW_g, 0.01_fp, SSAlk, 3    )
  HET(ind_IONO2, 6) = kIIR1Ltd( spcVec, H%IONO2%mId, H%SALCCL%mId,       &
                                kITemp, HetMinLife )
```
should be
```
  kITemp            = HETIXCycleSSA( H%IONO2%MW_g, 0.01_fp, SSAlk, 4    )
  HET(ind_IONO2, 6) = kIIR1Ltd( spcVec, H%IONO2%mId, H%SALCCL%mId,       &
                                kITemp, HetMinLife )
```
Because uptake of iodine species by SALCCL should be denoted by N=4 instead of N=3 (which is SALACL).

This fix will introduce differences in output at the level of numerical noise (differences 1e-6 or 1e-7 lower than values). Because this fix will change benchmark output, it should be added into a 13.Y.0 version.

Signed-off-by: Bob Yantosca <yantosca@seas.harvard.edu>