### PR TITLE
Include PET number in error messages if using ESMF

### DIFF
--- a/Headers/errcode_mod.F90
+++ b/Headers/errcode_mod.F90
@@ -62,6 +62,11 @@ CONTAINS
 #if defined( MODEL_CESM )
     USE CAM_ABORTUTILS, ONLY : ENDRUN
 #endif
+#if defined( ESMF_ )
+#include "MAPL_Generic.h"
+    USE ESMF
+    USE MAPL_Mod
+#endif
 !
 ! !INPUT PARAMETERS:
 !
@@ -81,10 +86,32 @@ CONTAINS
 !BOC
 
     CHARACTER(LEN=1000) :: Message
-
+#if defined( ESMF_)
+    INTEGER             :: localPET, STATUS
+    CHARACTER(4)        :: localPETchar
+    CHARACTER(LEN=1023) :: MSG, MSG1, MSG2
+    TYPE(ESMF_VM)       :: VM
+#endif
     !=======================================================================
     ! GC_ERROR begins here
     !=======================================================================
+
+    ! Construct error message
+#if defined( ESMF_ )
+    ! Get current thread number
+    CALL ESMF_VMGetCurrent(VM, RC=STATUS)
+    CALL ESMF_VmGet( VM, localPET=localPET, __RC__ )
+    WRITE(localPETchar,'(I4.4)') localPET
+    MSG1 = 'GEOS-Chem ERROR ['//TRIM(localPETchar)//']: '//TRIM(ErrMsg)
+    MSG2 = ''
+    IF ( PRESENT(THISLOC) ) THEN
+       MSG2 = NEW_LINE('a') // ' --> LOCATION: ' // TRIM( THISLOC )
+    ENDIF
+    MSG = NEW_LINE('a') // TRIM(MSG1) // TRIM(MSG2)
+
+    ! Print error message
+    WRITE(*,*) TRIM(MSG)
+#else
 
     ! Separator
     WRITE( 6, '(a)' ) REPEAT( '=', 79 )
@@ -108,6 +135,7 @@ CONTAINS
     ! Separators
     WRITE( 6, '(a)' ) REPEAT( '=', 79 )
     WRITE( 6, '(a)' ) ''
+#endif
 
     ! Force the message to be flushed to the log file
     CALL Flush( 6 )


### PR DESCRIPTION
This is a companion PR to go with [updates to HEMCO](https://github.com/geoschem/HEMCO/pull/111) to make error handling more clear and robust when using MPI. However, this update can also be applied without those HEMCO updates. The update for GEOS-Chem is simply to write the CPU number when writing error messages. If all threads print the same traceback via GC_ERROR then the many messages can be more easily parsed by isolating prints for a single CPU. If the error occurs on only one thread, or a subset of threads, this will more easily identify that.