### PR TITLE
[PULL REQUEST] Update run/shared/cleanRunDir.sh to remove additional GCHP logs (closes #982)

### DIFF
--- a/run/shared/cleanRunDir.sh
+++ b/run/shared/cleanRunDir.sh
@@ -19,6 +19,8 @@ rm -fv slurm-*
 rm -fv 1
 rm -fv EGRESS
 rm -fv core.*
+rm -fv PET*.ESMF_LogFile
+rm -fv allPEs.log
 
 # Clean data too. Prompt user to confirm they want to do this.
 # perhaps asking if they want to archive before deletion.


### PR DESCRIPTION
This is the corresponding PR to issue #982.  The cleanRunDir.sh script now removes additional log files that are produced by GCHP (but which will be discontinued in later versions).
