### PR TITLE
Sea salt aerosol debromination as an option -- off by default

### DIFF
--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -2285,6 +2285,14 @@ CONTAINS
     ENDIF
     READ( SUBSTRS(1:N), * ) Input_Opt%GAMMA_HO2
 
+    ! Use sea salt aerosol debromination?
+    CALL SPLIT_ONE_LINE( SUBSTRS, N, 1, 'SSAdebromination', RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+    READ( SUBSTRS(1:N), * ) Input_Opt%SSAdebromination
+
     ! Separator line
     CALL SPLIT_ONE_LINE( SUBSTRS, N, 1, 'separator 2', RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -2373,6 +2381,8 @@ CONTAINS
                             Input_Opt%USE_TOMS_O3
        WRITE( 6, 110     ) 'GAMMA HO2                   : ', &
                             Input_Opt%GAMMA_HO2
+       WRITE( 6, 100     ) 'Use SSA debromination?      : ', &
+                            Input_Opt%SSAdebromination
        IF ( Input_Opt%USE_ONLINE_O3 ) THEN
           WRITE( 6, '(a)' ) ''
           WRITE( 6, '(a)' ) 'NOTE ABOUT OVERHEAD O3 FOR FAST-JX:'

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -192,6 +192,7 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: USE_ONLINE_O3
      LOGICAL                     :: USE_O3_FROM_MET
      LOGICAL                     :: USE_TOMS_O3
+     LOGICAL                     :: SSAdebromination
 #ifdef MODEL_GEOS
      LOGICAL                     :: LGMIOZ
 #endif
@@ -708,6 +709,7 @@ CONTAINS
     Input_Opt%USE_ONLINE_O3          = .FALSE.
     Input_Opt%USE_O3_FROM_MET        = .FALSE.
     Input_Opt%USE_TOMS_O3            = .FALSE.
+    Input_Opt%SSAdebromination       = .FALSE.
 
     !----------------------------------------
     ! PHOTOLYSIS MENU fields

--- a/KPP/fullchem/fullchem.kpp
+++ b/KPP/fullchem/fullchem.kpp
@@ -169,6 +169,7 @@ PH2O2 : H2O2;
      REAL(dp) :: rIce           ! Ice radius
      REAL(dp) :: rLiq           ! Liquid radius
      REAL(dp) :: ssAlk(2)       ! Sea salt alk'nty (1=fine, 2=coarse)
+     LOGICAL  :: SSA_debrom     ! Use sea salt aerosol debromination?
      LOGICAL  :: SSA_is_Alk     ! Is fine sea-salt alkaline?
      LOGICAL  :: SSA_is_Acid    ! Is fine sea-salt acidic?
      LOGICAL  :: SSC_is_Alk     ! Is coarse sea-salt alkaline?

--- a/KPP/fullchem/fullchem_HetStateFuncs.F90
+++ b/KPP/fullchem/fullchem_HetStateFuncs.F90
@@ -151,8 +151,9 @@ CONTAINS
     H%SSC_is_Alk    = ( H%ssAlk(2) > 0.05_dp       )
     H%SSC_is_Acid   = ( .not.  H%SSC_is_Alk        )
 
-    ! Other fields
+    ! Fields specified in configuration file
     H%gamma_HO2     = Input_Opt%gamma_HO2
+    H%SSA_debrom    = Input_Opt%SSAdebromination
 
     ! Correction factors for HOBr and HOCl removal by SO2 [1]
     H%fupdateHOBr  = State_Chm%fupdateHOBr(I,J,L)
@@ -313,6 +314,14 @@ CONTAINS
     !=======================================================================
     ! Get halide conc's in cloud (gas-phase, fine & coarse sea salt)
     !=======================================================================
+
+    ! If sea salt aerosol debromination is off, set BrSALA and BrSALC
+    ! concentrations to a small number. This will essentially zero out
+    ! the rates for all reactions involving those species.
+    IF ( .not. H%SSA_debrom ) THEN
+       C(ind_BrSALA) = 1.0e-20_dp
+       C(ind_BrSALA) = 1.0e-20_dp
+    ENDIF
 
     ! Br- and Cl- grid-box concentrations
     HBr = C(ind_HBr) + ( C(ind_BrSALA) * 0.7_dp ) + C(ind_BrSALC)

--- a/KPP/fullchem/fullchem_HetStateFuncs.F90
+++ b/KPP/fullchem/fullchem_HetStateFuncs.F90
@@ -320,7 +320,7 @@ CONTAINS
     ! the rates for all reactions involving those species.
     IF ( .not. H%SSA_debrom ) THEN
        C(ind_BrSALA) = 1.0e-20_dp
-       C(ind_BrSALA) = 1.0e-20_dp
+       C(ind_BrSALC) = 1.0e-20_dp
     ENDIF
 
     ! Br- and Cl- grid-box concentrations

--- a/KPP/fullchem/gckpp_Global.F90
+++ b/KPP/fullchem/gckpp_Global.F90
@@ -232,6 +232,7 @@ MODULE gckpp_Global
      REAL(dp) :: rIce           ! Ice radius
      REAL(dp) :: rLiq           ! Liquid radius
      REAL(dp) :: ssAlk(2)       ! Sea salt alk'nty (1=fine, 2=coarse)
+     LOGICAL  :: SSA_debrom     ! Use sea salt aerosol debromination?
      LOGICAL  :: SSA_is_Alk     ! Is fine sea-salt alkaline?
      LOGICAL  :: SSA_is_Acid    ! Is fine sea-salt acidic?
      LOGICAL  :: SSC_is_Alk     ! Is coarse sea-salt alkaline?

--- a/run/CESM/input.geos
+++ b/run/CESM/input.geos
@@ -307,6 +307,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : T
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : {DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2020-10/

--- a/run/GCClassic/input.geos.templates/input.geos.CH4
+++ b/run/GCClassic/input.geos.templates/input.geos.CH4
@@ -85,6 +85,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.CO2
+++ b/run/GCClassic/input.geos.templates/input.geos.CO2
@@ -85,6 +85,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.Hg
+++ b/run/GCClassic/input.geos.templates/input.geos.Hg
@@ -109,6 +109,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : T
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.POPs
+++ b/run/GCClassic/input.geos.templates/input.geos.POPs
@@ -102,6 +102,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.TransportTracers
+++ b/run/GCClassic/input.geos.templates/input.geos.TransportTracers
@@ -112,6 +112,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.aerosol
+++ b/run/GCClassic/input.geos.templates/input.geos.aerosol
@@ -111,6 +111,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : T
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.fullchem
+++ b/run/GCClassic/input.geos.templates/input.geos.fullchem
@@ -304,6 +304,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : T
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.metals
+++ b/run/GCClassic/input.geos.templates/input.geos.metals
@@ -114,6 +114,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.tagCH4
+++ b/run/GCClassic/input.geos.templates/input.geos.tagCH4
@@ -99,6 +99,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.tagCO
+++ b/run/GCClassic/input.geos.templates/input.geos.tagCO
@@ -97,6 +97,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCClassic/input.geos.templates/input.geos.tagO3
+++ b/run/GCClassic/input.geos.templates/input.geos.tagO3
@@ -97,6 +97,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCHP/input.geos.templates/input.geos.CO2
+++ b/run/GCHP/input.geos.templates/input.geos.CO2
@@ -80,6 +80,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCHP/input.geos.templates/input.geos.TransportTracers
+++ b/run/GCHP/input.geos.templates/input.geos.TransportTracers
@@ -96,6 +96,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : F
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GCHP/input.geos.templates/input.geos.fullchem
+++ b/run/GCHP/input.geos.templates/input.geos.fullchem
@@ -294,6 +294,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : T
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2021-10/

--- a/run/GEOS/input.geos.rc
+++ b/run/GEOS/input.geos.rc
@@ -293,6 +293,7 @@ Overhead O3 for FAST-JX :---
  => O3 from met fields  : T
  => TOMS/SBUV O3        : F
 Gamma HO2               : 0.2
+Use SSA debromination?  : F
 ------------------------+------------------------------------------------------
 %%% PHOTOLYSIS MENU %%% :
 FAST-JX directory       : /discover/nobackup/ewlundgr/data/ExtData/FAST_JX/v2021-10/


### PR DESCRIPTION
In this PR, sea salt aerosol debromination is turned off and is include as an option set in input.geos. instead. This came out of concern over benchmark where ozone concentrations are too low, especially over the Southern Ocean.

This addresses issue https://github.com/geoschem/geos-chem/issues/1145. See the discussion there for more details.