### PR TITLE
[PULL REQUEST] Implement Luo et al 2020 wet deposition algorithm (supersedes PR #522)

### DIFF
--- a/GeosCore/convection_mod.F90
+++ b/GeosCore/convection_mod.F90
@@ -462,6 +462,9 @@ CONTAINS
 ! !DEFINED PARAMETERS:
 !
     REAL(fp), PARAMETER    :: TINYNUM = 1e-14_fp
+#ifdef LUO_WETDEP
+    REAL(fp), PARAMETER    :: pHRain = 5.6_fp
+#endif
 !
 ! !LOCAL VARIABLES:
 !
@@ -1095,6 +1098,9 @@ CONTAINS
                               K,         IC,         BXHEIGHT(K),   &
                               T(K),      QDOWN,      SDT,           &
                               F_WASHOUT, H2O2s(K),   SO2s(K),       &
+#ifdef LUO_WETDEP
+                              pHRain,                               &
+#endif
                               WASHFRAC,  AER,        Input_Opt,     &
                               State_Chm, State_Grid, State_Met,  RC )
 

--- a/GeosCore/flexgrid_read_mod.F90
+++ b/GeosCore/flexgrid_read_mod.F90
@@ -728,12 +728,20 @@ CONTAINS
     ! Read QI
     v_name = "QI"
     CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
+#ifdef LUO_WETDEP
+    State_Met%QI = MAX( 0.0_4, Q )
+#else
     State_Met%QI = Q
+#endif
 
     ! Read QL
     v_name = "QL"
     CALL Get_Met_3D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
+#ifdef LUO_WETDEP
+    State_Met%QL = MAX( 0.0_4, Q )
+#else
     State_Met%QL = Q
+#endif
 
     ! Read TAUCLI
     v_name = "TAUCLI"

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -2381,6 +2381,7 @@ CONTAINS
     REAL(fp),  PARAMETER  :: HPLUS_45  = 3.16227766016837953e-5_fp  !pH = 4.5
     REAL(fp),  PARAMETER  :: HPLUS_50  = 1.0e-5_fp  !pH = 5.0
     REAL(fp),  PARAMETER  :: MINDAT    = 1.e-20_fp
+    REAL(fp),  PARAMETER  :: TNA_CONV  = 31.6_fp * 0.359_fp / 23.0_fp
 !
 ! !LOCAL VARIABLES:
 !
@@ -2430,6 +2431,7 @@ CONTAINS
     REAL(fp)              :: SO4H3_vv, SO4H4_vv            !XW
     REAL(fp)              :: fupdateHOCl_0  !XW
     REAL(fp)              :: HCHOCl, KHOCl, f_srhocl, HOCl0 !XW
+    REAL(fp)              :: one_m_KRATE
 
     ! Arrays
     ! tdf 04/07/08
@@ -2438,9 +2440,9 @@ CONTAINS
     REAL(fp)              :: PSO4_d  (NDSTBIN)
     REAL(fp)              :: PNIT_d  (NDSTBIN)
     REAL(fp)              :: PH2SO4_d(NDSTBIN)
-    REAL(fp)              :: KTN(NDSTBIN)
-    REAL(fp)              :: KTS(NDSTBIN)
-    REAL(fp)              :: KTH(NDSTBIN)
+    REAL(fp)              :: KTN     (NDSTBIN)
+    REAL(fp)              :: KTS     (NDSTBIN)
+    REAL(fp)              :: KTH     (NDSTBIN)
     !tdf KTH now contains the fraction of uptake of H2SO4 on to each of the
     ! dust size bins, based on a size- and area-weighted formulism
     ! (GET_DUST_ALK)
@@ -2458,38 +2460,32 @@ CONTAINS
 
     CHARACTER(LEN=255)    :: ErrMsg, ThisLoc
 
-#ifdef LUO_WETDEP
-    ! For Luo et al wetdep scheme
-    LOGICAL               :: Is_QQ3D
-#endif
-
     !=================================================================
     ! CHEM_SO2 begins here!
     !=================================================================
     IF ( id_H2O2 < 0 .or. id_SO2 < 0  ) RETURN
 
     ! Assume success
-    RC      = GC_SUCCESS
-    ErrMsg  = ''
-    ThisLoc = ' -> at CHEM_SO2 (in module GeosCore/sulfate_mod.F90)'
+    RC          = GC_SUCCESS
+    ErrMsg      = ''
+    ThisLoc     = ' -> at CHEM_SO2 (in module GeosCore/sulfate_mod.F90)'
 
-    ! Initialize
+    ! Copy fields from INPUT_OPT to local variables for use below
     IS_FULLCHEM          =  Input_Opt%ITS_A_FULLCHEM_SIM
     IS_OFFLINE           =  Input_Opt%ITS_AN_AEROSOL_SIM
     LDSTUP               =  Input_Opt%LDSTUP
+    DTCHEM               =  GET_TS_CHEM()
     Spc                  => State_Chm%Species
     SSAlk                => State_Chm%SSAlk
     H2O2s                => State_Chm%H2O2AfterChem
     SO2s                 => State_Chm%SO2AfterChem
     State_Chm%isCloud    =  0.0_fp
-    State_Chm%pHCloud    =  0.0_fp
-    State_Chm%QLxpHCloud =  0.0_fp
-    DTCHEM               =  GET_TS_CHEM()  ! Timestep [s]
-
+    State_Chm%pHcloud    =  0.0_fp
+    State_Chm%QLxpHcloud =  0.0_fp
 #ifdef LUO_WETDEP
-    ! For Luo et al wetdep scheme
-    State_Chm%PSO4s = 0.0_fp
-    Is_QQ3D         = ASSOCIATED( State_Chm%QQ3D )
+    State_Chm%pHrain     =  5.6_fp
+    State_Chm%QQpHrain   =  0.0_fp
+    State_Chm%QQrain     =  0.0_fp
 #endif
 
     ! Factor to convert AIRDEN from [kg air/m3] to [molec air/cm3]
@@ -2570,7 +2566,7 @@ CONTAINS
        ENDIF
     ENDIF
 
-    ! Load emissions into buffer first for ALK1, ALK2 
+    ! Load emissions into buffer first for ALK1, ALK2
     ! BEFORE entering loop (hplin, 9/27/20)
     CALL LoadHcoValEmis ( Input_Opt, State_Grid, id_SALA )
     CALL LoadHcoValEmis ( Input_Opt, State_Grid, id_SALC, AltBuffer=.true. )
@@ -2608,7 +2604,7 @@ CONTAINS
     !$OMP PRIVATE( Mn_d,     FeIII,         MnII,      Fe_d_ant, Fe_d_nat   )&
     !$OMP PRIVATE( HCHOCl,   KHOCl,         f_srhocl,  HOCl0,    L6         )&
     !$OMP PRIVATE( L6S,      fupdateHOBr_0, SRhocl,    L6_1,     SO4H3_vv   )&
-    !$OMP PRIVATE( SO4H4_vv, fupdateHOCl_0, KaqO2,     TNA                  )&
+    !$OMP PRIVATE( SO4H4_vv, fupdateHOCl_0, KaqO2,     TNA,      one_m_KRATE)&
     !$OMP SCHEDULE( DYNAMIC, 1                                              )
     DO L = 1, State_Grid%NZ
     DO J = 1, State_Grid%NY
@@ -2621,6 +2617,12 @@ CONTAINS
 
        ! Skip non-chemistry boxes
        IF ( .not. State_Met%InChemGrid(I,J,L) ) CYCLE
+
+#ifdef LUO_WETDEP
+       ! Save the value of 1.0 - KRATE in a variable,
+       ! as this only has to be computed once per grid box
+       one_m_KRATE = 1.0_fp - State_Chm%KRATE(I,J,L)
+#endif
 
        ! Initial SO2, H2O2, HOBr, and O3 [v/v]
        SO20   = Spc(I,J,L,id_SO2)
@@ -2865,11 +2867,19 @@ CONTAINS
        ! Units: [kg H2O/kg air] * [kg air/m3 air] * [m3 H2O/1e3 kg H2O]
 #ifdef LUO_WETDEP
        ! Luo et al wetdep scheme
-       IF ( Is_QQ3D ) THEN
-          LWC = State_Met%QL(I,J,L) * State_Met%AIRDEN(I,J,L) * 1e-3_fp + &
-                MAX( 0.0_fp, State_Chm%QQ3D(I,J,L) * DTCHEM )
+       LWC = State_Met%QL(I,J,L)                                             &
+           * State_Met%AIRDEN(I,J,L)                                         &
+           * 1e-3_fp                                                         &
+           + MAX( 0.0_fp, State_Chm%QQ3D(I,J,L) * DTCHEM )
+
+       IF( LWC > 0.d0 ) THEN
+          FC = FC                                                            &
+             * LWC                                                           &
+             / ( LWC + MAX( 0.0_fp, State_Met%QI(I,J,L) )                    &
+                     *         State_Met%AIRDEN(I,J,L)                       &
+                     *         1e-3_fp                    )
        ELSE
-          LWC = State_Met%QL(I,J,L) * State_Met%AIRDEN(I,J,L) * 1e-3_fp
+          LWC = 0.d0
        ENDIF
 #else
        ! Default scheme
@@ -2913,7 +2923,11 @@ CONTAINS
        ! Prevent divide-by-zero if LWC=0 (mpayer, 9/6/13)
        IF ( ( FC     > 1.e-4_fp   )  .AND. &
             ( SO2_ss > MINDAT )  .AND. &
+#ifdef LUO_WETDEP
+            ( TK     > 237.0  )  .AND. &
+#else
             ( TK     > 258.0  )  .AND. &
+#endif
             ( LWC    > 0.e+0_fp   ) ) THEN
           !===========================================================
           ! NOTE...Sulfate production from aquatic reactions of SO2
@@ -2991,19 +3005,31 @@ CONTAINS
 	  ! Get sulfate concentration and convert from [v/v] to
           ! [moles/liter]
 	  ! Use a cloud scavenging ratio of 0.7
-          SO4nss  =  Spc(I,J,L,id_SO4) * State_Met%AIRDEN(I,J,L) * &
-                     0.7e+0_fp / ( AIRMW * LWC ) +                 &
-                     Spc(I,J,L,id_SO4s) * State_Met%AIRDEN(I,J,L)  &
-                     / ( AIRMW * LWC)
+#ifdef LUO_WETDEP
+          SO4nss = Spc(I,J,L,id_SO4)    * State_Met%AIRDEN(I,J,L) *         &
+                   one_m_KRATE          / ( AIRMW * LWC )
+#else
+          SO4nss = ( Spc(I,J,L,id_SO4)  * State_Met%AIRDEN(I,J,L) *         &
+                     0.7_fp             / ( AIRMW * LWC )           )       &
+                 + ( Spc(I,J,L,id_SO4s) * State_Met%AIRDEN(I,J,L) /         &
+                     ( AIRMW * LWC )                                )
+#endif
 
           ! Get total ammonia (NH3 + NH4+) concentration [v/v]
           ! Use a cloud scavenging ratio of 0.7 for NH4+
-          TNH3     = ( Spc(I,J,L,id_NH4) * 0.7e+0_fp ) + Spc(I,J,L,id_NH3)
+#ifdef LUO_WETDEP
+          TNH3 = ( Spc(I,J,L,id_NH4) * one_m_KRATE ) + Spc(I,J,L,id_NH3)
+#else
+          TNH3 = ( Spc(I,J,L,id_NH4) * 0.7_fp      ) + Spc(I,J,L,id_NH3)
+#endif
 
           ! Get total chloride (SALACL + HCL) concentration [v/v]
           ! Use a cloud scavenging ratio of 0.7
-          CL  = ( Spc(I,J,L,id_SALACL) * 0.7e+0_fp ) + &
-                  Spc(I,J,L,id_SALCCL)
+#ifdef LUO_WETDEP
+          CL = ( Spc(I,J,L,id_SALACL) * one_m_KRATE ) + Spc(I,J,L,id_SALCCL)
+#else
+          CL = ( Spc(I,J,L,id_SALACL) * 0.7_fp )      + Spc(I,J,L,id_SALCCL)
+#endif
           IF ( id_HCl > 0 ) THEN
              CL = CL + Spc(I,J,L,id_HCL)
           ELSE
@@ -3033,13 +3059,19 @@ CONTAINS
           ! NVC is calculated to balance initial Cl- + alkalinity in
           ! seas salt. Note that we should not consider SO4ss here.
           ! Use a cloud scavenging ratio of 0.7 for fine aerosols
-          TNA      = Spc(I,J,L,id_SALA) * State_Met%AIRDEN(I,J,L) *   &
-                      ( 31.6e+0_fp * 0.359e+0_fp / 23.e+0_fp ) *     &
-                      0.7e+0_fp / ( AIRMW * LWC )  +                 &
-                      Spc(I,J,L,id_SALC) * State_Met%AIRDEN(I,J,L) * &
-                      ( 31.6e+0_fp * 0.359e+0_fp / 23.e+0_fp )       &
-                      / ( AIRMW * LWC )
-
+#ifdef LUO_WETDEP
+          TNA = ( Spc(I,J,L,id_SALA) * State_Met%AIRDEN(I,J,L)   *           &
+                  TNA_CONV           * one_m_KRATE               /           &
+                  ( AIRMW * LWC )                                  )         &
+              + ( Spc(I,J,L,id_SALC) * State_Met%AIRDEN(I,J,L)   *           &
+                  TNA_CONV           / ( AIRMW * LWC )             )
+#else
+          TNA = ( Spc(I,J,L,id_SALA) * State_Met%AIRDEN(I,J,L)   *           &
+                  TNA_CONV           * 0.7_fp                    /           &
+                  ( AIRMW * LWC )                                  )         &
+              + ( Spc(I,J,L,id_SALC) * State_Met%AIRDEN(I,J,L)   *           &
+                  TNA_CONV           / ( AIRMW * LWC )             )
+#endif
           ! Get total dust cation concentration [mol/L]
           ! Use a cloud scavenging ratio of 1 for dust
           ! to be consistent for how it was calculated for
@@ -3055,13 +3087,19 @@ CONTAINS
           ! jmm (12/3/18)
           !
           ! Get dust concentrations [v/v -> ng/m3]
-
-          DUST = ( Spc(I,J,L,id_DST1)*0.7 + Spc(I,J,L,id_DST2) +       &
-                       Spc(I,J,L,id_DST3) + Spc(I,J,L,id_DST4) ) * &
-                       1.e+12_fp * State_Met%AD(I,J,L)             &
-                       / ( AIRMW                                   &
-                         / State_Chm%SpcData(id_DST1)%Info%MW_g )&
-                       / State_Met%AIRVOL(I,J,L)
+#ifdef LUO_WETDEP
+          DUST = ( Spc(I,J,L,id_DST1)*one_m_KRATE + Spc(I,J,L,id_DST2) +     &
+                   Spc(I,J,L,id_DST3)             + Spc(I,J,L,id_DST4)   )   &
+               * 1.e+12_fp * State_Met%AD(I,J,L)                             &
+               / ( AIRMW   / State_Chm%SpcData(id_DST1)%Info%MW_g        )   &
+               / State_Met%AIRVOL(I,J,L)
+#else
+          DUST = ( Spc(I,J,L,id_DST1)*0.7_fp + Spc(I,J,L,id_DST2) +          &
+                   Spc(I,J,L,id_DST3)        + Spc(I,J,L,id_DST4)   )        &
+               * 1.e+12_fp * State_Met%AD(I,J,L)                             &
+               / ( AIRMW   / State_Chm%SpcData(id_DST1)%Info%MW_g )          &
+               / State_Met%AIRVOL(I,J,L)
+#endif
 
           ! Conversion from dust mass to Ca2+ and Mg2+ mol:
           !     0.071*(1/40.08)+0.011*(1/24.31) = 2.22e-3
@@ -3072,9 +3110,15 @@ CONTAINS
           ! Get total nitrate (HNO3 + NIT) concentrations [v/v]
           ! Use a cloud scavenging ratio of 0.7 for NIT
           IF ( IS_FULLCHEM ) THEN
-             TNO3 = Spc(I,J,L,id_HNO3) +             &
-                  (Spc(I,J,L,id_NIT) * 0.7e+0_fp ) + &
-                  Spc(I,J,L,id_NITs)
+#ifdef LUO_WETDEP
+             TNO3 = ( Spc(I,J,L,id_HNO3)                                     &
+                  +   Spc(I,J,L,id_NIT )                                     &
+                  +   Spc(I,J,L,id_NITs) ) * one_m_KRATE
+#else
+             TNO3 = Spc(I,J,L,id_HNO3)                                       &
+                  + ( Spc(I,J,L,id_NIT) * 0.7_fp )                           &
+                  + Spc(I,J,L,id_NITs)
+#endif
              GNO3 = Spc(I,J,L,id_HNO3) !For Fahey & Pandis decision algorithm
           ELSE IF ( IS_OFFLINE ) THEN
              TANIT = Spc(I,J,L,id_NIT) !aerosol nitrate [v/v]
@@ -3727,16 +3771,6 @@ CONTAINS
        ! Add L5S (qjc, 11/04/16)
        PSO4_SO2(I,J,L) = L1 + L2S + L3S + L4S + L5S + PSO4E + SR + L6S
 
-#ifdef LUO_WETDEP
-       ! Luo et al scheme: archive PSO4s
-       IF ( (PSO4_SO2(I,J,L) + Spc(I,J,L,id_SO4) ) > 1.0e-30_fp ) THEN
-          State_Chm%PSO4s(I,J,L) = L2S + L3S + L4S + L5S + SR
-          State_Chm%PSO4s(I,J,L) = State_Chm%PSO4s(I,J,L) &
-                                   / (PSO4_SO2(I,J,L)+Spc(I,J,L,id_SO4))
-       ELSE
-          State_Chm%PSO4s(I,J,L) = 0.0_fp
-       ENDIF
-#endif
        ! Production of sulfate on sea salt
        PSO4_ss (I,J,L) = PSO4F
 
@@ -3865,6 +3899,33 @@ CONTAINS
              ENDIF
           ENDIF
        ENDIF
+#ifdef LUO_WETDEP
+       ! Luo et al 2020 wtdep
+       IF( SUM( State_Chm%QQ3D    (I,J,L:State_Grid%NZ) *                    &
+                State_Met%BXHEIGHT(I,J,L:State_Grid%NZ)   ) > 1.D-30 ) THEN
+
+         State_Chm%pHRain(I,J,L) =                                           &
+              SUM( State_Chm%pHCloud (I,J,L:State_Grid%NZ)    *              &
+                   State_Chm%QQ3D    (I,J,L:State_Grid%NZ)    *              &
+                   State_Met%BXHEIGHT(I,J,L:State_Grid%NZ) )  /              &
+              SUM( State_Chm%QQ3D    (I,J,L:State_Grid%NZ)    *              &
+                   State_Met%BXHEIGHT(I,J,L:State_Grid%NZ) )
+
+         State_Chm%QQpHRain(I,J,L) =                                         &
+              SUM( State_Chm%pHCloud (I,J,L:State_Grid%NZ)    *              &
+                   State_Chm%QQ3D    (I,J,L:State_Grid%NZ)    *              &
+                   State_Met%BXHEIGHT(I,J,L:State_Grid%NZ) )
+
+         State_Chm%QQRain(I,J,L) =                                           &
+              SUM( State_Chm%QQ3D    (I,J,L:State_Grid%NZ)    *              &
+                   State_Met%BXHEIGHT(I,J,L:State_Grid%NZ) )
+       ELSE
+          ! Default wetdep scheme
+         State_Chm%pHrain(I,J,L)   = 5.6D0
+         State_Chm%QQpHrain(I,J,L) = 0.D0
+         State_Chm%QQrain(I,J,L)   = 0.D0
+       ENDIF
+#endif
 
     ENDDO
     ENDDO
@@ -3876,10 +3937,10 @@ CONTAINS
     IF ( ASSOCIATED( NDENS_SALC ) ) DEALLOCATE ( NDENS_SALC )
 
     ! Free pointers
-    Spc     => NULL()
-    SSAlk   => NULL()
-    H2O2s   => NULL()
-    SO2s    => NULL()
+    Spc        => NULL()
+    SSAlk      => NULL()
+    H2O2s      => NULL()
+    SO2s       => NULL()
     NDENS_SALA => NULL()
     NDENS_SALC => NULL()
 
@@ -5008,7 +5069,11 @@ CONTAINS
 
     ! Non-volatile aerosol concentration [M]
     ! For now sulfate is the only non-volatile species
-    D = (2.e+0_fp*SO4nss) - TNA - (2.e+0_fp*TDCA)
+#ifdef LUO_WETDEP
+    D = ( 1.5_fp * SO4nss ) - TNA - ( 2.0_fp * TDCA )
+#else
+    D = ( 2.0_fp * SO4nss ) - TNA - ( 2.0_fp * TDCA )
+#endif
 
     ! Temperature dependent water equilibrium constant
     Kw_T = Kw*exp(DhrKw*((1.e+0_fp/T)-(1.e+0_fp/298.e+0_fp)))
@@ -5982,13 +6047,18 @@ CONTAINS
 ! !DEFINED PARAMETERS:
 !
     ! NH3 dissociation contants
-    REAL(fp),  PARAMETER  :: Ka1 = 1.7e-5
-    REAL(fp),  PARAMETER  :: Hnh3 = 60.
-    REAL(fp),  PARAMETER  :: Dhnh3 = 4200e+0_fp
-    REAL(fp),  PARAMETER  :: DhrKa1 = -450.
+    REAL(fp),  PARAMETER  :: Ka1    =  1.7e-5_fp
+    REAL(fp),  PARAMETER  :: Dhnh3  =  4200.0_fp
+#ifdef LUO_WETDEP
+    REAL(fp),  PARAMETER  :: Hnh3   =  59.8_fp
+    REAL(fp),  PARAMETER  :: DhrKa1 = -4325.0_fp
+#else
+    REAL(fp),  PARAMETER  :: Hnh3   =  60.0_fp
+    REAL(fp),  PARAMETER  :: DhrKa1 = -450.0_fp
+#endif
 
     ! Variables
-    REAL(fp)              :: Hnh3_T, Ka1_T
+    REAL(fp)              :: Hnh3_T,  Ka1_T
     REAL(fp)              :: Hnh3eff, xNH3, pNH3
 
     !=================================================================
@@ -6009,8 +6079,7 @@ CONTAINS
   END FUNCTION kNH3
 !EOC
 !------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model
-!                  !
+!                  GEOS-Chem Global Chemical Transport Model                  !
 !------------------------------------------------------------------------------
 !BOP
 !
@@ -6021,16 +6090,16 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-      FUNCTION dkNH3 ( P, T, LWC, HPLUS, NH3, Kw ) RESULT ( KNH3p )
+  FUNCTION dkNH3 ( P, T, LWC, HPLUS, NH3, Kw ) RESULT ( KNH3p )
 !
 
 ! !INPUT PARAMETERS:
 !
-      REAL(fp),  INTENT(IN) :: T, P, LWC, HPLUS, NH3, Kw
+    REAL(fp),  INTENT(IN) :: T, P, LWC, HPLUS, NH3, Kw
 !
 ! !OUTPUT PARAMETERS:
 !
-      REAL(fp)              :: KNH3p
+    REAL(fp)              :: KNH3p
 !
 ! !REVISION HISTORY:
 !  25 Jan 2012 - M. Payer    - Added ProTeX headers
@@ -6053,35 +6122,39 @@ CONTAINS
 !
 ! !DEFINED PARAMETERS:
 !
-      ! NH3 dissociation contants
-      REAL(fp),  PARAMETER  :: Ka1 = 1.7e-5
-      REAL(fp),  PARAMETER  :: Hnh3 = 60.
-      REAL(fp),  PARAMETER  :: Dhnh3 = 4200e+0_fp
-      REAL(fp),  PARAMETER  :: DhrKa1 = -450.
+    ! NH3 dissociation contants
+    REAL(fp),  PARAMETER  :: Ka1    =  1.7e-5_fp
+    REAL(fp),  PARAMETER  :: Dhnh3  =  4200.0_fp
+#ifdef LUO_WETDEP
+    REAL(fp),  PARAMETER  :: Hnh3   =  59.8_fp
+    REAL(fp),  PARAMETER  :: DhrKa1 = -4325.0_fp
+#else
+    REAL(fp),  PARAMETER  :: Hnh3   =  60.0_fp
+    REAL(fp),  PARAMETER  :: DhrKa1 = -450.0_fp
+#endif
 
-      ! Variables
-      REAL(fp)              :: Hnh3_T, Ka1_T
+    ! Variables
+    REAL(fp)              :: Hnh3_T, Ka1_T
 
-      !=================================================================
-      ! dkNH3 begins here!
-      !=================================================================
+    !=================================================================
+    ! dkNH3 begins here!
+    !=================================================================
 
-      !NH3 dissolution constants
-      Hnh3_T = Hnh3*exp(Dhnh3*((1.e+0_fp/T)-(1.e+0_fp/298.e+0_fp)))
-      Ka1_T = Ka1*exp(DhrKa1*((1.e+0_fp/T)-(1.e+0_fp/298.e+0_fp)))
+    !NH3 dissolution constants
+    Hnh3_T = Hnh3*exp(Dhnh3*((1.e+0_fp/T)-(1.e+0_fp/298.e+0_fp)))
+    Ka1_T = Ka1*exp(DhrKa1*((1.e+0_fp/T)-(1.e+0_fp/298.e+0_fp)))
 
-      !NH3 dissolutionnyn
+    !NH3 dissolutionnyn
 
-      KNH3p = Ka1_T * Hnh3_T * NH3 * Kw * P * ( 1.0e+0_fp +    &
-           Hnh3_T * 0.08205e+0_fp * T * LWC ) /                &
-           ( Hnh3_T * 0.08205e+0_fp * T * LWC * ( Kw + Ka1_T * &
-           HPLUS ) + Kw)**2
+    KNH3p = Ka1_T * Hnh3_T * NH3 * Kw * P * ( 1.0e+0_fp +    &
+         Hnh3_T * 0.08205e+0_fp * T * LWC ) /                &
+         ( Hnh3_T * 0.08205e+0_fp * T * LWC * ( Kw + Ka1_T * &
+         HPLUS ) + Kw)**2
 
-      END FUNCTION dkNH3
+  END FUNCTION dkNH3
 !EOC
 !------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model
-!                  !
+!                  GEOS-Chem Global Chemical Transport Model                  !
 !------------------------------------------------------------------------------
 !BOP
 !
@@ -6092,16 +6165,16 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-      FUNCTION kFA ( P, T, LWC, HPLUS, FA ) RESULT ( kFAp )
+  FUNCTION kFA ( P, T, LWC, HPLUS, FA ) RESULT ( kFAp )
 !
 
 ! !INPUT PARAMETERS:
 !
-      REAL(fp),  INTENT(IN) :: T, P, LWC, HPLUS, FA
+    REAL(fp),  INTENT(IN) :: T, P, LWC, HPLUS, FA
 !
 ! !OUTPUT PARAMETERS:
 !
-      REAL(fp)              :: KFAp
+    REAL(fp)              :: KFAp
 !
 ! !REVISION HISTORY:
 !  25 Jan 2012 - M. Payer    - Added ProTeX headers
@@ -6126,35 +6199,35 @@ CONTAINS
 !
 ! !DEFINED PARAMETERS:
 !
-      ! HCOOH dissociation constants
-      REAL(fp),  PARAMETER  :: Kformate = 1.8e-4_fp ! equib const
-      REAL(fp),  PARAMETER  :: Hfa = 8800e+0_fp ! henry const
-      REAL(fp),  PARAMETER  :: Dhfa = 6100e+0_fp ! henry temp
-      REAL(fp),  PARAMETER  :: DhrKfa = 151.e+0_fp ! equib temp
+    ! HCOOH dissociation constants
+    REAL(fp),  PARAMETER  :: Kformate = 1.8e-4_fp ! equib const
+    REAL(fp),  PARAMETER  :: Hfa      = 8800.0_fp ! henry const
+    REAL(fp),  PARAMETER  :: Dhfa     = 6100.0_fp ! henry temp
+    REAL(fp),  PARAMETER  :: DhrKfa   = 151.0_fp  ! equib temp
 !
 ! !LOCAL VARIABLES:
 !
-      REAL(fp)              :: Hfa_T, Kfa_T
-      REAL(fp)              :: Hfaeff, xFA, pFA
+    REAL(fp)              :: Hfa_T, Kfa_T
+    REAL(fp)              :: Hfaeff, xFA, pFA
 
-      !=================================================================
-      ! kFA begins here!
-      !=================================================================
+    !=================================================================
+    ! kFA begins here!
+    !=================================================================
 
-      ! Formic acid dissolution constants
-      HFA_T = Hfa*exp(Dhfa*((1.0e+0_fp/T)-(1.0e+0_fp/298.0e+0_fp)))
-      Kfa_T = Kformate*exp(DhrKfa*((1.0e+0_fp/T) &
-           - (1.0e+0_fp/298.0e+0_fp)))
+    ! Formic acid dissolution constants
+    HFA_T = Hfa*exp(Dhfa*((1.0e+0_fp/T)-(1.0e+0_fp/298.0e+0_fp)))
+    Kfa_T = Kformate*exp(DhrKfa*((1.0e+0_fp/T) &
+         - (1.0e+0_fp/298.0e+0_fp)))
 
-      !HCOOH  dissolution
-      Hfaeff = Hfa_T*(1.0e+0_fp+(Kfa_T/HPLUS))
-      xFA = 1.0e+0_fp / ( 1.0e+0_fp &
-          + ( Hfaeff * 0.08205e+0_fp * T * LWC ) )
-      pFA = FA * P * xFA
+    !HCOOH  dissolution
+    Hfaeff = Hfa_T*(1.0e+0_fp+(Kfa_T/HPLUS))
+    xFA = 1.0e+0_fp / ( 1.0e+0_fp &
+         + ( Hfaeff * 0.08205e+0_fp * T * LWC ) )
+    pFA = FA * P * xFA
 
-      kFAp = Hfa_T * Kfa_T * pFA / HPLUS
+    kFAp = Hfa_T * Kfa_T * pFA / HPLUS
 
-      END FUNCTION kFA
+  END FUNCTION kFA
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model
@@ -6278,9 +6351,9 @@ CONTAINS
 !
       ! CH3HCOOH dissociation constants
       REAL(fp),  PARAMETER  :: Kacetate = 1.75e-5_fp
-      REAL(fp),  PARAMETER  :: Haa = 4100e+0_fp
-      REAL(fp),  PARAMETER  :: Dhaa = 6200e+0_fp
-      REAL(fp),  PARAMETER  :: DhrKaa = 50.0e+0_fp
+      REAL(fp),  PARAMETER  :: Haa      = 4100.0_fp
+      REAL(fp),  PARAMETER  :: Dhaa     = 6200.0_fp
+      REAL(fp),  PARAMETER  :: DhrKaa   = 50.0_fp
 !
 ! !LOCAL VARIABLES:
 !
@@ -6353,9 +6426,9 @@ CONTAINS
 !
       ! HCOOH dissociation constants
       REAL(fp),  PARAMETER  :: Kacetate = 1.75e-5_fp
-      REAL(fp),  PARAMETER  :: Haa = 4100e+0_fp
-      REAL(fp),  PARAMETER  :: Dhaa = 6200e+0_fp
-      REAL(fp),  PARAMETER  :: DhrKaa = 50.0e+0_fp
+      REAL(fp),  PARAMETER  :: Haa      = 4100.0_fp
+      REAL(fp),  PARAMETER  :: Dhaa     = 6200.0_fp
+      REAL(fp),  PARAMETER  :: DhrKaa   = 50.0_fp
 !
 ! !LOCAL VARIABLES:
 !

--- a/Headers/species_database_mod.F90
+++ b/Headers/species_database_mod.F90
@@ -116,15 +116,29 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
+    LOGICAL                     :: found_dd_dvzaersnow_luo
+    LOGICAL                     :: found_dd_dvzminval_luo
+    LOGICAL                     :: found_henry_cr_luo
+    LOGICAL                     :: found_henry_k0_luo
+    LOGICAL                     :: found_wd_convfaci2g_luo
+    LOGICAL                     :: found_wd_kcscalefac_luo
+    LOGICAL                     :: found_wd_liqandgas_luo
+    LOGICAL                     :: found_wd_rainouteff_luo
+    LOGICAL                     :: found_wd_retfactor_luo
+    LOGICAL                     :: no_luo
     LOGICAL                     :: prtDebug
     LOGICAL                     :: v_bool
-    LOGICAL                     :: wd_kcscalefac_luo_found
-    LOGICAL                     :: wd_rainouteff_luo_found
+    LOGICAL                     :: wd_liqandgas_luo
     INTEGER                     :: v_int
     INTEGER                     :: nSpecies
     INTEGER                     :: N
     INTEGER                     :: S
     REAL(f4)                    :: v_real
+    REAL(f4)                    :: dd_dvzaersnow_luo
+    REAL(f4)                    :: henry_cr_luo
+    REAL(f4)                    :: henry_k0_luo
+    REAL(f4)                    :: wd_convfaci2g_luo
+    REAL(f4)                    :: wd_retfactor_luo
 
     ! Strings
     CHARACTER(LEN=14)           :: tag
@@ -137,11 +151,12 @@ CONTAINS
     ! Arrays
     REAL(f4)                    :: a_real_2(2)
     REAL(f4)                    :: a_real_3(3)
+    REAL(f4)                    :: dd_dvzminval_luo(2)
     REAL(f4)                    :: wd_kcscalefac_luo(3)
     REAL(f4)                    :: wd_rainouteff_luo(3)
 
     ! String arrays
-    CHARACTER(LEN=17)           :: tags(41)
+    CHARACTER(LEN=17)           :: tags(48)
 
     ! Objects
     TYPE(QFYAML_t)              :: yml
@@ -180,7 +195,9 @@ CONTAINS
              "DD_AeroDryDep    ",  &
              "DD_DustDryDep    ",  &
              "DD_DvzAerSnow    ",  &
+             "DD_DvzAerSnow_Luo",  &
              "DD_DvzMinVal     ",  &
+             "DD_DvzMinVal_Luo ",  &
              "DD_F0            ",  &
              "DD_Hstar         ",  &
              "DD_KOA           ",  &
@@ -199,7 +216,9 @@ CONTAINS
              "Is_RadioNuclide  ",  &
              "Is_WetDep        ",  &
              "Henry_CR         ",  &
+             "Henry_CR_Luo     ",  &
              "Henry_K0         ",  &
+             "Henry_K0_Luo     ",  &
              "Henry_pKa        ",  &
              "MP_SizeResAer    ",  &
              "MP_SizeResNum    ",  &
@@ -208,15 +227,18 @@ CONTAINS
              "WD_AerScavEff    ",  &
              "WD_CoarseAer     ",  &
              "WD_ConvFacI2G    ",  &
-             "WD_KcScaleFac_Luo",  &
+             "WD_ConvFacI2G_Luo",  &
              "WD_KcScaleFac    ",  &
+             "WD_KcScaleFac_Luo",  &
              "WD_Is_H2SO4      ",  &
              "WD_Is_HNO3       ",  &
              "WD_Is_SO2        ",  &
              "WD_LiqAndGas     ",  &
-             "WD_RainoutEff_Luo",  &
+             "WD_LiqAndGas_Luo ",  &
              "WD_RainoutEff    ",  &
-             "WD_RetFactor     "   /)
+             "WD_RainoutEff_Luo",  &
+             "WD_RetFactor     ",  &
+             "WD_RetFactor_Luo "   /)
 
     !=======================================================================
     ! Store the list unique GEOS-Chem species names in work arrays for use
@@ -312,8 +334,15 @@ CONTAINS
        !--------------------------------------------------------------------
        ! Initialize found flags
        !-------------------------------------------------------------------
-       wd_kcscalefac_luo_found = .FALSE.
-       wd_rainouteff_luo_found = .FALSE.
+       found_dd_dvzaersnow_luo = .FALSE.
+       found_dd_dvzminval_luo  = .FALSE.
+       found_henry_cr_luo      = .FALSE.
+       found_henry_k0_luo      = .FALSE.
+       found_wd_convfaci2g_luo = .FALSE.
+       found_wd_kcscalefac_luo = .FALSE.
+       found_wd_liqandgas_luo  = .FALSE.
+       found_wd_rainouteff_luo = .FALSE.
+       found_wd_retfactor_luo  = .FALSE.
 
        !--------------------------------------------------------------------
        ! Loop over the remaining tags in the species database and
@@ -334,6 +363,9 @@ CONTAINS
           ! Create search key for each variable
           key = TRIM( spc ) // '%' // TRIM( tags(N) )
 
+          ! Set a flag if "Luo" is not found in the key 
+          no_luo = ( INDEX( key, "Luo" ) <= 0 )
+          
           ! Save into the proper field of the species database
           ! NOTE: Attempt to round off values to 2 decimal places,
           ! unless the values can be either too large or too small
@@ -354,16 +386,33 @@ CONTAINS
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%DD_DustDryDep = v_bool
 
-          ELSE IF ( INDEX( key, "%DD_DvzAerSnow" ) > 0 ) THEN
+          ELSE IF ( INDEX( key, "%DD_DvzAerSnow" ) >  0  .and. no_luo ) THEN
              CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%DD_DvzAerSnow = Cast_and_RoundOff( v_real )
 
-          ELSE IF ( INDEX( key, "%DD_DvzMinVal" ) > 0 ) THEN
+          ELSE IF ( INDEX( key, "%DD_DvzAerSnow_Luo" ) > 0 ) THEN
+             CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             dd_dvzaersnow_luo = Cast_and_RoundOff( v_real )
+             IF ( dd_dvzaersnow_luo /= MISSING_R4 ) THEN
+                found_dd_dvzaersnow_luo = .TRUE.
+             ENDIF             
+             
+          ELSE IF ( INDEX( key, "%DD_DvzMinVal" ) > 0 .and. no_luo ) THEN
              CALL QFYAML_Add_Get( yml, key, a_real_2, "", RC )
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%DD_DvzMinVal(1) = Cast_and_RoundOff( a_real_2(1) )
              ThisSpc%DD_DvzMinVal(2) = Cast_and_RoundOff( a_real_2(2) )
+
+          ELSE IF ( INDEX( key, "%DD_DvzMinVal_Luo" ) > 0 ) THEN
+             CALL QFYAML_Add_Get( yml, key, a_real_2, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             dd_dvzminval_luo(1) = Cast_and_RoundOff( a_real_2(1) )
+             dd_dvzminval_luo(2) = Cast_and_RoundOff( a_real_2(2) )
+             IF ( dd_dvzminval_luo(1) /= MISSING_R4 ) THEN
+                found_dd_dvzminval_luo = .TRUE.
+             ENDIF  
 
           ELSE IF ( INDEX( key, "%DD_F0" ) > 0 ) THEN
              CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
@@ -395,15 +444,31 @@ CONTAINS
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%FullName = TRIM( v_str )
 
-          ELSE IF ( INDEX( key, "%Henry_CR" ) > 0 ) THEN
+          ELSE IF ( INDEX( key, "%Henry_CR" ) > 0 .and. no_luo ) THEN
              CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%Henry_CR = DBLE( v_real )       ! Don't round off
 
-          ELSE IF ( INDEX( key, "%Henry_K0" ) > 0 ) THEN
+          ELSE IF ( INDEX( key, "%Henry_CR_Luo" ) > 0 ) THEN
+             CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             henry_cr_luo = DBLE( v_real )           ! Don't round off
+             IF ( henry_cr_luo /= MISSING_R4 ) THEN
+                found_henry_cr_luo = .TRUE.
+             ENDIF
+
+          ELSE IF ( INDEX( key, "%Henry_K0" ) > 0 .and. no_luo ) THEN
              CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%Henry_K0 = DBLE( v_real )       ! Don't round off
+
+          ELSE IF ( INDEX( key, "%Henry_K0_Luo" ) > 0 ) THEN
+             CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             henry_k0_luo = DBLE( v_real )           ! Don't round off
+             IF ( henry_k0_luo /= MISSING_R4 ) THEN
+                found_henry_k0_luo = .TRUE.
+             ENDIF
 
           ELSE IF ( INDEX( key, "%Is_Aerosol" ) > 0  ) THEN
              CALL QFYAML_Add_Get( yml, key, v_bool, "", RC )
@@ -534,10 +599,25 @@ CONTAINS
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%WD_CoarseAer = v_bool
 
-          ELSE IF ( INDEX( key, "%WD_ConvFacI2G" ) > 0 ) THEN
+          ELSE IF ( INDEX( key, "%WD_ConvFacI2G" ) > 0 .and. no_luo ) THEN
              CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%WD_ConvFacI2G = DBLE( v_real )  ! Don't round off
+
+          ELSE IF ( INDEX( key, "%WD_ConvFacI2G_Luo" ) > 0 ) THEN
+             CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             wd_convfaci2g_luo = DBLE( v_real )      ! Don't round off
+             IF ( wd_convfaci2g_luo /= MISSING_R4 ) THEN
+                found_wd_convfaci2g_luo = .TRUE.
+             ENDIF
+
+          ELSE IF ( INDEX( key, "%WD_KcScaleFac" ) > 0  .and. no_luo ) THEN
+             CALL QFYAML_Add_Get( yml, key, a_real_3, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             ThisSpc%WD_KcScaleFac(1) = Cast_and_RoundOff( a_real_3(1) )
+             ThisSpc%WD_KcScaleFac(2) = Cast_and_RoundOff( a_real_3(2) )
+             ThisSpc%WD_KcScaleFac(3) = Cast_and_RoundOff( a_real_3(3) )
 
           ELSE IF ( INDEX( key, "%WD_KcScaleFac_Luo" ) > 0 ) THEN
              CALL QFYAML_Add_Get( yml, key, a_real_3, "", RC )
@@ -546,16 +626,8 @@ CONTAINS
              wd_kcscalefac_luo(2) = Cast_and_RoundOff( a_real_3(2) )
              wd_kcscalefac_luo(3) = Cast_and_RoundOff( a_real_3(3) )
              IF ( wd_kcscalefac_luo(1) /= MISSING_R4 ) THEN
-                wd_kcscalefac_luo_found = .TRUE.
+                found_wd_kcscalefac_luo = .TRUE.
              ENDIF
-
-          ELSE IF ( INDEX( key, "%WD_KcScaleFac" ) > 0 .AND. &
-                    INDEX( key, "Luo" ) <= 0 ) THEN
-             CALL QFYAML_Add_Get( yml, key, a_real_3, "", RC )
-             IF ( RC /= GC_SUCCESS ) GOTO 999
-             ThisSpc%WD_KcScaleFac(1) = Cast_and_RoundOff( a_real_3(1) )
-             ThisSpc%WD_KcScaleFac(2) = Cast_and_RoundOff( a_real_3(2) )
-             ThisSpc%WD_KcScaleFac(3) = Cast_and_RoundOff( a_real_3(3) )
 
           ELSE IF ( INDEX( key, "%WD_Is_H2SO4" ) > 0 ) THEN
              CALL QFYAML_Add_Get( yml, key, v_bool, "", RC )
@@ -572,10 +644,23 @@ CONTAINS
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%WD_Is_SO2 = v_bool
 
-          ELSE IF ( INDEX( key, "%WD_LiqAndGas" ) > 0 ) THEN
+          ELSE IF ( INDEX( key, "%WD_LiqAndGas" ) > 0 .and. no_luo ) THEN
              CALL QFYAML_Add_Get( yml, key, v_bool, "", RC )
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%WD_LiqAndGas = v_bool
+
+          ELSE IF ( INDEX( key, "%WD_LiqAndGas_Luo" ) > 0 ) THEN
+             CALL QFYAML_Add_Get( yml, key, v_bool, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             wd_liqandgas_luo = v_bool
+             found_wd_liqandgas_luo = wd_liqandgas_luo
+
+          ELSE IF ( INDEX( key, "%WD_RainoutEff" ) > 0 .and. no_luo ) THEN
+             CALL QFYAML_Add_Get( yml, key, a_real_3, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             ThisSpc%WD_RainoutEff(1) = Cast_and_RoundOff( a_real_3(1) )
+             ThisSpc%WD_RainoutEff(2) = Cast_and_RoundOff( a_real_3(2) )
+             ThisSpc%WD_RainoutEff(3) = Cast_and_RoundOff( a_real_3(3) )
 
           ELSE IF ( INDEX( key, "%WD_RainoutEff_Luo" ) > 0 ) THEN
              CALL QFYAML_Add_Get( yml, key, a_real_3, "", RC )
@@ -584,21 +669,21 @@ CONTAINS
              wd_rainouteff_luo(2) = Cast_and_RoundOff( a_real_3(2) )
              wd_rainouteff_luo(3) = Cast_and_RoundOff( a_real_3(3) )
              IF ( wd_rainouteff_luo(1) /= MISSING_R4 ) THEN
-                wd_rainouteff_luo_found = .TRUE.
+                found_wd_rainouteff_luo = .TRUE.
              ENDIF
 
-          ELSE IF ( INDEX( key, "%WD_RainoutEff" ) > 0 .AND. &
-                    INDEX( key, "Luo" ) <= 0 ) THEN
-             CALL QFYAML_Add_Get( yml, key, a_real_3, "", RC )
-             IF ( RC /= GC_SUCCESS ) GOTO 999
-             ThisSpc%WD_RainoutEff(1) = Cast_and_RoundOff( a_real_3(1) )
-             ThisSpc%WD_RainoutEff(2) = Cast_and_RoundOff( a_real_3(2) )
-             ThisSpc%WD_RainoutEff(3) = Cast_and_RoundOff( a_real_3(3) )
-
-          ELSE IF ( INDEX( key, "%WD_RetFactor" ) > 0 ) THEN
+          ELSE IF ( INDEX( key, "%WD_RetFactor" ) > 0 .and. no_luo ) THEN
              CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
              IF ( RC /= GC_SUCCESS ) GOTO 999
              ThisSpc%WD_RetFactor = Cast_and_RoundOff( v_real )
+
+          ELSE IF ( INDEX( key, "%WD_RetFactor_Luo" ) > 0 ) THEN
+             CALL QFYAML_Add_Get( yml, key, v_real, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             wd_retfactor_luo = Cast_and_RoundOff( v_real )
+             IF ( wd_retfactor_luo /= MISSING_R4 ) THEN
+                found_wd_retfactor_luo = .TRUE.
+             ENDIF
 
           ELSE
              ! Pass
@@ -608,16 +693,49 @@ CONTAINS
        ENDDO
 
 #ifdef LUO_WETDEP
+       !--------------------------------------------------------------------
+       ! For Luo et al 2020 wetdep
        ! Overwrite with special values if present in file
-       IF ( wd_kcscalefac_luo_found ) THEN
+       !--------------------------------------------------------------------
+       IF ( found_dd_dvzaersnow_luo ) THEN
+          ThisSpc%DD_DvzAerSnow = dd_dvzaersnow_luo
+       ENDIF
+
+       IF ( found_dd_dvzminval_luo ) THEN
+          ThisSpc%DD_DvzMinVal(1) = dd_dvzminval_luo(1)
+          ThisSpc%DD_DvzMinVal(2) = dd_dvzminval_luo(2)
+       ENDIF
+
+       IF ( found_henry_cr_luo ) THEN
+          ThisSpc%Henry_CR = henry_cr_luo
+       ENDIF
+
+       IF ( found_henry_k0_luo ) THEN
+          ThisSpc%Henry_K0 = henry_k0_luo
+       ENDIF
+
+       IF ( found_wd_convfaci2g_luo ) THEN
+          ThisSpc%WD_RetFactor = wd_convfaci2g_luo
+       ENDIF
+
+       IF ( found_wd_liqandgas_luo ) THEN
+          ThisSpc%WD_LiqAndGas = wd_liqandgas_luo
+       ENDIF
+
+       IF ( found_wd_kcscalefac_luo ) THEN
           ThisSpc%WD_KcScaleFac(1) = wd_kcscalefac_luo(1)
           ThisSpc%WD_KcScaleFac(2) = wd_kcscalefac_luo(2)
           ThisSpc%WD_KcScaleFac(3) = wd_kcscalefac_luo(3)
        ENDIF
-       IF ( wd_rainouteff_luo_found ) THEN
+
+       IF ( found_wd_rainouteff_luo ) THEN
           ThisSpc%WD_RainoutEff(1) = wd_rainouteff_luo(1)
           ThisSpc%WD_RainoutEff(2) = wd_rainouteff_luo(2)
           ThisSpc%WD_RainoutEff(3) = wd_rainouteff_luo(3)
+       ENDIF
+
+       IF ( found_wd_retfactor_luo ) THEN
+          ThisSpc%WD_RetFactor = wd_retfactor_luo
        ENDIF
 #endif
 
@@ -659,7 +777,9 @@ CONTAINS
              CASE( 'HNO3', 'SO2' )
                 ! HNO3 and SO2 drydep like gases but wetdep like fine
                 ! aerosols, so set certain fields to missing values.
+#ifndef LUO_WETDEP
                 ThisSpc%DD_DvzAerSnow = MISSING
+#endif
                 ThisSpc%MP_SizeResAer = MISSING_BOOL
                 ThisSpc%MP_SizeResNum = MISSING_BOOL
                 ThisSpc%WD_CoarseAer  = MISSING_BOOL

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -2305,22 +2305,22 @@ Warnings:                    1
 # ==> Now emit aircraft BC and OC into hydrophilic tracers BCPI and OCPI.
 #==============================================================================
 (((AEIC
-0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
-0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
-0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
-0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
-0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
-0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
-0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
-0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
+0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115    20 1
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110        20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280    20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111        20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112        20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113        20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113        20 1
+0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101/40 20 1
+0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102/41 20 1
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103/42 20 1
+0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104/45 20 1
+0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105/46 20 1
+0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106    20 1
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107/49 20 1
+0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108/83 20 1
+0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109/84 20 1
 )))AEIC
 
 #==============================================================================
@@ -3909,8 +3909,8 @@ Warnings:                    1
 43 CtoBENZ MATH:78.12/(6.0*12.0)   - - - xy unitless 1
 44 CtoC2H4 MATH:28.05/(2.0*12.0)   - - - xy unitless 1
 45 CtoC2H6 MATH:30.08/(2.0*12.0)   - - - xy unitless 1
-46 CtoC3H8 MATH:46.08/(3.0*12.0)   - - - xy unitless 1
-47 CtoEOH  MATH:46.06/(2.0*12.0)   - - - xy unitless 1
+46 CtoC3H8 MATH:44.11/(3.0*12.0)   - - - xy unitless 1
+47 CtoEOH  MATH:46.07/(2.0*12.0)   - - - xy unitless 1
 48 CtoMEK  MATH:72.11/(4.0*12.0)   - - - xy unitless 1
 49 CtoPRPE MATH:42.09/(3.0*12.0)   - - - xy unitless 1
 55 CtoTOLU MATH:92.15/(7.0*12.0)   - - - xy unitless 1
@@ -3920,6 +3920,8 @@ Warnings:                    1
 62 CtoMTPA MATH:136.26/(10.0*12.0) - - - xy unitless 1
 64 CtoMBOX MATH:86.13/(5.0*12.0)   - - - xy unitless 1
 67 CtoSESQ MATH:204.4/(15.0*12.0)  - - - xy unitless 1
+83 CtoMACR MATH:70.10/(4.0*12.0)   - - - xy unitless 1
+84 CtoRCHO MATH:58.09/(3.0*12.0)   - - - xy unitless 1
 
 # VOC speciations
 (((RCP_3PD.or.RCP_45.or.RCP_60.or.RCP_85

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -2307,22 +2307,22 @@ Warnings:                    1
 # ==> Now emit aircraft BC and OC into hydrophilic tracers BCPI and OCPI.
 #==============================================================================
 (((AEIC
-0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
-0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
-0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
-0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
-0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
-0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
-0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
-0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
+0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115    20 1
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110        20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280    20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111        20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112        20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113        20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113        20 1
+0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101/40 20 1
+0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102/41 20 1
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103/42 20 1
+0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104/45 20 1
+0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105/46 20 1
+0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106    20 1
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107/49 20 1
+0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108/83 20 1
+0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109/84 20 1
 )))AEIC
 
 #==============================================================================
@@ -3911,8 +3911,8 @@ Warnings:                    1
 43 CtoBENZ MATH:78.12/(6.0*12.0)   - - - xy unitless 1
 44 CtoC2H4 MATH:28.05/(2.0*12.0)   - - - xy unitless 1
 45 CtoC2H6 MATH:30.08/(2.0*12.0)   - - - xy unitless 1
-46 CtoC3H8 MATH:46.08/(3.0*12.0)   - - - xy unitless 1
-47 CtoEOH  MATH:46.06/(2.0*12.0)   - - - xy unitless 1
+46 CtoC3H8 MATH:44.11/(3.0*12.0)   - - - xy unitless 1
+47 CtoEOH  MATH:46.07/(2.0*12.0)   - - - xy unitless 1
 48 CtoMEK  MATH:72.11/(4.0*12.0)   - - - xy unitless 1
 49 CtoPRPE MATH:42.09/(3.0*12.0)   - - - xy unitless 1
 55 CtoTOLU MATH:92.15/(7.0*12.0)   - - - xy unitless 1
@@ -3922,6 +3922,8 @@ Warnings:                    1
 62 CtoMTPA MATH:136.26/(10.0*12.0) - - - xy unitless 1
 64 CtoMBOX MATH:86.13/(5.0*12.0)   - - - xy unitless 1
 67 CtoSESQ MATH:204.4/(15.0*12.0)  - - - xy unitless 1
+83 CtoMACR MATH:70.10/(4.0*12.0)   - - - xy unitless 1
+84 CtoRCHO MATH:58.09/(3.0*12.0)   - - - xy unitless 1
 
 # VOC speciations
 (((RCP_3PD.or.RCP_45.or.RCP_60.or.RCP_85

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -932,7 +932,7 @@ EOH:
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
-  MW_g: 46.08
+  MW_g: 46.07
   WD_RetFactor: 2.0e-2
 ETHLN:
   DD_F0: 1.0

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -46,6 +46,7 @@ AERI:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 DST1_PROP: &DST1properties
   DD_DustDryDep: true
   DD_F0: 0.0
@@ -59,6 +60,7 @@ DST1_PROP: &DST1properties
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 1.0, 1.0]
   WD_RainoutEff: [1.0, 1.0, 0.0]
+  WD_RainoutEff_Luo: [1.0, 0.1, 0.0]
 DST2_PROP: &DST2properties
   DD_DustDryDep: true
   DD_F0: 0.0
@@ -73,6 +75,7 @@ DST2_PROP: &DST2properties
   WD_CoarseAer: true
   WD_KcScaleFac: [1.0, 1.0, 1.0]
   WD_RainoutEff: [1.0, 1.0, 0.0]
+  WD_RainoutEff_Luo: [1.0, 0.1, 0.0]
 DST3_PROP: &DST3properties
   DD_DustDryDep: true
   DD_F0: 0.0
@@ -87,6 +90,7 @@ DST3_PROP: &DST3properties
   WD_CoarseAer: true
   WD_KcScaleFac: [1.0, 1.0, 1.0]
   WD_RainoutEff: [1.0, 1.0, 0.0]
+  WD_RainoutEff_Luo: [1.0, 0.1, 0.0] 
 DST4_PROP: &DST4properties
   DD_DustDryDep: true
   DD_F0: 0.0
@@ -101,6 +105,7 @@ DST4_PROP: &DST4properties
   WD_CoarseAer: true
   WD_KcScaleFac: [1.0, 1.0, 1.0]
   WD_RainoutEff: [1.0, 1.0, 0.0]
+  WD_RainoutEff_Luo: [1.0, 0.1, 0.0] 
 AlF1:
   << : *DST1properties
   Formula: Al
@@ -155,6 +160,7 @@ ASOA_PROP: &ASOAproperties
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 ASOA1:
   << : *ASOAproperties
 ASOA2:
@@ -221,7 +227,7 @@ BCPI:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
-  WD_RainoutEff_Luo: [0.5, 0.0, 0.5]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.5]
 BCPO:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -238,6 +244,7 @@ BCPO:
   WD_KcScaleFac: [1.0, 1.0, 0.5]
   WD_KcScaleFac_Luo: [1.0, 1.0, 0.0]
   WD_RainoutEff: [1.0, 1.0, 0.0]
+  WD_RainoutEff_Luo: [0.5, 0.05, 0.0]
 Be_PROP: &Beproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -250,6 +257,7 @@ Be_PROP: &Beproperties
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 Be10:
   << : *Beproperties
   Formula: Be10
@@ -353,6 +361,7 @@ SALA_PROP: &SALAproperties
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 BrSALA:
   << : *SALAproperties
   Formula: Br
@@ -372,6 +381,7 @@ SALC_PROP: &SALCproperties
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 BrSALC:
   << : *SALCproperties
   Formula: Br
@@ -889,6 +899,13 @@ DMS:
   Is_Advected: true
   Is_Aerosol: true
   MW_g: 62.13
+  DD_F0: 0.0
+  DD_Hstar: 0.0
+  Density: 2650.0
+  Is_Advected: true
+  Is_Aerosol: true
+  Is_DryDep: true
+  Is_WetDep: true
 DST1:
   << : *DST1properties
   FullName: Dust aerosol, Reff = 0.7 microns
@@ -1384,6 +1401,7 @@ HgP_PROP: &HgPproperties
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 1.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 1.0, 1.0]
 HgP:
   << : *HgPproperties
   FullName: Particulate mercury
@@ -1539,7 +1557,7 @@ HNO3:
   WD_KcScaleFac: [1.0, 1.0, 1.0]
   WD_KcScaleFac_Luo: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 1.0, 1.0]
-  WD_RainoutEff_Luo: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 HNO4:
   Background_VV: 4.0e-15
   Formula: HNO4
@@ -2057,6 +2075,7 @@ INDIOL:
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 INO:
   Formula: INO
   FullName: Nitrosyl iodide
@@ -2122,6 +2141,7 @@ IONITA:
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 IONO:
   DD_F0: 0.0
   DD_Hstar: 3.0e-1
@@ -2336,6 +2356,7 @@ LVOCOA:
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 LXRO2H:
   FullName: Dummy species to track oxidation of XRO2 by HO2
   Is_Gas: true
@@ -2574,6 +2595,7 @@ MONITA:
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 MONITS:
   DD_F0: 1.0
   DD_Hstar: 2.0e+6
@@ -2617,6 +2639,7 @@ MOPI:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 MOPO:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -2684,6 +2707,7 @@ MSA:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 MTPA:
   DD_F0: 0.0
   DD_Hstar: 4.9e-2
@@ -2848,14 +2872,13 @@ NAP:
   Is_Gas: true
   MW_g: 128.18
 NH3:
-  DD_DvzAerSnow: 0.03
-  DD_DvzMinVal: [0.2, 0.3]
+  DD_DvzMinVal: [0.01, 0.01]
   DD_F0: 0.0
   DD_Hstar: 2.0e+4
   Formula: NH3
   FullName: Ammonia
-  Henry_CR: 4100.0
-  Henry_K0: 3.3e+6
+  Henry_CR: 4200.0
+  Henry_K0: 59.78175
   Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
@@ -2879,6 +2902,7 @@ NH4:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 NHEmis90dayTracer:
   FullName: Northern_hemisphere_emitted_tracer_with_90day_lifetime_and_100ppbv_maintained_mi
   Is_Advected: true
@@ -2910,6 +2934,7 @@ NIT:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 NITD1:
   << : *DST1properties
   FullName: Nitrate on dust, Reff = 0.7 microns
@@ -3079,7 +3104,7 @@ OCPI:
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_KcScaleFac_Luo: [0.5, 0.25, 0.5]
   WD_RainoutEff: [1.0, 0.0, 1.0]
-  WD_RainoutEff_Luo: [0.5, 0.0, 0.5]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.5]
 OCPO:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3138,6 +3163,7 @@ OPOA1:
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 OPOA2:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3150,6 +3176,7 @@ OPOA2:
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 OPOG1:
   DD_F0: 0.0
   DD_Hstar: 1.0e+5
@@ -3210,6 +3237,7 @@ Pb210_PROP: &Pbproperties
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 Pb210:
   << : *Pbproperties
   FullName: Lead-210 isotope
@@ -3244,6 +3272,7 @@ pFe:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 PH2O2:
   FullName: Dummy species to track production rate of H2O2
   Is_Gas: true
@@ -3375,6 +3404,7 @@ POPPBCPI_BaP:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [ 1.0, 0.5, 1.0]
   WD_RainoutEff: [ 1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [ 0.4, 0.0, 1.0]
 POPPBCPI_PHE:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3388,6 +3418,7 @@ POPPBCPI_PHE:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [ 1.0, 0.5, 1.0]
   WD_RainoutEff: [ 1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [ 0.4, 0.0, 1.0]
 POPPBCPI_PYR:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3401,6 +3432,7 @@ POPPBCPI_PYR:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [ 1.0, 0.5, 1.0]
   WD_RainoutEff: [ 1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [ 0.4, 0.0, 1.0]
 POPPBCPO_BaP:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3414,6 +3446,7 @@ POPPBCPO_BaP:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 1.0, 0.5]
   WD_RainoutEff: [1.0, 1.0, 0.0]
+  WD_RainoutEff_Luo: [0.4, 1.0, 0.0]
 POPPBCPO_PHE:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3427,6 +3460,7 @@ POPPBCPO_PHE:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 1.0, 0.5]
   WD_RainoutEff: [1.0, 1.0, 0.0]
+  WD_RainoutEff_Luo: [0.4, 1.0, 0.0]
 POPPBCPO_PYR:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3440,6 +3474,7 @@ POPPBCPO_PYR:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 1.0, 0.5]
   WD_RainoutEff: [1.0, 1.0, 0.0]
+  WD_RainoutEff_Luo: [0.4, 1.0, 0.0]
 POPPOCPI_BaP:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3453,6 +3488,7 @@ POPPOCPI_BaP:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 POPPOCPI_PHE:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3466,6 +3502,7 @@ POPPOCPI_PHE:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 POPPOCPI_PYR:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3479,6 +3516,7 @@ POPPOCPI_PYR:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 POPPOCPO_BaP:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3836,12 +3874,13 @@ SiF2:
   Fullname: Silicon on dust, Reff = 1.4 microns
   MW_g: 28.09
 SO2:
-  DD_DvzAerSnow: 0.03
-  DD_DvzMinVal: [0.2, 0.3]
+  DD_DvzMinVal: [0.01, 0.01]
   DD_F0: 0.0
   DD_Hstar: 1.0e+5
   Formula: SO2
   FullName: Sulfur dioxide
+  Henry_CR: 3100.0
+  Henry_K0: 1.22
   Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
@@ -3851,6 +3890,10 @@ SO2:
   WD_Is_SO2: true
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
+  WD_RetFactor: 5.0e-2
+  WD_LiqAndGas: true
+  WD_ConvFacI2G: 6.17395e-1
 SO4:
   DD_DvzAerSnow: 0.03
   DD_DvzMinVal: [0.01, 0.01]
@@ -3869,6 +3912,7 @@ SO4:
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
+  WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
 SO4D1:
   << : *DST1properties
   FullName: Sulfate on dust, Reff = 0.7 microns
@@ -3923,6 +3967,7 @@ SOAGX:
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 SOAIE:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3937,6 +3982,7 @@ SOAIE:
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 SOAP:
   FullName: SOA Precursor - lumped species for simplified SOA parameterization
   Is_Advected: true
@@ -3955,6 +4001,7 @@ SOAS:
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 TiF1:
   << : *DST1properties
   Formula: Ti
@@ -3990,6 +4037,7 @@ TSOA_PROP: &TSOAproperties
   WD_AerScavEff: 0.8
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
+  WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 TSOA0:
   << : *TSOAproperties
 TSOA1:

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -2872,13 +2872,17 @@ NAP:
   Is_Gas: true
   MW_g: 128.18
 NH3:
-  DD_DvzMinVal: [0.01, 0.01]
+  DD_DvzAerSnow: 0.03
+  DD_DvzMinVal: [0.2, 0.3]
+  DD_DvzMinVal_Luo: [0.01, 0.01]
   DD_F0: 0.0
   DD_Hstar: 2.0e+4
   Formula: NH3
   FullName: Ammonia
-  Henry_CR: 4200.0
-  Henry_K0: 59.78175
+  Henry_CR: 4100.0
+  Henry_CR_Luo: 4200.0
+  Henry_K0: 3.3e+6
+  Henry_K0_Luo: 59.78175
   Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
@@ -3874,13 +3878,15 @@ SiF2:
   Fullname: Silicon on dust, Reff = 1.4 microns
   MW_g: 28.09
 SO2:
-  DD_DvzMinVal: [0.01, 0.01]
+  DD_DvzAerSnow: 0.03
+  DD_DvzMinVal: [0.2, 0.3]
+  DD_DvzMinVal_Luo: [0.01, 0.01]
   DD_F0: 0.0
   DD_Hstar: 1.0e+5
   Formula: SO2
   FullName: Sulfur dioxide
-  Henry_CR: 3100.0
-  Henry_K0: 1.22
+  Henry_CR_Luo: 3100.0
+  Henry_K0_Luo: 1.22
   Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
@@ -3891,9 +3897,9 @@ SO2:
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
   WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
-  WD_RetFactor: 5.0e-2
-  WD_LiqAndGas: true
-  WD_ConvFacI2G: 6.17395e-1
+  WD_RetFactor_Luo: 5.0e-2
+  WD_LiqAndGas_Luo: true
+  WD_ConvFacI2G_Luo: 6.17395e-1
 SO4:
   DD_DvzAerSnow: 0.03
   DD_DvzMinVal: [0.01, 0.01]

--- a/test/GCClassic/intTestCompile_slurm.sh
+++ b/test/GCClassic/intTestCompile_slurm.sh
@@ -85,7 +85,7 @@ let failed=0
 let remain=${numTests}
 
 # Loop over build directories
-for dir in default apm bpch rrtmg tomas15 tomas40; do
+for dir in default apm bpch luowd rrtmg tomas15 tomas40; do
 
     # Define build directory
     buildDir="${root}/build/${dir}"

--- a/test/GCClassic/intTestCreate.sh
+++ b/test/GCClassic/intTestCreate.sh
@@ -99,7 +99,7 @@ fi
 # now that the folder exists
 root=$(absolute_path ${root})
 
-# Remove everything in the test folde r
+# Remove everything in the test folder
 cleanup_files ${root}
 
 # Make the directory for the executables
@@ -110,7 +110,7 @@ mkdir -p ${root}/exe_files
 
 # Make the build directories
 if [[ ! -d ${root}/build ]]; then
-    for dir in apm bpch default rrtmg tomas15 tomas40; do
+    for dir in apm bpch default luowd rrtmg tomas15 tomas40; do
 	echo " ... ${root}/build/${dir}"
 	mkdir -p ${root}/build/${dir}
     done
@@ -197,6 +197,9 @@ create_rundir "9\n1\n2\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 dir="gc_2x25_TransportTracers_merra2"
 create_rundir "10\n1\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
+dir="gc_2x25_TransportTracers_LuoWd_merra2"
+create_rundir "10\n1\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
+
 dir="gc_2x25_metals_merra2"
 create_rundir "11\n1\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
@@ -259,6 +262,9 @@ create_rundir "10\n2\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 #dir="gc_2x25_metals_geosfp"
 #create_rundir "11\n2\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
+dir="gc_2x25_TransportTracers_LuoWd_geosfp"
+create_rundir "10\n2\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
+
 #=============================================================================
 # Create individual run directories: 4x5 - MERRA2 - 72L
 #=============================================================================
@@ -273,6 +279,9 @@ dir="gc_4x5_aerosol_merra2"
 create_rundir "2\n1\n1\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 
 dir="gc_4x5_fullchem_merra2"
+create_rundir "1\n1\n1\n1\n1\n1\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
+
+dir="gc_4x5_fullchem_LuoWd_merra2"
 create_rundir "1\n1\n1\n1\n1\n1\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
 
 dir="gc_4x5_fullchem_aciduptake_merra2"
@@ -317,6 +326,9 @@ create_rundir "9\n1\n1\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 dir="gc_4x5_TransportTracers_merra2"
 create_rundir "10\n1\n1\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
+dir="gc_4x5_TransportTracers_LuoWd_merra2"
+create_rundir "10\n1\n1\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
+
 dir="gc_4x5_metals_merra2"
 create_rundir "11\n1\n1\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
@@ -331,6 +343,9 @@ dir="gc_4x5_aerosol_geosfp"
 create_rundir "2\n2\n1\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 
 dir="gc_4x5_fullchem_geosfp"
+create_rundir "1\n1\n1\n1\n1\n1\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
+
+dir="gc_4x5_fullchem_LuoWd_geosfp"
 create_rundir "1\n1\n1\n1\n1\n1\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
 
 dir="gc_4x5_fullchem_aciduptake_geosfp"
@@ -376,6 +391,9 @@ dir="gc_4x5_tagO3_geosfp"
 create_rundir "9\n2\n1\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 
 dir="gc_4x5_TransportTracers_geosfp"
+create_rundir "10\n2\n1\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
+
+dir="gc_4x5_TransportTracers_LuoWd_geosfp"
 create_rundir "10\n2\n1\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
 # NOTE: The metals simulation runs from 2011-2013, the earlier part of

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -245,7 +245,7 @@ function gcclassic_exe_name() {
     exeFileName="gcclassic"
 
     # Append a suffix to the executable file name for specific directories
-    for suffix in apm bpch rrtmg tomas15 tomas40; do
+    for suffix in apm bpch luowd rrtmg tomas15 tomas40; do
 	if [[ ${1} =~ ${suffix} ]]; then
 	    exeFileName+=".${suffix}"
 	    break
@@ -282,6 +282,8 @@ function gcclassic_config_options() {
 	options="${baseOptions} -DAPM=y -DEXE_FILE_NAME=${exeFileName}"
     elif [[ ${dir} =~ "bpch" ]]; then
 	options="${baseOptions} -DBPCH_DIAG=y -DEXE_FILE_NAME=${exeFileName}"
+    elif [[ ${dir} =~ "luowd" ]]; then
+	options="${baseOptions} -DLUO_WETDEP=y -DEXE_FILE_NAME=${exeFileName}"
     elif [[ ${dir} =~ "rrtmg" ]]; then
 	options="${baseOptions} -DRRTMG=y -DEXE_FILE_NAME=${exeFileName}"
     elif [[ ${dir} =~ "tomas15" ]]; then
@@ -318,6 +320,8 @@ function gcclassic_compiletest_name() {
 	result="GCClassic with APM"
     elif [[ ${dir} =~ "bpch" ]]; then
 	result="GCClassic with BPCH diagnostics"
+    elif [[ ${dir} =~ "luowd" ]]; then
+	result="GCClassic with Luo et al wetdep"
     elif [[ ${dir} =~ "rrtmg" ]]; then
 	result="GCClassic with RRTMG"
     elif [[ ${dir} =~ "tomas15" ]]; then


### PR DESCRIPTION
This pull request, which implements the Luo et al 2020 wet deposition scheme, supersedes the original pull request #522.

Starting with PR #522, I manually merged that into a branch off of GEOS_Chem 13.1.2.  The merge had to be made manually due to the fact the the current GC has evolved from the base code.

I added some modifications for efficiency in the commits since PR #522. These are:
  - Parallelized the computation of HSTAR3D in drydep_mod.F90 and split it into a separate routine
  - Replaced string comparisons to test for species -- we now test against the species names
  - Optimized computations of Henry's law parameters -- avoid recomputing terms needlessly
  - Added integration tests (GCClassic only for now) for the Luo et al 2020 wet deposition option

The current conflict is probably due to the integration test scripts -- this branch does not include the specialty simulation for trace metals.  I will resolve that conflict when merging.