### PR TITLE
[PULL REQUEST] Integration test bug fixes: (1) nested-grid int tests; (2) run directory naming

### DIFF
--- a/GeosCore/tagged_o3_mod.F90
+++ b/GeosCore/tagged_o3_mod.F90
@@ -243,6 +243,9 @@ CONTAINS
     ! P24H is in kg/m3 per emission time step (ckeller, 9/17/2014).
     PPROD = P24H(I,J,L) * BOXVL * ( GET_TS_CHEM()/TS_EMIS )
 
+    ! Prevent denormal numbers (bmy, 01 Oct 2021)
+    PPROD = MAX( PPROD, 1.0e-30_fp )
+
     !-----------------------
     ! #1: Total P(O3)
     !-----------------------
@@ -525,10 +528,11 @@ CONTAINS
           ENDIF
 
           ! L(O3) is now in [1/m3] (ckeller, 9/17/2014)
+          ! Prevent denormal numbers (bmy, 01 Oct 2021
+          LL = 0.0_fp
           IF ( State_Met%InTroposphere(I,J,L) ) THEN
              LL = Spc(I,J,L,N) * L24H(I,J,L) * BOXVL * DT
-          ELSE
-             LL = 0.0e+0_fp
+             LL = MAX( LL, 1.0e-30_fp )
           ENDIF
 
           !===========================================================
@@ -540,7 +544,11 @@ CONTAINS
           ! Production of tagged O3 species [kg/s]
           IF ( State_Diag%Archive_Prod ) THEN
              IF ( PP(I,J,L,N) > 0e+0_fp ) THEN
-                State_Diag%Prod(I,J,L,N) = P24Hptr(I,J,L) * BOXVL / TS_EMIS
+                !-------------------------------------------------------------
+                ! This seems to cause a floating point exception error
+                !State_Diag%Prod(I,J,L,N) = P24Hptr(I,J,L) * BOXVL / TS_EMIS
+                !-------------------------------------------------------------
+                State_Diag%Prod(I,J,L,N) = PP(I,J,L,N) * BOXVL / TS_EMIS
              ENDIF
           ENDIF
 
@@ -554,6 +562,9 @@ CONTAINS
           ! Apply chemical P(O3) - L(O3) to each tagged species
           !===========================================================
           Spc(I,J,L,N) = Spc(I,J,L,N) + PP(I,J,L,N) - LL
+
+          ! Prevent denormal values (bmy, 10/1/21)
+          IF ( Spc(I,J,L,N) < 1.0e-30_fp ) Spc(I,J,L,N) = 0.0_fp
 
        ENDDO
        ENDDO

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -1143,7 +1143,7 @@ ETO:
   Formula: HOCH2CH2O
   FullName: alkoxy radical from ETOO
   Is_Gas: true
-  MW_g: 61.0
+  MW_g: 61.06
 ETOO:
   Formula: HOCH2CH2OO
   FullName: peroxy radical from ethene

--- a/test/GCClassic/intTestCreate.sh
+++ b/test/GCClassic/intTestCreate.sh
@@ -197,7 +197,7 @@ create_rundir "9\n1\n2\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 dir="gc_2x25_TransportTracers_merra2"
 create_rundir "10\n1\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
-dir="gc_2x25_TransportTracers_LuoWd_merra2"
+dir="gc_2x25_TransportTracers_merra2_LuoWd"
 create_rundir "10\n1\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
 dir="gc_2x25_metals_merra2"
@@ -262,7 +262,7 @@ create_rundir "10\n2\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 #dir="gc_2x25_metals_geosfp"
 #create_rundir "11\n2\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
-dir="gc_2x25_TransportTracers_LuoWd_geosfp"
+dir="gc_2x25_TransportTracers_geosfp_LuoWd"
 create_rundir "10\n2\n2\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
 #=============================================================================
@@ -278,7 +278,7 @@ create_rundir "2\n1\n1\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 dir="gc_4x5_fullchem_merra2"
 create_rundir "1\n1\n1\n1\n1\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 
-dir="gc_4x5_fullchem_LuoWd_merra2"
+dir="gc_4x5_fullchem_merra2_LuoWd"
 create_rundir "1\n1\n1\n1\n1\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 
 dir="gc_4x5_fullchem_aciduptake_merra2"
@@ -302,10 +302,10 @@ create_rundir "1\n4\n1\n1\n1\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 dir="gc_4x5_fullchem_RRTMG_merra2"
 create_rundir "1\n8\n1\n1\n1\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 
-dir="gc_4x5_fullchem_TOMAS15_merra2"
+dir="gc_4x5_fullchem_TOMAS15_merra2_47L"
 create_rundir "1\n6\n1\n1\n1\n2\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
 
-dir="gc_4x5_fullchem_TOMAS40_merra2"
+dir="gc_4x5_fullchem_TOMAS40_merra2_47L"
 create_rundir "1\n6\n2\n1\n1\n2\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
 
 dir="gc_4x5_Hg_merra2"
@@ -326,7 +326,7 @@ create_rundir "9\n1\n1\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 dir="gc_4x5_TransportTracers_merra2"
 create_rundir "10\n1\n1\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
-dir="gc_4x5_TransportTracers_LuoWd_merra2"
+dir="gc_4x5_TransportTracers_merra2_LuoWd"
 create_rundir "10\n1\n1\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
 dir="gc_4x5_metals_merra2"
@@ -345,7 +345,7 @@ create_rundir "2\n2\n1\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 dir="gc_4x5_fullchem_geosfp"
 create_rundir "1\n1\n2\n1\n1\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 
-dir="gc_4x5_fullchem_LuoWd_geosfp"
+dir="gc_4x5_fullchem_geosfp_LuoWd"
 create_rundir "1\n1\n2\n1\n1\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 
 dir="gc_4x5_fullchem_aciduptake_geosfp"
@@ -369,10 +369,10 @@ create_rundir "1\n4\n2\n1\n1\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 dir="gc_4x5_fullchem_RRTMG_geosfp"
 create_rundir "1\n8\n2\n1\n1\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 
-dir="gc_4x5_fullchem_TOMAS15_geosfp"
+dir="gc_4x5_fullchem_TOMAS15_geosfp_47L"
 create_rundir "1\n6\n1\n2\n1\n2\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
 
-dir="gc_4x5_fullchem_TOMAS40_geosfp"
+dir="gc_4x5_fullchem_TOMAS40_geosfp_47L"
 create_rundir "1\n6\n2\n2\n1\n2\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
 
 dir="gc_4x5_Hg_geosfp"
@@ -393,7 +393,7 @@ create_rundir "9\n2\n1\n1\n${root}\n${dir}\nn\n"          ${root} ${dir} ${log}
 dir="gc_4x5_TransportTracers_geosfp"
 create_rundir "10\n2\n1\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
-dir="gc_4x5_TransportTracers_LuoWd_geosfp"
+dir="gc_4x5_TransportTracers_geosfp_LuoWd"
 create_rundir "10\n2\n1\n1\n${root}\n${dir}\nn\n"         ${root} ${dir} ${log}
 
 # NOTE: The metals simulation runs from 2011-2013, the earlier part of
@@ -416,16 +416,16 @@ create_rundir "1\n1\n2\n1\n2\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 # Nested-grid simulations
 #=============================================================================
 
-dir="merra2_05x0625_CH4_na_47L"
+dir="gc_05x0625_CH4_merra2_47L_na"
 create_rundir "3\n1\n3\n4\n2\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 
-dir="geosfp_025x03125_CH4_na_47L"
+dir="gc_025x03125_CH4_geosfp_47L_na"
 create_rundir "3\n2\n4\n4\n2\n${root}\n${dir}\nn\n"       ${root} ${dir} ${log}
 
-dir="merra2_05x0625_fullchem_as_47L"
-create_rundir "1\n1\n1\n3\n2\n2\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
+dir="gc_05x0625_fullchem_merra2_47L_na"
+create_rundir "1\n1\n1\n3\n4\n2\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
 
-dir="geosfp_025x03125_fullchem_na_47L"
+dir="gc_025x03125_fullchem_geosfp_47L_na"
 create_rundir "1\n1\n2\n4\n4\n2\n${root}\n${dir}\nn\n"    ${root} ${dir} ${log}
 
 #=============================================================================

--- a/test/GCClassic/intTestExecute_slurm.sh
+++ b/test/GCClassic/intTestExecute_slurm.sh
@@ -2,9 +2,9 @@
 
 #SBATCH -c 24
 #SBATCH -N 1
-#SBATCH -t 0-05:00
+#SBATCH -t 0-06:00
 #SBATCH -p huce_cascade
-#SBATCH --mem=80000
+#SBATCH --mem=90000
 #SBATCH --mail-type=END
 
 #------------------------------------------------------------------------------

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -153,15 +153,20 @@ function update_config_files() {
     sed_ie "${SED_INPUT_GEOS_6}" "${root}/${runDir}/input.geos"
     sed_ie "${SED_HEMCO_CONF_1}" "${root}/${runDir}/HEMCO_Config.rc"
     sed_ie "${SED_HEMCO_CONF_2}" "${root}/${runDir}/HEMCO_Config.rc"
-    sed_ie "${SED_HEMCO_CONF_3}" "${root}/${runDir}/HEMCO_Config.rc"
     sed_ie "${SED_HISTORY_RC_1}" "${root}/${runDir}/HISTORY.rc"
     sed_ie "${SED_HISTORY_RC_2}" "${root}/${runDir}/HISTORY.rc"
 
-    # For GCHP only
+    # For nested-grid rundirs, add a NA into the entries for met fields
+    if grep -q "025x03125" <<< "${runDir}"; then
+	sed_ie "${SED_HEMCO_CONF_3}" "${root}/${runDir}/HEMCO_Config.rc"
+    fi
+    if grep -q "05x0625" <<< "${runDir}"; then
+	sed_ie "${SED_HEMCO_CONF_3}" "${root}/${runDir}/HEMCO_Config.rc"
+    fi
+
+    # For GCHP only: replace text in runConfig.sh
     expr=$(is_gchp_rundir "${root}/${runDir}")
     if [[ "x${expr}" == "xTRUE" ]]; then
-
-	# Replace text in run.config.sh
 	sed_ie "${SED_RUN_CONFIG_1}" ${root}/${runDir}/runConfig.sh
 	sed_ie "${SED_RUN_CONFIG_2}" ${root}/${runDir}/runConfig.sh
 	sed_ie "${SED_RUN_CONFIG_3}" ${root}/${runDir}/runConfig.sh

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -149,12 +149,6 @@ function update_config_files() {
     #------------------------------------------------------------------------
     # Replace text in input.geos
     #------------------------------------------------------------------------
-    sed_ie "${SED_INPUT_GEOS_1}" "${root}/${runDir}/input.geos"
-    sed_ie "${SED_INPUT_GEOS_2}" "${root}/${runDir}/input.geos"
-    sed_ie "${SED_INPUT_GEOS_3}" "${root}/${runDir}/input.geos"
-    sed_ie "${SED_INPUT_GEOS_4}" "${root}/${runDir}/input.geos"
-    sed_ie "${SED_INPUT_GEOS_5}" "${root}/${runDir}/input.geos"
-    sed_ie "${SED_INPUT_GEOS_6}" "${root}/${runDir}/input.geos"
 
     # For nested-grid fullchem runs, change simulation time to 20 minutes
     # in order to reduce the run time of the whole set of integration tests.
@@ -165,11 +159,17 @@ function update_config_files() {
 	sed_ie "${SED_INPUT_GEOS_N}" "${root}/${runDir}/input.geos"
     fi
 
+    # Other text replacements
+    sed_ie "${SED_INPUT_GEOS_1}" "${root}/${runDir}/input.geos"
+    sed_ie "${SED_INPUT_GEOS_2}" "${root}/${runDir}/input.geos"
+    sed_ie "${SED_INPUT_GEOS_3}" "${root}/${runDir}/input.geos"
+    sed_ie "${SED_INPUT_GEOS_4}" "${root}/${runDir}/input.geos"
+    sed_ie "${SED_INPUT_GEOS_5}" "${root}/${runDir}/input.geos"
+    sed_ie "${SED_INPUT_GEOS_6}" "${root}/${runDir}/input.geos"
+
     #------------------------------------------------------------------------
     # Replace text in HEMCO_Config.rc
     #------------------------------------------------------------------------
-    sed_ie "${SED_HEMCO_CONF_1}" "${root}/${runDir}/HEMCO_Config.rc"
-    sed_ie "${SED_HEMCO_CONF_2}" "${root}/${runDir}/HEMCO_Config.rc"
 
     # For all nested-grid rundirs, add a NA into the entries for met fields
     if grep -q "025x03125" <<< "${runDir}"; then
@@ -179,11 +179,13 @@ function update_config_files() {
 	sed_ie "${SED_HEMCO_CONF_N}" "${root}/${runDir}/HEMCO_Config.rc"
     fi
 
+    # Other text replacements
+    sed_ie "${SED_HEMCO_CONF_1}" "${root}/${runDir}/HEMCO_Config.rc"
+    sed_ie "${SED_HEMCO_CONF_2}" "${root}/${runDir}/HEMCO_Config.rc"
+
     #------------------------------------------------------------------------
     # Replace text in HISTORY.rc
     #------------------------------------------------------------------------
-    sed_ie "${SED_HISTORY_RC_1}" "${root}/${runDir}/HISTORY.rc"
-    sed_ie "${SED_HISTORY_RC_2}" "${root}/${runDir}/HISTORY.rc"
 
     # For nested-grid fullchem runs, change frequency and duration to 20 mins
     # in order to reduce the run time of the whole set of integration tests.
@@ -193,6 +195,10 @@ function update_config_files() {
     if grep -q "05x0625_fullchem" <<< "${runDir}"; then
 	sed_ie "${SED_HISTORY_RC_N}" "${root}/${runDir}/HISTORY.rc"
     fi
+
+    # Other text replacements
+    sed_ie "${SED_HISTORY_RC_1}" "${root}/${runDir}/HISTORY.rc"
+    sed_ie "${SED_HISTORY_RC_2}" "${root}/${runDir}/HISTORY.rc"
 
     #------------------------------------------------------------------------
     # Replace text in runConfig.sh (GCHP_only)

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -21,13 +21,16 @@
 FILL=$(printf '.%.0s' {1..44})
 SEP_MAJOR=$(printf '=%.0s' {1..78})
 SEP_MINOR=$(printf '\055%.0s' {1..78})
-SED_INPUT_GEOS_1='s/End   YYYYMMDD, hhmmss  : 20190801 000000/End   YYYYMMDD, hhmmss  : 20190701 002000/'
-SED_INPUT_GEOS_2='s/End   YYYYMMDD, hhmmss  : 20190201 000000/End   YYYYMMDD, hhmmss  : 20190101 002000/'
+SED_INPUT_GEOS_1='s/End   YYYYMMDD, hhmmss  : 20190801 000000/End   YYYYMMDD, hhmmss  : 20190701 010000/'
+SED_INPUT_GEOS_2='s/End   YYYYMMDD, hhmmss  : 20190201 000000/End   YYYYMMDD, hhmmss  : 20190101 010000/'
 SED_INPUT_GEOS_3='s/Start YYYYMMDD, hhmmss  : 20160101 000000/Start YYYYMMDD, hhmmss  : 20190101 000000/'
 SED_INPUT_GEOS_4='s/End   YYYYMMDD, hhmmss  : 20160201 000000/End   YYYYMMDD, hhmmss  : 20190101 010000/'
 SED_INPUT_GEOS_5='s/End   YYYYMMDD, hhmmss  : 20160101 010000/End   YYYYMMDD, hhmmss  : 20190101 010000/'
-SED_INPUT_GEOS_6='s/End   YYYYMMDD, hhmmss  : 20110201 000000/End   YYYYMMDD, hhmmss  : 20110101 002000/'
-SED_HISTORY_RC_1='s/00000100 000000/00000000 002000/'
+SED_INPUT_GEOS_6='s/End   YYYYMMDD, hhmmss  : 20110201 000000/End   YYYYMMDD, hhmmss  : 20110101 010000/'
+SED_HEMCO_CONF_1='s/GEOS_0.25x0.3125/GEOS_0.25x0.3125_NA/'
+SED_HEMCO_CONF_2='s/GEOS_0.5x0.625/GEOS_0.5x0.625_NA/'
+SED_HEMCO_CONF_3='s/\$RES.\$NC/\$RES.NA.\$NC/'
+SED_HISTORY_RC_1='s/00000100 000000/00000000 010000/'
 SED_HISTORY_RC_2='s/7440000/010000/'
 SED_RUN_CONFIG_1='s/20160101 000000/20190101 000000/'
 SED_RUN_CONFIG_2='s/20160201 000000/20190101 010000/'
@@ -148,6 +151,9 @@ function update_config_files() {
     sed_ie "${SED_INPUT_GEOS_4}" "${root}/${runDir}/input.geos"
     sed_ie "${SED_INPUT_GEOS_5}" "${root}/${runDir}/input.geos"
     sed_ie "${SED_INPUT_GEOS_6}" "${root}/${runDir}/input.geos"
+    sed_ie "${SED_HEMCO_CONF_1}" "${root}/${runDir}/HEMCO_Config.rc"
+    sed_ie "${SED_HEMCO_CONF_2}" "${root}/${runDir}/HEMCO_Config.rc"
+    sed_ie "${SED_HEMCO_CONF_3}" "${root}/${runDir}/HEMCO_Config.rc"
     sed_ie "${SED_HISTORY_RC_1}" "${root}/${runDir}/HISTORY.rc"
     sed_ie "${SED_HISTORY_RC_2}" "${root}/${runDir}/HISTORY.rc"
 


### PR DESCRIPTION
This PR includes the updates in #918 and #928, with improvements for GEOS-Chem Classic integration tests:

- Run directories use a more consistent naming scheme (starting with gc_RES_SIM)
- We only run nested-grid integration tests for the NA grid
- The `intTestCreate.sh` script for GEOS-Chem Classic now makes the required edits in `HEMCO_Config.rc` to use the cropped native-resolution met fields for the NA domain rather than the global native-resolution met fields.  This will speed up the nested-grid tests as they will not need to do regridding on the global data.