### PR TITLE
GCHP interface should use LEN=ESMF_MAXPATHLEN for restart file path variable

### DIFF
--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -377,7 +377,8 @@ CONTAINS
     INTEGER                       :: Nadv, landTypeInt
     LOGICAL                       :: FOUND 
     LOGICAL                       :: EOF
-    CHARACTER(LEN=60)             :: rstFile, landTypeStr, importName, simType
+    CHARACTER(LEN=60)             :: landTypeStr, importName, simType
+    CHARACTER(LEN=ESMF_MAXPATHLEN):: rstFile
     INTEGER                       :: restartAttr
     CHARACTER(LEN=ESMF_MAXSTR)    :: HistoryConfigFile ! HISTORY config file
     INTEGER                       :: T


### PR DESCRIPTION
Fixes https://github.com/geoschem/GCHP/issues/134