### PR TITLE
[PULL REQUEST] GEOS-Chem Classic History can now archive irregular intervals (e.g. a month and a day) -- Closes #1020

### DIFF
--- a/run/GCClassic/runScriptSamples/geoschem.benchmark.run
+++ b/run/GCClassic/runScriptSamples/geoschem.benchmark.run
@@ -2,7 +2,7 @@
 
 #SBATCH -c 48
 #SBATCH -N 1
-#SBATCH -t 0-12:00
+#SBATCH -t 0-5:00
 #SBATCH -p huce_cascade
 #SBATCH --mem=16000
 #SBATCH --mail-type=END

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.benchmark.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_gcst/gchp.benchmark.run
@@ -3,7 +3,7 @@
 #SBATCH -n 96
 #SBATCH -N 2
 #SBATCH --exclusive
-#SBATCH -t 0-20:00
+#SBATCH -t 0-8:00
 #SBATCH -p huce_cascade
 #SBATCH --mem=180000
 #SBATCH --mail-type=END

--- a/test/GCClassic/intTestExecute_slurm.sh
+++ b/test/GCClassic/intTestExecute_slurm.sh
@@ -2,7 +2,7 @@
 
 #SBATCH -c 24
 #SBATCH -N 1
-#SBATCH -t 0-06:00
+#SBATCH -t 0-03:00
 #SBATCH -p huce_cascade
 #SBATCH --mem=90000
 #SBATCH --mail-type=END


### PR DESCRIPTION
## Description

### What was fixed 
This PR corresponds to issue #1020, which was raised by @drewpendergrass.  Commit 5998e3c099cf2eda80d36f24d2d8bb7b6a5c8d72 fixes the computation of the History alarm intervals (i.e. that tell History when to update, write, and close files) so that intervals such as a month and a day will cause output to be saved properly.

This update only affects GEOS-Chem Classic History.  GCHP History is done via MAPL and thus is unaffected.

### Other modifications in this PR
Piggybacking on this PR, commits e652badb06122a36c5b9c3000457d3d0586a4fed and d258b5abbcc75910b78d454aaf02dd300d3ccb7e reduce the amount of time requested via SLURM for GEOS-Chem Classic integration tests, GEOS-Chem Classic benchmark simulations, and GCHP benchmark simulations (for running on the Harvard "Cannon" cluster).  Recent updates have (1) reduced the amount of diagnostic output and (2) reduced the number of integration tests, which cause these runs to require less time to finish.  Reducing the requested time should make the SLURM scheduler more likely to pick up these jobs. 

## Validation

### GCHP integration tests
```console
==============================================================================
GCHP: Execution Test Results

Number of execution tests: 3
==============================================================================
 
Execution tests:
------------------------------------------------------------------------------
gchp_fullchem_benchmark_merra2_c48...............Execute Simulation.....PASS
gchp_fullchem_standard_merra2_c24................Execute Simulation.....PASS
gchp_TransportTracers_geosfp_c24.................Execute Simulation.....PASS
 
Summary of execution test results:
------------------------------------------------------------------------------
Execution tests passed:        3
Execution tests failed:        0
Execution tests not completed: 0

%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%%  All execution tests passed!  %%%
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
```

### GEOS-Chem Classic integration tests
```console
==============================================================================
GEOS-Chem Classic: Execution Test Results

Using 24 OpenMP threads
Number of execution tests: 48
==============================================================================
 
Execution tests:
------------------------------------------------------------------------------
gc_025x03125_CH4_geosfp_47L_na...................Execute Simulation.....PASS
gc_025x03125_fullchem_geosfp_47L_na..............Execute Simulation.....PASS
gc_05x0625_CH4_merra2_47L_na.....................Execute Simulation.....PASS
gc_05x0625_fullchem_merra2_47L_na................Execute Simulation.....PASS
gc_2x25_aerosol_merra2...........................Execute Simulation.....PASS
gc_2x25_CH4_merra2...............................Execute Simulation.....PASS
gc_2x25_CO2_merra2...............................Execute Simulation.....PASS
gc_2x25_fullchem_merra2..........................Execute Simulation.....PASS
gc_2x25_Hg_merra2................................Execute Simulation.....PASS
gc_2x25_metals_merra2............................Execute Simulation.....PASS
gc_2x25_POPs_BaP_merra2..........................Execute Simulation.....PASS
gc_2x25_tagCH4_merra2............................Execute Simulation.....PASS
gc_2x25_tagCO_merra2.............................Execute Simulation.....PASS
gc_2x25_tagO3_merra2.............................Execute Simulation.....PASS
gc_2x25_TransportTracers_merra2..................Execute Simulation.....PASS
gc_2x25_TransportTracers_merra2_LuoWd............Execute Simulation.....PASS
gc_4x5_aerosol_geosfp............................Execute Simulation.....PASS
gc_4x5_aerosol_merra2............................Execute Simulation.....PASS
gc_4x5_CH4_geosfp................................Execute Simulation.....PASS
gc_4x5_CH4_merra2................................Execute Simulation.....PASS
gc_4x5_fullchem_aciduptake_merra2................Execute Simulation.....PASS
gc_4x5_fullchem_APM_merra2.......................Execute Simulation.....PASS
gc_4x5_fullchem_benchmark_merra2.................Execute Simulation.....PASS
gc_4x5_fullchem_complexSOA_merra2................Execute Simulation.....PASS
gc_4x5_fullchem_complexSOA_SVPOA_merra2..........Execute Simulation.....PASS
gc_4x5_fullchem_geosfp...........................Execute Simulation.....PASS
gc_4x5_fullchem_marinePOA_merra2.................Execute Simulation.....PASS
gc_4x5_fullchem_merra2...........................Execute Simulation.....PASS
gc_4x5_fullchem_merra2_47L.......................Execute Simulation.....PASS
gc_4x5_fullchem_merra2_LuoWd.....................Execute Simulation.....PASS
gc_4x5_fullchem_RRTMG_merra2.....................Execute Simulation.....PASS
gc_4x5_fullchem_TOMAS15_merra2_47L...............Execute Simulation.....PASS
gc_4x5_fullchem_TOMAS40_merra2_47L...............Execute Simulation.....PASS
gc_4x5_Hg_geosfp.................................Execute Simulation.....PASS
gc_4x5_Hg_merra2.................................Execute Simulation.....PASS
gc_4x5_metals_merra2.............................Execute Simulation.....PASS
gc_4x5_POPs_BaP_geosfp...........................Execute Simulation.....PASS
gc_4x5_POPs_BaP_merra2...........................Execute Simulation.....PASS
gc_4x5_tagCH4_geosfp.............................Execute Simulation.....PASS
gc_4x5_tagCH4_merra2.............................Execute Simulation.....PASS
gc_4x5_tagCO_geosfp..............................Execute Simulation.....PASS
gc_4x5_tagCO_merra2..............................Execute Simulation.....PASS
gc_4x5_tagO3_geosfp..............................Execute Simulation.....PASS
gc_4x5_tagO3_merra2..............................Execute Simulation.....PASS
gc_4x5_TransportTracers_geosfp...................Execute Simulation.....PASS
gc_4x5_TransportTracers_geosfp_LuoWd.............Execute Simulation.....PASS
gc_4x5_TransportTracers_merra2...................Execute Simulation.....PASS
gc_4x5_TransportTracers_merra2_LuoWd.............Execute Simulation.....PASS
 
Summary of test results:
------------------------------------------------------------------------------
Execution tests passed: 48
Execution tests failed: 0
Execution tests not yet completed: 0

%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%%  All execution tests passed!  %%%
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
```

### Difference tests (CH4 simulation)

Comparing restart files:
```console
(base) [holyjacob01 rundirs]$ ./compare_diags.py rst.yml 
Using configuration file rst.yml
... Printing totals and differences
Variable               Ref=alpha.13             Dev=histAlarm            Dev - Ref
AREA                 : 510065600000000.0      | 510065600000000.0      | 0.0 
Met_PS1DRY           : 3186964.8              | 3186964.8              | 0.0 
Met_PS1WET           : 3192633.0              | 3192633.0              | 0.0 
Met_DELPDRY          : 3186609.0              | 3186609.0              | 0.0 
Met_SPHU1            : 302758.9               | 302758.9               | 0.0 
Met_TMPU1            : 57916410.0             | 57916410.0             | 0.0 
SpeciesRst_CH4       : 0.31569356             | 0.31569356             | 0.0 
```