### PR TITLE
[PULL REQUEST] More stable stratospheric H2O boundary condition

### DIFF
--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -1961,6 +1961,14 @@ CONTAINS
     ENDIF
     READ( SUBSTRS(1:N), * ) Input_Opt%LSETH2O
 
+    ! Use static strat H2O boundary condition?
+    CALL SPLIT_ONE_LINE( SUBSTRS, N, 1, 'LSTATICH2OBC', RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+    READ( SUBSTRS(1:N), * ) Input_Opt%LStaticH2OBC
+
     ! Separator line
     CALL SPLIT_ONE_LINE( SUBSTRS, N, 1, 'separator 4', RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -1971,11 +1979,6 @@ CONTAINS
     !=================================================================
     ! Error check logical flags
     !=================================================================
-
-    ! Turn off full-chem only switches
-    IF ( .not. Input_Opt%ITS_A_FULLCHEM_SIM ) THEN
-       Input_Opt%LSETH2O = .FALSE.
-    ENDIF
 
     ! Return success
     RC = GC_SUCCESS
@@ -1994,6 +1997,8 @@ CONTAINS
                         Input_Opt%LCH4EMIS
        WRITE( 6, 100 ) 'Set initial strat H2O?      : ', &
                         Input_Opt%LSETH2O
+       WRITE( 6, 100 ) 'Use robust strat H2O BC?    : ', &
+                        Input_Opt%LStaticH2OBC
     ENDIF
 
     ! FORMAT statements

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -3678,8 +3678,12 @@ CONTAINS
        IF ( ABS(State_Grid%YMid(I,J)) <= 30 ) THEN
           ! Level with minimum temperature,
           ! use MASK to screen for >10 hPa
-          LEVCPT = MINLOC( State_Met%T(I,J,:), DIM=1, &
-                           MASK=(State_Met%PMID(I,J,:) >= 10) )
+          If (Input_Opt%LStaticH2OBC) Then
+             LEVCPT = MINLOC(ABS(State_Met%PMID(I,J,:) - 70), DIM=1)
+          Else
+             LEVCPT = MINLOC( State_Met%T(I,J,:), DIM=1, &
+                              MASK=(State_Met%PMID(I,J,:) >= 10) )
+          End If
        ELSE
           LEVCPT = -1
        ENDIF

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -147,6 +147,7 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: LCH4EMIS
      LOGICAL                     :: LCH4SBC
      LOGICAL                     :: LSETH2O
+     LOGICAL                     :: LStaticH2OBC
      LOGICAL                     :: LHCodedOrgHal
      LOGICAL                     :: LCMIP6OrgHal
      LOGICAL                     :: DoLightNOx ! Shadow for LightNOX extension
@@ -643,6 +644,7 @@ CONTAINS
     Input_Opt%LCH4EMIS               = .FALSE.
     Input_Opt%LCH4SBC                = .FALSE.
     Input_Opt%LSETH2O                = .FALSE.
+    Input_Opt%LStaticH2OBC           = .FALSE.
     Input_Opt%LHCodedOrgHal          = .FALSE.
     Input_Opt%LCMIP6OrgHal           = .FALSE.
     Input_Opt%DoLightNOx             = .FALSE.

--- a/run/GCHP/input.geos.templates/input.geos.TransportTracers
+++ b/run/GCHP/input.geos.templates/input.geos.TransportTracers
@@ -53,6 +53,7 @@ HEMCO Input file        : HEMCO_Config.rc
 Switches for UCX        :---
  => Use CH4 emissions?  : F
  => Set init. strat. H2O: F
+ => Use static H2O BC   : T
 ------------------------+------------------------------------------------------
 %%% AEROSOL MENU %%%    :
 Online SULFATE AEROSOLS : F

--- a/run/GCHP/input.geos.templates/input.geos.fullchem
+++ b/run/GCHP/input.geos.templates/input.geos.fullchem
@@ -235,6 +235,7 @@ HEMCO Input file        : HEMCO_Config.rc
 Switches for UCX        :---
  => Use CH4 emissions?  : F
  => Set init. strat. H2O: T
+ => Use static H2O BC   : T
 ------------------------+------------------------------------------------------
 %%% AEROSOL MENU %%%    :
 Online SULFATE AEROSOLS : T


### PR DESCRIPTION
By selecting the "static" H2O option in input.geos, the user can now request that stratospheric water vapor be specified up to 70 hPa in the tropics. This results in a more stable water vapor signal in the stratosphere. If this option is not selected, the water vapor in the stratosphere may grow continuously over multi-year simulations.

The change significantly reduces the accumulation when running a full-chemistry simulation at C24 in GCHP (see plot; old approach on the right, new approach on the left).

![image](https://user-images.githubusercontent.com/6618732/114316427-8c712600-9ad1-11eb-9529-f4d9f0198f67.png)
