### PR TITLE
[PULL REQUEST] Bugfix: Wrong Timer_End call at the beginning of Integrate 2

### DIFF
--- a/GeosCore/flexchem_mod.F90
+++ b/GeosCore/flexchem_mod.F90
@@ -920,7 +920,7 @@ CONTAINS
           FIX = C(NVAR+1:NSPEC)
           CALL Update_RCONST( )
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "     Integrate 2", RC, InLoop=.TRUE., ThreadNum=Thread )
+             CALL Timer_Start( "     Integrate 2", RC, InLoop=.TRUE., ThreadNum=Thread )
           ENDIF
           CALL Integrate( TIN,    TOUT,    ICNTRL,                           &
                           RCNTRL, ISTATUS, RSTATE, IERR                     )


### PR DESCRIPTION
This fixes a minor issue in flexchem_mod where the timer for Integrate 2
was erroneously initiated at the beginning of the integration. This wrong call results in gibberish results for the Integrate 2 timer if it is ever triggered.