### PR TITLE
[PULL REQUEST] Fix numerical issues that halted GCHP benchmark simulations (closes geoschem/gchp #170)

### DIFF
--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -2998,19 +2998,18 @@ CONTAINS
        L8      = 0.e+0_fp !(jmm, 06/26/18)
        L8S     = 0.e+0_fp !(jmm, 06/26/18)
 
-       ! If we are not using KPP to compute reaction rates, then
-       ! compute SO2 cloud chemistry (1) if there is cloud, (2) if there
-       ! is SO2 present, (3) if T > -15 C, and (4) if there is liquid
-       ! water content (prevents div-by-zero).
-       IF ( ( State_Chm%Do_SulfateMod_Cld )   .and.                          &
-            ( FC     > 1.e-4_fp           )   .and.                          &
-            ( SO2_ss > MINDAT             )   .and.                          &
+       ! If (1) there is cloud, (2) there is SO2 present, (3) T > -15 C, and
+       ! (4) liquid water content (LWC) is present (but not small enough to
+       ! make divisions blow up), then compute sulfate production in cloud.
+       IF ( ( State_Chm%Do_SulfateMod_Cld )                            .and. &
+            ( FC     > 1.e-4_fp           )                            .and. &
+            ( SO2_ss > MINDAT             )                            .and. &
 #ifdef LUO_WETDEP
-            ( TK     > 237.0              )   .and.                          &
+            ( TK     > 237.0_fp           )                            .and. &
 #else
-            ( TK     > 258.0              )   .and.                          &
+            ( TK     > 258.0_fp           )                            .and. &
 #endif
-            ( LWC    > 0.e+0_fp           ) ) THEN
+            ( LWC    > 1.0e-20_fp         ) ) THEN
 
           !===========================================================
           ! NOTE...Sulfate production from aquatic reactions of SO2

--- a/KPP/fullchem/rateLawUtilFuncs.F90
+++ b/KPP/fullchem/rateLawUtilFuncs.F90
@@ -111,11 +111,11 @@ CONTAINS
     kIEduct = 0.0_dp
     kII     = 0.0_dp
     !
-    ! Prevent div by zero.   NOTE: Now use 1.0e-20 as the error trap for
+    ! Prevent div by zero.   NOTE: Now use 1.0e-8 as the error trap for
     ! concEduct.  100 (the previous criterion) was too large.  We should
-    ! never have have a concentration as low as 1e-20 molec/cm3, as that
-    ! will definitely blow up the division. (bmy, 9/20/21)
-    IF ( concEduct < 1.0e-20_dp                          ) RETURN
+    ! never have have a concentration as low as 1e-8 molec/cm3, as that
+    ! will definitely blow up the division. (bmy, 11/1/21)
+    IF ( concEduct < 1.0e-8_dp                           ) RETURN
     IF ( .not. Is_SafeDiv( concGas*kISource, concEduct ) ) RETURN
     !
     ! Compute rates


### PR DESCRIPTION
This PR addresses the issues brought up in https://github.com/geoschem/GCHP/issues/170 (GCHP 13.3.0-alpha.9 benchmark fails).

We have modified some error traps that should now prevent certain equations from blowing up due to very small denominators.  In particular:

  1. In routine `CHEM_SO2`, we skip computing in-cloud sulfur chemistry if liquid water content (`LWC`) is less than 1e-20.
  2. In hetchem utility routine `kIIR1Ltd`, we exit if `concEduct` (i.e. the "abundant" species) is less than 1e-8 molec/cm3.

@msulprizio, @lizziel, I have this PR going into the "release" branch so that we can use these fixes to run 13.0.0-rc.1 benchmarks.  Feel free to change the destination branch.
