### PR TITLE
[PULL REQUEST] Bug fix: add carbon to species scale factors to AEIC VOC emissions.

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3985,8 +3985,8 @@ Warnings:                    1
 43 CtoBENZ MATH:78.12/(6.0*12.0)   - - - xy unitless 1
 44 CtoC2H4 MATH:28.05/(2.0*12.0)   - - - xy unitless 1
 45 CtoC2H6 MATH:30.08/(2.0*12.0)   - - - xy unitless 1
-46 CtoC3H8 MATH:46.08/(3.0*12.0)   - - - xy unitless 1
-47 CtoEOH  MATH:46.06/(2.0*12.0)   - - - xy unitless 1
+46 CtoC3H8 MATH:44.11/(3.0*12.0)   - - - xy unitless 1
+47 CtoEOH  MATH:46.07/(2.0*12.0)   - - - xy unitless 1
 48 CtoMEK  MATH:72.11/(4.0*12.0)   - - - xy unitless 1
 49 CtoPRPE MATH:42.09/(3.0*12.0)   - - - xy unitless 1
 55 CtoTOLU MATH:92.15/(7.0*12.0)   - - - xy unitless 1

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -2379,22 +2379,22 @@ Warnings:                    1
 # ==> Now emit aircraft BC and OC into hydrophilic tracers BCPI and OCPI.
 #==============================================================================
 (((AEIC
-0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
-0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
-0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
-0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
-0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
-0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
-0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
-0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
+0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115    20 1
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110        20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280    20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111        20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112        20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113        20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113        20 1
+0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101/40 20 1
+0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102/41 20 1
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103/42 20 1
+0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104/45 20 1
+0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105/46 20 1
+0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106    20 1
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107/49 20 1
+0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108/83 20 1
+0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109/84 20 1
 )))AEIC
 
 #==============================================================================
@@ -3996,6 +3996,8 @@ Warnings:                    1
 62 CtoMTPA MATH:136.26/(10.0*12.0) - - - xy unitless 1
 64 CtoMBOX MATH:86.13/(5.0*12.0)   - - - xy unitless 1
 67 CtoSESQ MATH:204.4/(15.0*12.0)  - - - xy unitless 1
+83 CtoMACR MATH:70.10/(4.0*12.0)   - - - xy unitless 1
+84 CtoRCHO MATH:58.09/(3.0*12.0)   - - - xy unitless 1
 
 # VOC speciations
 (((RCP_3PD.or.RCP_45.or.RCP_60.or.RCP_85

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3987,8 +3987,8 @@ Warnings:                    1
 43 CtoBENZ MATH:78.12/(6.0*12.0)   - - - xy unitless 1
 44 CtoC2H4 MATH:28.05/(2.0*12.0)   - - - xy unitless 1
 45 CtoC2H6 MATH:30.08/(2.0*12.0)   - - - xy unitless 1
-46 CtoC3H8 MATH:46.08/(3.0*12.0)   - - - xy unitless 1
-47 CtoEOH  MATH:46.06/(2.0*12.0)   - - - xy unitless 1
+46 CtoC3H8 MATH:44.11/(3.0*12.0)   - - - xy unitless 1
+47 CtoEOH  MATH:46.07/(2.0*12.0)   - - - xy unitless 1
 48 CtoMEK  MATH:72.11/(4.0*12.0)   - - - xy unitless 1
 49 CtoPRPE MATH:42.09/(3.0*12.0)   - - - xy unitless 1
 55 CtoTOLU MATH:92.15/(7.0*12.0)   - - - xy unitless 1

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -2381,22 +2381,22 @@ Warnings:                    1
 # ==> Now emit aircraft BC and OC into hydrophilic tracers BCPI and OCPI.
 #==============================================================================
 (((AEIC
-0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
-0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
-0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
-0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
-0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
-0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
-0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
-0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
+0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115    20 1
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110        20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280    20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111        20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112        20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113        20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113        20 1
+0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101/40 20 1
+0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102/41 20 1
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103/42 20 1
+0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104/45 20 1
+0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105/46 20 1
+0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106    20 1
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107/49 20 1
+0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108/83 20 1
+0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109/84 20 1
 )))AEIC
 
 #==============================================================================
@@ -3998,6 +3998,8 @@ Warnings:                    1
 62 CtoMTPA MATH:136.26/(10.0*12.0) - - - xy unitless 1
 64 CtoMBOX MATH:86.13/(5.0*12.0)   - - - xy unitless 1
 67 CtoSESQ MATH:204.4/(15.0*12.0)  - - - xy unitless 1
+83 CtoMACR MATH:70.10/(4.0*12.0)   - - - xy unitless 1
+84 CtoRCHO MATH:58.09/(3.0*12.0)   - - - xy unitless 1
 
 # VOC speciations
 (((RCP_3PD.or.RCP_45.or.RCP_60.or.RCP_85

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -874,7 +874,7 @@ EOH:
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
-  MW_g: 46.08
+  MW_g: 46.07
   WD_RetFactor: 2.0e-2
 ETHLN:
   DD_F0: 1.0


### PR DESCRIPTION
The AEIC VOC emissions are still being emitted in units of kgC instead of kg species. This bug fix adds the carbon to species scale factors to all AEIC VOC emissions. This requires the definition of two new scale factors, CtoMACR and CtoRCHO. I assigned scale factor IDs 83 and 84 to them.
This bug fix results in an increase in aircraft emissions of ACET, ALD2, ALK4, C2H6, C3H8, PRPE, MACR, and RCHO by up to a factor of 1.6. The resulting changes in modeled trace gas concentrations are small. In a test simulation using GEOS with GEOS-Chem at c90 resolution, changes in species concentrations were less than 1% after one month.