### PR TITLE
GCHP Harvard run script updates

### DIFF
--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -435,9 +435,9 @@ sed -i -e "s|{DATE2}|${enddate}|"       ${rundir}/CAP.rc
 
 # Special handling for benchmark simulation
 if [[ ${sim_extra_option} = "benchmark" || ${sim_name} == "TransportTracers" ]]; then
-    total_cores=48
+    total_cores=96
     num_nodes=2
-    num_cores_per_node=24
+    num_cores_per_node=48
     grid_res=48
     timeAvg_monthly="1"
     timeAvg_freq="7440000"
@@ -447,7 +447,7 @@ if [[ ${sim_extra_option} = "benchmark" || ${sim_name} == "TransportTracers" ]];
     dYYYYMMDD="00000100"
     dHHmmSS="000000"
     printf "\n  -- This run directory has been set up for $startdate $start_time - $enddate $end_time."
-    printf "\n  -- The default diagnostic frequency, duration, and mode is monthly average."
+    printf "\n  -- Monthly time-averaged diagnostics are enabled in HISTORY.rc."
 elif [ "${sim_type}" == "CO2" ]; then
     total_cores=48
     num_nodes=2

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.benchmark.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.benchmark.run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH -n 48
+#SBATCH -n 96
 #SBATCH -N 2
 #SBATCH --exclusive
 #SBATCH -t 0-20:00

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.local.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.local.run
@@ -5,6 +5,14 @@
 # variables NY and NUM_CORES_PER_NODE match nCores set below.
 nCores=6
 
+# Exit with error if nCores does not match number of cores configured in
+# runConfig.sh
+cfgCores=$( grep -oP 'TOTAL_CORES=\s*\K\d+' runConfig.sh )
+if [[ ${nCores} != ${cfgCores} ]]; then
+   echo "ERROR: number of cores set in gchp.local.run does not match TOTAL_CORES set in runConfig.sh."
+   exit 1
+fi
+
 # Define log
 log=gchp.log
 

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.run
@@ -5,8 +5,6 @@
 #SBATCH -t 0-20:00
 #SBATCH -p huce_cascade
 #SBATCH --mem=180000
-## Use lower memory if doing Transport Tracers simulation:
-##SBATCH --mem=30000
 #SBATCH --mail-type=ALL
 #SBATCH -o slurm-%j.out
 #SBATCH -e slurm-%j.err

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.run
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-#SBATCH -n 24
-#SBATCH -N 1
-#SBATCH -t 0-0:10
+#SBATCH -n 48
+#SBATCH -N 2
+#SBATCH -t 0-20:00
 #SBATCH -p huce_cascade
-#SBATCH --mem=110000
+#SBATCH --mem=180000
 ## Use lower memory if doing Transport Tracers simulation:
 ##SBATCH --mem=30000
 #SBATCH --mail-type=ALL

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH -n 48
+#SBATCH -n 96
 #SBATCH -N 2
 #SBATCH -t 0-20:00
 #SBATCH -p huce_cascade

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.run
@@ -82,30 +82,37 @@ fi
 
 source runConfig.sh --silent
 
-# Monthly diagnostic option automatically updates HISTORY.rc freq/duration
-# with number of hours for the month of the run. Includes leap year handling.
-# NOTE: This feature is enabled from runConfig.sh where Monthly_Diag is defined
-if [ ${Monthly_Diag} = "1" ]; then
-   if [ -e cap_restart ]; then    
-      yr_str=${cap_rst:0:4}
-      mo_str=$((10#${cap_rst:4:2}))
-   else
-      yr_str=${Start_Time:0:4}
-      mo_str=$((10#${Start_Time:4:2}))
-   fi
-   feb_hrs=672
-   if [ "$((yr_str%4))" = "0" ]; then
-      if [ ! "$((yr_str%100))" = "0" ] || [ "$((yr_str%400))" = "0" ]; then
-         feb_hrs=696   
-      fi
-      fi
-   dpm=(744 $feb_hrs 744 720 744 720 744 744 720 744 720 744)
-   hrs_str=${dpm[$((mo_str-1))]}
-   sed -i "s|timeAvg_freq\=.*|timeAvg_freq\=\"${hrs_str}0000\"|" ./runConfig.sh
-   sed -i "s|timeAvg_dur\=.*|timeAvg_dur\=\"${hrs_str}0000\"|"   ./runConfig.sh
-   sed -i "s|inst_freq\=.*|inst_freq\=\"${hrs_str}0000\"|"       ./runConfig.sh
-   sed -i "s|inst_dur\=.*|inst_dur\=\"${hrs_str}0000\"|"         ./runConfig.sh
-fi
+##---------------------------------------------------------------------------
+## Below is commented out code that previously was used to update HISTORY.rc
+## frequency and duration for the case of months for monthly mean diagnostics.
+## It is no longer needed for monthly mean since MAPL History now allows
+## monthly diagnostic configuration for time-averaged collections without
+## setting number of hours in frequency and duration. The code is kept here,
+## however, if needed for instantaneous collection output with frequency of
+## one month, and as an example of how to configure irregular output frequency
+## in general. It could be adapted to output time-averaged weekday and weekend
+## files, for example
+##---------------------------------------------------------------------------
+#if [ -e cap_restart ]; then    
+#   yr_str=${cap_rst:0:4}
+#   mo_str=$((10#${cap_rst:4:2}))
+#else
+#   yr_str=${Start_Time:0:4}
+#   mo_str=$((10#${Start_Time:4:2}))
+#fi
+#feb_hrs=672
+#if [ "$((yr_str%4))" = "0" ]; then
+#   if [ ! "$((yr_str%100))" = "0" ] || [ "$((yr_str%400))" = "0" ]; then
+#      feb_hrs=696   
+#   fi
+#   fi
+#dpm=(744 $feb_hrs 744 720 744 720 744 744 720 744 720 744)
+#hrs_str=${dpm[$((mo_str-1))]}
+#sed -i "s|timeAvg_freq\=.*|timeAvg_freq\=\"${hrs_str}0000\"|" ./runConfig.sh
+#sed -i "s|timeAvg_dur\=.*|timeAvg_dur\=\"${hrs_str}0000\"|"   ./runConfig.sh
+#sed -i "s|inst_freq\=.*|inst_freq\=\"${hrs_str}0000\"|"       ./runConfig.sh
+#sed -i "s|inst_dur\=.*|inst_dur\=\"${hrs_str}0000\"|"         ./runConfig.sh
+##---------------------------------------------------------------------------
 
 echo " "
 echo "Settings from runConfig.sh: "

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.multirun.sh
@@ -16,32 +16,40 @@
 #
 # Special Notes:
 #
-#  1. Configure the total number of runs within runConfig.sh. This is 
+#  1. Configure the total number of runs via command line argument. This is 
 #     equivalent to how many jobs will be submitted to SLURM. Make sure that 
-#     the end date in runConfig.sh is sufficiently past the start date to 
-#     accommodate all configured runs.
+#     the end date in runConfig.sh is sufficiently PAST the start date to 
+#     accommodate all configured runs. It does not need to equal actual last
+#     run end date.
 #
 #  2. This script uses a special run script for multi-run segments 
 #     (gchp.multirun.run). Using the default run script instead (gchp.run) 
 #     will not work for multi-segmented runs without updates. 
 #
 #  3. The run script submitted on loop in this shell script will send stdout to
-#     to gchp.log. Log output is not over-written by subsequent runs. 
+#     to slurm-jobid.out. Log output is not over-written by subsequent runs. 
 #
-#  4. Because GCHP output diagnostics files contain the date, diagnostic output
+#  4. Because GCHP output diagnostic files contain the date, diagnostic output
 #     files will also not be over-written by subsequent runs. 
 #
 #  5. Restart files will always be produced at the end of a run for use in 
-#     the next run, but will not include the date in the filename. They will 
-#     therefore be over-written. However, you can configure regular restart
-#     output with the Checkpoint_Freq option in runConfig.sh. This will
-#     regularly output restart files with date/time in the filenames. 
+#     the next run, but will not include the date in the filename. The run
+#     script therefore renames them to include the date. If your run fails
+#     mid-run then that renaming does not happen. In that case you may see 
+#     a restart file called gcchem_internal_checkpoint. It will get deleted
+#     upon rerun of the multi-run script. Properly renamed restart files
+#     will not get deleted.
 # 
-#  6. gchp.log and cap_restart.log are both deleted at the top of this script.
-#     If you want to keep logs from a prior run you must archive elsewhere.
-#     Use the archiveRun.sh script to archive past runs. Using this script
-#     at the end of a multi-segmented run will archive files for all segements
-#     into one archive directory.
+#  6. You may use the archiveRun.sh script to archive ALL runs in the multi-run. However,
+#     note that the config files saved will only reflect settings for the last run in the
+#     series.
+
+# Set argument to number of runs
+Num_Runs=${1}
+if [[ "x${Num_Runs}" == "x" ]]; then
+    echo "ERROR: Specify number of runs as argument, e.g. ./gchp.multirun.sh 12"
+    exit
+fi
 
 # Set multirun log filename (separate from GEOS-Chem log file gchp.log)
 multirunlog="multirun.log"

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.run
@@ -5,8 +5,6 @@
 #SBATCH -t 0-0:10
 #SBATCH -p huce_cascade
 #SBATCH --mem=110000
-## Use lower memory if doing Transport Tracers simulation:
-##SBATCH --mem=30000
 #SBATCH --mail-type=ALL
 
 # See SLURM documentation for descriptions of all possible settings.


### PR DESCRIPTION
This PR makes bug fixes and improvements to the run scripts stored in `run/GCHP/runScriptSamples/operational_examples/harvard_gcst`.

- Fix incompatibilities of `gchp.multirun.*` scripts with 13.1.2
- Customize `gchp.multirun.*` scripts for GCHP benchmarking
- Add error handling in `gchp.local.run` for case of mismatch of total cores in `gchp.local.run` and `runConfig.sh`
- Remove lower memory suggestion for Transport Tracers (leave up to the user instead)