### PR TITLE
Fixed timesteps and Dust_SF for stretched-grid simulations (runConfig.sh)

### DIFF
--- a/run/GCHP/runConfig.sh.template
+++ b/run/GCHP/runConfig.sh.template
@@ -229,11 +229,16 @@ inst_collections=(ConcAboveSfc      \
 #    LESS FREQUENTLY CHANGED SETTINGS
 ########################################################
 
+CS_RES_EFFECTIVE=${CS_RES}
+if [[ ${STRETCH_GRID} == 'ON' ]]; then
+    CS_RES_EFFECTIVE=$( echo $CS_RES $STRETCH_FACTOR | awk '{printf "%.0f",$1*$2}' )
+fi
+
 #------------------------------------------------
 #    Timesteps
 #------------------------------------------------
 # WARNING: these settings will override settings in input.geos!
-if [[ $CS_RES -lt 180 ]]; then
+if [[ $CS_RES_EFFECTIVE -lt 180 ]]; then
     ChemEmiss_Timestep_sec=1200
     TransConv_Timestep_sec=600
     TransConv_Timestep_HHMMSS=001000
@@ -260,6 +265,10 @@ RRTMG_Timestep_sec=10800
 dustEntry=$(grep "105.*DustDead" HEMCO_Config.rc)
 dustSetting=(${dustEntry// / })
 if [[ ${dustSetting[3]} = "on" ]]; then
+    if [[ ${STRETCH_GRID} == 'ON' ]]; then
+        echo "WARNING: Online dust (DustDead) is not recommended for stretched-grid simulation. Consider using OFFLINE_DUST."
+    fi 
+
     if [[ $CS_RES -eq 24 ]]; then
         Dust_SF=6.0e-4
     elif [[ $CS_RES -eq 48 ]]; then
@@ -729,5 +738,3 @@ else
     print_msg "ERROR: unknown setting for AutoUpdate_Diagnostics. Must be ON or OFF."
     exit 1
 fi
-
-


### PR DESCRIPTION
Modified runConfig.sh to set timesteps and Dust_SF according to the CS_RES_EFFECTIVE rather than CS_RES