### PR TITLE
[PULL REQUEST] Fix typo in CloudHet functions: Use MIN instead of MAX for ff

### DIFF
--- a/KPP/fullchem/fullchem_SulfurChemFuncs.F90
+++ b/KPP/fullchem/fullchem_SulfurChemFuncs.F90
@@ -3349,7 +3349,7 @@ CONTAINS
     ! Ratio of volume inside to outside cloud
     ! FF has a range [0,+inf], so cap it at 1e30
     FF = SafeDiv( FC, ( 1.0_fp - FC ), 1e30_fp )
-    FF = MAX( FF, 1e30_fp )
+    FF = MIN( FF, 1.0e30_fp )
 
     ! Avoid div by zero for the TAUC/FF term
     term1 = 0.0_fp
@@ -3466,7 +3466,7 @@ CONTAINS
     ! Ratio of volume inside to outside cloud
     ! ff has a range [0,+inf], so cap it at 1e30
     ff = SafeDiv( fc, (1e0_fp - fc), 1e30_fp )
-    ff = max( ff, 1e30_fp )
+    ff = MIN( ff, 1.0e30_fp )
 
     ! Ratio of mass inside to outside cloud
     ! xx has range [0,+inf], but ff is capped at 1e30, so this shouldn't overflow

--- a/KPP/fullchem/rateLawUtilFuncs.F90
+++ b/KPP/fullchem/rateLawUtilFuncs.F90
@@ -256,7 +256,7 @@ CONTAINS
     ! Ratio of volume inside to outside cloud
     ! ff has a range [0,+inf], so cap it at 1e30
     ff = SafeDiv( H%CldFr, H%ClearFr, 1.0e+30_dp )
-    ff = MAX( ff, 1.0e+30_dp )
+    ff = MIN( ff, 1.0e+30_dp )
 
     ! Ratio of mass inside to outside cloud
     ! xx has range [0,+inf], but ff is capped at 1e30, so this shouldn't overflow


### PR DESCRIPTION
This is the corresponding PR to bug report #906.

These updates are 1-line fixes (changing MAX to MIN), but we will run "alpha" benchmarks on this update, as it has the potential to cause significant changes in the chemistry output.