### PR TITLE
Feature/SatDiagnUpdates (netCDF Satellite Diagnostics)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -245,6 +245,7 @@ Viral Shah
 Jingyuan Shao
 Lu Shen
 Tomas Sherwen
+Joshua Shutter
 Sam Silva
 Nicole Smith-Downey
 Anne Laerke Soerensen

--- a/GeosCore/diag51_mod.F90
+++ b/GeosCore/diag51_mod.F90
@@ -158,9 +158,9 @@ MODULE DIAG51_MOD
   INTEGER              :: IU_ND51
 
   ! Arrays
-  INTEGER, ALLOCATABLE :: GOOD(:)
-  INTEGER, ALLOCATABLE :: GOOD_CT(:)
-  INTEGER, ALLOCATABLE :: COUNT_CHEM3D(:,:,:)
+  REAL(fp), ALLOCATABLE :: GOOD(:)
+  REAL(fp), ALLOCATABLE :: GOOD_CT(:)
+  REAL(fp), ALLOCATABLE :: COUNT_CHEM3D(:,:,:)
   REAL(fp),ALLOCATABLE :: Q(:,:,:,:)
 
 CONTAINS
@@ -295,7 +295,7 @@ CONTAINS
        ! GOOD indicates which boxes have local times between HR1 and HR2
        IF ( LT >= Input_Opt%ND51_HR1 .and. &
             LT <= Input_Opt%ND51_HR2 ) THEN
-          GOOD(I) = 1
+          GOOD(I) = 1e+0_fp
        ENDIF
     ENDDO
 
@@ -552,7 +552,7 @@ CONTAINS
                 ! Accumulate data
                 Q(X,Y,K,W) = Q(X,Y,K,W) +                                    &
                      ( State_Chm%Species(I,J,L,id_OH) * GOOD(X) ) *          &
-                     ( State_Met%AIRDEN(I,J,L)        * CONV_OH )
+                     ( State_Met%AIRDEN(I,J,L)        * CONV_OH   * 1.0e+3_fp) !1.0e+3_fp added by JDS for correct unit conversion (1/20/22)
 
 
              ELSE IF ( N == 502 .and. IS_NOy ) THEN
@@ -1082,7 +1082,7 @@ CONTAINS
        ENDDO
        !$OMP END PARALLEL DO
 
-       GOOD(:) = 0
+       GOOD(:) = 0e+0_fp
 
        ! Free pointers
        Spc => NULL()
@@ -1944,22 +1944,22 @@ CONTAINS
     ! Array denoting where LT is between HR1 and HR2
     ALLOCATE( GOOD( State_Grid%NX ), STAT=AS )
     IF ( AS /= 0 ) CALL ALLOC_ERR( 'GOOD' )
-    GOOD = 0
+    GOOD = 0e+0_fp
 
     ! Counter of "good" times per day at each grid box
     ALLOCATE( GOOD_CT( ND51_NI ), STAT=AS )
     IF ( AS /= 0 ) CALL ALLOC_ERR( 'GOOD_CT' )
-    GOOD_CT = 0
+    GOOD_CT = 0e+0_fp
 
     ! Accumulating array
     ALLOCATE( Q( ND51_NI, ND51_NJ, ND51_NL, Input_Opt%N_ND51),STAT=AS)
     IF ( AS /= 0 ) CALL ALLOC_ERR( 'Q' )
-    Q = 0d0
+    Q = 0e+0_fp
 
     ! Accumulating array
     ALLOCATE( COUNT_CHEM3D( ND51_NI, ND51_NJ, ND51_NL ), STAT=AS )
     IF ( AS /= 0 ) CALL ALLOC_ERR( 'COUNT_CHEM3D' )
-    COUNT_CHEM3D = 0
+    COUNT_CHEM3D = 0e+0_fp
 
   END SUBROUTINE INIT_DIAG51
 !EOC

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -2,7 +2,7 @@
 !                  GEOS-Chem Global Chemical Transport Model                  !
 !------------------------------------------------------------------------------
 !BOP
-!SatDiagn
+!SatDiagn Another Edit in Jupyter (remove JDS!)
 !
 ! !MODULE: diagnostics_mod.F90
 !

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -2,7 +2,6 @@
 !                  GEOS-Chem Global Chemical Transport Model                  !
 !------------------------------------------------------------------------------
 !BOP
-!SatDiagn Another Edit in Jupyter (remove JDS!)
 !
 ! !MODULE: diagnostics_mod.F90
 !
@@ -65,9 +64,10 @@ CONTAINS
     USE Input_Opt_Mod,    ONLY : OptInput
     USE State_Met_Mod,    ONLY : MetState
     USE State_Chm_Mod,    ONLY : ChmState, Ind_
-    USE State_Diag_Mod,   ONLY : DgnState
+    USE State_Diag_Mod,   ONLY : DgnState, DgnMap 
     USE State_Grid_Mod,   ONLY : GrdState
-    USE PhysConstants,    ONLY : AIRMW
+    USE PhysConstants,    ONLY : AIRMW,  AVO
+    USE TIME_MOD,         ONLY : GET_LOCALTIME
 !
 ! !INPUT PARAMETERS:
 !
@@ -95,15 +95,20 @@ CONTAINS
 !
     ! Scalars
     INTEGER                 :: I, J, L, N, S
-    REAL(fp)                :: ToPptv
+    REAL(fp)                :: ToPptv, LT, GOOD
 
     ! SAVEd scalars
     INTEGER, SAVE           :: id_Hg2 = -1
     INTEGER, SAVE           :: id_HgP = -1
-    LOGICAL, SAVE           :: FIRST  = .TRUE.
+    LOGICAL, SAVE           :: FIRST_Hg  = .TRUE.
+    INTEGER, SAVE           :: id_OH = -1
+    LOGICAL, SAVE           :: FIRST_Sat = .TRUE.
 
     ! Strings
     CHARACTER(LEN=255)      :: ErrMsg, ThisLoc
+    
+    ! Objects
+    TYPE(DgnMap), POINTER   :: mapData
 
     !=======================================================================
     ! Set_Diagnostics_EndofTimestep begins here
@@ -194,10 +199,10 @@ CONTAINS
     IF ( Input_Opt%ITS_A_MERCURY_SIM ) THEN
 
        ! Get species indices for Hg2 and HgP
-       IF ( FIRST ) THEN
+       IF ( FIRST_Hg ) THEN
           id_Hg2 = Ind_('Hg2')
           id_HgP = Ind_('HgP')
-          FIRST  = .FALSE.
+          FIRST_Hg  = .FALSE.
        ENDIF
 
        !--------------------------------------------
@@ -230,6 +235,423 @@ CONTAINS
                                         * ToPptv
        ENDIF
     ENDIF
+
+    !=======================================================================
+    ! Satellite diagnostics:
+    !=======================================================================
+    IF ( FIRST_Sat ) THEN
+
+       ! Get the species ID for OH
+       id_OH  = Ind_('OH')
+       IF ( id_OH < 0 ) THEN
+          errMsg = 'OH is not a defined species in this simulation!!!'
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       FIRST_Sat = .FALSE.
+
+    ENDIF
+       
+    ! Loop over longitudes:
+    DO I = 1, State_Grid%NX
+          
+       ! Get local time in hours:
+       LT = GET_LOCALTIME(I, 1, 1, State_Grid)
+       IF ( LT < 0 ) LT = LT + 24e+0_fp
+       
+       ! Determine whether during satellite overpass time window:
+       IF ( LT >= State_Diag%SatDiagn_StartHr .and. &
+            LT <= State_Diag%SatDiagn_EndHr ) THEN
+
+          ! GOOD = 1 if during local time range, 0 otherwise:
+          GOOD = 1e+0_fp
+          
+       ELSE
+          
+          GOOD = 0e+0_fp
+          
+       ENDIF
+       
+       !ENDIF
+
+       ! --------------------------------------------
+       ! Count number of local times:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnCount ) THEN
+
+          State_Diag%SatDiagnCount(I,:,:) = &
+                  State_Diag%SatDiagnCount(I,:,:) + GOOD
+       ENDIF
+
+       ! --------------------------------------------
+       ! OH concentration [molec/cm3]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnOH ) THEN
+
+          State_Diag%SatDiagnOH(I,:,1:State_Grid%MaxChemLev) = &
+               (State_Chm%Species(I,:,1:State_Grid%MaxChemLev,id_OH) * GOOD * &
+                State_Met%AIRDEN(I,:,1:State_Grid%MaxChemLev)  * AVO ) /      &
+               ( State_Chm%SpcData(id_OH)%Info%Mw_g ) / 1.0e+3_fp !JDS Changed to 1.0e+3_fp (orig 1.0e+6) (1/20/22)
+       ENDIF
+    
+       ! --------------------------------------------
+       ! Relative humidity [%]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnRH ) THEN
+          
+          State_Diag%SatDiagnRH(I,:,:) = State_Met%RH(I,:,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Air density [molec/m3]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnAirDen ) THEN
+          
+          State_Diag%SatDiagnAirDen(I,:,:) = State_Met%AirNumDen(I,:,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Grid box height [m]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnBoxHeight ) THEN
+          
+          State_Diag%SatDiagnBoxHeight(I,:,:) = State_Met%BXHEIGHT(I,:,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Pressure edges [hPa]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnPEdge ) THEN
+          
+          State_Diag%SatDiagnPEdge(I,:,:) = &
+               State_Met%PEDGE(I,:,1:State_Grid%NZ) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Tropopause pressure [hPa]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnTROPP ) THEN
+          
+          State_Diag%SatDiagnTROPP(I,:) = State_Met%TROPP(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! PBL Height [m]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnPBLHeight ) THEN
+          
+          State_Diag%SatDiagnPBLHeight(I,:) = State_Met%PBLH(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! PBL Top [m]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnPBLTop ) THEN
+          
+          State_Diag%SatDiagnPBLTop(I,:) = State_Met%PBL_TOP_m(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Air temperature [K]: Temperature Interpolated to Current Time
+       ! This temperture is interpolated from 3 h Met Field (TMPU1 and TMPU2)
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnTAir ) THEN
+          
+          State_Diag%SatDiagnTAir(I,:,:) = State_Met%T(I,:,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Root Zone Soil Moisture (or Wetness) [fraction]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnGWETROOT ) THEN
+          
+          State_Diag%SatDiagnGWETROOT(I,:) = State_Met%GWETROOT(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Topsoil Moisture (or Wetness) [fraction]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnGWETTOP ) THEN
+          
+          State_Diag%SatDiagnGWETTOP(I,:) = State_Met%GWETTOP(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Direct Photosynthetically Active Radiation [W/m2]:
+       ! Aka Surface downward PAR beam flux
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnPARDR ) THEN
+          
+          State_Diag%SatDiagnPARDR(I,:) = State_Met%PARDR(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Diffuse Photosynthetically Active Radiation [W/m2]:
+       ! Aka Surface downward PAR diffuse flux
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnPARDF ) THEN
+          
+          State_Diag%SatDiagnPARDF(I,:) = State_Met%PARDF(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Total Precipitation (at surface) [mm/day]:
+       ! Documentation says this variable is converted from original units of kg/m2/s
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnPRECTOT ) THEN
+          
+          State_Diag%SatDiagnPRECTOT(I,:) = State_Met%PRECTOT(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Sea Level Pressure [hPa]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnSLP ) THEN
+          
+          State_Diag%SatDiagnSLP(I,:) = State_Met%SLP(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Specific Humidity Interpolated to Current Time [g H2O/kg air]:
+       ! Linearly interpolated from 3 h met field (SPHU1 and SPHU2)
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnSPHU ) THEN
+          
+          State_Diag%SatDiagnSPHU(I,:,:) = State_Met%SPHU(I,:,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! Surface Temperature at 2m [K]
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnTS ) THEN
+          
+          State_Diag%SatDiagnTS(I,:) = State_Met%TS(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! PBL Top Height [Levels]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnPBLTOPL ) THEN
+          
+          State_Diag%SatDiagnPBLTOPL(I,:) = State_Met%PBL_TOP_L(I,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! MODIS Daily LAI [m2/m2]:
+       ! Don't use Met_LAI (lacks interannual variability); use MODIS LAI instead
+       ! MODIS LAI used by MEGAN and Soil NOx extension
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnMODISLAI ) THEN
+          
+          State_Diag%SatDiagnMODISLAI(I,:) = State_Met%MODISLAI(I,:) * GOOD
+          
+       ENDIF
+
+       !=======================================================================
+       ! SatDiagn Diagnostic for WetLossLS [units of kg/s as per WetLossLS]
+       !=======================================================================
+       IF ( State_Diag%Archive_SatDiagnWetLossLS ) THEN
+   
+             ! Point to mapping obj specific to species boundary conditions
+             mapData => State_Diag%Map_SatDiagnWetLossLS
+
+                !$OMP PARALLEL DO       &
+                !$OMP DEFAULT( SHARED ) &
+                !$OMP PRIVATE( N, S   )
+                DO S = 1, mapData%nSlots
+                   N = mapData%slot2id(S)
+                   State_Diag%SatDiagnWetLossLS(I,:,:,S) = State_Diag%WetLossLS(I,:,:,N) * GOOD   
+                ENDDO
+               !$OMP END PARALLEL DO
+  
+             ! Free pointer
+             mapData => NULL()
+       ENDIF
+
+       !=======================================================================
+       ! SatDiagn Diagnostic for WetLossConv [units of kg/s as per WetLossConv]
+       !=======================================================================
+       IF ( State_Diag%Archive_SatDiagnWetLossConv ) THEN
+   
+             ! Point to mapping obj specific to species boundary conditions
+             mapData => State_Diag%Map_SatDiagnWetLossConv
+
+                !$OMP PARALLEL DO       &
+                !$OMP DEFAULT( SHARED ) &
+                !$OMP PRIVATE( N, S   )
+                DO S = 1, mapData%nSlots
+                   N = mapData%slot2id(S)
+                   State_Diag%SatDiagnWetLossConv(I,:,:,S) = State_Diag%WetLossConv(I,:,:,N) * GOOD
+                ENDDO
+               !$OMP END PARALLEL DO
+  
+             ! Free pointer
+             mapData => NULL()
+       ENDIF
+
+       !=======================================================================
+       ! SatDiagn Diagnostic for Jval [units of s-1 as per Jval]
+       !=======================================================================
+       IF ( State_Diag%Archive_SatDiagnJval ) THEN
+   
+             ! Point to mapping obj specific to species boundary conditions
+             mapData => State_Diag%Map_SatDiagnJval
+
+                !$OMP PARALLEL DO       &
+                !$OMP DEFAULT( SHARED ) &
+                !$OMP PRIVATE( N, S   )
+                DO S = 1, mapData%nSlots
+                   N = mapData%slot2id(S)
+                   State_Diag%SatDiagnJval(I,:,:,S) = State_Diag%Jval(I,:,:,N) * GOOD
+                ENDDO
+               !$OMP END PARALLEL DO
+  
+             ! Free pointer
+             mapData => NULL()
+       ENDIF
+
+       ! --------------------------------------------
+       ! SatDiagn Diagnostic for JvalO3O1D [units of s-1 as per JvalO3O1D]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnJvalO3O1D ) THEN
+          
+          State_Diag%SatDiagnJvalO3O1D(I,:,:) = State_Diag%JvalO3O1D(I,:,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! SatDiagn Diagnostic for JvalO3O3P [units of s-1 as per JvalO3O3P]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnJvalO3O3P ) THEN
+          
+          State_Diag%SatDiagnJvalO3O3P(I,:,:) = State_Diag%JvalO3O3P(I,:,:) * GOOD
+          
+       ENDIF
+
+       !=======================================================================
+       ! SatDiagn Diagnostic for DryDep [units of molec cm-2 s-1 as per DryDep]
+       !=======================================================================
+       IF ( State_Diag%Archive_SatDiagnDryDep ) THEN
+   
+             ! Point to mapping obj specific to species boundary conditions
+             mapData => State_Diag%Map_SatDiagnDryDep
+
+                !$OMP PARALLEL DO       &
+                !$OMP DEFAULT( SHARED ) &
+                !$OMP PRIVATE( N, S   )
+                DO S = 1, mapData%nSlots
+                   N = mapData%slot2id(S)
+                   State_Diag%SatDiagnDryDep(I,:,S) = State_Diag%DryDep(I,:,N) * GOOD
+                ENDDO
+               !$OMP END PARALLEL DO
+  
+             ! Free pointer
+             mapData => NULL()
+       ENDIF
+
+       !=======================================================================
+       ! SatDiagn Diagnostic for DryDepVel [units of cm s-1 as per DryDepVel]
+       !=======================================================================
+       IF ( State_Diag%Archive_SatDiagnDryDepVel ) THEN
+   
+             ! Point to mapping obj specific to species boundary conditions
+             mapData => State_Diag%Map_SatDiagnDryDepVel
+
+                !$OMP PARALLEL DO       &
+                !$OMP DEFAULT( SHARED ) &
+                !$OMP PRIVATE( N, S   )
+                DO S = 1, mapData%nSlots
+                   N = mapData%slot2id(S)
+                   State_Diag%SatDiagnDryDepVel(I,:,S) = State_Diag%DryDepVel(I,:,N) * GOOD
+                ENDDO
+               !$OMP END PARALLEL DO
+  
+             ! Free pointer
+             mapData => NULL()
+       ENDIF
+
+       ! --------------------------------------------
+       ! SatDiagn Diagnostic for OH Reactivity [units of s-1 as per OHreactivity]:
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnOHreactivity ) THEN
+          
+          State_Diag%SatDiagnOHreactivity(I,:,:) = State_Diag%OHreactivity(I,:,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! SatDiagn Diagnostic for Surface Emissions (eflx) [units of kg/m2/s]:
+       ! From surface to top of the PBL for Advected Species
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnColEmis ) THEN
+          
+          State_Diag%SatDiagnColEmis(I,:,:) = State_Diag%SatDiagnColEmis(I,:,:) * GOOD
+          
+       ENDIF
+
+       ! --------------------------------------------
+       ! SatDiagn Diagnostic for Total Surface Fluxes [units of kg/m2/s]:
+       ! From surface to top of the PBL for Advected Species (eflx (emis) - dflx(drydep)))
+       ! --------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnSurfFlux ) THEN
+          
+          State_Diag%SatDiagnSurfFlux(I,:,:) = State_Diag%SatDiagnSurfFlux(I,:,:) * GOOD
+          
+       ENDIF
+
+       !=======================================================================
+       ! SatDiagn Diagnostic for Chemical Loss
+       !=======================================================================
+       IF ( State_Diag%Archive_SatDiagnLoss ) THEN
+   
+          State_Diag%SatDiagnLoss(I,:,:,:) = State_Diag%Loss(I,:,:,:) * GOOD
+       ENDIF
+
+       !=======================================================================
+       ! SatDiagn Diagnostic for Chemical Production
+       !=======================================================================
+       IF ( State_Diag%Archive_SatDiagnProd ) THEN
+       
+          State_Diag%SatDiagnProd(I,:,:,:) = State_Diag%Prod(I,:,:,:) * GOOD
+       ENDIF
+
+       !=======================================================================
+       ! SatDiagn Diagnostic for Reaction Rates
+       ! SatDiagnRxnRate was previously defined in fullchem_mod.F90
+       !=======================================================================
+       IF ( State_Diag%Archive_SatDiagnRxnRate ) THEN
+       
+          State_Diag%SatDiagnRxnRate(I,:,:,:) = State_Diag%SatDiagnRxnRate(I,:,:,:) * GOOD
+       ENDIF
+
+
+    ENDDO
+
+    ! Error handling
+    IF ( RC /= GC_SUCCESS ) THEN
+       ErrMsg = 'Error converting species units for archiving diagnostics #2'
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+    
 
   END SUBROUTINE Set_Diagnostics_EndofTimestep
 !EOC
@@ -393,7 +815,7 @@ CONTAINS
     ! Scalars
     LOGICAL               :: Found
     INTEGER               :: D, I, J, L, N, S
-    REAL(fp)              :: TmpVal, Conv
+    REAL(fp)              :: TmpVal, Conv, LT,  GOOD
 
     ! Strings
     CHARACTER(LEN=255)    :: ErrMsg, ThisLoc, Units, OrigUnit
@@ -461,6 +883,51 @@ CONTAINS
 
     ENDIF
 
+    !=======================================================================
+    ! Copy species to SatDiagn (satellite diagnostic output) [v/v dry]
+    !=======================================================================
+    IF ( State_Diag%Archive_SatDiagnConc ) THEN
+
+       ! Point to mapping obj specific to species boundary conditions
+       mapData => State_Diag%Map_SatDiagnConc
+
+       ! Loop over the number of advected species that we wish
+       ! to save at a user-specified local time range
+       ! Loop over longitudes:
+       DO I = 1, State_Grid%NX
+
+          ! Get local time in hours:
+          LT = GET_LOCALTIME(I, 1, 1, State_Grid)
+          IF ( LT < 0  ) LT = LT + 24e+0_fp
+          ! Check if local time is during satellite overpass time:
+          IF ( LT >= State_Diag%SatDiagn_StartHr .and. &
+               LT <= State_Diag%SatDiagn_EndHr ) THEN
+
+             ! GOOD = 1 if during local time range, 0 otherwise:
+             GOOD = 1e+0_fp 
+
+          ELSE
+
+             GOOD = 0e+0_fp
+
+          ENDIF
+             
+          !$OMP PARALLEL DO       &
+          !$OMP DEFAULT( SHARED ) &
+          !$OMP PRIVATE( N, S   )
+          DO S = 1, mapData%nSlots
+             N = mapData%slot2id(S)
+             State_Diag%SatDiagnConc(I,:,:,S) = TmpSpcArr(I,:,:,N) * GOOD
+          ENDDO
+          !$OMP END PARALLEL DO
+
+       ENDDO
+
+       ! Free pointer
+       mapData => NULL()
+
+    ENDIF
+
     ! Error handling
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error converting species units for archiving diagnostics #2'
@@ -498,6 +965,7 @@ CONTAINS
     USE State_Diag_Mod, ONLY : DgnState
     USE State_Grid_Mod, ONLY : GrdState
     USE UnitConv_Mod,   ONLY : Convert_Spc_Units
+    USE TIME_MOD,       ONLY : GET_LOCALTIME
 !
 ! !INPUT PARAMETERS:
 !
@@ -526,7 +994,7 @@ CONTAINS
     ! Scalars
     LOGICAL               :: Found
     INTEGER               :: D, I, J, L, N, S
-    REAL(fp)              :: TmpVal, Conv
+    REAL(fp)              :: TmpVal, Conv, LT, GOOD
 
     ! Strings
     CHARACTER(LEN=255)    :: ErrMsg, ThisLoc, Units, OrigUnit
@@ -559,7 +1027,8 @@ CONTAINS
     IF ( State_Diag%Archive_SpeciesConc .OR. &
          State_Diag%Archive_SpeciesBC   .OR. &
          State_Diag%Archive_SpeciesRst  .OR. &
-         State_Diag%Archive_ConcAboveSfc ) THEN
+         State_Diag%Archive_ConcAboveSfc .OR. &
+         State_Diag%Archive_SatDiagnConc ) THEN
 
        !$OMP PARALLEL DO       &
        !$OMP DEFAULT( SHARED ) &
@@ -594,6 +1063,52 @@ CONTAINS
           State_Diag%SpeciesConc(:,:,:,S) = TmpSpcArr(:,:,:,N)
        ENDDO
        !$OMP END PARALLEL DO
+
+       ! Free pointer
+       mapData => NULL()
+
+    ENDIF
+
+    !=======================================================================
+    ! Copy species to SatDiagn (satellite diagnostic output) [v/v dry]
+    !=======================================================================
+    IF ( State_Diag%Archive_SatDiagnConc ) THEN
+
+       ! Point to mapping obj specific to species boundary conditions
+       mapData => State_Diag%Map_SatDiagnConc
+
+       ! Loop over the number of advected species that we wish
+       ! to save at a user-specified local time range
+       ! Loop over longitudes:
+       DO I = 1, State_Grid%NX
+
+          ! Get local time in hours:
+          LT = GET_LOCALTIME(I, 1, 1, State_Grid)
+          
+          IF ( LT < 0  ) LT = LT + 24e+0_fp
+          ! Check if local time is during satellite overpass time:
+          IF ( LT >= State_Diag%SatDiagn_StartHr .and. &
+               LT <= State_Diag%SatDiagn_EndHr ) THEN
+
+             ! GOOD = 1 if during local time range, 0 otherwise:
+             GOOD = 1e+0_fp 
+
+          ELSE
+
+             GOOD = 0e+0_fp
+
+          ENDIF
+             
+          !$OMP PARALLEL DO       &
+          !$OMP DEFAULT( SHARED ) &
+          !$OMP PRIVATE( N, S   )
+          DO S = 1, mapData%nSlots
+             N = mapData%slot2id(S)
+             State_Diag%SatDiagnConc(I,:,:,S) = TmpSpcArr(I,:,:,N) * GOOD             
+          ENDDO
+          !$OMP END PARALLEL DO
+
+       ENDDO
 
        ! Free pointer
        mapData => NULL()

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -299,64 +299,50 @@ CONTAINS
        ! Relative humidity [%]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnRH ) THEN
-          
           State_Diag%SatDiagnRH(I,:,:) = State_Met%RH(I,:,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! Air density [molec/m3]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnAirDen ) THEN
-          
           State_Diag%SatDiagnAirDen(I,:,:) = State_Met%AirNumDen(I,:,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! Grid box height [m]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnBoxHeight ) THEN
-          
           State_Diag%SatDiagnBoxHeight(I,:,:) = State_Met%BXHEIGHT(I,:,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! Pressure edges [hPa]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPEdge ) THEN
-          
           State_Diag%SatDiagnPEdge(I,:,:) = &
                State_Met%PEDGE(I,:,1:State_Grid%NZ) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! Tropopause pressure [hPa]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnTROPP ) THEN
-          
           State_Diag%SatDiagnTROPP(I,:) = State_Met%TROPP(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! PBL Height [m]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPBLHeight ) THEN
-          
           State_Diag%SatDiagnPBLHeight(I,:) = State_Met%PBLH(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! PBL Top [m]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPBLTop ) THEN
-          
           State_Diag%SatDiagnPBLTop(I,:) = State_Met%PBL_TOP_m(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
@@ -364,27 +350,21 @@ CONTAINS
        ! This temperture is interpolated from 3 h Met Field (TMPU1 and TMPU2)
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnTAir ) THEN
-          
           State_Diag%SatDiagnTAir(I,:,:) = State_Met%T(I,:,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! Root Zone Soil Moisture (or Wetness) [fraction]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnGWETROOT ) THEN
-          
           State_Diag%SatDiagnGWETROOT(I,:) = State_Met%GWETROOT(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! Topsoil Moisture (or Wetness) [fraction]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnGWETTOP ) THEN
-          
           State_Diag%SatDiagnGWETTOP(I,:) = State_Met%GWETTOP(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
@@ -392,9 +372,7 @@ CONTAINS
        ! Aka Surface downward PAR beam flux
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPARDR ) THEN
-          
           State_Diag%SatDiagnPARDR(I,:) = State_Met%PARDR(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
@@ -402,9 +380,7 @@ CONTAINS
        ! Aka Surface downward PAR diffuse flux
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPARDF ) THEN
-          
           State_Diag%SatDiagnPARDF(I,:) = State_Met%PARDF(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
@@ -412,18 +388,14 @@ CONTAINS
        ! Documentation says this variable is converted from original units of kg/m2/s
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPRECTOT ) THEN
-          
           State_Diag%SatDiagnPRECTOT(I,:) = State_Met%PRECTOT(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! Sea Level Pressure [hPa]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnSLP ) THEN
-          
           State_Diag%SatDiagnSLP(I,:) = State_Met%SLP(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
@@ -431,27 +403,21 @@ CONTAINS
        ! Linearly interpolated from 3 h met field (SPHU1 and SPHU2)
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnSPHU ) THEN
-          
           State_Diag%SatDiagnSPHU(I,:,:) = State_Met%SPHU(I,:,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! Surface Temperature at 2m [K]
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnTS ) THEN
-          
           State_Diag%SatDiagnTS(I,:) = State_Met%TS(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! PBL Top Height [Levels]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPBLTOPL ) THEN
-          
           State_Diag%SatDiagnPBLTOPL(I,:) = State_Met%PBL_TOP_L(I,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
@@ -460,9 +426,7 @@ CONTAINS
        ! MODIS LAI used by MEGAN and Soil NOx extension
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnMODISLAI ) THEN
-          
           State_Diag%SatDiagnMODISLAI(I,:) = State_Met%MODISLAI(I,:) * GOOD
-          
        ENDIF
 
        !=======================================================================
@@ -532,18 +496,14 @@ CONTAINS
        ! SatDiagn Diagnostic for JvalO3O1D [units of s-1 as per JvalO3O1D]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnJvalO3O1D ) THEN
-          
           State_Diag%SatDiagnJvalO3O1D(I,:,:) = State_Diag%JvalO3O1D(I,:,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
        ! SatDiagn Diagnostic for JvalO3O3P [units of s-1 as per JvalO3O3P]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnJvalO3O3P ) THEN
-          
           State_Diag%SatDiagnJvalO3O3P(I,:,:) = State_Diag%JvalO3O3P(I,:,:) * GOOD
-          
        ENDIF
 
        !=======================================================================
@@ -592,19 +552,15 @@ CONTAINS
        ! SatDiagn Diagnostic for OH Reactivity [units of s-1 as per OHreactivity]:
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnOHreactivity ) THEN
-          
           State_Diag%SatDiagnOHreactivity(I,:,:) = State_Diag%OHreactivity(I,:,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
-       ! SatDiagn Diagnostic for Surface Emissions (eflx) [units of kg/m2/s]:
-       ! From surface to top of the PBL for Advected Species
+       ! SatDiagn Diagnostic for Column Emissions (ColEmis) [units of kg/m2/s]:
+       ! From surface to maximum vertical level for advected species
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnColEmis ) THEN
-          
           State_Diag%SatDiagnColEmis(I,:,:) = State_Diag%SatDiagnColEmis(I,:,:) * GOOD
-          
        ENDIF
 
        ! --------------------------------------------
@@ -612,16 +568,13 @@ CONTAINS
        ! From surface to top of the PBL for Advected Species (eflx (emis) - dflx(drydep)))
        ! --------------------------------------------
        IF ( State_Diag%Archive_SatDiagnSurfFlux ) THEN
-          
           State_Diag%SatDiagnSurfFlux(I,:,:) = State_Diag%SatDiagnSurfFlux(I,:,:) * GOOD
-          
        ENDIF
 
        !=======================================================================
        ! SatDiagn Diagnostic for Chemical Loss
        !=======================================================================
        IF ( State_Diag%Archive_SatDiagnLoss ) THEN
-   
           State_Diag%SatDiagnLoss(I,:,:,:) = State_Diag%Loss(I,:,:,:) * GOOD
        ENDIF
 
@@ -629,7 +582,6 @@ CONTAINS
        ! SatDiagn Diagnostic for Chemical Production
        !=======================================================================
        IF ( State_Diag%Archive_SatDiagnProd ) THEN
-       
           State_Diag%SatDiagnProd(I,:,:,:) = State_Diag%Prod(I,:,:,:) * GOOD
        ENDIF
 
@@ -638,7 +590,6 @@ CONTAINS
        ! SatDiagnRxnRate was previously defined in fullchem_mod.F90
        !=======================================================================
        IF ( State_Diag%Archive_SatDiagnRxnRate ) THEN
-       
           State_Diag%SatDiagnRxnRate(I,:,:,:) = State_Diag%SatDiagnRxnRate(I,:,:,:) * GOOD
        ENDIF
 

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -2,6 +2,7 @@
 !                  GEOS-Chem Global Chemical Transport Model                  !
 !------------------------------------------------------------------------------
 !BOP
+!SatDiagn
 !
 ! !MODULE: diagnostics_mod.F90
 !

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -231,6 +231,7 @@ CONTAINS
     IF (State_Diag%Archive_ProdCOfromNMVOC) State_Diag%ProdCOfromNMVOC= 0.0_f4
     IF (State_Diag%Archive_OHreactivity   ) State_Diag%OHreactivity   = 0.0_f4
     IF (State_Diag%Archive_RxnRate        ) State_Diag%RxnRate        = 0.0_f4
+    IF (State_Diag%Archive_SatDiagnRxnRate) State_Diag%SatDiagnRxnRate= 0.0_f4
     IF (State_Diag%Archive_KppDiags) THEN
        IF (State_Diag%Archive_KppIntCounts) State_Diag%KppIntCounts   = 0.0_f4
        IF (State_Diag%Archive_KppJacCounts) State_Diag%KppJacCounts   = 0.0_f4
@@ -866,6 +867,14 @@ CONTAINS
           DO S = 1, State_Diag%Map_RxnRate%nSlots
              N = State_Diag%Map_RxnRate%slot2Id(S)
              State_Diag%RxnRate(I,J,L,S) = Aout(N)
+          ENDDO
+       ENDIF
+
+       IF ( State_Diag%Archive_SatDiagnRxnRate ) THEN
+          CALL Fun( VAR, FIX, RCONST, Vloc, Aout=Aout )
+          DO S = 1, State_Diag%Map_SatDiagnRxnRate%nSlots
+             N = State_Diag%Map_SatDiagnRxnRate%slot2Id(S)
+             State_Diag%SatDiagnRxnRate(I,J,L,S) = Aout(N)
           ENDDO
        ENDIF
 

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -226,6 +226,14 @@ MODULE State_Diag_Mod
      TYPE(DgnMap),       POINTER :: Map_DryDepVel
      LOGICAL                     :: Archive_DryDepVel
 
+     REAL(f4),           POINTER :: SatDiagnDryDep(:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnDryDep
+     LOGICAL                     :: Archive_SatDiagnDryDep
+
+     REAL(f4),           POINTER :: SatDiagnDryDepVel(:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnDryDepVel
+     LOGICAL                     :: Archive_SatDiagnDryDepVel
+
      !%%%%% Photolysis %%%%%
 
      REAL(f4),           POINTER :: Jval(:,:,:,:)
@@ -237,6 +245,16 @@ MODULE State_Diag_Mod
 
      REAL(f4),           POINTER :: JvalO3O3P(:,:,:)
      LOGICAL                     :: Archive_JvalO3O3P
+
+     REAL(f4),           POINTER :: SatDiagnJval(:,:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnJval
+     LOGICAL                     :: Archive_SatDiagnJval
+
+     REAL(f4),           POINTER :: SatDiagnJvalO3O1D(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnJvalO3O1D
+
+     REAL(f4),           POINTER :: SatDiagnJvalO3O3P(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnJvalO3O3P
 
      REAL(f4),           POINTER :: JNoon(:,:,:,:)
      TYPE(DgnMap),       POINTER :: Map_JNoon
@@ -263,8 +281,15 @@ MODULE State_Diag_Mod
      TYPE(DgnMap),       POINTER :: Map_RxnRate
      LOGICAL                     :: Archive_RxnRate
 
+     REAL(f4),           POINTER :: SatDiagnRxnRate(:,:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnRxnRate
+     LOGICAL                     :: Archive_SatDiagnRxnRate     
+
      REAL(f4),           POINTER :: OHreactivity(:,:,:)
      LOGICAL                     :: Archive_OHreactivity
+
+     REAL(f4),           POINTER :: SatDiagnOHreactivity(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnOHreactivity     
 
      REAL(f4),           POINTER :: OHconcAfterChem(:,:,:)
      LOGICAL                     :: Archive_OHconcAfterChem
@@ -278,9 +303,17 @@ MODULE State_Diag_Mod
      REAL(f4),           POINTER :: O3PconcAfterChem(:,:,:)
      LOGICAL                     :: Archive_O3PconcAfterChem
 
+     REAL(f4),           POINTER :: SatDiagnLoss(:,:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnLoss
+     LOGICAL                     :: Archive_SatDiagnLoss
+
      REAL(f4),           POINTER :: Loss(:,:,:,:)
      TYPE(DgnMap),       POINTER :: Map_Loss
      LOGICAL                     :: Archive_Loss
+
+     REAL(f4),           POINTER :: SatDiagnProd(:,:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnProd
+     LOGICAL                     :: Archive_SatDiagnProd
 
      REAL(f4),           POINTER :: Prod(:,:,:,:)
      TYPE(DgnMap),       POINTER :: Map_Prod
@@ -472,9 +505,17 @@ MODULE State_Diag_Mod
      TYPE(DgnMap),       POINTER :: Map_WetLossConv
      LOGICAL                     :: Archive_WetLossConv
 
+     REAL(f4),           POINTER :: SatDiagnWetLossConv(:,:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnWetLossConv
+     LOGICAL                     :: Archive_SatDiagnWetLossConv
+
      REAL(f4),           POINTER :: WetLossLS(:,:,:,:)
      TYPE(DgnMap),       POINTER :: Map_WetLossLS
      LOGICAL                     :: Archive_WetLossLS
+
+     REAL(f4),           POINTER :: SatDiagnWetLossLS(:,:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnWetLossLS
+     LOGICAL                     :: Archive_SatDiagnWetLossLS
 
      ! These are obsolete diagnostics
      !REAL(f4),  POINTER :: PrecipFracLS    (:,:,:  )
@@ -627,6 +668,84 @@ MODULE State_Diag_Mod
 
      REAL(f8),           POINTER :: OHwgtByAirMassColumnTrop(:,:)
      LOGICAL                     :: Archive_OHwgtByAirMassColumnTrop
+
+     !%%%%% Satellite diagnostic %%%%%
+
+     REAL(fp)                    :: SatDiagn_StartHr
+     REAL(fp)                    :: SatDiagn_EndHr
+     REAL(fp)                    :: SatDiagn_Count
+
+     REAL(f8),           POINTER :: SatDiagnCount(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnCount
+     
+     REAL(f8),           POINTER :: SatDiagnConc(:,:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnConc
+     LOGICAL                     :: Archive_SatDiagnConc
+
+     REAL(f8),           POINTER :: SatDiagnColEmis(:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnColEmis
+     LOGICAL                     :: Archive_SatDiagnColEmis
+
+     REAL(f8),           POINTER :: SatDiagnSurfFlux(:,:,:)
+     TYPE(DgnMap),       POINTER :: Map_SatDiagnSurfFlux
+     LOGICAL                     :: Archive_SatDiagnSurfFlux
+    
+     REAL(f8),           POINTER :: SatDiagnOH(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnOH
+     
+     REAL(f8),           POINTER :: SatDiagnRH(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnRH
+
+     REAL(f8),           POINTER :: SatDiagnAirDen(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnAirDen
+
+     REAL(f8),           POINTER :: SatDiagnBoxHeight(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnBoxHeight
+
+     REAL(f8),           POINTER :: SatDiagnPEdge(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnPEdge
+
+     REAL(f8),           POINTER :: SatDiagnTROPP(:,:)
+     LOGICAL                     :: Archive_SatDiagnTROPP
+
+     REAL(f8),           POINTER :: SatDiagnPBLHeight(:,:)
+     LOGICAL                     :: Archive_SatDiagnPBLHeight
+
+     REAL(f8),           POINTER :: SatDiagnPBLTop(:,:)
+     LOGICAL                     :: Archive_SatDiagnPBLTop
+
+     REAL(f8),           POINTER :: SatDiagnTAir(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnTAir
+
+     REAL(f8),           POINTER :: SatDiagnGWETROOT(:,:)
+     LOGICAL                     :: Archive_SatDiagnGWETROOT
+
+     REAL(f8),           POINTER :: SatDiagnGWETTOP(:,:)
+     LOGICAL                     :: Archive_SatDiagnGWETTOP
+
+     REAL(f8),           POINTER :: SatDiagnPARDR(:,:)
+     LOGICAL                     :: Archive_SatDiagnPARDR
+
+     REAL(f8),           POINTER :: SatDiagnPARDF(:,:)
+     LOGICAL                     :: Archive_SatDiagnPARDF
+
+     REAL(f8),           POINTER :: SatDiagnPRECTOT(:,:)
+     LOGICAL                     :: Archive_SatDiagnPRECTOT
+
+     REAL(f8),           POINTER :: SatDiagnSLP(:,:)
+     LOGICAL                     :: Archive_SatDiagnSLP
+
+     REAL(f8),           POINTER :: SatDiagnSPHU(:,:,:)
+     LOGICAL                     :: Archive_SatDiagnSPHU
+
+     REAL(f8),           POINTER :: SatDiagnTS(:,:)
+     LOGICAL                     :: Archive_SatDiagnTS
+
+     REAL(f8),           POINTER :: SatDiagnPBLTOPL(:,:)
+     LOGICAL                     :: Archive_SatDiagnPBLTOPL
+
+     REAL(f8),           POINTER :: SatDiagnMODISLAI(:,:)
+     LOGICAL                     :: Archive_SatDiagnMODISLAI
 
      !----------------------------------------------------------------------
      ! Specialty Simulation Diagnostic Arrays
@@ -1259,6 +1378,14 @@ CONTAINS
     State_Diag%Map_DryDepVel                       => NULL()
     State_Diag%Archive_DryDepVel                   = .FALSE.
 
+    State_Diag%SatDiagnDryDep                      => NULL()
+    State_Diag%Map_SatDiagnDryDep                  => NULL()
+    State_Diag%Archive_SatDiagnDryDep              = .FALSE.
+
+    State_Diag%SatDiagnDryDepVel                   => NULL()
+    State_Diag%Map_SatDiagnDryDepVel               => NULL()
+    State_Diag%Archive_SatDiagnDryDepVel           = .FALSE.
+
     !%%%%% Chemistry, J-value, Prod/Loss diagnostics %%%%%
 
     State_Diag%Jval                                => NULL()
@@ -1271,6 +1398,16 @@ CONTAINS
     State_Diag%JvalO3O3P                           => NULL()
     State_Diag%Archive_JvalO3O3P                   = .FALSE.
 
+    State_Diag%SatDiagnJval                        => NULL()
+    State_Diag%Map_SatDiagnJval                    => NULL()
+    State_Diag%Archive_SatDiagnJval                = .FALSE.
+
+    State_Diag%SatDiagnJvalO3O1D                   => NULL()
+    State_Diag%Archive_SatDiagnJvalO3O1D           = .FALSE.
+
+    State_Diag%SatDiagnJvalO3O3P                   => NULL()
+    State_Diag%Archive_SatDiagnJvalO3O3P           = .FALSE.
+
     State_Diag%JNoon                               => NULL()
     State_Diag%Map_JNoon                           => NULL()
     State_Diag%Archive_JNoon                       = .FALSE.
@@ -1282,8 +1419,15 @@ CONTAINS
     State_Diag%Map_RxnRate                         => NULL()
     State_Diag%Archive_RxnRate                     = .FALSE.
 
+    State_Diag%SatDiagnRxnRate                     => NULL()
+    State_Diag%Map_SatDiagnRxnRate                 => NULL()
+    State_Diag%Archive_SatDiagnRxnRate             = .FALSE.
+
     State_Diag%OHreactivity                        => NULL()
     State_Diag%Archive_OHreactivity                = .FALSE.
+
+    State_Diag%SatDiagnOHreactivity                => NULL()
+    State_Diag%Archive_SatDiagnOHreactivity        = .FALSE.    
 
     State_Diag%UVFluxDiffuse                       => NULL()
     State_Diag%Map_UvFluxDiffuse                   => NULL()
@@ -1309,9 +1453,17 @@ CONTAINS
     State_Diag%O3PconcAfterChem                    => NULL()
     State_Diag%Archive_O3PconcAfterChem            = .FALSE.
 
+    State_Diag%SatDiagnLoss                        => NULL()
+    State_Diag%Map_SatDiagnLoss                    => NULL()
+    State_Diag%Archive_SatDiagnLoss                = .FALSE.
+
     State_Diag%Loss                                => NULL()
     State_Diag%Map_Loss                            => NULL()
     State_Diag%Archive_Loss                        = .FALSE.
+
+    State_Diag%SatDiagnProd                        => NULL()
+    State_Diag%Map_SatDiagnProd                    => NULL()
+    State_Diag%Archive_SatDiagnProd                = .FALSE.
 
     State_Diag%Prod                                => NULL()
     State_Diag%Map_Prod                            => NULL()
@@ -1497,6 +1649,10 @@ CONTAINS
     State_Diag%Map_WetLossConv                     => NULL()
     State_Diag%Archive_WetLossConv                 = .FALSE.
 
+    State_Diag%SatDiagnWetLossConv                 => NULL()
+    State_Diag%Map_SatDiagnWetLossConv             => NULL()
+    State_Diag%Archive_SatDiagnWetLossConv         = .FALSE.
+
     State_Diag%WetLossConvFrac                     => NULL()
     State_Diag%Map_WetLossConvFrac                 => NULL()
     State_Diag%Archive_WetLossConvFrac             = .FALSE.
@@ -1504,6 +1660,10 @@ CONTAINS
     State_Diag%WetLossLS                           => NULL()
     State_Diag%Map_WetLossLS                       => NULL()
     State_Diag%Archive_WetLossLS                   = .FALSE.
+
+    State_Diag%SatDiagnWetLossLS                   => NULL()
+    State_Diag%Map_SatDiagnWetLossLS               => NULL()
+    State_Diag%Archive_SatDiagnWetLossLS           = .FALSE.    
 
 !### Comment out these diagnostics for now (bmy, 6/2/20)
 !###    State_Diag%PrecipFracLS                        => NULL()
@@ -1665,6 +1825,84 @@ CONTAINS
     State_Diag%RadDecay                            => NULL()
     State_Diag%Map_RadDecay                        => NULL()
     State_Diag%Archive_RadDecay                    = .FALSE.
+
+    !%%%%% Satellite diagnostic %%%%%
+
+    State_Diag%SatDiagn_StartHr                    =  0.0
+    State_Diag%SatDiagn_EndHr                      =  0.0
+    State_Diag%SatDiagn_Count                      =  0.0
+
+    State_Diag%SatDiagnCount                       => NULL()
+    State_Diag%Archive_SatDiagnCount               = .FALSE.
+    
+    State_Diag%SatDiagnConc                        => NULL()
+    State_Diag%Map_SatDiagnConc                    => NULL()
+    State_Diag%Archive_SatDiagnConc                = .FALSE.
+
+    State_Diag%SatDiagnColEmis                     => NULL()
+    State_Diag%Map_SatDiagnColEmis                 => NULL()
+    State_Diag%Archive_SatDiagnColEmis             = .FALSE.
+
+    State_Diag%SatDiagnSurfFlux                    => NULL()
+    State_Diag%Map_SatDiagnSurfFlux                => NULL()
+    State_Diag%Archive_SatDiagnSurfFlux            = .FALSE.
+
+    State_Diag%SatDiagnOH                          => NULL()
+    State_Diag%Archive_SatDiagnOH                  = .FALSE.
+
+    State_Diag%SatDiagnRH                          => NULL()
+    State_Diag%Archive_SatDiagnRH                  = .FALSE.
+
+    State_Diag%SatDiagnAirDen                      => NULL()
+    State_Diag%Archive_SatDiagnAirDen              = .FALSE.
+
+    State_Diag%SatDiagnBoxHeight                   => NULL()
+    State_Diag%Archive_SatDiagnBoxHeight           = .FALSE.
+
+    State_Diag%SatDiagnPEdge                       => NULL()
+    State_Diag%Archive_SatDiagnPEdge               = .FALSE.
+
+    State_Diag%SatDiagnTROPP                       => NULL()
+    State_Diag%Archive_SatDiagnTROPP               = .FALSE.
+
+    State_Diag%SatDiagnPBLHeight                   => NULL()
+    State_Diag%Archive_SatDiagnPBLHeight           = .FALSE.
+
+    State_Diag%SatDiagnPBLTop                      => NULL()
+    State_Diag%Archive_SatDiagnPBLTop              = .FALSE.
+
+    State_Diag%SatDiagnTAir                        => NULL()
+    State_Diag%Archive_SatDiagnTAir                = .FALSE.
+
+    State_Diag%SatDiagnGWETROOT                    => NULL()
+    State_Diag%Archive_SatDiagnGWETROOT            = .FALSE.
+
+    State_Diag%SatDiagnGWETTOP                     => NULL()
+    State_Diag%Archive_SatDiagnGWETTOP             = .FALSE.
+
+    State_Diag%SatDiagnPARDR                       => NULL()
+    State_Diag%Archive_SatDiagnPARDR               = .FALSE.
+
+    State_Diag%SatDiagnPARDF                       => NULL()
+    State_Diag%Archive_SatDiagnPARDF               = .FALSE.
+
+    State_Diag%SatDiagnPRECTOT                     => NULL()
+    State_Diag%Archive_SatDiagnPRECTOT             = .FALSE.
+
+    State_Diag%SatDiagnSLP                         => NULL()
+    State_Diag%Archive_SatDiagnSLP                 = .FALSE.
+
+    State_Diag%SatDiagnSPHU                        => NULL()
+    State_Diag%Archive_SatDiagnSPHU                = .FALSE.
+
+    State_Diag%SatDiagnTS                          => NULL()
+    State_Diag%Archive_SatDiagnTS                  = .FALSE.
+
+    State_Diag%SatDiagnPBLTOPL                     => NULL()
+    State_Diag%Archive_SatDiagnPBLTOPL             = .FALSE.
+
+    State_Diag%SatDiagnMODISLAI                    => NULL()
+    State_Diag%Archive_SatDiagnMODISLAI            = .FALSE.
 
     ! RRTMG simulation diagnostics
 
@@ -2745,6 +2983,30 @@ CONTAINS
     ENDIF
 
     !------------------------------------------------------------------------
+    ! Satellite Diagnostic: Total dry deposition flux
+    !------------------------------------------------------------------------
+    diagID  = 'SatDiagnDryDep'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnDryDep,                         &
+         archiveData    = State_Diag%Archive_SatDiagnDryDep,                 &
+         mapData        = State_Diag%Map_SatDiagnDryDep,                     &
+         diagId         = diagId,                                            &
+         diagFlag       = 'D',                                               &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF    
+
+    !------------------------------------------------------------------------
     ! Dry deposition flux from chemistry
     ! NOTE: Turn on this diagnostic if we are saving total drydep,
     ! but do not register individual fields unless they are in HISTORY.rc
@@ -2860,6 +3122,31 @@ CONTAINS
        CALL GC_Error( errMsg, RC, thisLoc )
        RETURN
     ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Satellite Diagnostic: Dry deposition velocity
+    !-----------------------------------------------------------------------
+    diagID  = 'SatDiagnDryDepVel'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnDryDepVel,                      &
+         archiveData    = State_Diag%Archive_SatDiagnDryDepVel,              &
+         mapData        = State_Diag%Map_SatDiagnDryDepVel,                  &
+         diagId         = diagId,                                            &
+         diagFlag       = 'D',                                               &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
 
 #ifdef MODEL_GEOS
     !-----------------------------------------------------------------------
@@ -3296,6 +3583,30 @@ CONTAINS
     ENDIF
 
     !-----------------------------------------------------------------------
+    ! Satellite Diagnostics: Loss of soluble species in convective updrafts
+    !-----------------------------------------------------------------------
+    diagID  = 'SatDiagnWetLossConv'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnWetLossConv,                    &
+         archiveData    = State_Diag%Archive_SatDiagnWetLossConv,            &
+         mapData        = State_Diag%Map_SatDiagnWetLossConv,                &
+         diagId         = diagId,                                            &
+         diagFlag       = 'W',                                               &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
     ! Loss of solutble species in large-scale rainout/washout
     !-----------------------------------------------------------------------
     diagID  = 'WetLossLS'
@@ -3309,6 +3620,30 @@ CONTAINS
          Ptr2Data       = State_Diag%WetLossLS,                              &
          archiveData    = State_Diag%Archive_WetLossLS,                      &
          mapData        = State_Diag%Map_WetLossLS,                          &
+         diagId         = diagId,                                            &
+         diagFlag       = 'W',                                               &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! SatDiagn Diagnostic: Loss of soluble species in large-scale rainout/washout
+    !-----------------------------------------------------------------------
+    diagID  = 'SatDiagnWetLossLS'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnWetLossLS,                      &
+         archiveData    = State_Diag%Archive_SatDiagnWetLossLS,              &
+         mapData        = State_Diag%Map_SatDiagnWetLossLS,                  &
          diagId         = diagId,                                            &
          diagFlag       = 'W',                                               &
          RC             = RC                                                )
@@ -3458,6 +3793,540 @@ CONTAINS
           ENDIF
        ENDDO
 
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Advected species concentrations
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnConc'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnConc,                           &
+         archiveData    = State_Diag%Archive_SatDiagnConc,                   &
+         mapData        = State_Diag%Map_SatDiagnConc,                       &
+         diagId         = diagId,                                            &
+         diagFlag       = 'S',                                               &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Column Emissions [kg/m2/s] for Advected Species
+    ! From Surface to Maximum Vertical Level
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnColEmis'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnColEmis,                        &
+         archiveData    = State_Diag%Archive_SatDiagnColEmis,                &
+         mapData        = State_Diag%Map_SatDiagnColEmis,                    &
+         diagId         = diagId,                                            &
+         diagFlag       = 'A',                                               &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Total Surface Fluxes [kg/m2/s] [eflx (emis)- dflx (drydep)]
+    ! From Surface to Top of the PBL; For Advected Species
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnSurfFlux'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnSurfFlux,                       &
+         archiveData    = State_Diag%Archive_SatDiagnSurfFlux,               &
+         mapData        = State_Diag%Map_SatDiagnSurfFlux,                   &
+         diagId         = diagId,                                            &
+         diagFlag       = 'A',                                               &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: OH number density
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnOH'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnOH,                             &
+         archiveData    = State_Diag%Archive_SatDiagnOH,                     &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Relative humidity (RH)
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnRH'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnRH,                             &
+         archiveData    = State_Diag%Archive_SatDiagnRH,                     &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Air density (AirDen)
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnAirDen'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnAirDen,                         &
+         archiveData    = State_Diag%Archive_SatDiagnAirDen,                 &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Box height (BoxHeight)
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnBoxHeight'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnBoxHeight,                      &
+         archiveData    = State_Diag%Archive_SatDiagnBoxHeight,              &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Pressure edges (PEDGE)
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnPEdge'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnPEdge,                          &
+         archiveData    = State_Diag%Archive_SatDiagnPEdge,                  &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Tropopause pressure (TROPP)
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnTROPP'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnTROPP,                          &
+         archiveData    = State_Diag%Archive_SatDiagnTROPP,                  &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: PBL Height (m)
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnPBLHeight'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnPBLHeight,                      &
+         archiveData    = State_Diag%Archive_SatDiagnPBLHeight,              &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: PBL Height (m)
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnPBLTop'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnPBLTop,                         &
+         archiveData    = State_Diag%Archive_SatDiagnPBLTop,                 &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Air temperature (K)
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnTAir'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnTAir,                           &
+         archiveData    = State_Diag%Archive_SatDiagnTAir,                   &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Root Zone Soil Moisture (or Wetness): GWETROOT
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnGWETROOT'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnGWETROOT,                       &
+         archiveData    = State_Diag%Archive_SatDiagnGWETROOT,               &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Topsoil Moisture (or Wetness): GWETTOP
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnGWETTOP'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnGWETTOP,                        &
+         archiveData    = State_Diag%Archive_SatDiagnGWETTOP,                &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Direct Photosynthetically Active Radiation [W/m2]
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnPARDR'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnPARDR,                          &
+         archiveData    = State_Diag%Archive_SatDiagnPARDR,                  &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Diffuse Photosynthetically Active Radiation [W/m2]
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnPARDF'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnPARDF,                          &
+         archiveData    = State_Diag%Archive_SatDiagnPARDF,                  &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Total Precipitation (at surface) [mm/day]: PRECTOT
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnPRECTOT'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnPRECTOT,                        &
+         archiveData    = State_Diag%Archive_SatDiagnPRECTOT,                &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Sea Level Pressure [hPa]
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnSLP'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnSLP,                            &
+         archiveData    = State_Diag%Archive_SatDiagnSLP,                    &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Specific Humidity Interpolated to Current Time [g H2O/kg air]
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnSPHU'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnSPHU,                           &
+         archiveData    = State_Diag%Archive_SatDiagnSPHU,                   &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: Surface Temperature at 2m [K]
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnTS'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnTS,                             &
+         archiveData    = State_Diag%Archive_SatDiagnTS,                     &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: PBL Top Height [Levels]
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnPBLTOPL'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnPBLTOPL,                        &
+         archiveData    = State_Diag%Archive_SatDiagnPBLTOPL,                &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! Satellite diagnostic: MODIS Daily LAI [m2/m2]
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnMODISLAI'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnMODISLAI,                       &
+         archiveData    = State_Diag%Archive_SatDiagnMODISLAI,               &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    ! ------------------------------------------------------------------------
+    ! Satellite diagnostic: Counter
+    !------------------------------------------------------------------------
+    IF ( State_Diag%Archive_SatDiagnConc        .OR. &
+         State_Diag%Archive_SatDiagnColEmis     .OR. &
+         State_Diag%Archive_SatDiagnSurfFlux    .OR. &
+         State_Diag%Archive_SatDiagnOH          .OR. &
+         State_Diag%Archive_SatDiagnRH          .OR. &
+         State_Diag%Archive_SatDiagnAirDen      .OR. &
+         State_Diag%Archive_SatDiagnBoxHeight   .OR. &
+         State_Diag%Archive_SatDiagnPEdge       .OR. &
+         State_Diag%Archive_SatDiagnTROPP       .OR. &
+         State_Diag%Archive_SatDiagnPBLHeight   .OR. &
+         State_Diag%Archive_SatDiagnPBLTop      .OR. &
+         State_Diag%Archive_SatDiagnTAir        .OR. &
+         State_Diag%Archive_SatDiagnGWETROOT    .OR. &
+         State_Diag%Archive_SatDiagnGWETTOP     .OR. &
+         State_Diag%Archive_SatDiagnPARDR       .OR. &
+         State_Diag%Archive_SatDiagnPARDF       .OR. &
+         State_Diag%Archive_SatDiagnPRECTOT     .OR. &
+         State_Diag%Archive_SatDiagnSLP         .OR. &
+         State_Diag%Archive_SatDiagnSPHU        .OR. &
+         State_Diag%Archive_SatDiagnTS          .OR. &
+         State_Diag%Archive_SatDiagnPBLTOPL     .OR. &
+         State_Diag%Archive_SatDiagnMODISLAI    .OR. &
+         State_Diag%Archive_SatDiagnWetLossLS   .OR. &
+         State_Diag%Archive_SatDiagnWetLossConv .OR. &
+         State_Diag%Archive_SatDiagnJval        .OR. &
+         State_Diag%Archive_SatDiagnJvalO3O1D   .OR. &
+         State_Diag%Archive_SatDiagnJvalO3O3P   .OR. &
+         State_Diag%Archive_SatDiagnDryDep      .OR. &
+         State_Diag%Archive_SatDiagnDryDepVel   .OR. &
+         State_Diag%Archive_SatDiagnOHreactivity ) THEN
+       ! Array to contain the satellite diagnostic weights
+       ALLOCATE( State_Diag%SatDiagnCount( State_Grid%NX, State_Grid%NY, State_Grid%NZ ), &
+                 STAT=RC )
+       CALL GC_CheckVar( 'State_Diag%DiagnCount', 0, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Diag%SatDiagnCount = 0.0_f4
+       State_Diag%Archive_SatDiagnCount = .TRUE.
     ENDIF
 
     !=======================================================================
@@ -3974,6 +4843,30 @@ CONTAINS
        ENDIF
 
        !--------------------------------------------------------------------
+       ! Satellite Diagnostic: KPP Reaction Rates
+       !--------------------------------------------------------------------
+       diagID  = 'SatDiagnRxnRate'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%SatDiagnRxnRate,                     &
+            archiveData    = State_Diag%Archive_SatDiagnRxnRate,             &
+            mapData        = State_Diag%Map_SatDiagnRxnRate,                 &
+            diagId         = diagId,                                         &
+            diagFlag       = 'R',                                            &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !--------------------------------------------------------------------
        ! OH reactivity
        !--------------------------------------------------------------------
        diagID  = 'OHreactivity'
@@ -3994,6 +4887,28 @@ CONTAINS
           CALL GC_Error( errMsg, RC, thisLoc )
           RETURN
        ENDIF
+
+       !--------------------------------------------------------------------
+       ! Satellite Diagnostic: OH reactivity
+       !--------------------------------------------------------------------
+       diagID  = 'SatDiagnOHreactivity'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%SatDiagnOHreactivity,                &
+            archiveData    = State_Diag%Archive_SatDiagnOHreactivity,        &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF       
 
        !--------------------------------------------------------------------
        ! J-Values (instantaneous values)
@@ -4054,6 +4969,74 @@ CONTAINS
             TaggedDiagList = TaggedDiag_List,                                &
             Ptr2Data       = State_Diag%JvalO3O3P,                           &
             archiveData    = State_Diag%Archive_JvalO3O3P,                   &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !--------------------------------------------------------------------
+       ! Satellite Diagnostics J-Values (instantaneous values)
+       !--------------------------------------------------------------------
+       diagID  = 'SatDiagnJval'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%SatDiagnJval,                        &
+            archiveData    = State_Diag%Archive_SatDiagnJval,                &
+            mapData        = State_Diag%Map_SatDiagnJval,                    &
+            diagId         = diagId,                                         &
+            diagFlag       = 'P',                                            &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !--------------------------------------------------------------------
+       ! Satellite Diagnostics J-Values for O3_O1D (instantaneous values)
+       !--------------------------------------------------------------------
+       diagID  = 'SatDiagnJvalO3O1D'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%SatDiagnJvalO3O1D,                   &
+            archiveData    = State_Diag%Archive_SatDiagnJvalO3O1D,           &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !--------------------------------------------------------------------
+       ! Satellite Diagnostics J-Values for O3_O3P (instantaneous values)
+       !--------------------------------------------------------------------
+       diagID  = 'SatDiagnJvalO3O3P'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%SatDiagnJvalO3O3P,                   &
+            archiveData    = State_Diag%Archive_SatDiagnJvalO3O3P,           &
             diagId         = diagId,                                         &
             RC             = RC                                             )
 
@@ -6765,6 +7748,30 @@ CONTAINS
          Input_Opt%ITS_A_TAGCO_SIM    .or. Input_Opt%ITS_A_TAGO3_SIM ) THEN
 
        !--------------------------------------------------------------------
+       ! Satellite Diagnostic: Chemical loss for selected species or families
+       !--------------------------------------------------------------------
+       diagID  = 'SatDiagnLoss'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%SatDiagnLoss,                        &
+            archiveData    = State_Diag%Archive_SatDiagnLoss,                &
+            mapData        = State_Diag%Map_SatDiagnLoss,                    &
+            diagId         = diagId,                                         &
+            diagFlag       = 'X',                                            &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !--------------------------------------------------------------------
        ! Chemical loss for selected species or families
        !--------------------------------------------------------------------
        diagID  = 'Loss'
@@ -6780,6 +7787,30 @@ CONTAINS
             mapData        = State_Diag%Map_Loss,                            &
             diagId         = diagId,                                         &
             diagFlag       = 'X',                                            &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !--------------------------------------------------------------------
+       ! Satellite Diagnostic: Chemical production for selected species or families
+       !--------------------------------------------------------------------
+       diagID  = 'SatDiagnProd'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%SatDiagnProd,                        &
+            archiveData    = State_Diag%Archive_SatDiagnProd,                &
+            mapData        = State_Diag%Map_SatDiagnProd,                    &
+            diagId         = diagId,                                         &
+            diagFlag       = 'Y',                                            &
             RC             = RC                                             )
 
        IF ( RC /= GC_SUCCESS ) THEN
@@ -8982,6 +10013,18 @@ CONTAINS
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
+    CALL Finalize( diagId   = 'SatDiagnDryDep',                              &
+                   Ptr2Data = State_Diag%SatDiagnDryDep,                     &
+                   mapData  = State_Diag%Map_SatDiagnDryDep,                 &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnDryDepVel',                           &
+                   Ptr2Data = State_Diag%SatDiagnDryDepVel,                  &
+                   mapData  = State_Diag%Map_SatDiagnDryDepVel,              &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
     CALL Finalize( diagId   = 'Jval',                                        &
                    Ptr2Data = State_Diag%Jval,                               &
                    mapData  = State_Diag%Map_Jval,                           &
@@ -8995,6 +10038,22 @@ CONTAINS
 
     CALL Finalize( diagId   = 'JvalO3O3P',                                   &
                    Ptr2Data = State_Diag%Jval,                               &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnJval',                                 &
+                   Ptr2Data = State_Diag%SatDiagnJval,                        &
+                   mapData  = State_Diag%Map_SatDiagnJval,                    &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnJvalO3O1D',                            &
+                   Ptr2Data = State_Diag%SatDiagnJval,                        &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnJvalO3O3P',                            &
+                   Ptr2Data = State_Diag%SatDiagnJval,                        &
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
@@ -9015,8 +10074,19 @@ CONTAINS
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
+    CALL Finalize( diagId   = 'SatDiagnRxnRate',                             &
+                   Ptr2Data = State_Diag%SatDiagnRxnRate,                    &
+                   mapData  = State_Diag%Map_SatDiagnRxnRate,                &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
     CALL Finalize( diagId   = 'OHreactivity',                                &
                    Ptr2Data = State_Diag%OHreactivity,                       &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnOHreactivity',                        &
+                   Ptr2Data = State_Diag%SatDiagnOHreactivity,               &
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
@@ -9079,6 +10149,12 @@ CONTAINS
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
+    CALL Finalize( diagId   = 'SatDiagnWetLossConv',                         &
+                   Ptr2Data = State_Diag%SatDiagnWetLossConv,                &
+                   mapData  = State_Diag%Map_SatDiagnWetLossConv,            &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
     CALL Finalize( diagId   = 'WetLossConvFrac',                             &
                    Ptr2Data = State_Diag%WetLossConvFrac,                    &
                    RC       = RC                                            )
@@ -9087,6 +10163,12 @@ CONTAINS
     CALL Finalize( diagId   = 'WetLossLS',                                   &
                    Ptr2Data = State_Diag%WetLossLS,                          &
                    mapData  = State_Diag%Map_WetLossLS,                      &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnWetLossLS',                           &
+                   Ptr2Data = State_Diag%SatDiagnWetLossLS,                  &
+                   mapData  = State_Diag%Map_SatDiagnWetLossLS,              &
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
@@ -9110,6 +10192,119 @@ CONTAINS
 !       IF ( RC /= GC_SUCCESS ) RETURN
 !       State_Diag%WashFracLS => NULL()
 !    ENDIF
+
+    CALL Finalize( diagId   = 'SatDiagnConc',                                &
+                   Ptr2Data = State_Diag%SatDiagnConc,                       &
+                   mapData  = State_Diag%Map_SatDiagnConc,                   &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnColEmis',                             &
+                   Ptr2Data = State_Diag%SatDiagnColEmis,                    &
+                   mapData  = State_Diag%Map_SatDiagnColEmis,                &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnSurfFlux',                            &
+                   Ptr2Data = State_Diag%SatDiagnSurfFlux,                   &
+                   mapData  = State_Diag%Map_SatDiagnSurfFlux,               &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnOH',                                &
+                   Ptr2Data = State_Diag%SatDiagnOH,                       &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnRH',                                &
+                   Ptr2Data = State_Diag%SatDiagnRH,                       &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnAirDen',                            &
+                   Ptr2Data = State_Diag%SatDiagnAirDen,                   &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnBoxHeight',                         &
+                   Ptr2Data = State_Diag%SatDiagnBoxHeight,                &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnPEdge',                             &
+                   Ptr2Data = State_Diag%SatDiagnPEdge,                    &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnTROPP',                             &
+                   Ptr2Data = State_Diag%SatDiagnTROPP,                    &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnPBLHeight',                         &
+                   Ptr2Data = State_Diag%SatDiagnPBLHeight,                &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnPBLTop',                            &
+                   Ptr2Data = State_Diag%SatDiagnPBLTop,                   &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnTAir',                              &
+                   Ptr2Data = State_Diag%SatDiagnTAir,                     &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnGWETROOT',                          &
+                   Ptr2Data = State_Diag%SatDiagnGWETROOT,                 &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnGWETTOP',                           &
+                   Ptr2Data = State_Diag%SatDiagnGWETTOP,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnPARDR',                             &
+                   Ptr2Data = State_Diag%SatDiagnPARDR,                    &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnPARDF',                             &
+                   Ptr2Data = State_Diag%SatDiagnPARDF,                    &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnPRECTOT',                           &
+                   Ptr2Data = State_Diag%SatDiagnPRECTOT,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnSLP',                               &
+                   Ptr2Data = State_Diag%SatDiagnSLP,                      &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnSPHU',                              &
+                   Ptr2Data = State_Diag%SatDiagnSPHU,                     &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnTS',                                &
+                   Ptr2Data = State_Diag%SatDiagnTS,                       &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnPBLTOPL',                           &
+                   Ptr2Data = State_Diag%SatDiagnPBLTOPL,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnMODISLAI',                          &
+                   Ptr2Data = State_Diag%SatDiagnMODISLAI,                 &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
 
     CALL Finalize( diagId   = 'PbFromRnDecay',                               &
                    Ptr2Data = State_Diag%PbFromRnDecay,                      &
@@ -9359,9 +10554,21 @@ CONTAINS
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
+    CALL Finalize( diagId   = 'SatDiagnLoss',                                &
+                   Ptr2Data = State_Diag%SatDiagnLoss,                       &
+                   mapData  = State_Diag%Map_SatDiagnLoss,                   &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
     CALL Finalize( diagId   = 'Loss',                                        &
                    Ptr2Data = State_Diag%Loss,                               &
                    mapData  = State_Diag%Map_Loss,                           &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'SatDiagnProd',                                &
+                   Ptr2Data = State_Diag%SatDiagnProd,                       &
+                   mapData  = State_Diag%Map_SatDiagnProd,                   &
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
@@ -10466,6 +11673,18 @@ CONTAINS
        IF ( isRank    ) Rank  = 2
        IF ( isTagged  ) TagId = 'DRY'
 
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNDRYDEP' ) THEN
+       IF ( isDesc    ) Desc  = 'Dry deposition flux of species'
+       IF ( isUnits   ) Units = 'molec cm-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagId = 'DRY'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNDRYDEPVEL' ) THEN
+       IF ( isDesc    ) Desc  = 'Dry deposition velocity of species'
+       IF ( isUnits   ) Units = 'cm s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagId = 'DRY'       
+
 #ifdef MODEL_GEOS
     ELSE IF ( TRIM( Name_AllCaps ) == 'MONINOBUKHOV' ) THEN
        IF ( isDesc    ) Desc  = 'Monin-Obukhov length'
@@ -10558,6 +11777,22 @@ CONTAINS
        IF ( isUnits   ) Units = 's-1'
        IF ( isRank    ) Rank  = 3
 
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNJVAL' ) THEN
+       IF ( isDesc    ) Desc  = 'Photolysis rate for species'
+       IF ( isUnits   ) Units = 's-1'
+       IF ( isRank    ) Rank  = 3
+       IF ( isTagged  ) TagId = 'PHO'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNJVALO3O1D' ) THEN
+       IF ( isDesc    ) Desc  = 'Photolysis rate for O3 -> O1D'
+       IF ( isUnits   ) Units = 's-1'
+       IF ( isRank    ) Rank  = 3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNJVALO3O3P' ) THEN
+       IF ( isDesc    ) Desc  = 'Photolysis rate for O3 -> O3P'
+       IF ( isUnits   ) Units = 's-1'
+       IF ( isRank    ) Rank  = 3
+
     ELSE IF ( TRIM( Name_AllCaps ) == 'JNOON' ) THEN
        IF ( isDesc    ) Desc  = 'Noontime photolysis rate for species'
        IF ( isUnits   ) Units = 's-1'
@@ -10576,10 +11811,21 @@ CONTAINS
        IF ( isRank    ) Rank  = 3
        IF ( isTagged  ) TagId = 'RXN'
 
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNRXNRATE' ) THEN
+       IF ( isDesc    ) Desc  = 'KPP equation reaction rates'
+       IF ( isUnits   ) Units = 's-1'
+       IF ( isRank    ) Rank  = 3
+       IF ( isTagged  ) TagId = 'RXN'
+
     ELSE IF ( TRIM( Name_AllCaps ) == 'OHREACTIVITY' ) THEN
        IF ( isDesc    ) Desc  = 'OH reactivity'
        IF ( isUnits   ) Units = 's-1'
        IF ( isRank    ) Rank  = 3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNOHREACTIVITY' ) THEN
+       IF ( isDesc    ) Desc  = 'OH reactivity'
+       IF ( isUnits   ) Units = 's-1'
+       IF ( isRank    ) Rank  = 3       
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'UVFLUXDIFFUSE' ) THEN
        IF ( isDesc    ) Desc  = 'Diffuse UV flux in bin'
@@ -10650,6 +11896,13 @@ CONTAINS
        IF ( isRank    ) Rank  = 3
        IF ( isTagged  ) TagId = 'WET'
 
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNWETLOSSCONV' ) THEN
+       IF ( isDesc    ) Desc  = &
+            'Loss of soluble species in convective updrafts'
+       IF ( isUnits   ) Units = 'kg s-1'
+       IF ( isRank    ) Rank  = 3
+       IF ( isTagged  ) TagId = 'WET'
+
     ELSE IF ( TRIM( Name_AllCaps ) == 'PRECIPFRACCONV' ) THEN
        IF ( isDesc    ) Desc  = 'Fraction of grid box undergoing ' // &
                                 'convective precipitation'
@@ -10671,6 +11924,13 @@ CONTAINS
        IF ( isTagged  ) TagId = 'WET'
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'WETLOSSLS' ) THEN
+       IF ( isDesc    ) Desc  = 'Loss of soluble species in large-scale ' // &
+                                'precipitation'
+       IF ( isUnits   ) Units = 'kg s-1'
+       IF ( isRank    ) Rank  = 3
+       IF ( isTagged  ) TagId = 'WET'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNWETLOSSLS' ) THEN
        IF ( isDesc    ) Desc  = 'Loss of soluble species in large-scale ' // &
                                 'precipitation'
        IF ( isUnits   ) Units = 'kg s-1'
@@ -10708,6 +11968,121 @@ CONTAINS
        IF ( isUnits   ) Units = 'kg s-1'
        IF ( isRank    ) Rank  = 3
        IF ( isTagged  ) TagId = 'ADV'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNCONC' ) THEN
+       IF ( isDesc    ) Desc  = 'Dry mixing ratio of species'
+       IF ( isUnits   ) Units = 'mol mol-1 dry'
+       IF ( isRank    ) Rank  = 3
+       IF ( isTagged  ) TagId = 'ALL'
+       IF ( isSrcType ) SrcType  = KINDVAL_F8
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNCOLEMIS' ) THEN
+       IF ( isDesc    ) Desc  = 'Column Emissions for Advected Species'
+       IF ( isUnits   ) Units = 'kg m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagId = 'ADV'
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNSURFFLUX' ) THEN
+       IF ( isDesc    ) Desc  = 'Total Surface Fluxes (EFLX (emis) - DFLX (drydep)); from Surface to Top of PBL) for Advected Species'
+       IF ( isUnits   ) Units = 'kg m-2 s-1'
+       IF ( isRank    ) Rank  = 2
+       IF ( isTagged  ) TagId = 'ADV'       
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNOH' ) THEN
+       IF ( isDesc    ) Desc  = 'OH number density'
+       IF ( isUnits   ) Units = 'molec cm-3'
+       IF ( isRank    ) Rank  = 3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNRH' ) THEN
+       IF ( isDesc    ) Desc  = 'Relative humidity'
+       IF ( isUnits   ) Units = '%'
+       IF ( isRank    ) Rank  = 3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNAIRDEN' ) THEN
+       IF ( isDesc    ) Desc  = 'Air density'
+       IF ( isUnits   ) Units = 'molec/cm3'
+       IF ( isRank    ) Rank  = 3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNBOXHEIGHT' ) THEN
+       IF ( isDesc    ) Desc  = 'Box height'
+       IF ( isUnits   ) Units = 'm'
+       IF ( isRank    ) Rank  = 3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNPEDGE' ) THEN
+       IF ( isDesc    ) Desc  = 'Pressure edges'
+       IF ( isUnits   ) Units = 'hPa'
+       IF ( isRank    ) Rank  = 3
+       !IF ( isVLoc    ) VLoc  = VLocationEdge
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNTROPP' ) THEN
+       IF ( isDesc    ) Desc  = 'Tropopause pressure'
+       IF ( isUnits   ) Units = 'hPa'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNPBLHEIGHT' ) THEN
+       IF ( isDesc    ) Desc  = 'PBL Height'
+       IF ( isUnits   ) Units = 'm'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNPBLTOP' ) THEN
+       IF ( isDesc    ) Desc  = 'PBL Top'
+       IF ( isUnits   ) Units = 'm'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNTAIR' ) THEN
+       IF ( isDesc    ) Desc  = 'Air temperature'
+       IF ( isUnits   ) Units = 'K'
+       IF ( isRank    ) Rank  = 3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNGWETROOT' ) THEN
+       IF ( isDesc    ) Desc  = 'Root Zone Soil Moisture (or Wetness)'
+       IF ( isUnits   ) Units = 'Fraction'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNGWETTOP' ) THEN
+       IF ( isDesc    ) Desc  = 'Topsoil Moisture (or Wetness)'
+       IF ( isUnits   ) Units = 'Fraction'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNPARDR' ) THEN
+       IF ( isDesc    ) Desc  = 'Direct Photosynthetically Active Radiation'
+       IF ( isUnits   ) Units = 'W/m2'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNPARDF' ) THEN
+       IF ( isDesc    ) Desc  = 'Diffuse Photosynthetically Active Radiation'
+       IF ( isUnits   ) Units = 'W/m2'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNPRECTOT' ) THEN
+       IF ( isDesc    ) Desc  = 'Total Precipitation (at surface)'
+       IF ( isUnits   ) Units = 'mm/day'
+       IF ( isRank    ) Rank  = 2       
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNSLP' ) THEN
+       IF ( isDesc    ) Desc  = 'Sea Level Pressure'
+       IF ( isUnits   ) Units = 'hPa'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNSPHU' ) THEN
+       IF ( isDesc    ) Desc  = 'Specific Humidity Interpolated to Current Time'
+       IF ( isUnits   ) Units = 'g H2O/kg air'
+       IF ( isRank    ) Rank  = 3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNTS' ) THEN
+       IF ( isDesc    ) Desc  = 'Surface Temperature at 2m'
+       IF ( isUnits   ) Units = 'K'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNPBLTOPL' ) THEN
+       IF ( isDesc    ) Desc  = 'PBL Top Height'
+       IF ( isUnits   ) Units = 'Levels'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNMODISLAI' ) THEN
+       IF ( isDesc    ) Desc  = 'MODIS Daily LAI'
+       IF ( isUnits   ) Units = 'm2/m2'
+       IF ( isRank    ) Rank  = 2
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'RADALLSKYLWSURF' ) THEN
        IF ( isDesc    ) Desc  = 'All-sky long-wave radiation at surface'
@@ -11115,10 +12490,42 @@ CONTAINS
        IF ( isUnits   ) Units = 'ug m-3'
        IF ( isRank    ) Rank  =  3
 
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNLOSS' ) THEN
+       IF ( IsDesc    ) Desc  = 'Chemical loss of'
+       IF ( isRank    ) Rank  = 3
+       IF ( isTagged  ) TagId = 'LOS'
+
+       ! NOTE: Units are different depending on simulation, due to historical
+       ! baggage.  Maybe clean this up at a later point to use the same units
+       ! regardless of simulation type. (bmy, 12/4/17)
+       IF ( isUnits   ) THEN
+          IF ( IsFullChem ) THEN
+             Units = 'molec cm-3 s-1'
+          ELSE
+             Units = 'kg s-1'
+          ENDIF
+       ENDIF
+
     ELSE IF ( TRIM( Name_AllCaps ) == 'LOSS' ) THEN
        IF ( IsDesc    ) Desc  = 'Chemical loss of'
        IF ( isRank    ) Rank  = 3
        IF ( isTagged  ) TagId = 'LOS'
+
+       ! NOTE: Units are different depending on simulation, due to historical
+       ! baggage.  Maybe clean this up at a later point to use the same units
+       ! regardless of simulation type. (bmy, 12/4/17)
+       IF ( isUnits   ) THEN
+          IF ( IsFullChem ) THEN
+             Units = 'molec cm-3 s-1'
+          ELSE
+             Units = 'kg s-1'
+          ENDIF
+       ENDIF
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNPROD' ) THEN
+       IF ( isDesc    ) Desc  = 'Chemical production of'
+       IF ( isRank    ) Rank  = 3
+       IF ( isTagged  ) TagId = 'PRD'
 
        ! NOTE: Units are different depending on simulation, due to historical
        ! baggage.  Maybe clean this up at a later point to use the same units
@@ -14233,7 +15640,7 @@ CONTAINS
     TYPE(OptInput),        INTENT(IN)  :: Input_Opt      ! Input Options
     TYPE(ChmState),        INTENT(IN)  :: State_Chm      ! Chemistry State
     TYPE(TaggedDgnList),   INTENT(IN)  :: TaggedDiagList ! Tags/WCs per diag
-    CHARACTER(LEN=*),      INTENT(IN)  :: metadataId     ! Diangnostic name
+    CHARACTER(LEN=*),      INTENT(IN)  :: metadataId     ! Diagnostic name
     CHARACTER(LEN=*),      INTENT(IN)  :: indFlag        !
 !
 ! !OUTPUT PARAMETERS:

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -1855,7 +1855,7 @@ PROGRAM GEOS_Chem
           ENDIF
 
           ! Update each HISTORY ITEM from its data source
-          CALL History_Update( Input_Opt, RC )
+          CALL History_Update( Input_Opt, State_Diag, RC )
 
           ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
@@ -2079,7 +2079,7 @@ PROGRAM GEOS_Chem
 
           ! Write HISTORY ITEMS in each diagnostic collection to disk
           ! (or skip writing if it is not the proper output time.
-          CALL History_Write( Input_Opt, State_Chm%Spc_Units, RC )
+          CALL History_Write( Input_Opt, State_Diag, State_Chm%Spc_Units, RC )
 
           ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN


### PR DESCRIPTION
### Related GitHub Issue: 
[FEATURE REQUEST] Output satellite diagnostic as NetCDF #770

### Motivation and Context:

This pull request builds upon the work of @eamarais when she created a new netCDF satellite diagnostics patch for GCv13.0.2 that would eliminate the need to use the BPCH format for satellite diagnostics. For information on that patch and discussion, check out: [FEATURE REQUEST] Output satellite diagnostic as NetCDF #770

I have added more functionality to the SatDiagn Collection created by Eloise for GC13.3.3 to output additional diagnostics that were not done with the previous BPCH version. Specifically, additional outputs now include wet deposition, J-values, dry deposition, surface emission and surface flux of a given advected species, production and loss rates, OH reactivity, and individual reaction rates that can all be averaged between two time intervals (local time; LT) as specified by SatDiagn.hrrange.

### Update Type:
New feature (GC 14.0.0 Milestone)

### Update Impacts:
GEOS-Chem source code

### Compiler Used in Testing:
Intel Fortran Compiler (aka ifort), version 2017/Update 4

### Update Submitted By:

This update is a combination of code written by @eamarais and @jdshutter

Professor Eloise Marais: University College London (UCL) (e.marais@ucl.ac.uk)
Dr. Joshua Shutter: University of Minnesota (UMN) (shutt038@umn.edu)

### Useful Notes for GCST:

(1) As I was reading the code, I noticed there was a missing factor of 1000 for OH in both the BPCH and SatDiagn satellite diagnostics. This pull request corrects both those diagnostics.

(2) When comparing between BPCH and the new SatDiagn Collection, they differed if the averaging period specified in the ND51 menu (located in input.geos) or the SatDiagn.hrrange (located in HISTORY.rc) were specified as INTEGERS. I noticed that the evaluation of the logic statement in diagnostics_mod.F90 (see code below) would sometimes return false when it should have been true (or vice-versa) if INTEGERS were used. 

       ! Determine whether during satellite overpass time window:
       IF ( LT >= State_Diag%SatDiagn_StartHr .and. &
            LT <= State_Diag%SatDiagn_EndHr ) THEN

As a workaround, I simply specified an averaging range of 11.98 and 15.02 (corresponding closely to the desired 12 and 15 LT), which then caused the BPCH and netCDF satellite diagnostics to agree. I suppose an epsilon could also be added to the logic statement so that this isn’t a problem, but maybe there’s a better way when dealing with floating point numbers in evaluating logic statements.

The attached plot shows output of a few selected diagnostics from the new SatDiagn Collection that was generated using the code changes in this pull request. As Eloise showed before in Feature Request #770, the changes I made did not cause the BPCH and netCDF diagnostics to differ.

![download](https://user-images.githubusercontent.com/21131161/154828869-6e97bf17-41f6-42ea-8cbf-3d5215921f5c.png)

(3) Given how some of the satellite diagnostics are defined, some of the new satellite diagnostics that I’ve added need to have their corresponding collections activated (or else some diagnostics will be inadvertently undefined). Said another way, in order to output SatDiagnJval, you would also need to have output activated for the normal JValues Collection in HISTORY.rc. This holds true for the following satellite diagnostics: SatDiagnWetLossLS, SatDiagnWetLossConv, SatDiagnJval, SatDiagnDryDep, SatDiagnDryDepVel, SatDiagnOHReactivity (located in the ProdLoss Collection). For SatDiagnColEmis or SatDiagnSurfFlux, activate AdvFluxVert Collection since the advected species map will then be generated.

I realize this is non-ideal, but the workaround would have required even more modifications to the code that would just be specific to satellite diagnostics.

(4) Given the updates by @eamarais and myself, others can add additional satellite diagnostics that they might find useful for their research. As a starting place, folks will definitely need to modify GeosCore/diagnostics_mod.F90 and Headers/state_diag_mod.F90 if adding a new diagnostic. Folks may also need to modify other files as well depending on what is being defined.

(5) Currently, the HISTORY.rc file does not automatically include the SatDiagn Collection when creating a new run. 

(6) I don’t know why this is an issue, but the SatDiagn Collection must be placed at the bottom of the HISTORY.rc file (which makes it the first file to have diagnostics generated when I’ve looked at the run logs). When it wasn’t placed at the bottom of HISTORY.rc, the satellite diagnostic would output NaNs and INFs.

Below are the SatDiagn fields that I’ve successfully used thus far and placed at the bottom of the HISTORY.rc file. Just like with the normal diagnostic collections, the SatDiagn diagnostics also allow for individual species to be named within a given diagnostic (i.e., SatDiagnJval_CH2O or SatDiagnJval_NO2). 

I hope this makes some sense, but please don't hesitate to contact @jdshutter with questions about this pull request

```

#==============================================================================
# %%%%% THE SatDiagn COLLECTION %%%%%
#
# GEOS-Chem data during satellite overpass
#
# Available for all simulations
#==============================================================================
  SatDiagn.template:          '%y4%m2%d2_%h2%n2z.nc4',
  SatDiagn.format:            'CFIO',
  SatDiagn.frequency:         00000001 000000
  SatDiagn.duration:          00000100 000000
  SatDiagn.hrrange:           11.98 15.02
  SatDiagn.mode:              'time-averaged'
  SatDiagn.fields:            'SatDiagnConc_ISOP              ', 'GIGCchem',
                              'SatDiagnConc_CH2O              ', 'GIGCchem',
                              'SatDiagnConc_MVK               ', 'GIGCchem',
                              'SatDiagnConc_MACR              ', 'GIGCchem',
                              'SatDiagnConc_MOH               ', 'GIGCchem',
                              'SatDiagnConc_CO                ', 'GIGCchem',
                              'SatDiagnConc_NO                ', 'GIGCchem',
                              'SatDiagnConc_NO2               ', 'GIGCchem',
                              'SatDiagnConc_NO3               ', 'GIGCchem',
                              'SatDiagnConc_O3                ', 'GIGCchem',
                              'SatDiagnConc_HO2               ', 'GIGCchem',
                              'SatDiagnOH                     ', 'GIGCchem',
                              'SatDiagnRH                     ', 'GIGCchem',
                              'SatDiagnAirDen                 ', 'GIGCchem',
                              'SatDiagnBoxHeight              ', 'GIGCchem',
                              'SatDiagnPEdge                  ', 'GIGCchem',
                              'SatDiagnTROPP                  ', 'GIGCchem',
                              'SatDiagnPBLHeight              ', 'GIGCchem',
                              'SatDiagnPBLTop                 ', 'GIGCchem',
                              'SatDiagnTAir                   ', 'GIGCchem',
                              'SatDiagnGWETROOT               ', 'GIGCchem',
                              'SatDiagnGWETTOP                ', 'GIGCchem',
                              'SatDiagnPARDR                  ', 'GIGCchem',
                              'SatDiagnPARDF                  ', 'GIGCchem',
                              'SatDiagnPRECTOT                ', 'GIGCchem',
                              'SatDiagnSLP                    ', 'GIGCchem',
                              'SatDiagnSPHU                   ', 'GIGCchem',
                              'SatDiagnTS                     ', 'GIGCchem',
                              'SatDiagnPBLTOPL                ', 'GIGCchem',
                              'SatDiagnMODISLAI               ', 'GIGCchem',
                              'SatDiagnWetLossLS_CH2O         ', 'GIGCchem',
                              'SatDiagnWetLossConv_CH2O       ', 'GIGCchem',
                              'SatDiagnJval_CH2O              ', 'GIGCchem',
                              'SatDiagnJval_NO2               ', 'GIGCchem',
                              'SatDiagnJval_NO3               ', 'GIGCchem',
                              'SatDiagnJval_O3                ', 'GIGCchem',
                              'SatDiagnJvalO3O1D              ', 'GIGCchem',
                              'SatDiagnJvalO3O3P              ', 'GIGCchem',
                              'SatDiagnDryDep_CH2O            ', 'GIGCchem',
                              'SatDiagnDryDep_NO2             ', 'GIGCchem',
                              'SatDiagnDryDep_O3              ', 'GIGCchem',
                              'SatDiagnDryDepVel_CH2O         ', 'GIGCchem',
                              'SatDiagnDryDepVel_NO2          ', 'GIGCchem',
                              'SatDiagnDryDepVel_O3           ', 'GIGCchem',
                              'SatDiagnOHreactivity           ', 'GIGCchem',
                              'SatDiagnColEmis_ISOP           ', 'GIGCchem',
                              'SatDiagnSurfFlux_ISOP          ', 'GIGCchem',
                              'SatDiagnColEmis_CH2O           ', 'GIGCchem',
                              'SatDiagnSurfFlux_CH2O          ', 'GIGCchem',
                              'SatDiagnColEmis_NO             ', 'GIGCchem',
                              'SatDiagnSurfFlux_NO            ', 'GIGCchem',
                              'SatDiagnProd_?PRD?             ', 'GIGCchem',
                              'SatDiagnLoss_?LOS?             ', 'GIGCchem',
                              'SatDiagnRxnRate_EQ385          ', 'GIGCchem', #ISOP + OH
                              'SatDiagnRxnRate_EQ386          ', 'GIGCchem', #ISOP + OH
                              'SatDiagnRxnRate_EQ387          ', 'GIGCchem', #ISOP + OH
                              'SatDiagnRxnRate_EQ388          ', 'GIGCchem', #ISOP + OH
::
```