### PR TITLE
[PULL REQUEST] GCHP restart updates for compatibility with newer MAPL

### DIFF
--- a/run/GCHP/GCHP.rc.template
+++ b/run/GCHP/GCHP.rc.template
@@ -56,6 +56,10 @@ NUM_WRITERS: 1
 # ----------------------------
 BKG_FREQUENCY: 0
 
+# Enable bootstrapping restart file fields missing from restart
+#-----------------------------------------------------------------
+MAPL_ENABLE_BOOTSTRAP: YES
+
 # Settings for production of restart files
 #---------------------------------------------------------------
 # Record frequency (HHMMSS) : Frequency of restart file write

--- a/run/GCHP/GCHP.rc.template
+++ b/run/GCHP/GCHP.rc.template
@@ -71,18 +71,18 @@ RECORD_REF_DATE: 20000101
 RECORD_REF_TIME: 000000
 
 # Chemistry/AEROSOL Model Restart Files
-# Enter +none for GCHPchem_INTERNAL_RESTART_FILE not use an initial restart file
 # -------------------------------------
-GCHPchem_INTERNAL_RESTART_FILE:     +initial_GEOSChem_rst.c24_${RUNDIR_SIM_NAME}.nc
+GCHPchem_INTERNAL_RESTART_FILE:     initial_GEOSChem_rst.c24_${RUNDIR_SIM_NAME}.nc
 GCHPchem_INTERNAL_RESTART_TYPE:     pnc4
 GCHPchem_INTERNAL_CHECKPOINT_FILE:  gcchem_internal_checkpoint
 GCHPchem_INTERNAL_CHECKPOINT_TYPE:  pnc4
 
-DYN_INTERNAL_RESTART_FILE:    -fvcore_internal_rst
-DYN_INTERNAL_RESTART_TYPE:    pbinary
-DYN_INTERNAL_CHECKPOINT_FILE: -fvcore_internal_checkpoint
-DYN_INTERNAL_CHECKPOINT_TYPE: pbinary
-DYN_INTERNAL_HEADER:          1
+# GCHP dynamics (FV3) does not use a restart file because its internal state is empty
+#DYN_INTERNAL_RESTART_FILE:    fvcore_internal_rst
+#DYN_INTERNAL_RESTART_TYPE:    pbinary
+#DYN_INTERNAL_CHECKPOINT_FILE: fvcore_internal_checkpoint
+#DYN_INTERNAL_CHECKPOINT_TYPE: pbinary
+#DYN_INTERNAL_HEADER:          1
 
 RUN_PHASES:           1
 

--- a/run/GCHP/runConfig.sh.template
+++ b/run/GCHP/runConfig.sh.template
@@ -622,7 +622,7 @@ fi
 print_msg " "
 print_msg "Initial restart file:"
 print_msg "---------------------"
-replace_val GCHPchem_INTERNAL_RESTART_FILE "+${INITIAL_RESTART}" GCHP.rc
+replace_val GCHPchem_INTERNAL_RESTART_FILE "${INITIAL_RESTART}" GCHP.rc
 
 ### adjoint model phase
 replace_val MODEL_PHASE "FORWARD" GCHP.rc


### PR DESCRIPTION
**[UPDATE: This PR goes with GCHP PR #[214](https://github.com/geoschem/GCHP/pull/214)]**

This PR continues the work originally begun in #128, and merges that on top of the GEOS-Chem 13.4.0-alpha.18 tag.

This update originally failed a GCHP integration test with;
```CONSOLE
At line 256 of file /n/holyscratch01/jacob_lab/ryantosca/tests/GCHP_alpha.18/CodeDir/src/GCHP_GridComp/HEMCO_GridComp/HEMCO/src/Core/interpreter.F90
Fortran runtime error: Recursive call to nonrecursive procedure 'add_sub'
```
using the following software versions:
```
Currently Loaded Modules:
  1) git/2.17.0-fasrc01      7) zlib/1.2.11-fasrc01
  2) gmp/6.2.1-fasrc01       8) szip/2.1.1-fasrc01
  3) mpfr/4.1.0-fasrc01      9) hdf5/1.10.7-fasrc02
  4) mpc/1.2.1-fasrc01      10) netcdf/4.8.0-fasrc03
  5) gcc/10.2.0-fasrc01     11) netcdf-fortran/4.5.3-fasrc03
  6) openmpi/4.1.0-fasrc01  12) cmake/3.16.1-fasrc01
```
As @lizziel suggested, this might be related to issue: https://github.com/GEOS-ESM/MAPL/issues/589, in which a `--no-recursion` flag had to be added for GNU Fortran builds.

This issue is under investigation by @LiamBindle 