### PR TITLE
[PULL REQUEST] GEOS-Chem Classic and GCHP fullchem benchmarks now use degassing volcano climatology (Closes #1005)

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -176,8 +176,8 @@ Warnings:                    1
 115     DustAlk                : ${RUNDIR_DUSTALK_EXT}   DSTAL1/DSTAL2/DSTAL3/DSTAL4
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
-    --> Volcano_Table          :       $ROOT/VOLCANO/v2021-09/${RUNDIR_VOLC_YEAR}/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
-    --> Volcano_Climatology    :       $ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc
+    --> Volcano_Table          :       ${RUNDIR_VOLC_TABLE}
+    --> Volcano_Climatology    :       ${RUNDIR_VOLC_CLIMATOLOGY}
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -194,8 +194,8 @@ Warnings:                    1
 115     DustAlk                : ${RUNDIR_DUSTALK_EXT}   DSTAL1/DSTAL2/DSTAL3/DSTAL4
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
-    --> Volcano_Table          :       $ROOT/VOLCANO/v2021-09/${RUNDIR_VOLC_YEAR}/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
-    --> Volcano_Climatology    :       $ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc
+    --> Volcano_Table          :       ${RUNDIR_VOLC_TABLE}
+    --> Volcano_Climatology    :       ${RUNDIR_VOLC_CLIMATOLOGY}
 120     Inorg_Iodine           : on    HOI/I2
     --> Emit HOI               :       true
     --> Emit I2                :       true

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -368,7 +368,8 @@ if [[ ${met} = "ModelE2.1" ]]; then
 	RUNDIR_VARS+="RUNDIR_GCAP2_RUNID='$runid'\n"
     done
 
-    if [[ "${sim_name}" == "fullchem" ]] || [[ "${sim_name}" == "aerosol" ]]; then
+    if [[ "x${sim_name}" == "xfullchem" ]] || \
+       [[ "x${sim_name}" == "xaerosol" ]]; then
 	printf "${thinline}Choose a fixed year for volcanic emissions (1978-2020)\n or -1 for year of simulation (assuming year exists):${thinline}"
 	valid_volc=0
 	while [ "${valid_volc}" -eq 0 ]; do
@@ -391,7 +392,21 @@ else
     RUNDIR_VARS+="RUNDIR_GCAP2_RUNID='not_used'\n"
     RUNDIR_VARS+="RUNDIR_VOLC_YEAR='\$YYYY'\n"
     RUNDIR_VARS+="RUNDIR_MET_AVAIL='# 1980-2021'\n"
-fi
+    
+    # Define the volcano paths for the HEMCO_Config.rc file
+    # NOTE: Benchmark simulations always use the climatological emissions!
+    if [[ "x${sim_name}" == "xfullchem" ]]  ||  \
+       [[ "x${sim_name}" == "xaerosol"  ]]; then	
+	RUNDIR_VARS+="RUNDIR_VOLC_CLIMATOLOGY='\$ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc'\n"
+
+	if [[ "x${sim_extra_option}" == "xbenchmark" ]]; then
+	    RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc'\n"
+	else
+	    RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/\${RUNDIR_VOLC_YEAR}/\$MM/so2_volcanic_emissions_Carns.\$YYYY\$MM\$DD.rc'\n"
+	fi
+    fi
+
+ fi
 
 #-----------------------------------------------------------------
 # Ask user to select horizontal resolution
@@ -766,7 +781,7 @@ elif [[ ${sim_extra_option} =~ "APM" ]]; then
 fi
 
 # If benchmark simulation, put run script in directory
-if [[ ${sim_extra_option} == "benchmark" ]]; then
+if [[ "x${sim_extra_option}" == "xbenchmark" ]]; then
     cp ./runScriptSamples/geoschem.benchmark.run ${rundir}
     chmod 744 ${rundir}/geoschem.benchmark.run
 fi
@@ -1085,7 +1100,6 @@ while [ "$valid_response" -eq 0 ]; do
 	printf "\n"
 	git init
 	git add *.rc *.sh *.yml *.run *.py input.geos getRunInfo
-	git add runScriptSamples/* README .gitignore
 	printf " " >> ${version_log}
 	git commit -m "Initial run directory" >> ${version_log}
 	cd ${srcrundir}

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -390,7 +390,6 @@ if [[ ${met} = "ModelE2.1" ]]; then
 else
     RUNDIR_VARS+="RUNDIR_GCAP2_SCENARIO='not_used'\n"
     RUNDIR_VARS+="RUNDIR_GCAP2_RUNID='not_used'\n"
-    RUNDIR_VARS+="RUNDIR_VOLC_YEAR='\$YYYY'\n"
     RUNDIR_VARS+="RUNDIR_MET_AVAIL='# 1980-2021'\n"
     
     # Define the volcano paths for the HEMCO_Config.rc file
@@ -402,7 +401,7 @@ else
 	if [[ "x${sim_extra_option}" == "xbenchmark" ]]; then
 	    RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc'\n"
 	else
-	    RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/\${RUNDIR_VOLC_YEAR}/\$MM/so2_volcanic_emissions_Carns.\$YYYY\$MM\$DD.rc'\n"
+	    RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/\$YYYY/\$MM/so2_volcanic_emissions_Carns.\$YYYY\$MM\$DD.rc'\n"
 	fi
     fi
 

--- a/run/GCClassic/gitignore
+++ b/run/GCClassic/gitignore
@@ -16,4 +16,8 @@ OutputDir/HEMCO_diagnostics*
 CodeDir
 build
 Plots
+Results
+BenchmarkResults
 rundir.version
+runScriptSamples
+README

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -193,8 +193,8 @@ Warnings:                    1
 115     DustAlk                : off   DSTAL1/DSTAL2/DSTAL3/DSTAL4
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
-    --> Volcano_Table          :       $ROOT/VOLCANO/v2021-09/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
-    --> Volcano_Climatology    :       $ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc
+    --> Volcano_Table          :       ${RUNDIR_VOLC_TABLE}
+    --> Volcano_Climatology    :       ${RUNDIR_VOLC_CLIMATOLOGY}
 120     Inorg_Iodine           : on    HOI/I2
     --> Emit HOI               :       true
     --> Emit I2                :       true

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -224,13 +224,12 @@ fi
 
 # NOTE: Fullchem benchmarks use the climatological volcano emissions!
 if [[ "x${sim_name}" == "xfullchem" ]]; then
-    RUNDIR_VARS+="RUNDIR_VOLC_YEAR='\$YYYY'\n"
     RUNDIR_VARS+="RUNDIR_VOLC_CLIMATOLOGY='\$ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc'\n"
 
     if [[ "x${sim_extra_option}" == "xbenchmark" ]]; then
 	RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc'\n"
     else
-	RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/\${RUNDIR_VOLC_YEAR}/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc'\n"
+	RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/\$YYYY/\$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc'\n"
     fi
 fi
 

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -222,6 +222,18 @@ else
     RUNDIR_VARS+="RUNDIR_USE_ONLINE_O3='T'\n"
 fi
 
+# NOTE: Fullchem benchmarks use the climatological volcano emissions!
+if [[ "x${sim_name}" == "xfullchem" ]]; then
+    RUNDIR_VARS+="RUNDIR_VOLC_YEAR='\$YYYY'\n"
+    RUNDIR_VARS+="RUNDIR_VOLC_CLIMATOLOGY='\$ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc'\n"
+
+    if [[ "x${sim_extra_option}" == "xbenchmark" ]]; then
+	RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc'\n"
+    else
+	RUNDIR_VARS+="RUNDIR_VOLC_TABLE='\$ROOT/VOLCANO/v2021-09/\${RUNDIR_VOLC_YEAR}/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc'\n"
+    fi
+fi
+
 #-----------------------------------------------------------------
 # Ask user to select meteorology source
 #-----------------------------------------------------------------
@@ -575,7 +587,6 @@ while [ "$valid_response" -eq 0 ]; do
 	printf "\n"
 	git init
 	git add *.rc *.sh *.yml *.run *.py input.geos input.nml
-	git add README .gitignore
 	printf " " >> ${version_log}
 	git commit -m "Initial run directory" >> ${version_log}
 	cd ${srcrundir}

--- a/run/GCHP/gitignore
+++ b/run/GCHP/gitignore
@@ -17,3 +17,6 @@ fort.11
 geos
 setEnvironment
 *.out
+RunScriptSamples
+README
+build


### PR DESCRIPTION
This is the corresponding PR for #1005.  We have updated the run directory creation scripts and HEMCO_Config.rc template files so that the Volc_Table entry in HEMCO_Config.rc is set to use the degassing-only volcano climatology rather than daily volcano emissions that contain eruptive volcanos.  This should make it easier to compare benchmarks if the base year is ever changed, since it will remove time-specific eruptions.