### PR TITLE
[PULL REQUEST] Modify fullchem_mod.F90 to print concentrations & rates after KPP "Integrate failed twice" error

### DIFF
--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -173,7 +173,7 @@ CONTAINS
     INTEGER,  SAVE         :: CH4_YEAR  = -1
 
 #ifdef MODEL_CLASSIC
-#ifdef OMP
+#ifndef NO_OMP
     INTEGER, EXTERNAL      :: OMP_GET_THREAD_NUM
 #endif
 #endif


### PR DESCRIPTION
This modifies fullchem_mod.F90 so that:

  1. If KPP fails to converge twice, instead of just stopping the run, we set a flag (`Failed2x = True`), and continue with the loop over grid boxes.  Then at the end of the loop we check the status of `Failed2x` ; if true, we declare GC_FAILURE and propagate the error status up to the main program, where the run can be terminated gracefully.  This is especially necessary for GCHP, because otherwise only the execution on one core will halt, which will put the run in a "hung" state.
  2. We have also added code to print out the species concentrations and reaction rates for grid boxes where the KPP "Integrate Failed Twice" occurs.  This will assist in debugging.
  3. Updated calls to Timer_Start & Timer_End to use keyword arguments (for clarity).
  4. Also added cosmetic changes & trimmed trailing whitespace.