### PR TITLE
Minor GCHP run directory updates

### DIFF
--- a/run/GCHP/runConfig.sh.template
+++ b/run/GCHP/runConfig.sh.template
@@ -547,9 +547,12 @@ replace_val NY            ${NY}                 GCHP.rc
 replace_val CoresPerNode  ${NUM_CORES_PER_NODE} HISTORY.rc
 
 #### If # cores exceeds 1000 then write restart via o-server
-if [ ${TOTAL_CORES} -gt 1000 ]; then
-   print_msg "WARNING: write restarts by o-server is enabled since >1000 cores"
+if [ ${TOTAL_CORES} -ge 1000 ]; then
+   print_msg "WARNING: write restarts by o-server is enabled since >=1000 cores"
    replace_val WRITE_RESTART_BY_OSERVER   YES   GCHP.rc
+else
+   print_msg "WARNING: write restarts by o-server is disabled since <1000 cores"
+   replace_val WRITE_RESTART_BY_OSERVER   NO    GCHP.rc
 fi
 
 ### Uncomment out Adjoint collection in HISTORY.rc. It's not 

--- a/run/GCHP/runScriptSamples/simple_examples/simple_batch_job.slurm.sh
+++ b/run/GCHP/runScriptSamples/simple_examples/simple_batch_job.slurm.sh
@@ -37,4 +37,12 @@ ulimit -s unlimited          # stacksize
 # Simple GCHP launch
 rm -f cap_restart                                # delete restart start time file if present
 ./runConfig.sh                                   # update configuration files
- srun -n 60 -N 2 -m plane=30 --mpi=pmix ./gchp   # launch 60 GCHP processes
+ srun -n 60 -N 2 -m plane=30 --mpi=pmix ./gchp   # launch 60 GCHP processes across 2
+                                                 # nodes, with 30 processes per node
+
+# Please note that there are several commands that may work to execute GCHP, and the
+# provided example may not be appropriate for your system. The command above is for SLURM
+# built with PMIx support. Some SLURM implementations have PMI2 support instead, or no
+# special MPI processing. Check with your system administrator about the appropriate
+# way to use srun. Some users have had better experience using mpirun or mpiexec which
+# are MPI-specific run commands implemented in MPI rather than SLURM.


### PR DESCRIPTION
This PR is for small updates for GCHP related to run directories. So far it includes expanding clarifying comments in example GCHP SLURM run scripts (discussed in https://github.com/geoschem/GCHP/issues/129) and ensuring GCHP option to write restart files via o-server is disabled if using less than 1000 cores (discussed in https://github.com/geoschem/GCHP/issues/133). This PR is for merge into GEOS-Chem 13.2.1.
