### PR TITLE
Upgraded MAPL to 2.16

### DIFF
--- a/run/GCHP/GCHP.rc.template
+++ b/run/GCHP/GCHP.rc.template
@@ -67,9 +67,8 @@ RECORD_REF_DATE: 20000101
 RECORD_REF_TIME: 000000
 
 # Chemistry/AEROSOL Model Restart Files
-# Enter +none for GCHPchem_INTERNAL_RESTART_FILE not use an initial restart file
 # -------------------------------------
-GCHPchem_INTERNAL_RESTART_FILE:     +initial_GEOSChem_rst.c24_${RUNDIR_SIM_NAME}.nc
+GCHPchem_INTERNAL_RESTART_FILE:     initial_GEOSChem_rst.c24_${RUNDIR_SIM_NAME}.nc
 GCHPchem_INTERNAL_RESTART_TYPE:     pnc4
 GCHPchem_INTERNAL_CHECKPOINT_FILE:  gcchem_internal_checkpoint
 GCHPchem_INTERNAL_CHECKPOINT_TYPE:  pnc4

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -419,7 +419,7 @@ do
     elif [[ ${sim_name} = "TransportTracers" ]]; then
         start_date="20190101_0000z"
         src_name="${src_prefix}${start_date}${src_suffix}"
-        ln -s ${restarts}/GC_13.0.0/${src_name} ${rundir}/${target_name}
+        ln -s ${restarts}/v2022-01/${src_name} ${rundir}/${target_name}
     fi
 done
 

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -409,8 +409,13 @@ do
 	# NOTE: We must now link restart files from v2021-09, since these will
 	# have extra species such as HMS, C2H2, C2H4, etc. (bmy, 9/23/21)
         #ln -s ${restarts}/GC_13.0.0/${src_name} ${rundir}/${target_name}
+        #
+        # UPDATE: We now link restarts from v2022-01. These are the v2021-09 
+        # restart files with explicit zero-arrays for variables that were 
+        # previously missing. This is because MAPL 2.12 removed the '+' 
+        # bootstrapping option.
 	#----------------------------------------------------------------------
-        ln -s ${restarts}/v2021-09/${src_name} ${rundir}/${target_name}
+        ln -s ${restarts}/v2022-01/${src_name} ${rundir}/${target_name}
     elif [[ ${sim_name} = "TransportTracers" ]]; then
         start_date="20190101_0000z"
         src_name="${src_prefix}${start_date}${src_suffix}"

--- a/run/GCHP/runConfig.sh.template
+++ b/run/GCHP/runConfig.sh.template
@@ -609,7 +609,7 @@ fi
 print_msg " "
 print_msg "Initial restart file:"
 print_msg "---------------------"
-replace_val GCHPchem_INTERNAL_RESTART_FILE "+${INITIAL_RESTART}" GCHP.rc
+replace_val GCHPchem_INTERNAL_RESTART_FILE "${INITIAL_RESTART}" GCHP.rc
 
 ### adjoint model phase
 replace_val MODEL_PHASE "FORWARD" GCHP.rc


### PR DESCRIPTION
GCHP uses v2022-01 restart files now. 

See https://github.com/geoschem/GCHP/pull/191.