### PR TITLE
[PULL REQUEST] Meng offline dust

### DIFF
--- a/run/CESM/HEMCO_Config.rc
+++ b/run/CESM/HEMCO_Config.rc
@@ -106,7 +106,7 @@ Warnings:                    1
 #   OFFLINE_SEASALT     - SeaSalt
 #   OFFLINE_SOILNOX     - SoilNOx
 #--------------------------------------------------------------
-    --> OFFLINE_DUST           :       false    # 1980-2021
+    --> OFFLINE_DUST           :       true     # 1980-2021
     --> OFFLINE_BIOGENICVOC    :       false    # 1980-2021
     --> OFFLINE_SEASALT        :       false    # 1980-2021
     --> OFFLINE_SOILNOX        :       true     # 1980-2021
@@ -2373,10 +2373,10 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_DUST
 (((.not.DustDead.or.DustGinoux
-0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2019-01/0.5x0.625/$YYYY/$MM/dust_emissions_05.$YYYY$MM$DD.nc EMIS_DST1 1980-2017/1-12/1-31/* C xy kg/m2/s DST1 606 3 2
-0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2019-01/0.5x0.625/$YYYY/$MM/dust_emissions_05.$YYYY$MM$DD.nc EMIS_DST2 1980-2017/1-12/1-31/* C xy kg/m2/s DST2 606 3 2
-0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2019-01/0.5x0.625/$YYYY/$MM/dust_emissions_05.$YYYY$MM$DD.nc EMIS_DST3 1980-2017/1-12/1-31/* C xy kg/m2/s DST3 606 3 2
-0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2019-01/0.5x0.625/$YYYY/$MM/dust_emissions_05.$YYYY$MM$DD.nc EMIS_DST4 1980-2017/1-12/1-31/* C xy kg/m2/s DST4 606 3 2
+0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2020-05/0.5x0.625/$YYYY/$MM/dust_emissions_05.$YYYY$MM$DD.nc EMIS_DST1 1980-2017/1-12/1-31/* C xy kg/m2/s DST1 666/676 3 2
+0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2020-05/0.5x0.625/$YYYY/$MM/dust_emissions_05.$YYYY$MM$DD.nc EMIS_DST2 1980-2017/1-12/1-31/* C xy kg/m2/s DST2 666/676 3 2
+0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2020-05/0.5x0.625/$YYYY/$MM/dust_emissions_05.$YYYY$MM$DD.nc EMIS_DST3 1980-2017/1-12/1-31/* C xy kg/m2/s DST3 666/676 3 2
+0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2020-05/0.5x0.625/$YYYY/$MM/dust_emissions_05.$YYYY$MM$DD.nc EMIS_DST4 1980-2017/1-12/1-31/* C xy kg/m2/s DST4 666/676 3 2
 ))).not.DustDead.or.DustGinoux
 )))OFFLINE_DUST
 
@@ -3954,10 +3954,11 @@ Warnings:                    1
 # --- Offline dust scale factors ---
 #
 # Scale annual emission totals for offline dust to 2x2.5 online dust values
-# Use 6.42e-5 for GEOS-FP and 3.86e-4 for MERRA-2
+# Use 5.7141e-04 for GEOS-FP and 4.7376e-04 for MERRA-2
 #==============================================================================
 (((OFFLINE_DUST
-606 DST_SF {DUST_SF} - - - xy 1 1
+666 DST_SF {DUST_SF} - - - xy 1 1
+676 DST_NA_opt $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/DustEmis_scalefactor_NA_optimized.nc dustemis_factor  2016/1/1/0 C xy 1 1
 )))OFFLINE_DUST
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -104,7 +104,7 @@ Warnings:                    1
 # NOTE: The offline dust emissions are considered to be buggy.
 #  Until further notice online dust emissions are recommended.
 #--------------------------------------------------------------
-    --> OFFLINE_DUST           :       false    # 1980-2021
+    --> OFFLINE_DUST           :       true     # 1980-2021
     --> OFFLINE_BIOGENICVOC    :       true     # 1980-2021
     --> OFFLINE_SEASALT        :       true     # 1980-2021
     --> OFFLINE_SOILNOX        :       true     # 1980-2021
@@ -1170,10 +1170,10 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_DUST
 (((.not.DustDead.or.DustGinoux
-0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2017/1-12/1-31/* C xy kg/m2/s DST1 606 3 2
-0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2017/1-12/1-31/* C xy kg/m2/s DST2 606 3 2
-0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2017/1-12/1-31/* C xy kg/m2/s DST3 606 3 2
-0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2017/1-12/1-31/* C xy kg/m2/s DST4 606 3 2
+0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2017/1-12/1-31/* C xy kg/m2/s DST1 666/676 3 2
+0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2017/1-12/1-31/* C xy kg/m2/s DST2 666/676 3 2
+0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2017/1-12/1-31/* C xy kg/m2/s DST3 666/676 3 2
+0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2017/1-12/1-31/* C xy kg/m2/s DST4 666/676 3 2
 ))).not.DustDead.or.DustGinoux
 )))OFFLINE_DUST
 
@@ -1989,10 +1989,11 @@ Warnings:                    1
 # --- Offline dust scale factors ---
 #
 # Scale annual emission totals for offline dust to 2x2.5 online dust values
-# Use 6.42e-5 for GEOS-FP and 3.86e-4 for MERRA-2
+# Use 5.7141e-04 for GEOS-FP and 4.7376e-04 for MERRA-2
 #==============================================================================
 (((OFFLINE_DUST
-606 DST_SF {DUST_SF} - - - xy 1 1
+666 DST_SF {DUST_SF} - - - xy 1 1
+676 DST_NA_opt $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/DustEmis_scalefactor_NA_optimized.nc dustemis_factor  2016/1/1/0 C xy 1 1
 )))OFFLINE_DUST
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -110,7 +110,7 @@ Warnings:                    1
 # NOTE: The offline dust emissions are considered to be buggy.
 #  Until further notice online dust emissions are recommended.
 #--------------------------------------------------------------
-    --> OFFLINE_DUST           :       false    # 1980-2021
+    --> OFFLINE_DUST           :       true     # 1980-2021
     --> OFFLINE_BIOGENICVOC    :       true     # 1980-2021
     --> OFFLINE_SEASALT        :       true     # 1980-2021
     --> OFFLINE_SOILNOX        :       true     # 1980-2021
@@ -2646,10 +2646,10 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_DUST
 (((.not.DustDead.or.DustGinoux
-0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2021/1-12/1-31/* C xy kg/m2/s DST1 606 3 2
-0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2021/1-12/1-31/* C xy kg/m2/s DST2 606 3 2
-0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2021/1-12/1-31/* C xy kg/m2/s DST3 606 3 2
-0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2021/1-12/1-31/* C xy kg/m2/s DST4 606 3 2
+0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2021/1-12/1-31/* C xy kg/m2/s DST1 666/676 3 2
+0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2021/1-12/1-31/* C xy kg/m2/s DST2 666/676 3 2
+0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2021/1-12/1-31/* C xy kg/m2/s DST3 666/676 3 2
+0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2021/1-12/1-31/* C xy kg/m2/s DST4 666/676 3 2
 ))).not.DustDead.or.DustGinoux
 )))OFFLINE_DUST
 
@@ -4240,10 +4240,11 @@ Warnings:                    1
 # --- Offline dust scale factors ---
 #
 # Scale annual emission totals for offline dust to 2x2.5 online dust values
-# Use 6.42e-5 for GEOS-FP and 3.86e-4 for MERRA-2
+# Use 5.7141e-04 for GEOS-FP and 4.7376e-04 for MERRA-2
 #==============================================================================
 (((OFFLINE_DUST
-606 DST_SF {DUST_SF} - - - xy 1 1
+666 DST_SF {DUST_SF} - - - xy 1 1
+676 DST_NA_opt $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/DustEmis_scalefactor_NA_optimized.nc dustemis_factor  2016/1/1/0 C xy 1 1
 )))OFFLINE_DUST
 
 #==============================================================================
@@ -4260,7 +4261,7 @@ Warnings:                    1
 612 OTHRtoSOA 0.0567 - - - xy 1 1
 )))OFFLINE_BIOGENICVOC
 
-#==============================================================================
+#========================================================
 # --- Offline sea salt scale factors ---
 #
 # NOTES:

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -279,7 +279,7 @@ while [ "${valid_met}" -eq 0 ]; do
 	met_cn_year='2015'
 	pressure_unit='Pa '
 	pressure_scale='0.01'
-	offline_dust_sf='3.86e-4'
+	offline_dust_sf='4.7376e-04'
     elif [[ ${met_num} = "2" ]]; then
 	met_name='GEOSFP'
 	met_name_lc="geosfp"
@@ -292,7 +292,7 @@ while [ "${valid_met}" -eq 0 ]; do
 	met_cn_year='2011'
 	pressure_unit='hPa'
 	pressure_scale='1.0 '
-	offline_dust_sf='6.42e-5'
+	offline_dust_sf='5.7141e-04'
     elif [[ ${met_num} = "3" ]]; then
 	met_name='ModelE2.1'
 	met_name_lc='modele2.1'

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -113,7 +113,7 @@ Warnings:                    1
 # NOTE: The offline dust emissions are considered to be buggy.
 #  Until further notice online dust emissions are recommended.
 #--------------------------------------------------------------
-    --> OFFLINE_DUST           :       false    # 1980-2021
+    --> OFFLINE_DUST           :       true     # 1980-2021
     --> OFFLINE_BIOGENICVOC    :       true     # 1980-2021
     --> OFFLINE_SEASALT        :       true     # 1980-2021
     --> OFFLINE_SOILNOX        :       true     # 1980-2021
@@ -2648,10 +2648,10 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_DUST
 (((.not.DustDead.or.DustGinoux
-0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2021/1-12/1-31/* C xy kg/m2/s DST1 606 3 2
-0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2021/1-12/1-31/* C xy kg/m2/s DST2 606 3 2
-0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2021/1-12/1-31/* C xy kg/m2/s DST3 606 3 2
-0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2019-01/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2021/1-12/1-31/* C xy kg/m2/s DST4 606 3 2
+0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2021/1-12/1-31/* C xy kg/m2/s DST1 666/676 3 2
+0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2021/1-12/1-31/* C xy kg/m2/s DST2 666/676 3 2
+0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2021/1-12/1-31/* C xy kg/m2/s DST3 666/676 3 2
+0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/$YYYY/$MM/dust_emissions_{LATRES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2021/1-12/1-31/* C xy kg/m2/s DST4 666/676 3 2
 ))).not.DustDead.or.DustGinoux
 )))OFFLINE_DUST
 
@@ -4242,10 +4242,11 @@ Warnings:                    1
 # --- Offline dust scale factors ---
 #
 # Scale annual emission totals for offline dust to 2x2.5 online dust values
-# Use 6.42e-5 for GEOS-FP and 3.86e-4 for MERRA-2
+# Use 5.7141e-04 for GEOS-FP and 4.7376e-04 for MERRA-2
 #==============================================================================
 (((OFFLINE_DUST
-606 DST_SF {DUST_SF} - - - xy 1 1
+666 DST_SF {DUST_SF} - - - xy 1 1
+676 DST_NA_opt $ROOT/OFFLINE_DUST/v2020-05/{NATIVE_RES}/DustEmis_scalefactor_NA_optimized.nc dustemis_factor  2016/1/1/0 C xy 1 1
 )))OFFLINE_DUST
 
 #==============================================================================

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -192,7 +192,7 @@ while [ "${valid_met}" -eq 0 ]; do
 	met_cn_year='2015'
 	pressure_unit='Pa '
 	pressure_scale='0.01'
-	dust_sf='3.86e-4'
+	dust_sf='4.7376e-04'
     elif [[ ${met_num} = "2" ]]; then
 	met_name='GEOSFP'
 	met_name_lc="merra2"
@@ -205,7 +205,7 @@ while [ "${valid_met}" -eq 0 ]; do
 	met_cn_year='2011'
 	pressure_unit='hPa'
 	pressure_scale='1.0 '
-	dust_sf='6.42e-5'
+	dust_sf='5.7141e-04'
     else
 	valid_met=0
 	printf "Invalid meteorology option. Try again.\n"

--- a/run/GEOS/HEMCO_Config.rc
+++ b/run/GEOS/HEMCO_Config.rc
@@ -129,7 +129,7 @@ Warnings:                    1
 #   OFFLINE_SEASALT     - SeaSalt
 #   OFFLINE_SOILNOX     - SoilNOx
 #--------------------------------------------
-    --> OFFLINE_DUST           :       false
+    --> OFFLINE_DUST           :       true
     --> OFFLINE_BIOGENICVOC    :       false
     --> OFFLINE_SEASALT        :       false
     --> OFFLINE_SOILNOX        :       false


### PR DESCRIPTION
Hi,

In this version. The offline dust emissions are updated from v2019-01 to v2020-05. The scaling factors for make the total annual dust emission to 2000 Tg were updated as:

GEOS-FP: 5.7141e-04
(North America dust source optimizing (reducing 30% emission) by applying scale factor 666, which includes a mask file of "DustEmis_scalefactor_NA_optimized.nc". See the example "HEMCO_Config_w_NA_optimizing.rc")

MERRA2: 4.7376e-04
(North America dust source optimizing (reducing 30% emission) by applying scale factor 666, which includes a mask file of "DustEmis_scalefactor_NA_optimized.nc". See the example "HEMCO_Config_w_NA_optimizing.rc")

Thanks,
Yanshun
