### PR TITLE
[PULL-REQUEST] Allow wildcard input for ObsPack to output all advected species 

### DIFF
--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -3983,18 +3983,6 @@ CONTAINS
       N =Input_Opt%N_ADVECT			
     ENDIF  
 	
-	! Test if there is an "?ALL" wildcard present as the first/only substring
-    ! argument to the ObsPack output Species Line. 
-    IF ( N==1 .AND. INDEX( SUBSTRS(1) , '?ALL' ) >  0)  THEN
-
-	  ! If wildcard for all species is requested then update the 
-      ! list of species to track to be the list of advected species 
-	  SUBSTRS= Input_Opt%AdvectSpc_Name
-
-	  ! And update the number of species to track with ObsPack as the # of advected species.  
-	  N =Input_Opt%N_ADVECT	
-    ENDIF 
-	
     ! Populate the ObsPack species name list
     Input_Opt%ObsPack_nSpc = N
     DO S = 1, Input_Opt%ObsPack_nSpc

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -3962,7 +3962,19 @@ CONTAINS
        CALL GC_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
+	
+	! Test if there is an "?ALL" wildcard present as the FIRST substring
+    ! argument to the ObsPack output Species Line. 
+    IF ( N==1 .AND. INDEX( SUBSTRS(1) , '?ALL' ) >  0)  THEN
 
+	! If wildcard for all species is requested then update the 
+        ! list of species to track to be the list of advected species 
+	SUBSTRS= Input_Opt%AdvectSpc_Name
+
+	! And update the number of species to track with ObsPack as the # of advected species.  
+	N =Input_Opt%N_ADVECT	
+    ENDIF 
+	
     ! Populate the ObsPack species name list
     Input_Opt%ObsPack_nSpc = N
     DO S = 1, Input_Opt%ObsPack_nSpc

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -3880,6 +3880,7 @@ CONTAINS
 !
     USE ErrCode_Mod
     USE Input_Opt_Mod, ONLY : OptInput
+	USE ERROR_MOD,  ONLY : GEOS_CHEM_STOP
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -3963,16 +3964,35 @@ CONTAINS
        RETURN
     ENDIF
 	
-	! Test if there is an "?ALL" wildcard present as the FIRST substring
+    IF ( N > 85 .AND. Input_Opt%amIRoot) THEN 
+	   WRITE( 6, '(/,a)' ) 'OBSPACK_MENU'
+       WRITE( 6, '(  a)' ) '----------------'
+       WRITE( 6, '(a)') 'WARNING: Too many ObsPack individual output species detected on one line input.'
+       WRITE( 6, '(a)') 'Consider using wildcard SpeciesConc_?ALL? to track all advected species.'  
+       CALL GEOS_CHEM_STOP
+    ENDIF
+
+    ! Test if there is an "?ALL" wildcard present as the FIRST substring
+    ! argument to the ObsPack output Species Line. 
+    IF ( N==1 .AND. INDEX( SUBSTRS(1) , '?ALL' ) >  0)  THEN
+      ! If wildcard for all species is requested then update the 
+      ! list of species to track to be the list of advected species 
+      SUBSTRS= Input_Opt%AdvectSpc_Name
+
+      ! And update the number of species to track with ObsPack as the # of advected species.  
+      N =Input_Opt%N_ADVECT			
+    ENDIF  
+	
+	! Test if there is an "?ALL" wildcard present as the first/only substring
     ! argument to the ObsPack output Species Line. 
     IF ( N==1 .AND. INDEX( SUBSTRS(1) , '?ALL' ) >  0)  THEN
 
-	! If wildcard for all species is requested then update the 
-        ! list of species to track to be the list of advected species 
-	SUBSTRS= Input_Opt%AdvectSpc_Name
+	  ! If wildcard for all species is requested then update the 
+      ! list of species to track to be the list of advected species 
+	  SUBSTRS= Input_Opt%AdvectSpc_Name
 
-	! And update the number of species to track with ObsPack as the # of advected species.  
-	N =Input_Opt%N_ADVECT	
+	  ! And update the number of species to track with ObsPack as the # of advected species.  
+	  N =Input_Opt%N_ADVECT	
     ENDIF 
 	
     ! Populate the ObsPack species name list


### PR DESCRIPTION
Formerly, in the `input.geos` file, to track a number of species using the ObsPack Menu, you had to list each tracer with a space in between as follows on the "ObsPack output species" line. 

```
------------------------+------------------------------------------------------
%%% OBSPACK MENU %%%    :
Turn on ObsPack diag?   : T
Quiet logfile output    : T
ObsPack input file      : ./Obspack_Inputs/obspack_input.YYYYMMDD.nc
ObsPack output file     : ./OutputDir/GEOSChem.ObsPack.YYYYMMDD_hhmmz.nc4
ObsPack output species  :  CO NO NO2 O3
------------------------+------------------------------------------------------
```
However, the number of species written to the output file is limited to ~86 even if there were more than 86 tracers listed on the ObsPack output species line. This is because the way this line is read in `input_mod.F90`, not because there is a limit in the number of species written to the ObsPack output file in `obspack_mod.F90`. 

Here by modifying the way the line is read in `input_mod.F90`, I've added an option to use a wildcard on the ObsPack output species menu of the input file that will track all advected species. I've also added a warning/stop if the user has passed too many individual input species where the model would run completely and print output to an Obspack output file, but would not print all of the desired species (e.g. if they ask for more than 85 tracers). 

Now, users who want to track a bunch of species using Obspack can do so using the following wildcard input in the input.geos file. Here I'm following the wildcard conventions in `HISTORY.rc`, but the condition is triggered by looking for the string "?ALL" within the FIRST and ONLY input to the ObsPack output species line in the input.geos file. 
```
------------------------+------------------------------------------------------
%%% OBSPACK MENU %%%    :
Turn on ObsPack diag?   : T
Quiet logfile output    : T
ObsPack input file      : ./Obspack_Inputs/obspack_input.YYYYMMDD.nc
ObsPack output file     : ./OutputDir/GEOSChem.ObsPack.YYYYMMDD_hhmmz.nc4
ObsPack output species  :  SpeciesConc_?ALL?
------------------------+------------------------------------------------------
```
I've accomplished this by overwriting the "SUBSTRS" list of variables that's written to Input_Opt%ObsPack_SpcName with the list compiled for Input_Opt%AdvectSpc_Name earlier in input_mod.F90. 

