### PR TITLE
[PULL REQUEST] Add updates for numerical stability (should be merged before #1170)

### DIFF
--- a/GeosCore/aerosol_mod.F90
+++ b/GeosCore/aerosol_mod.F90
@@ -141,10 +141,11 @@ MODULE AEROSOL_MOD
   ! NOTE: Increasing value of NRHAER in CMN_SIZE_Mod.F90 (e.g. if there is
   ! a new hygroscopic species) requires manual update of this mapping
   ! (ewl, 1/23/17)
-  INTEGER :: Map_NRHAER(5)
+  INTEGER  :: Map_NRHAER(5)
 
   ! Diagnostic switches
-  LOGICAL :: Is_POA
+  LOGICAL  :: Is_POA
+  LOGICAL  :: Is_OPOA
 
   ! Conversionf factors to ugC/m3 for Total Organic Carbon diagnostic
   REAL(fp) :: Fac_INDIOL
@@ -2653,9 +2654,12 @@ CONTAINS
        id_LVOCOA  = Ind_( 'LVOCOA' )
        id_POA1    = Ind_( 'POA1'   )
        id_POA2    = Ind_( 'POA2'   )
+       id_OPOA1   = Ind_( 'OPOA1'  )
+       id_OPOA2   = Ind_( 'OPOA2'  )
        id_SOAGX   = Ind_( 'SOAGX'  )
        id_SOAIE   = Ind_( 'SOAIE'  )
-       Is_POA     = ( id_POA1 > 0 .and. id_POA2 > 0 )
+       Is_POA     = ( id_POA1  > 0 .and. id_POA2  > 0 )
+       Is_OPOA    = ( id_OPOA1 > 0 .and. id_OPOA2 > 0 )
 
        ! Initialize conversion factors for total OC diagnostic
        Fac_INDIOL = 0.0_fp
@@ -2896,7 +2900,7 @@ CONTAINS
                     + OCPI(I,J,L) + OPOA(I,J,L) ) / OCFOPOA(I,J) &
                     + OCPO(I,J,L) / OCFPOA(I,J) ) * kgm3_to_ugm3
 
-          ELSE
+          ELSE IF ( IS_OPOA ) THEN
              State_Diag%TotalOC(I,J,L) = &
                   ( ( TSOA(I,J,L) + ASOA(I,J,L) &
                     + OCPO(I,J,L) + OCPI(I,J,L) + OPOA(I,J,L) ) &

--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -165,7 +165,7 @@ MODULE DRYDEP_MOD
   INTEGER                        :: id_H2O2,  id_SO2,   id_NH3
 
   ! Arrays for Baldocchi drydep polynomial coefficients
-  REAL(fp), TARGET               :: DRYCOEFF(NPOLY    )
+  REAL(fp), TARGET               :: DRYCOEFF(NPOLY    ) = 0.0_fp
 
   ! Arrays that hold information for each of the 74 Olson land types
   INTEGER                        :: INDOLSON(NSURFTYPE )

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -97,6 +97,7 @@ CONTAINS
     USE ErrCode_Mod
     USE ERROR_MOD
     USE FAST_JX_MOD,              ONLY : PHOTRATE_ADJ, FAST_JX
+    USE fullchem_HetStateFuncs,   ONLY : fullchem_SetStateHet
     USE fullchem_SulfurChemFuncs, ONLY : fullchem_ConvertAlkToEquiv
     USE fullchem_SulfurChemFuncs, ONLY : fullchem_ConvertEquivToAlk
     USE fullchem_SulfurChemFuncs, ONLY : fullchem_HetDropChem
@@ -451,7 +452,7 @@ CONTAINS
 #endif
 
     !=======================================================================
-    ! Archive concentrations before chemistry 
+    ! Archive concentrations before chemistry
     !=======================================================================
     IF ( State_Diag%Archive_ConcBeforeChem ) THEN
        ! Point to mapping obj specific to SpeciesConc diagnostic collection
@@ -583,7 +584,6 @@ CONTAINS
        !=====================================================================
        IERR      = 0                        ! KPP success or failure flag
        ISTATUS   = 0.0_dp                   ! Rosenbrock output
-       PHOTOL    = 0.0_dp                   ! Photolysis array for KPP
        RCNTRL    = 0.0_fp                   ! Rosenbrock input
        RSTATE    = 0.0_dp                   ! Rosenbrock output
        SO4_FRAC  = 0.0_fp                   ! Frac of SO4 avail for photolysis
@@ -595,6 +595,11 @@ CONTAINS
        SR        = 0.0_fp                   ! Enhancement to O2 catalysis rate
        LWC       = 0.0_fp                   ! Liquid water content
        SIZE_RES  = .FALSE.                  ! Size resolved calculation?
+       C         = 0.0_dp                   ! KPP species conc's
+       VAR       = 0.0_dp                   ! KPP variable species conc's
+       FIX       = 0.0_dp                   ! KPP fixed species conc's
+       RCONST    = 0.0_dp                   ! KPP rate constants
+       PHOTOL    = 0.0_dp                   ! Photolysis array for KPP
        K_CLD     = 0.0_dp                   ! Sulfur in-cloud rxn het rates
        K_MT      = 0.0_dp                   ! Sulfur sea salt rxn het rates
 #ifdef MODEL_CLASSIC
@@ -778,11 +783,58 @@ CONTAINS
        ENDIF
 
        !=====================================================================
+       ! CHEMISTRY MECHANISM INITIALIZATION (#1)
+       !
+       ! Populate KPP global variables and arrays in gckpp_global.F90
+       !
+       ! NOTE: This has to be done before Set_Sulfur_Chem_Rates, so that
+       ! the NUMDEN and SR_TEMP KPP variables will be populated first.
+       ! Otherwise this can lead to differences in output that are evident
+       ! when running with different numbers of OpenMP cores.
+       ! See https://github.com/geoschem/geos-chem/issues/1157
+       !    -- Bob Yantosca (08 Mar 2022)
+       !=====================================================================
+
+       ! Start timer
+       IF ( Input_Opt%useTimers ) THEN
+          CALL Timer_Start( TimerName = "  -> Init KPP",                     &
+                            InLoop    = .TRUE.,                              &
+                            ThreadNum = Thread,                              &
+                            RC        =  RC                                 )
+       ENDIF
+
+       ! Initialize KPP for this grid box
+       CALL Init_KPP()
+
+       ! Copy values into the various KPP global variables
+       CALL Set_Kpp_GridBox_Values( I          = I,                          &
+                                    J          = J,                          &
+                                    L          = L,                          &
+                                    Input_Opt  = Input_Opt,                  &
+                                    State_Chm  = State_Chm,                  &
+                                    State_Grid = State_Grid,                 &
+                                    State_Met  = State_Met,                  &
+                                    RC         = RC                         )
+
+       ! Stop timer
+       IF ( Input_Opt%useTimers ) THEN
+          CALL Timer_End( TimerName =  "  -> Init KPP",                      &
+                          InLoop    = .TRUE.,                                &
+                          ThreadNum = Thread,                                &
+                          RC        =  RC                                   )
+       ENDIF
+
+       !=====================================================================
+       ! CHEMISTRY MECHANISM INITIALIZATION (#2)
+       !
        ! Update reaction rates [1/s] for sulfur chemistry in cloud and on
        ! seasalt.  These will be passed to the KPP chemical solver.
        !
-       ! NOTE: This has to be done before Set_Kpp_Gridbox_Values so that
-       ! State_Chm%HSO3_aq and State_Chm%SO3_aq will be populated properly!
+       ! NOTE: This has to be done before fullchem_SetStateHet so that
+       ! State_Chm%HSO3_aq and State_Chm%SO3_aq will be populated first.
+       ! These are copied into State_Het%HSO3_aq and State_Het%SO3_aq.
+       ! See https://github.com/geoschem/geos-chem/issues/1157
+       !    -- Bob Yantosca (08 Mar 2022)
        !=====================================================================
 
        ! Start timer
@@ -814,7 +866,15 @@ CONTAINS
        ENDIF
 
        !=====================================================================
-       ! Intialize KPP solver arrays: CFACTOR, VAR, FIX, etc.
+       ! CHEMISTRY MECHANISM INITIALIZATION (#3)
+       !
+       ! Populate the various fields of the State_Het object.
+       !
+       ! NOTE: This has to be done after fullchem_SetStateHet so that
+       ! State_Chm%HSO3_aq and State_Chm%SO3_aq will be populated first.
+       ! These are copied into State_Het%HSO3_aq and State_Het%SO3_aq.
+       ! See https://github.com/geoschem/geos-chem/issues/1157
+       !    -- Bob Yantosca (08 Mar 2022)
        !=====================================================================
 
        ! Start timer
@@ -825,19 +885,25 @@ CONTAINS
                             RC        =  RC                                 )
        ENDIF
 
-       ! Initialize KPP for this grid box
-       CALL Init_KPP()
+       ! Populate fields of the State_Het object
+       CALL fullchem_SetStateHet( I         = I,                             &
+                                  J         = J,                             &
+                                  L         = L,                             &
+                                  Input_Opt = Input_Opt,                     &
+                                  State_Chm = State_Chm,                     &
+                                  State_Met = State_Met,                     &
+                                  H         = State_Het,                     &
+                                  RC        = RC                            )
 
-       ! Copy values at each gridbox into KPP global variables
-       ! in gckpp_Global.F90 and into the HetChem state object
-       CALL Set_Kpp_GridBox_Values( I          = I,                          &
-                                    J          = J,                          &
-                                    L          = L,                          &
-                                    Input_Opt  = Input_Opt,                  &
-                                    State_Chm  = State_Chm,                  &
-                                    State_Grid = State_Grid,                 &
-                                    State_Met  = State_Met,                  &
-                                    RC         = RC                         )
+       !=====================================================================
+       ! CHEMISTRY MECHANISM INITIALIZATION (#4)
+       !
+       ! Update HSO3- and SO3-- concentrations [molec/cm3] and divide by
+       ! cloud fraction.  These are stored as C(ind_HSO3m) and C(ind_SO3mm)
+       ! in KPP module gckpp_Global.F90.
+       !=====================================================================
+       CALL fullchem_UpdateHSO3mAndSO3mm( I,         J,         L,           &
+                                          State_Chm, State_Het, State_Met   )
 
        ! Stop timer
        IF ( Input_Opt%useTimers ) THEN
@@ -847,12 +913,9 @@ CONTAINS
                           RC        =  RC                                   )
        ENDIF
 
-       ! Update HSO3- and SO3-- concentrations [molec/cm3]
-       ! and divide by cloud fraction
-       CALL fullchem_UpdateHSO3mAndSO3mm( I,         J,         L,           &
-                                          State_Chm, State_Het, State_Met   )
-
        !=====================================================================
+       ! CHEMISTRY MECHANISM INITIALIZATION (#5)
+       !
        ! Call Het_Drop_Chem (formerly located in sulfate_mod.F90) to
        ! estimate the in-cloud sulfate production rate in heterogeneous
        ! cloud droplets based on the Yuen et al., 1996 parameterization.
@@ -1485,7 +1548,7 @@ CONTAINS
     ENDIF
 
     !=======================================================================
-    ! Archive concentrations after chemistry 
+    ! Archive concentrations after chemistry
     !=======================================================================
     IF ( State_Diag%Archive_ConcAfterChem ) THEN
        ! Point to mapping obj specific to SpeciesConc diagnostic collection
@@ -1670,9 +1733,12 @@ CONTAINS
 !  Seasalt aerosol chemistry reaction rate-law functions are now contained
 !  in module fullchem_RateLawFuncs.F90.
 !
-!  NOTE: This call must come before Set_Kpp_Gridbox_Values, or else
-!  State_Chm%HSO3_aq and State_Chm%SO3aq will be zero!
-!    -- Mike Long, Bob Yantosca (30 Aug 2021)
+!  NOTE This routine defines the variables State_Chm%HSO3_aq and
+!  State_Chm%SO3aq.  Therefore, we must call Set_Sulfur_Chem_Rates after
+!  Set_KPP_GridBox_Values, but before fullchem_SetStateHet.  Otherwise we
+!  will not be able to copy State_Chm%HSO3_aq to State_Het%HSO3_aq and
+!  State_Chm%SO3_aq to State_Het%SO3_aq properly.
+!    -- Mike Long, Bob Yantosca (08 Mar 2022)
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -1757,7 +1823,6 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE fullchem_HetStateFuncs, ONLY : fullchem_SetStateHet
     USE GcKpp_Global
     USE GcKpp_Parameters
     USE Input_Opt_Mod,          ONLY : OptInput
@@ -1828,26 +1893,6 @@ CONTAINS
     CONSEXP         = 17.2693882_dp * (TEMP - 273.16_dp) / (TEMP - 35.86_dp)
     VPRESH2O        = CONSVAP * EXP( CONSEXP ) / TEMP
     RELHUM          = ( H2O / VPRESH2O ) * 100_dp
-
-    !========================================================================
-    ! Populate variables in the HetChem state object
-    !========================================================================
-    CALL fullchem_SetStateHet(                                               &
-         I         = I,                                                      &
-         J         = J,                                                      &
-         L         = L,                                                      &
-         Input_Opt = Input_Opt,                                              &
-         State_Chm = State_Chm,                                              &
-         State_Met = State_Met,                                              &
-         H         = State_Het,                                              &
-         RC        = RC                                                     )
-
-    ! Trap potential errors
-    IF ( RC /= GC_SUCCESS ) THEN
-       ErrMsg = 'Error encountered in routine "fullchem_SetStateHet"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc )
-       RETURN
-    ENDIF
 
   END SUBROUTINE Set_Kpp_GridBox_Values
 !EOC

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -1883,7 +1883,7 @@ CONTAINS
 ! LOCAL VARIABLES:
 !
     ! Pointers
-    REAL(hp), POINTER  :: Trgt3D(:,:,:) => NULL()
+    REAL(hp), POINTER  :: Trgt3D(:,:,:)
 
     ! SAVEd scalars
     LOGICAL, SAVE      :: FIRST = .TRUE.
@@ -1902,6 +1902,7 @@ CONTAINS
     ! Initialize
     RC       = GC_SUCCESS
     HMRC     = HCO_SUCCESS
+    Trgt3d   => NULL()
     ErrMsg   = ''
     ThisLoc  = &
        ' -> at ExtState_SetFields (in module GeosCore/hco_interface_gc_mod.F90)'
@@ -2867,7 +2868,8 @@ CONTAINS
 #endif
 
     ! Not first call any more
-    FIRST = .FALSE.
+    FIRST  = .FALSE.
+    Trgt3D => NULL()
 
     ! Leave with success
     RC = GC_SUCCESS

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -382,7 +382,7 @@ CONTAINS
       ! due to a compiler bug in ifort 19
       ! we have to use PRESENT and not copy the value, as sometimes it becomes
       ! flipped! (hplin, 9/29/20)
-      IF ( PRESENT( AltBuffer ) ) THEN 
+      IF ( PRESENT( AltBuffer ) ) THEN
         TMP_MDL_target => TMP_MDLb
       ELSE
         TMP_MDL_target => TMP_MDL
@@ -634,9 +634,13 @@ CONTAINS
 
 #ifdef MODEL_CLASSIC
     IF ( Input_Opt%LIMGRID ) THEN
+      !=====================================================================
+      ! We ARE USING the HEMCO intermediate grid
+      !=====================================================================
 
-      ! Sanity check - output array must be sized correctly for MODEL grid 
-      IF ( SIZE(Arr3D, 1) /= State_Grid%NX .or. SIZE(Arr3D, 2) /= State_Grid%NY ) THEN
+      ! Sanity check - output array must be sized correctly for MODEL grid
+      IF ( SIZE(Arr3D, 1) /= State_Grid%NX   .or.                            &
+           SIZE(Arr3D, 2) /= State_Grid%NY ) THEN
         RC = GC_FAILURE
         ErrMsg = 'Input array dimensions are incorrect!'
         CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -650,9 +654,10 @@ CONTAINS
         CALL GC_Error( ErrMsg, RC, ThisLoc )
       ENDIF
 
-      ! Check if cName is existing in the regrid buffer. If not, regrid on-the-fly
+      ! Check if cName is existing in the regrid buffer.
+      !If not, regrid on-the-fly
       IF ( cName /= LAST_TMP_REGRID_H2M ) THEN
-        ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Last regrid not equal, looking up field ", cName
+        !IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Last regrid not equal, looking up field ", cName
 
         ! Now retrieve data into the HEMCO temporary!
         ! The bdy is a slice to ensure safety
@@ -669,7 +674,8 @@ CONTAINS
           ! For safety, overwrite the temporary
           LAST_TMP_REGRID_H2M = "_HCO_Eval3D_TBD"
 
-          ! Regrid the buffer appropriately. We do not use TMP_MDL here in EvalFld,
+          ! Regrid the buffer appropriately.
+          ! We do not use TMP_MDL here in EvalFld,
           ! because the field target is given.
           ! ( Input_Opt, State_Grid, State_Grid_HCO, PtrIn, PtrOut, ZBND )
           CALL Regrid_HCO2MDL( Input_Opt, State_Grid, State_Grid_HCO, TMP_HCO, Arr3D, ZBND )
@@ -689,7 +695,9 @@ CONTAINS
         ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_3D: Last regrid equal, reading from buffer"
       ENDIF
     ELSE
-      ! Not within the intermediate grid code path
+      !=====================================================================
+      ! We ARE NOT USING the HEMCO intermediate grid
+      !=====================================================================
 #endif
       ! In which case, we just pass the call through
       CALL HCO_EvalFld( HcoState, cName, Arr3D, RC, FND )
@@ -768,8 +776,11 @@ CONTAINS
 
 #ifdef MODEL_CLASSIC
     IF ( Input_Opt%LIMGRID ) THEN
+      !=====================================================================
+      ! We ARE USING the HEMCO intermediate grid
+      !=====================================================================
 
-      ! Sanity check - output array must be sized correctly for MODEL grid 
+      ! Sanity check - output array must be sized correctly for MODEL grid
       IF ( SIZE(Arr2D, 1) /= State_Grid%NX .or. SIZE(Arr2D, 2) /= State_Grid%NY ) THEN
         RC = GC_FAILURE
         ErrMsg = 'Input array dimensions are incorrect!'
@@ -789,7 +800,7 @@ CONTAINS
         IF ( RC /= GC_SUCCESS ) RETURN
 
         ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Lookup complete", cName, FND
-        
+
         ! If not found, return
         IF ( FND ) THEN
 
@@ -819,7 +830,9 @@ CONTAINS
         ! IF ( Input_Opt%LPRT .and. Input_Opt%amIRoot ) WRITE(6,*) "# HCO_GC_EvalFld_2D: Last regrid equal, reading from buffer"
       ENDIF
     ELSE
-      ! Not within the intermediate grid code path
+      !=====================================================================
+      ! We ARE NOT USING the HEMCO intermediate grid
+      !=====================================================================
 #endif
       ! In which case, we just pass the call through
       CALL HCO_EvalFld( HcoState, cName, Arr2D, RC, FND )
@@ -941,7 +954,7 @@ CONTAINS
         ! If failure, return up the chain. The calls to this function will
         ! be able to propagate the error above.
         IF ( RC /= GC_SUCCESS ) RETURN
-        
+
         ! If not found, return
         IF ( iFOUND .and. iFILLED ) THEN
 
@@ -1106,7 +1119,7 @@ CONTAINS
         ! If failure, return up the chain. The calls to this function will
         ! be able to propagate the error above.
         IF ( RC /= GC_SUCCESS ) RETURN
-        
+
         ! If not found, return
         IF ( iFOUND .and. iFILLED ) THEN
 
@@ -1263,7 +1276,7 @@ CONTAINS
       ! The first call to the critical section will update the container!!
       !$OMP CRITICAL
 
-      IF ( PRESENT( AltBuffer ) ) THEN 
+      IF ( PRESENT( AltBuffer ) ) THEN
         TMP_MDL_target => TMP_MDLb
         TMP_MDL_target4 => TMP_MDL_r4b
       ELSE
@@ -1283,7 +1296,7 @@ CONTAINS
         ! then demoted again for output.
         CALL GetHcoDiagn( HcoState, ExtState, DiagnName, StopIfNotFound, RC, &
                           Ptr3D=TMP_Ptr3D,    COL=iCOL,  AutoFill=iAF )
-        
+
         ! If not found, return
         IF ( ASSOCIATED( TMP_Ptr3D ) ) THEN
 
@@ -1428,7 +1441,7 @@ CONTAINS
       ! The first call to the critical section will update the container!!
       !$OMP CRITICAL
 
-      IF ( PRESENT( AltBuffer ) ) THEN 
+      IF ( PRESENT( AltBuffer ) ) THEN
         TMP_MDL_target => TMP_MDLb
         TMP_MDL_target4 => TMP_MDL_r4b
       ELSE
@@ -1448,7 +1461,7 @@ CONTAINS
         ! then demoted again for output.
         CALL GetHcoDiagn( HcoState, ExtState, DiagnName, StopIfNotFound, RC, &
                           Ptr2D=TMP_Ptr2D,    COL=iCOL,  AutoFill=iAF )
-        
+
         ! If not found, return
         IF ( ASSOCIATED( TMP_Ptr2D ) ) THEN
 

--- a/GeosCore/modis_lai_mod.F90
+++ b/GeosCore/modis_lai_mod.F90
@@ -204,6 +204,9 @@ CONTAINS
     DO J = 1, State_Grid%NY
     DO I = 1, State_Grid%NX
 
+       ! Zero for safety's sake
+       landFrac = 0.0_fp
+
        ! Loop over all surface types present in this grid cell
        DO S = 1, State_Met%IREG(I,J)
 

--- a/GeosCore/olson_landmap_mod.F90
+++ b/GeosCore/olson_landmap_mod.F90
@@ -388,6 +388,9 @@ CONTAINS
     ThisLoc = &
       ' -> at Init_LandTypeFrac (in module "GeosCore/olson_landmap_mod.F90'
 
+    ! Zero land type fractions array for safety's sake
+    State_Met%LandTypeFrac = 0.0_fp
+
     ! Loop over the number of Olson land types
     DO T = 1, NSURFTYPE
 
@@ -403,7 +406,7 @@ CONTAINS
           CALL GC_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
-     
+
        ! Copy into State_Met%LandTypeFrac
        State_Met%LandTypeFrac(:,:,T) = Ptr2D
 

--- a/GeosCore/tpcore_fvdas_mod.F90
+++ b/GeosCore/tpcore_fvdas_mod.F90
@@ -309,41 +309,41 @@ CONTAINS
     ! Define quantities
     !-----------------------------------------------------------------------
 
-    dlon = 2.e+0_fp * PI / DBLE( IM )
+    dlon = 2.0_fp * PI / DBLE( IM )
 
     ! S. Pole
-    elat(1)    = -0.5e+0_fp*PI
-    sine(1)    = -1.0e+0_fp
-    SINE_25(1) = -1.0e+0_fp
-    cose(1)    =  0.0e+0_fp
+    elat(1)    = -0.5_fp*PI
+    sine(1)    = -1.0_fp
+    SINE_25(1) = -1.0_fp
+    cose(1)    =  0.0_fp
 
     do j=2,jm
-       elat(j)    = 0.5e+0_fp*(clat(j-1) + clat(j))
+       elat(j)    = 0.5_fp*(clat(j-1) + clat(j))
        sine(j)    = SIN( elat(j) )
        SINE_25(J) = SIN( CLAT(J) )
        cose(j)    = COS( elat(j) )
     enddo
 
     ! N. Pole
-    elat(jm+1)    = 0.5e+0_fp*PI
-    sine(jm+1)    = 1.0e+0_fp
-    SINE_25(JM+1) = 1.0e+0_fp
+    elat(jm+1)    = 0.5_fp*PI
+    sine(jm+1)    = 1.0_fp
+    SINE_25(JM+1) = 1.0_fp
 
     ! Polar cap (S. Pole)
-    dlat(1) = 2.e+0_fp*(elat(2) - elat(1))
+    dlat(1) = 2.0_fp*(elat(2) - elat(1))
     do j=2,jm-1
        dlat(j) = elat(j+1) - elat(j)
     enddo
 
     ! Polar cap (N. Pole)
-    dlat(jm) = 2.0e+0_fp*(elat(jm+1) - elat(jm))
+    dlat(jm) = 2.0_fp*(elat(jm+1) - elat(jm))
 
     do j=1,jm
        gw(j)     = sine(j+1) - sine(j)
        cosp(j)   = gw(j) / dlat(j)
 
-       dtdx5(j)  = 0.5e+0_fp * dt / (dlon*ae*cosp(j))
-       dtdy5(j)  = 0.5e+0_fp * dt / (ae*dlat(j))
+       dtdx5(j)  = 0.5_fp * dt / (dlon*ae*cosp(j))
+       dtdy5(j)  = 0.5_fp * dt / (ae*dlat(j))
     enddo
 
     ! Echo info to stdout
@@ -422,77 +422,77 @@ CONTAINS
 ! !INPUT PARAMETERS:
 !
     ! Transport time step [s]
-    REAL(fp),  INTENT(IN)  :: dt
+    REAL(fp),       INTENT(IN)    :: dt
 
     ! Earth's radius [m]
-    REAL(fp),  INTENT(IN)  :: ae
+    REAL(fp),       INTENT(IN)    :: ae
 
     ! Global E-W, N-S, and vertical dimensions
-    INTEGER, INTENT(IN)    :: IM
-    INTEGER, INTENT(IN)    :: JM
-    INTEGER, INTENT(IN)    :: KM
+    INTEGER,        INTENT(IN)    :: IM
+    INTEGER,        INTENT(IN)    :: JM
+    INTEGER,        INTENT(IN)    :: KM
 
     ! Latitude indices for local first box and local last box
     ! (NOTE: for global grids these are 1 and JM, respectively)
-    INTEGER, INTENT(IN)    :: JFIRST
-    INTEGER, INTENT(IN)    :: JLAST
+    INTEGER,        INTENT(IN)    :: JFIRST
+    INTEGER,        INTENT(IN)    :: JLAST
 
     ! Primary ghost region
     ! (NOTE: only required for MPI parallelization; use 0 otherwise)
-    INTEGER, INTENT(IN)    :: ng
+    INTEGER,        INTENT(IN)    :: ng
 
     ! Secondary ghost region
     ! (NOTE: only required for MPI parallelization; use 0 otherwise)
-    INTEGER, INTENT(IN)    :: mg
+    INTEGER,        INTENT(IN)    :: mg
 
     ! Ghosted latitudes (3 required by PPM)
     ! (NOTE: only required for MPI parallelization; use 0 otherwise)
-    INTEGER, INTENT(IN)    :: nq
+    INTEGER,        INTENT(IN)    :: nq
 
     ! Flags to denote E-W, N-S, and vertical transport schemes
-    INTEGER, INTENT(IN)    :: iord
-    INTEGER, INTENT(IN)    :: jord
-    INTEGER, INTENT(IN)    :: kord
+    INTEGER,        INTENT(IN)    :: iord
+    INTEGER,        INTENT(IN)    :: jord
+    INTEGER,        INTENT(IN)    :: kord
 
     ! Number of adjustments to air_mass_flux (0 = no adjustment)
-    INTEGER, INTENT(IN)    :: n_adj
+    INTEGER,        INTENT(IN)    :: n_adj
 
     ! Ak and Bk coordinates to specify the hybrid grid
     ! (see the REMARKS section below)
-    REAL(fp),  INTENT(IN)  :: ak(KM+1)
-    REAL(fp),  INTENT(IN)  :: bk(KM+1)
+    REAL(fp),       INTENT(IN)    :: ak(KM+1)
+    REAL(fp),       INTENT(IN)    :: bk(KM+1)
 
     ! u-wind (m/s) at mid-time-level (t=t+dt/2)
-    REAL(fp),  INTENT(IN)  :: u(:,:,:)
+    REAL(fp),       INTENT(IN)    :: u(:,:,:)
 
     ! E/W and N/S mass fluxes [kg/s]
     ! (These are computed by the pressure fixer, and passed into TPCORE)
-    REAL(fp),  INTENT(IN)  :: XMASS(:,:,:)
-    REAL(fp),  INTENT(IN)  :: YMASS(:,:,:)
+    REAL(fp),       INTENT(IN)    :: XMASS(:,:,:)
+    REAL(fp),       INTENT(IN)    :: YMASS(:,:,:)
 
     ! Grid box surface area for mass flux diag [m2]
-    REAL(fp),  INTENT(IN)  :: AREA_M2(JM)
+    REAL(fp),       INTENT(IN)    :: AREA_M2(JM)
 
     ! Diagnostic flags
-    INTEGER, INTENT(IN)    :: ND24    ! Turns on E/W     flux diagnostic
-    INTEGER, INTENT(IN)    :: ND25    ! Turns on N/S     flux diagnostic
-    INTEGER, INTENT(IN)    :: ND26    ! Turns on up/down flux diagnostic
+    INTEGER,        INTENT(IN)    :: ND24  ! Turns on E/W     flux diagnostic
+    INTEGER,        INTENT(IN)    :: ND25  ! Turns on N/S     flux diagnostic
+    INTEGER,        INTENT(IN)    :: ND26  ! Turns on up/down flux diagnostic
 
-    LOGICAL, INTENT(IN)    :: FILL    ! Fill negatives ?
+    LOGICAL,        INTENT(IN)    :: FILL  ! Fill negatives ?
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
     ! V-wind (m/s) at mid-time-level (t=t+dt/2)
-    REAL(fp),  INTENT(INOUT) :: v(:,:,:)
+    REAL(fp),       INTENT(INOUT) :: v(:,:,:)
 
     ! surface pressure at current time
-    REAL(fp),  INTENT(INOUT) :: ps1(IM, JFIRST:JLAST)
+    REAL(fp),       INTENT(INOUT) :: ps1(IM, JFIRST:JLAST)
 
     ! surface pressure at future time=t+dt
-    REAL(fp),  INTENT(INOUT) :: ps2(IM, JFIRST:JLAST)
+    REAL(fp),       INTENT(INOUT) :: ps2(IM, JFIRST:JLAST)
 
     ! Tracer "mixing ratios" [kg tracer/moist air kg]
-    REAL(fp),  INTENT(INOUT), TARGET :: q(:,:,:,:)
+    REAL(fp), TARGET,INTENT(INOUT):: q(:,:,:,:)
 
     ! Diagnostics state object
     TYPE(DgnState), INTENT(INOUT) :: State_Diag
@@ -500,7 +500,7 @@ CONTAINS
 ! !OUTPUT PARAMETERS:
 !
     ! "Predicted" surface pressure [hPa]
-    REAL(fp),  INTENT(OUT)   :: ps(IM,JFIRST:JLAST)
+    REAL(fp),  INTENT(OUT)        :: ps(IM,JFIRST:JLAST)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO)
@@ -588,6 +588,34 @@ CONTAINS
     !     Begin execution.
     !     ----------------
 
+    ! Set output argument to zero for safety's sake
+    ps      = 0.0_fp
+
+    ! Zero local arrays for safety's sake
+    dap     = 0.0_fp
+    dbk     = 0.0_fp
+    cx      = 0.0_fp
+    cy      = 0.0_fp
+    delp1   = 0.0_fp
+    delp2   = 0.0_fp
+    delpm   = 0.0_fp
+    pu      = 0.0_fp
+    dpi     = 0.0_fp
+    geofac  = 0.0_fp
+    dps_ctm = 0.0_fp
+    ua      = 0.0_fp
+    va      = 0.0_fp
+    wz      = 0.0_fp
+    dq1     = 0.0_fp
+    qqu     = 0.0_fp
+    qqv     = 0.0_fp
+    adx     = 0.0_fp
+    ady     = 0.0_fp
+    fx      = 0.0_fp
+    fy      = 0.0_fp
+    fz      = 0.0_fp
+    qtemp   = 0.0_fp
+
     ! Determine if we need to save any of the bpch diagnostics
     Do_ND24 = ( ND24 > 0 )
     Do_ND25 = ( ND25 > 0 )
@@ -602,26 +630,6 @@ CONTAINS
     j1p = 3
     j2p = jm - j1p + 1
 
-#ifdef TOMAS
-      !================================================================
-      ! For TOMAS microphysics: zero out UA and VA.
-      !
-      ! Segregate this block from the code with an #ifdef block.
-      ! We can't bring this into the standard GEOS-Chem yet, since
-      ! that will make it hard to compare benchmark results to prior
-      ! versions.  When we do bring this change into the standard code,
-      ! we will have to benchmark it. (sfarina, bmy, 5/30/13)
-      !================================================================
-      do ik= 1, km
-      do ij= 1, jm
-      do il= 1, im
-         va(il,ij,ik) = 0.e+0_fp
-         ua(il,ij,ik) = 0.e+0_fp
-      end do
-      end do
-      end do
-#endif
-
     ! Average surf. pressures in the polar cap. (ccc, 11/20/08)
     CALL Average_Press_Poles( area_m2, ps1, 1, im, 1, jm, 1, im, 1, jm )
     CALL Average_Press_Poles( area_m2, ps2, 1, im, 1, jm, 1, im, 1, jm )
@@ -632,11 +640,11 @@ CONTAINS
     dp    = PI / rj2m1
 
     do ij = 1, jm
-       geofac(ij) = dp / (2.0e+0_fp * area_m2(ij)/(sum(area_m2) * im) * im)
+       geofac(ij) = dp / (2.0_fp * area_m2(ij)/(sum(area_m2) * im) * im)
     end do
 
     geofac_pc =  &
-         dp / (2.0e+0_fp * (Sum (area_m2(1:2))/(sum(area_m2) * im)) * im)
+         dp / (2.0_fp * (Sum (area_m2(1:2))/(sum(area_m2) * im)) * im)
 
 
     if (first) then
@@ -944,7 +952,6 @@ CONTAINS
        !.sds
 
 
-
        if (FILL) then
         ! ===========
           call Qckxyz                                                        &
@@ -954,7 +961,6 @@ CONTAINS
 
        q(:,:,:,iq) =  &
             dq1 / delp2
-
 
        if (j1p /= 2) then
 
@@ -1159,30 +1165,30 @@ CONTAINS
 ! !INPUT PARAMETERS:
 !
     ! Global latitude indices of the South Pole and North Pole
-    INTEGER, INTENT(IN)   :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)    :: JU1_GL, J2_GL
 
     ! Global max longitude index
-    INTEGER, INTENT(IN)   :: I2_GL
+    INTEGER,  INTENT(IN)    :: I2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)   :: I1,  I2
-    INTEGER, INTENT(IN)   :: JU1, J2
+    INTEGER,  INTENT(IN)    :: I1,  I2
+    INTEGER,  INTENT(IN)    :: JU1, J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)   :: ILO,  IHI
-    INTEGER, INTENT(IN)   :: JULO, JHI
+    INTEGER,  INTENT(IN)    :: ILO,  IHI
+    INTEGER,  INTENT(IN)    :: JULO, JHI
 
     ! Pressure difference across layer from (ai * pt) term [hPa]
-    REAL(fp),  INTENT(IN)   :: dap
+    REAL(fp), INTENT(IN)    :: dap
 
     ! Difference in bi across layer - the dSigma term
-    REAL(fp),  INTENT(IN)   :: dbk
+    REAL(fp), INTENT(IN)    :: dbk
 
     ! Relative surface area of grid box [fraction]
-    REAL(fp),  INTENT(IN)   :: rel_area(JU1:J2)
+    REAL(fp), INTENT(IN)    :: rel_area(JU1:J2)
 
     ! CTM surface pressure at t1 [hPa]
-    REAL(fp),  INTENT(IN)   :: pctm1( ILO:IHI, JULO:JHI )
+    REAL(fp), INTENT(IN)    :: pctm1( ILO:IHI, JULO:JHI )
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -1205,10 +1211,10 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: ik, il
+    INTEGER  :: ik, il
 
-    REAL(fp)  :: meanq
-    REAL(fp)  :: sum1, sum2
+    REAL(fp) :: meanq
+    REAL(fp) :: sum1, sum2
 
 !   -----------------------------------------------------------------
 !   delp1n : pressure thickness at North Pole, the psudo-density in a
@@ -1217,13 +1223,21 @@ CONTAINS
 !            hydrostatic system at t1 (mb)
 !   -----------------------------------------------------------------
 
-    REAL(fp)  :: delp1n(i1:i2, j2-1:j2)
-    REAL(fp)  :: delp1s(i1:i2,  ju1:ju1+1)
+    REAL(fp) :: delp1n(i1:i2, j2-1:j2)
+    REAL(fp) :: delp1s(i1:i2,  ju1:ju1+1)
 
 
 !   ----------------
 !   Begin execution.
 !   ----------------
+
+    ! Zero local variables for safety's sake
+    meanq  = 0.0_fp
+    sum1   = 0.0_fp
+    sum2   = 0.0_fp
+    delp1n = 0.0_fp
+    delp1s = 0.0_fp
+
 
 !   =================
     if (ju1 == ju1_gl) then
@@ -1233,8 +1247,8 @@ CONTAINS
             dap +                             &
             (dbk * pctm1(i1:i2,ju1:ju1+1))
 
-       sum1=0.0e+0_fp
-       sum2=0.0e+0_fp
+       sum1=0.0_fp
+       sum2=0.0_fp
        do il = i1, i2
           sum1 = sum1 +                            &
                Sum (const1  (il,ju1:ju1+1) *  &
@@ -1264,8 +1278,8 @@ CONTAINS
             dap +                           &
             (dbk * pctm1(i1:i2,j2-1:j2))
 
-       sum1=0.0e+0_fp
-       sum2=0.0e+0_fp
+       sum1=0.0_fp
+       sum2=0.0_fp
        do il = i1, i2
           sum1 = sum1 +                         &
                Sum (const1  (il,j2-1:j2) * &
@@ -1311,19 +1325,19 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)   :: J1P,    J2P
+    INTEGER,  INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)   :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)   :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)   :: I1,     I2
-    INTEGER, INTENT(IN)   :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)   :: ILO,    IHI
-    INTEGER, INTENT(IN)   :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! Courant number in E-W direction
     REAL(fp),  INTENT(IN) :: crx(ILO:IHI, JULO:JHI)
@@ -1332,7 +1346,7 @@ CONTAINS
     REAL(fp),  INTENT(IN) :: cry(ILO:IHI, JULO:JHI)
 
     ! Logical switch.  If CROSS=T then cross-terms will be computed.
-    LOGICAL, INTENT(IN) :: CROSS
+    LOGICAL,  INTENT(IN)  :: CROSS
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -1369,24 +1383,29 @@ CONTAINS
 
     if (.not. CROSS) then
 
-       ua(:,:) = 0.0e+0_fp
-       va(:,:) = 0.0e+0_fp
+       ua = 0.0_fp
+       va = 0.0_fp
 
     else
+
+       ! Zero output arguments for safety's sake
+       ua = 0.0_fp
+       va = 0.0_fp
+
 
        do ij = j1p, j2p
           do il = i1, i2-1
 
-             ua(il,ij) = 0.5e+0_fp * (crx(il,ij) + crx(il+1,ij))
+             ua(il,ij) = 0.5_fp * (crx(il,ij) + crx(il+1,ij))
 
           end do
-          ua(i2,ij) = 0.5e+0_fp * (crx(i2,ij) + crx(1,ij))
+          ua(i2,ij) = 0.5_fp * (crx(i2,ij) + crx(1,ij))
        end do
 
        do ij = ju1+1, j2-1
           do il = i1, i2
 
-             va(il,ij) = 0.5e+0_fp * (cry(il,ij) + cry(il,ij+1))
+             va(il,ij) = 0.5_fp * (cry(il,ij) + cry(il,ij+1))
           end do
        end do
 
@@ -1421,19 +1440,19 @@ CONTAINS
 ! !INPUT PARAMETERS:
 !
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)   :: I1,  I2
-    INTEGER, INTENT(IN)   :: JU1, J2
-    INTEGER, INTENT(IN)   :: K1,  K2
+    INTEGER,  INTENT(IN)  :: I1,  I2
+    INTEGER,  INTENT(IN)  :: JU1, J2
+    INTEGER,  INTENT(IN)  :: K1,  K2
 
     ! Difference in bi across layer - the dSigma term
-    REAL(fp),  INTENT(IN)  :: dbk(K1:K2)
+    REAL(fp), INTENT(IN)  :: dbk(K1:K2)
 
     ! CTM surface pressure tendency; sum over vertical of dpi
     ! calculated from original mass fluxes [hPa]
-    REAL(fp),  INTENT(IN)  :: dps_ctm(I1:I2, JU1:J2)
+    REAL(fp), INTENT(IN)  :: dps_ctm(I1:I2, JU1:J2)
 
     ! Divergence at a grid point; used to calculate vertical motion [mb]
-    REAL(fp),  INTENT(IN)  :: dpi(I1:I2, JU1:J2, K1:K2)
+    REAL(fp), INTENT(IN)  :: dpi(I1:I2, JU1:J2, K1:K2)
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -1463,6 +1482,9 @@ CONTAINS
 !   Begin execution.
 !   ----------------
 
+    ! Zero output argument for safety's sake
+    wz = 0.0_fp
+
 !   --------------------------------------------------
 !   Compute vertical mass flux from mass conservation.
 !   --------------------------------------------------
@@ -1476,7 +1498,7 @@ CONTAINS
             dpi(il,ij,k1) -  &
             (dbk(k1) * dps_ctm(il,ij))
 
-       wz(il,ij,k2) = 0.0e+0_fp
+       wz(il,ij,k2) = 0.0_fp
     end do
     end do
     !$OMP END PARALLEL DO
@@ -1524,22 +1546,22 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)   :: J1P,    J2P
+    INTEGER, INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)   :: JU1_GL, J2_GL
+    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)   :: I1,     I2
-    INTEGER, INTENT(IN)   :: JU1,    J2
-    INTEGER, INTENT(IN)   :: K1,     K2
+    INTEGER, INTENT(IN)  :: I1,     I2
+    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER, INTENT(IN)  :: K1,     K2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)   :: ILO,    IHI
-    INTEGER, INTENT(IN)   :: JULO,   JHI
+    INTEGER, INTENT(IN)  :: ILO,    IHI
+    INTEGER, INTENT(IN)  :: JULO,   JHI
 
     ! Courant number in E-W direction
-    REAL(fp),  INTENT(IN)  :: crx(ILO:IHI, JULO:JHI, K1:K2)
+    REAL(fp), INTENT(IN) :: crx(ILO:IHI, JULO:JHI, K1:K2)
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -1575,10 +1597,13 @@ CONTAINS
     INTEGER :: jn0, js0
     INTEGER :: jst, jend
 
-
     !     ----------------
     !     Begin execution.
     !     ----------------
+
+    ! Zero output arguments for safety's sake
+    jn = 0
+    js = 0
 
     js0  = (j2_gl + 1 ) / 2
     jn0  = j2_gl - js0 + 1
@@ -1593,7 +1618,7 @@ CONTAINS
        do ij = jend, jst, -1
           do il = i1, i2
 
-             if (Abs (crx(il,ij,ik)) > 1.0e+0_fp) then
+             if (Abs (crx(il,ij,ik)) > 1.0_fp) then
 
                 js(ik) = ij
 
@@ -1619,7 +1644,7 @@ CONTAINS
        do ij = jst, jend
           do il = i1, i2
 
-             if (Abs (crx(il,ij,ik)) > 1.0e+0_fp) then
+             if (Abs (crx(il,ij,ik)) > 1.0_fp) then
 
                 jn(ik) = ij
 
@@ -1660,27 +1685,27 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER,   INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  ::         I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,   INTENT(IN)  ::         I2_GL
+    INTEGER,   INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,   INTENT(IN)  :: I1,     I2
+    INTEGER,   INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,   INTENT(IN)  :: ILO,    IHI
+    INTEGER,   INTENT(IN)  :: JULO,   JHI
 
     ! Northward of latitude index = jn, Courant numbers could be > 1,
     ! so use the flux-form semi-Lagrangian scheme
-    INTEGER, INTENT(IN)  :: Jn
+    INTEGER,   INTENT(IN)  :: Jn
 
     ! Southward of latitude index = js, Courant numbers could be > 1,
     ! so use the flux-form semi-Lagrangian scheme
-    INTEGER, INTENT(IN)  :: Js
+    INTEGER,   INTENT(IN)  :: Js
 
     ! Species concentration (mixing ratio)
     REAL(fp),  INTENT(IN)  :: qq1(ILO:IHI, JULO:JHI)
@@ -1692,7 +1717,7 @@ CONTAINS
     REAL(fp),  INTENT(IN)  :: va (ILO:IHI, JULO:JHI)
 
     ! Logical switch: If CROSS=T then cross-terms are being computed
-    LOGICAL, INTENT(IN)  :: CROSS
+    LOGICAL,   INTENT(IN)  :: CROSS
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -1718,15 +1743,19 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: i, imp, il, ij, iu
-    INTEGER :: jv, iuw, iue
-    REAL(fp)  :: ril, rij, riu
-    REAL(fp)  :: ru
-    REAL(fp)  :: qtmp(-i2/3:i2+i2/3, julo:jhi)
+    INTEGER  :: i, imp, il, ij, iu
+    INTEGER  :: jv, iuw, iue
+    REAL(fp) :: ril, rij, riu
+    REAL(fp) :: ru
+    REAL(fp) :: qtmp(-i2/3:i2+i2/3, julo:jhi)
 
     !     ----------------
     !     Begin execution.
     !     ----------------
+
+    ! Zero local variables for safety's sake
+    qtmp = 0.0
+
 
     do ij = julo, jhi
        do i = 1, i2
@@ -1754,8 +1783,8 @@ CONTAINS
     else
 !   ====
 
-       qqu(:,:) = 0.0e+0_fp
-       qqv(:,:) = 0.0e+0_fp
+       qqu(:,:) = 0.0_fp
+       qqv(:,:) = 0.0_fp
 
        do ij = j1p, j2p
 
@@ -1773,7 +1802,7 @@ CONTAINS
                 ru  = ua(il,ij) - riu
                 iu  = il - iu
 
-                if (ua(il,ij) >= 0.0e+0_fp) then
+                if (ua(il,ij) >= 0.0_fp) then
 
                    qqu(il,ij) =  &
                         qtmp(iu,ij) +  &
@@ -1826,10 +1855,10 @@ CONTAINS
        do ij = ju1, j2
        do il = i1,  i2
           qqu(il,ij) =  &
-               qtmp(il,ij) + (0.5e+0_fp * qqu(il,ij))
+               qtmp(il,ij) + (0.5_fp * qqu(il,ij))
 
           qqv(il,ij) =  &
-               qtmp(il,ij) + (0.5e+0_fp * qqv(il,ij))
+               qtmp(il,ij) + (0.5_fp * qqv(il,ij))
        enddo
        enddo
 
@@ -1861,24 +1890,24 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER, INTENT(IN)     :: J1P,    J2P
 
     ! Global min & max latitude (J) indices
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER, INTENT(IN)     :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
-    INTEGER, INTENT(IN)  :: K1,     K2
+    INTEGER, INTENT(IN)     :: I1,     I2
+    INTEGER, INTENT(IN)     :: JU1,    J2
+    INTEGER, INTENT(IN)     :: K1,     K2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER, INTENT(IN)     :: ILO,    IHI
+    INTEGER, INTENT(IN)     :: JULO,   JHI
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
     ! Species density [hPa]
-    REAL(fp),  INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI, K1:K2)
+    REAL(fp), INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI, K1:K2)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO)
@@ -1900,20 +1929,9 @@ CONTAINS
 !
 ! LOCAL VARIABLES:
 !
-    INTEGER :: il, ij, ik
-    INTEGER :: ip
-    INTEGER :: k1p1, k2m1
-    REAL(fp)  :: dup, qup
-    REAL(fp)  :: qly
-    REAL(fp)  :: sum
-
-
-!     ----------------
-!     Begin execution.
-!     ----------------
-
-    ip = 0
-
+    INTEGER  :: il,   ij,   ik
+    INTEGER  :: k1p1, k2m1
+    REAL(fp) :: dup,  qup,  qly
 
 !     ----------
 !     Top layer.
@@ -1921,18 +1939,16 @@ CONTAINS
 
     k1p1 = k1 + 1
 
-    !$OMP PARALLEL DO          &
-    !$OMP DEFAULT( SHARED )    &
-    !$OMP PRIVATE( IJ, IL, IP )
+    !$OMP PARALLEL DO        &
+    !$OMP DEFAULT( SHARED  ) &
+    !$OMP PRIVATE( IJ, IL  )
     do ij = j1p, j2p
        do il = i1, i2
 
-          if (dq1(il,ij,k1) < 0.0e+0_fp) then
-
-             ip = ip + 1
+          if (dq1(il,ij,k1) < 0.0_fp) then
 
              dq1(il,ij,k1p1) = dq1(il,ij,k1p1) + dq1(il,ij,k1)
-             dq1(il,ij,k1)   = 0.0e+0_fp
+             dq1(il,ij,k1)   = 0.0_fp
 
           end if
 
@@ -1943,15 +1959,18 @@ CONTAINS
 
     do ik = k1 + 1, k2 - 1
 
-       !$OMP PARALLEL DO                         &
-       !$OMP DEFAULT( SHARED )                   &
-       !$OMP PRIVATE( IJ, IL, IP, QUP, QLY, DUP )
+       !$OMP PARALLEL DO                      &
+       !$OMP DEFAULT( SHARED                ) &
+       !$OMP PRIVATE( IJ, IL, QUP, QLY, DUP )
        do ij = j1p, j2p
           do il = i1, i2
 
-             if (dq1(il,ij,ik) < 0.0e+0_fp) then
+             ! Zero private loop variables for safety's sake
+             qup = 0.0_fp
+             qly = 0.0_fp
+             dup = 0.0_fp
 
-                ip = ip + 1
+             if (dq1(il,ij,ik) < 0.0_fp) then
 
 !             -----------
 !             From above.
@@ -1969,7 +1988,7 @@ CONTAINS
 !             -----------
 
                 dq1(il,ij,ik+1) = dq1(il,ij,ik+1) + dq1(il,ij,ik)
-                dq1(il,ij,ik)   = 0.0e+0_fp
+                dq1(il,ij,ik)   = 0.0_fp
 
              end if
 
@@ -1984,21 +2003,21 @@ CONTAINS
 !     Bottom layer.
 !     -------------
 
-    sum  = 0.0e+0_fp
-
     k2m1 = k2 - 1
 
     ! NOTE: Sum seems to be not used in the loop below!
-    !$OMP PARALLEL DO                          &
-    !$OMP DEFAULT( SHARED )                    &
-    !$OMP PRIVATE( IJ, IL, IP, QUP, QLY, DUP ) &
-    !$OMP REDUCTION( +:SUM )
+    !$OMP PARALLEL DO                      &
+    !$OMP DEFAULT( SHARED )                &
+    !$OMP PRIVATE( IJ, IL, QUP, QLY, DUP )
     do ij = j1p, j2p
        do il = i1, i2
 
-          if (dq1(il,ij,k2) < 0.0e+0_fp) then
+          ! Zero private loop variables for safety's sake
+          qup = 0.0_fp
+          qly = 0.0_fp
+          dup = 0.0_fp
 
-             ip = ip + 1
+          if (dq1(il,ij,k2) < 0.0_fp) then
 
 !           -----------
 !           From above.
@@ -2014,9 +2033,7 @@ CONTAINS
 !           From "below" the surface.
 !           -------------------------
 
-             sum = sum + qly - dup
-
-             dq1(il,ij,k2) = 0.0e+0_fp
+             dq1(il,ij,k2) = 0.0_fp
 
           end if
 
@@ -2088,6 +2105,11 @@ CONTAINS
 !     Begin execution.
 !     ----------------
 
+    ! Zero output arguments for safety's sake
+    ilmt = 0
+    jlmt = 0
+    klmt = 0
+
     j2_glm1 = j2_gl - 1
 
 !c?
@@ -2144,30 +2166,30 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER,   INTENT(IN) :: J1P,    J2P
 
     ! Global min & max latitude (J) indices
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,   INTENT(IN) :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,   INTENT(IN) :: I1,     I2
+    INTEGER,   INTENT(IN) :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,   INTENT(IN) :: ILO,    IHI
+    INTEGER,   INTENT(IN) :: JULO,   JHI
 
     ! Pressure difference across layer from (ai * pt) term [hPa]
-    REAL(fp),  INTENT(IN)  :: dap
+    REAL(fp),  INTENT(IN) :: dap
 
     ! Difference in bi across layer - the dSigma term
-    REAL(fp),  INTENT(IN)  :: dbk
+    REAL(fp),  INTENT(IN) :: dbk
 
     ! Surface pressure at t1 [hPa]
-    REAL(fp),  INTENT(IN)  :: pres1(ILO:IHI, JULO:JHI)
+    REAL(fp),  INTENT(IN) :: pres1(ILO:IHI, JULO:JHI)
 
     ! Surface pressure at t1+tdt [hPa]
-    REAL(fp),  INTENT(IN)  :: pres2(ILO:IHI, JULO:JHI)
+    REAL(fp),  INTENT(IN) :: pres2(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -2200,22 +2222,24 @@ CONTAINS
 !
     INTEGER :: il, ij
 
+    ! Zero output arguments for safety's sake
+    delp1 = 0.0_fp
+    delpm = 0.0_fp
+    pu    = 0.0_fp
+
 !   ----------------
 !   Begin execution.
 !   ----------------
 
-       delp1(:,:) = dap + (dbk * pres1(:,:))
+    delp1(:,:) = dap + (dbk * pres1(:,:))
 
-       delpm(:,:) =  &
-                dap+  &
-                (dbk * 0.5e+0_fp * (pres1(:,:) + pres2(:,:)))
+    delpm(:,:) = dap+  &
+                (dbk * 0.5_fp * (pres1(:,:) + pres2(:,:)))
 
     do ij = j1p, j2p
-       pu(1,ij) = 0.5e+0_fp * (delpm(1,ij) + delpm(i2,ij))
+       pu(1,ij) = 0.5_fp * (delpm(1,ij) + delpm(i2,ij))
        do il = i1+1, i2
-
-          pu(il,ij) = 0.5e+0_fp * (delpm(il,ij) + delpm(il-1,ij))
-
+          pu(il,ij) = 0.5_fp * (delpm(il,ij) + delpm(il-1,ij))
        end do
     end do
 
@@ -2244,38 +2268,38 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER,  INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max latitude (J) indices
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! Cosine of grid box edges
-    REAL(fp),  INTENT(IN)  :: cose (JU1_GL:J2_GL)
+    REAL(fp), INTENT(IN)  :: cose (JU1_GL:J2_GL)
 
     ! Pressure thickness, the pseudo-density in a hydrostatic system
     ! at t1+tdt/2 (approximate) (mb)
-    REAL(fp),  INTENT(IN)  :: delpm(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: delpm(ILO:IHI, JULO:JHI)
 
     ! pressure at edges in "u"  (mb)
-    REAL(fp),  INTENT(IN)  :: pu   (iLO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: pu   (iLO:IHI, JULO:JHI)
 
     ! horizontal mass flux in E-W and N-S directions [hPa]
-    REAL(fp),  INTENT(IN)  :: xmass(ILO:IHI, JULO:JHI)
-    REAL(fp),  INTENT(IN)  :: ymass(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: xmass(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: ymass(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Courant numbers in E-W and N-S directions
-    REAL(fp),  INTENT(OUT) :: crx(ILO:IHI, JULO:JHI)
-    REAL(fp),  INTENT(OUT) :: cry(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: crx(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: cry(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO)
@@ -2299,8 +2323,9 @@ CONTAINS
 !   Begin execution.
 !   ----------------
 
-    crx(:,:) = 0.0e+0_fp
-    cry(:,:) = 0.0e+0_fp
+    ! Zero ouptput arguments for safety's sake
+    crx = 0.0_fp
+    cry = 0.0_fp
 
 !      ---------------------------------------------
 !      Calculate E-W and N-S horizontal mass fluxes.
@@ -2313,13 +2338,13 @@ CONTAINS
 
           cry(:,ij) =  &
                ymass(:,ij) /  &
-               ((0.5e+0_fp * cose(ij)) *  &
+               ((0.5_fp * cose(ij)) *  &
                (delpm(:,ij) + delpm(:,ij-1)))
        end do
 
        cry(:,j2p+1) =  &
                ymass(:,j2p+1) /  &
-               ((0.5e+0_fp * cose(j2p+1)) *  &
+               ((0.5_fp * cose(j2p+1)) *  &
                (delpm(:,j2p+1) + delpm(:,j2p)))
 
 
@@ -2350,23 +2375,23 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER,   INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,   INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,   INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,   INTENT(IN)  :: I1,     I2
+    INTEGER,   INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,   INTENT(IN)  :: ILO,    IHI
+    INTEGER,   INTENT(IN)  :: JULO,   JHI
 
     ! Set to F if called on root core or T if called by secondary cores
     ! (NOTE: This is only for MPI parallelization, for OPENMP it should be F)
-    LOGICAL, INTENT(IN)  :: do_reduction
+    LOGICAL,   INTENT(IN)  :: do_reduction
 
     ! Special geometrical factor (geofac) for Polar cap
     REAL(fp) , INTENT(IN)  :: geofac_pc
@@ -2406,6 +2431,9 @@ CONTAINS
 !   ----------------
 !   Begin execution.
 !   ----------------
+
+    ! Zero output argument for safety's sake
+    dpi = 0.0_fp
 
 !      -------------------------
 !      Calculate N-S divergence.
@@ -2480,34 +2508,34 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER,  INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! Set to T if called on root core or F if called by secondary cores
     ! NOTE: This seems not to be used here....)
-    LOGICAL, INTENT(IN)   :: do_reduction
+    LOGICAL,  INTENT(IN)  :: do_reduction
 
     ! Special geometrical factor (geofac) for Polar cap
-    REAL(fp),  INTENT(in)   :: geofac_pc
+    REAL(fp), INTENT(IN)  :: geofac_pc
 
     ! Horizontal mass flux in N-S direction [hPa]
-    REAL(fp),  INTENT(IN)   :: ymass(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: ymass(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Divergence at a grid point; used to calculate vertical motion [hPa]
-    REAL(fp),  INTENT(OUT)  :: dpi(I1:I2, JU1:J2)
+    REAL(fp), INTENT(OUT) :: dpi(I1:I2, JU1:J2)
 
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -2525,26 +2553,32 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: il
-    REAL(fp)  :: ri2
-    REAL(fp)  :: mean_np
-    REAL(fp)  :: mean_sp
-    REAL(fp)  :: sumnp
-    REAL(fp)  :: sumsp
-
+    INTEGER  :: il
+    REAL(fp) :: ri2
+    REAL(fp) :: mean_np
+    REAL(fp) :: mean_sp
+    REAL(fp) :: sumnp
+    REAL(fp) :: sumsp
 
 !   ----------------
 !   Begin execution.
 !   ----------------
 
-    ri2 = i2_gl
+    ! Zero output argument for safety's sake
+    dpi     = 0.0_fp
 
+    ! Zero/initialize local variables for safety's sake
+    mean_np = 0.0_fp
+    mean_sp = 0.0_fp
+    sumnp   = 0.0_fp
+    sumsp   = 0.0_fp
+    ri2     = i2_gl
 
 !   ==================
     if (ju1 == ju1_gl) then
 !   ==================
 
-          sumsp = 0.0e+0_fp
+          sumsp = 0.0_fp
 
           do il = i1, i2
 
@@ -2569,7 +2603,7 @@ CONTAINS
     if (j2 == j2_gl) then
 !   ================
 
-          sumnp = 0.0e+0_fp
+          sumnp = 0.0_fp
 
           do il = i1, i2
 
@@ -2612,27 +2646,27 @@ CONTAINS
     ! Global latitude indices at the edge of the South polar cap
     ! J1P=JU1_GL+1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P
+    INTEGER,  INTENT(IN)  :: J1P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! Courant number in N-S direction
-    REAL(fp),  INTENT(IN)  :: cry(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: cry(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Average of Courant numbers from ij and ij+1
-    REAL(fp),  INTENT(OUT) :: va(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: va(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -2657,6 +2691,9 @@ CONTAINS
 !   Begin execution.
 !   ----------------
 
+    ! Zero output arguments for safety's sake
+    va = 0.0_fp
+
     i2d2 = i2_gl / 2
 
 
@@ -2676,7 +2713,7 @@ CONTAINS
           do il = i1, i2d2
 
              va(il,ju1) =  &
-                  0.5e+0_fp * (cry(il,ju1+1) - cry(il+i2d2,ju1+1))
+                  0.5_fp * (cry(il,ju1+1) - cry(il+i2d2,ju1+1))
 
              va(il+i2d2,ju1) = -va(il,ju1)
 
@@ -2694,7 +2731,7 @@ CONTAINS
           do il = i1, i2d2
 
              va(il,j2) =  &
-                  0.5e+0_fp * (cry(il,j2) - cry(il+i2d2,j2-1))
+                  0.5_fp * (cry(il,j2) - cry(il+i2d2,j2-1))
 
              va(il+i2d2,j2) = -va(il,j2)
 
@@ -2734,41 +2771,41 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER,  INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max latitude (J) indices
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! if iad = 1, use 1st order accurate scheme;
     ! if iad = 2, use 2nd order accurate scheme
-    INTEGER, INTENT(IN)  :: iad
+    INTEGER,  INTENT(IN)  :: iad
 
     ! Northward of latitude index = jn, Courant numbers could be > 1,
     ! so use the flux-form semi-Lagrangian scheme
-    INTEGER, INTENT(IN)  :: jn
+    INTEGER,  INTENT(IN)  :: jn
 
     ! southward of latitude index = js, Courant numbers could be > 1,
     ! so use the flux-form semi-Lagrangian scheme
-    INTEGER, INTENT(IN)  :: js
+    INTEGER,  INTENT(IN)  :: js
 
     ! Concentration contribution from N-S advection [mixing ratio]
-    REAL(fp),  INTENT(IN)  :: qqv(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: qqv(ILO:IHI, JULO:JHI)
 
     ! Average of Courant numbers from il and il+1
-    REAL(fp),  INTENT(IN)  :: ua(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: ua(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Cross term due to E-W advection [mixing ratio]
-    REAL(fp),  INTENT(OUT) :: adx(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: adx(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -2787,12 +2824,12 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: il, ij, iu
-    INTEGER :: imp, iue, iuw
-    REAL(fp)  :: a1, b1, c1
-    REAL(fp)  :: rdiff
-    REAL(fp)  :: ril, riu
-    real(fp)  :: ru
+    INTEGER  :: il, ij, iu
+    INTEGER  :: imp, iue, iuw
+    REAL(fp) :: a1, b1, c1
+    REAL(fp) :: rdiff
+    REAL(fp) :: ril, riu
+    real(fp) :: ru
 
     ! Arrays
     REAL(fp)  :: qtmp(-i2/3:i2+i2/3, julo:jhi)
@@ -2801,8 +2838,12 @@ CONTAINS
     !     Begin execution.
     !     ----------------
 
-    ! Zero output array
-    adx = 0e+0_fp
+    ! Zero output argument for safety's sake
+    adx = 0.0_fp
+
+    ! Zero local array for safety's sake
+    qtmp = 0.0_fp
+
 
        do ij = julo, jhi
 
@@ -2843,7 +2884,7 @@ CONTAINS
                    ru  = ua(il,ij) - riu
                    iu  = il - iu
 
-                   if (ua(il,ij) >= 0.0e+0_fp) then
+                   if (ua(il,ij) >= 0.0_fp) then
                       rdiff = qtmp(iu-1,ij) - qtmp(iu,ij)
                    else
                       rdiff = qtmp(iu,ij)   - qtmp(iu+1,ij)
@@ -2895,10 +2936,10 @@ CONTAINS
                    ru  = riu - ua(il,ij)
                    iu  = il - iu
 
-                   a1 = 0.5e+0_fp * (qtmp(iu+1,ij) + qtmp(iu-1,ij)) -  &
+                   a1 = 0.5_fp * (qtmp(iu+1,ij) + qtmp(iu-1,ij)) -  &
                                  qtmp(iu,ij)
 
-                   b1 = 0.5e+0_fp * (qtmp(iu+1,ij) - qtmp(iu-1,ij))
+                   b1 = 0.5_fp * (qtmp(iu+1,ij) - qtmp(iu-1,ij))
 
                    c1 = qtmp(iu,ij) - qtmp(il,ij)
 
@@ -2919,10 +2960,10 @@ CONTAINS
                    ru  = riu - ua(il,ij)
                    iu  = il - iu
 
-                   a1 = 0.5e+0_fp * (qtmp(iu+1,ij) + qtmp(iu-1,ij)) -  &
+                   a1 = 0.5_fp * (qtmp(iu+1,ij) + qtmp(iu-1,ij)) -  &
                                  qtmp(iu,ij)
 
-                   b1 = 0.5e+0_fp * (qtmp(iu+1,ij) - qtmp(iu-1,ij))
+                   b1 = 0.5_fp * (qtmp(iu+1,ij) - qtmp(iu-1,ij))
 
                    c1 = qtmp(iu,ij) - qtmp(il,ij)
 
@@ -2940,11 +2981,11 @@ CONTAINS
 
     if (ju1 == ju1_gl) then
 
-          adx(i1:i2,ju1) = 0.0e+0_fp
+          adx(i1:i2,ju1) = 0.0_fp
 
           if (j1p /= ju1_gl+1) then
 
-             adx(i1:i2,ju1+1) = 0.0e+0_fp
+             adx(i1:i2,ju1+1) = 0.0_fp
 
           end if
 
@@ -2953,11 +2994,11 @@ CONTAINS
 
     if (j2 == j2_gl) then
 
-          adx(i1:i2,j2) = 0.0e+0_fp
+          adx(i1:i2,j2) = 0.0_fp
 
           if (j1p /= ju1_gl+1) then
 
-             adx(i1:i2,j2-1) = 0.0e+0_fp
+             adx(i1:i2,j2-1) = 0.0_fp
 
           end if
 
@@ -2989,34 +3030,34 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER,  INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! If iad = 1, use 1st order accurate scheme;
     ! If iad = 2, use 2nd order accurate scheme
-    INTEGER, INTENT(IN)  :: iad
+    INTEGER,  INTENT(IN)  :: iad
 
     ! Concentration contribution from E-W advection [mixing ratio]
-    REAL(fp),  INTENT(IN)  :: qqu(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: qqu(ILO:IHI, JULO:JHI)
 
     ! Average of Courant numbers from ij and ij+1
-    REAL(fp),  INTENT(IN)  :: va(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: va(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Cross term due to N-S advection (mixing ratio)
-    REAL(fp),  INTENT(OUT) :: ady(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: ady(ILO:IHI, JULO:JHI)
 
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -3035,25 +3076,26 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: il, ij
-    INTEGER :: jv
-    REAL(fp)  :: a1, b1, c1
-    REAL(fp)  :: rij, rjv
-    REAL(fp)  :: rv
+    INTEGER  :: il, ij
+    INTEGER  :: jv
+    REAL(fp) :: a1, b1, c1
+    REAL(fp) :: rij, rjv
+    REAL(fp) :: rv
 
     ! Arrays
     ! We may need a small ghost zone depending
     ! on the polar cap used
-    REAL(fp)  :: qquwk(ilo:ihi, julo-2:jhi+2)
+    REAL(fp) :: qquwk(ilo:ihi, julo-2:jhi+2)
 
 !     ----------------
 !     Begin execution.
 !     ----------------
 
-    ! Zero output array
-    ady = 0e+0_fp
+    ! Zero output argument for safety's sake
+    ady   = 0.0_fp
 
-    ! Make work array
+    ! Initialize work array
+    qquwk = 0.0_fp
     do ij = julo, jhi
        qquwk(:,ij) = qqu(:,ij)
     end do
@@ -3104,10 +3146,10 @@ CONTAINS
                 rv  = rjv - va(il,ij)
                 jv  = ij - jv
 
-                a1 = 0.5e+0_fp * (qquwk(il,jv+1) + qquwk(il,jv-1)) -  &
-                              qquwk(il,jv)
+                a1 = 0.5_fp * (qquwk(il,jv+1) + qquwk(il,jv-1)) -  &
+                               qquwk(il,jv)
 
-                b1 = 0.5e+0_fp * (qquwk(il,jv+1) - qquwk(il,jv-1))
+                b1 = 0.5_fp * (qquwk(il,jv+1) - qquwk(il,jv-1))
 
                 c1 = qquwk(il,jv) - qquwk(il,ij)
 
@@ -3150,27 +3192,27 @@ CONTAINS
     ! Global latitude indices at the edges of the South polar cap
     ! J1P=JU1_GL+1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P
+    INTEGER,  INTENT(IN)  :: J1P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! concentration contribution from E-W advection [mixing ratio]
-    REAL(fp),  INTENT(IN)  :: qqu(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: qqu(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! qqu working array [mixing ratio]
-    REAL(fp),  INTENT(OUT) :: qquwk(ILO:IHI, JULO-2:JHI+2)
+    REAL(fp), INTENT(OUT) :: qquwk(ILO:IHI, JULO-2:JHI+2)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -3197,6 +3239,9 @@ CONTAINS
 !   ----------------
 !   Begin execution.
 !   ----------------
+
+    ! Zero output argument for safety's sake
+    qquwk = 0.0_fp
 
     i2d2 = i2_gl / 2
 
@@ -3275,24 +3320,24 @@ CONTAINS
     ! Global latitude index at the edge of the South polar cap
     ! J1P=JU1_GL+1; for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)    :: J1P
+    INTEGER,  INTENT(IN)    :: J1P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)    :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)    :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)    :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)    :: I1,     I2
-    INTEGER, INTENT(IN)    :: JU1,    J2
+    INTEGER,  INTENT(IN)    :: I1,     I2
+    INTEGER,  INTENT(IN)    :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: ILO,    IHI
-    INTEGER, INTENT(IN)    :: JULO,   JHI
+    INTEGER,  INTENT(IN)    :: ILO,    IHI
+    INTEGER,  INTENT(IN)    :: JULO,   JHI
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Cross term due to N-S advection (mixing ratio)
-    REAL(fp),  INTENT(INOUT) :: ady(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(INOUT) :: ady(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -3312,11 +3357,11 @@ CONTAINS
 !
 
     ! Scalars
-    INTEGER :: il
+    INTEGER  :: il
 
     ! Arrays
-    REAL(fp)  :: sumnp
-    REAL(fp)  :: sumsp
+    REAL(fp) :: sumnp
+    REAL(fp) :: sumsp
 
     ! Add
     LOGICAL :: IS_EXT_POLAR_CAP
@@ -3326,6 +3371,14 @@ CONTAINS
     ! Begin execution.
     ! ----------------
 
+    ! Zero output argument for safety's sake
+    ady   = 0.0_fp
+
+    ! Zero local variables for safety's sake
+    sumsp = 0.0_fp
+    sumnp = 0.0_fp
+
+
     ! Test if we are using extended polar caps (i.e. the S pole and next N
     ! latitude and N. Pole and next S latitude).  Do this outside the loops.
     ! (bmy, 12/11/08)
@@ -3334,9 +3387,6 @@ CONTAINS
     ! ------------
     !  South Pole
     ! ------------
-
-          sumsp = 0.0e+0_fp
-          sumnp = 0.0e+0_fp
 
           if ( IS_EXT_POLAR_CAP ) then
 
@@ -3411,55 +3461,55 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)    :: J1P,    J2P
+    INTEGER,  INTENT(IN)    :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    ::         I2_GL
-    INTEGER, INTENT(IN)    :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)    ::         I2_GL
+    INTEGER,  INTENT(IN)    :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)    :: I1,     I2
-    INTEGER, INTENT(IN)    :: JU1,    J2
+    INTEGER,  INTENT(IN)    :: I1,     I2
+    INTEGER,  INTENT(IN)    :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: ILO,    IHI
-    INTEGER, INTENT(IN)    :: JULO,   JHI
+    INTEGER,  INTENT(IN)    :: ILO,    IHI
+    INTEGER,  INTENT(IN)    :: JULO,   JHI
 
     ! Controls various options in E-W advection
-    INTEGER, INTENT(IN)    :: ilmt
+    INTEGER,  INTENT(IN)    :: ilmt
 
     ! Northward of latitude index = jn, Courant numbers could be > 1,
     ! so use the flux-form semi-Lagrangian scheme
-    INTEGER, INTENT(IN)    :: jn
+    INTEGER,  INTENT(IN)    :: jn
 
     ! Southward of latitude index = js, Courant numbers could be > 1,
     ! so use the flux-form semi-Lagrangian scheme
-    INTEGER, INTENT(IN)    :: js
+    INTEGER,  INTENT(IN)    :: js
 
     ! Option for E-W transport scheme.  See module header for more info.
-    INTEGER, INTENT(IN)    :: iord
+    INTEGER,  INTENT(IN)    :: iord
 
     ! pressure at edges in "u" [hPa]
-    REAL(fp),  INTENT(IN)    :: pu(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)    :: pu(ILO:IHI, JULO:JHI)
 
     ! Courant number in E-W direction
-    REAL(fp),  INTENT(IN)    :: crx(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)    :: crx(ILO:IHI, JULO:JHI)
 
     ! Horizontal mass flux in E-W direction [hPa]
-    REAL(fp),  INTENT(IN)    :: xmass(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)    :: xmass(ILO:IHI, JULO:JHI)
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
     ! Species density [hPa]
-    REAL(fp),  INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI)
 
     ! Concentration contribution from N-S advection [mixing ratio]
-    REAL(fp),  INTENT(INOUT) :: qqv(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(INOUT) :: qqv(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! E-W flux [mixing ratio]
-    REAL(fp),  INTENT(OUT)   :: fx(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT)   :: fx(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -3478,30 +3528,34 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: il, ij, ic
-    INTEGER :: iu, ix, iuw, iue, imp
-    INTEGER :: jvan
-    REAL(fp)  :: rc
-    REAL(fp)  :: ric, ril
+    INTEGER  :: il, ij, ic
+    INTEGER  :: iu, ix, iuw, iue, imp
+    INTEGER  :: jvan
+    REAL(fp) :: rc
+    REAL(fp) :: ric, ril
 
     ! Arrays
-    INTEGER :: isav(i1:i2)
-    REAL(fp)  :: dcx(-i2/3:i2+i2/3, julo:jhi)
-    REAL(fp)  :: qtmp(-i2/3:i2+i2/3, julo:jhi)
+    INTEGER  :: isav(i1:i2)
+    REAL(fp) :: dcx(-i2/3:i2+i2/3, julo:jhi)
+    REAL(fp) :: qtmp(-i2/3:i2+i2/3, julo:jhi)
 
 
     !     ----------------
     !     Begin execution.
     !     ----------------
 
-    dcx(:,:) = 0.0e+0_fp
-    fx(:,:) = 0.0e+0_fp
+    ! Zero output argument for safety's sake
+    fx   = 0.0_fp
 
-    imp = i2+1
+    ! Zero/initialize local variables for safety's sake
+    isav = 0
+    dcx  = 0.0_fp
+    imp  = i2+1
 
     ! NOTE: these loops do not parallelize well (bmy, 12/5/08)
 
-    ! Populate qtmp
+    ! Populate qtmp work array
+    qtmp = 0.0_fp
     do il=i1,i2
        qtmp(il,:) = qqv(il,:)
     enddo
@@ -3566,7 +3620,7 @@ CONTAINS
                       fx(il,ij) =  &
                            qtmp(iu,ij) +  &
                            (dcx(iu,ij) *  &
-                           (Sign (1.0e+0_fp, crx(il,ij)) - crx(il,ij)))
+                           (Sign (1.0_fp, crx(il,ij)) - crx(il,ij)))
                    end do
 
                 else
@@ -3622,20 +3676,20 @@ CONTAINS
                    fx(il,ij) =  &
                         rc *  &
                         (qtmp(iu,ij) +  &
-                        (dcx(iu,ij) * (Sign (1.0e+0_fp, rc) - rc)))
+                        (dcx(iu,ij) * (Sign (1.0_fp, rc) - rc)))
                 end do
 
              end if
 
              do il = i1, i2
 
-                if (crx(il,ij) > 1.0e+0_fp) then
+                if (crx(il,ij) > 1.0_fp) then
 
                    do ix = isav(il), il - 1
                       fx(il,ij) = fx(il,ij) + qtmp(ix,ij)
                    end do
 
-                else if (crx(il,ij) < -1.0e+0_fp) then
+                else if (crx(il,ij) < -1.0_fp) then
 
                    do ix = il, isav(il) - 1
                       fx(il,ij) = fx(il,ij) - qtmp(ix,ij)
@@ -3692,27 +3746,27 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER,  INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  ::         I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  ::         I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! Concentration contribution from N-S advection [mixing ratio]
-    REAL(fp),  INTENT(IN)  :: qqv(-I2/3:I2+I2/3, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: qqv(-I2/3:I2+I2/3, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Slope of concentration distribution in E-W direction [mixing ratio]
-    REAL(fp),  INTENT(OUT) :: dcx(-I2/3:I2+I2/3, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: dcx(-I2/3:I2+I2/3, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -3731,23 +3785,29 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: il, ij
-    REAL(fp)  :: pmax, pmin
-    REAL(fp)  :: r24
-    REAL(fp)  :: tmp
-
+    INTEGER  :: il, ij
+    REAL(fp) :: pmax, pmin
+    REAL(fp) :: r24
+    REAL(fp) :: tmp
 
 !   ----------------
 !   Begin execution.
 !   ----------------
 
-    r24 = 1.0e+0_fp / 24.0e+0_fp
+    ! Zero output argument for safety's sake
+    dcx = 0.0_fp
+
+    ! Zero/initialize local variables for safety's sake
+    pmax = 0.0_fp
+    pmin = 0.0_fp
+    tmp  = 0.0_fp
+    r24  = 1.0_fp / 24.0_fp
 
        do ij = j1p+1, j2p-1
           do il = i1, i2
 
              tmp =  &
-                  ((8.0e+0_fp * (qqv(il+1,ij) - qqv(il-1,ij))) +  &
+                  ((8.0_fp * (qqv(il+1,ij) - qqv(il-1,ij))) +  &
                   qqv(il-2,ij) - qqv(il+2,ij)) *  &
                   r24
 
@@ -3800,33 +3860,33 @@ CONTAINS
 ! !INPUT PARAMETERS:
 !
     ! Local min & max longitude (I) and altitude (K) indices
-    INTEGER, INTENT(IN)    :: I1,     I2
+    INTEGER,  INTENT(IN)    :: I1,     I2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: ILO,    IHI
-    INTEGER, INTENT(IN)    :: JULO,   JHI
+    INTEGER,  INTENT(IN)    :: ILO,    IHI
+    INTEGER,  INTENT(IN)    :: JULO,   JHI
 
     ! Latitude (IJ) and altitude (IK) indices
-    INTEGER, INTENT(IN)    :: ij
+    INTEGER,  INTENT(IN)    :: ij
 
     ! Controls various options in E-W advection
-    INTEGER, INTENT(IN)    :: ilmt
+    INTEGER,  INTENT(IN)    :: ilmt
 
     ! Courant number in E-W direction
-    REAL(fp),  INTENT(IN)    :: crx(I1:I2, JULO:JHI)
+    REAL(fp), INTENT(IN)    :: crx(I1:I2, JULO:JHI)
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
       ! Concentration contribution from N-S advection [mixing ratio]
-    REAL(fp),  INTENT(INOUT) :: qqv(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(INOUT) :: qqv(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Slope of concentration distribution in E-W direction (mixing ratio)
-    REAL(fp),  INTENT(OUT)   :: dcx(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT)   :: dcx(ILO:IHI, JULO:JHI)
 
     ! E-W flux [mixing ratio]
-    REAL(fp),  INTENT(OUT)   :: fx(I1:I2, JULO:JHI)
+    REAL(fp), INTENT(OUT)   :: fx(I1:I2, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -3849,44 +3909,47 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER                   :: il
-    INTEGER                   :: ilm1
-    INTEGER                   :: lenx
-    REAL(fp)                    :: r13, r23
-    REAL(fp)                    :: rval
+    INTEGER  :: il
+    INTEGER  :: ilm1
+    INTEGER  :: lenx
+    REAL(fp) :: r13, r23
+    REAL(fp) :: rval
 
     ! Arrays
-    REAL(fp)                    :: a6( ILO:IHI )
-    REAL(fp)                    :: al( ILO:IHI )
-    REAL(fp)                    :: ar( ILO:IHI )
-    REAL(fp)                    :: a61(   (IHI-1) - (ILO+1) + 1 )
-    REAL(fp)                    :: al1(   (IHI-1) - (ILO+1) + 1 )
-    REAL(fp)                    :: ar1(   (IHI-1) - (ILO+1) + 1 )
-    REAL(fp)                    :: dcxi1( (IHI-1) - (ILO+1) + 1 )
-    REAL(fp)                    :: qqvi1( (IHI-1) - (ILO+1) + 1 )
+    REAL(fp) :: a6( ILO:IHI )
+    REAL(fp) :: al( ILO:IHI )
+    REAL(fp) :: ar( ILO:IHI )
+    REAL(fp) :: a61(   (IHI-1) - (ILO+1) + 1 )
+    REAL(fp) :: al1(   (IHI-1) - (ILO+1) + 1 )
+    REAL(fp) :: ar1(   (IHI-1) - (ILO+1) + 1 )
+    REAL(fp) :: dcxi1( (IHI-1) - (ILO+1) + 1 )
+    REAL(fp) :: qqvi1( (IHI-1) - (ILO+1) + 1 )
 
     !     ----------------
     !     Begin execution.
     !     ----------------
 
-    ! Zero arrays (bmy, 12/5/08)
-    a6    = 0.0e+0_fp
-    al    = 0.0e+0_fp
-    ar    = 0.0e+0_fp
-    a61   = 0.0e+0_fp
-    al1   = 0.0e+0_fp
-    ar1   = 0.0e+0_fp
-    dcxi1 = 0.0e+0_fp
-    qqvi1 = 0.0e+0_fp
+    ! Zero output arguments for safety's sake
+    dcx   = 0.0_fp
+    fx    = 0.0_fp
 
-    r13 = 1.0e+0_fp / 3.0e+0_fp
-    r23 = 2.0e+0_fp / 3.0e+0_fp
+    ! Zero/initialize local variables for safety's sake
+    a6    = 0.0_fp
+    al    = 0.0_fp
+    ar    = 0.0_fp
+    a61   = 0.0_fp
+    al1   = 0.0_fp
+    ar1   = 0.0_fp
+    dcxi1 = 0.0_fp
+    qqvi1 = 0.0_fp
+    r13   = 1.0_fp / 3.0_fp
+    r23   = 2.0_fp / 3.0_fp
 
 
     do il = ilo + 1, ihi
 
-       rval = 0.5e+0_fp * (qqv(il-1,ij) + qqv(il,ij)) +  &
-                      (dcx(il-1,ij) - dcx(il,ij)) * r13
+       rval = 0.5_fp * (qqv(il-1,ij) + qqv(il,ij)) +  &
+                       (dcx(il-1,ij) - dcx(il,ij)) * r13
 
        al(il)   = rval
        ar(il-1) = rval
@@ -3895,7 +3958,7 @@ CONTAINS
 
 
     do il = ilo + 1, ihi - 1
-       a6(il) = 3.0e+0_fp *  &
+       a6(il) = 3.0_fp *  &
                 (qqv(il,ij) + qqv(il,ij) - (al(il) + ar(il)))
     end do
 
@@ -3904,12 +3967,12 @@ CONTAINS
     if (ilmt <= 2) then
 !   ==============
 
-       a61(:) = 0.0e+0_fp
-       al1(:) = 0.0e+0_fp
-       ar1(:) = 0.0e+0_fp
+       a61(:) = 0.0_fp
+       al1(:) = 0.0_fp
+       ar1(:) = 0.0_fp
 
-       dcxi1(:) = 0.0e+0_fp
-       qqvi1(:) = 0.0e+0_fp
+       dcxi1(:) = 0.0_fp
+       qqvi1(:) = 0.0_fp
 
        lenx = 0
 
@@ -3962,46 +4025,46 @@ CONTAINS
 
     do il = i1+1, i2
 
-       if (crx(il,ij) > 0.0e+0_fp) then
+       if (crx(il,ij) > 0.0_fp) then
 
           ilm1 = il - 1
 
           fx(il,ij) =  &
                ar(ilm1) +  &
-               0.5e+0_fp * crx(il,ij) *  &
+               0.5_fp * crx(il,ij) *  &
                (al(ilm1) - ar(ilm1) +  &
-               (a6(ilm1) * (1.0e+0_fp - (r23 * crx(il,ij)))))
+               (a6(ilm1) * (1.0_fp - (r23 * crx(il,ij)))))
 
        else
 
           fx(il,ij) =  &
                al(il) -  &
-               0.5e+0_fp * crx(il,ij) *  &
+               0.5_fp * crx(il,ij) *  &
                (ar(il) - al(il) +  &
-               (a6(il) * (1.0e+0_fp + (r23 * crx(il,ij)))))
+               (a6(il) * (1.0_fp + (r23 * crx(il,ij)))))
 
        end if
 
     end do
 
     ! First box case (ccc, 11/20/08)
-    if (crx(i1,ij) > 0.0e+0_fp) then
+    if (crx(i1,ij) > 0.0_fp) then
 
        ilm1 = i2
 
        fx(i1,ij) =  &
             ar(ilm1) +  &
-            0.5e+0_fp * crx(i1,ij) *  &
+            0.5_fp * crx(i1,ij) *  &
             (al(ilm1) - ar(ilm1) +  &
-            (a6(ilm1) * (1.0e+0_fp - (r23 * crx(i1,ij)))))
+            (a6(ilm1) * (1.0_fp - (r23 * crx(i1,ij)))))
 
     else
 
        fx(i1,ij) =  &
             al(i1) -  &
-            0.5e+0_fp * crx(i1,ij) *  &
+            0.5_fp * crx(i1,ij) *  &
             (ar(i1) - al(i1) +  &
-            (a6(i1) * (1.0e+0_fp + (r23 * crx(i1,ij)))))
+            (a6(i1) * (1.0_fp + (r23 * crx(i1,ij)))))
 
     end if
 
@@ -4030,27 +4093,27 @@ CONTAINS
     ! If 0 => full monotonicity;
     ! If 1 => semi-monotonic constraint (no undershoots);
     ! If 2 => positive-definite constraint
-    INTEGER, INTENT(IN)    :: lmt
+    INTEGER,  INTENT(IN)    :: lmt
 
     ! Vector length
-    INTEGER, INTENT(IN)    :: lenx
+    INTEGER,  INTENT(IN)    :: lenx
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
     ! Curvature of the test parabola
-    REAL(fp),  INTENT(INOUT) :: a6(lenx)
+    REAL(fp), INTENT(INOUT) :: a6(lenx)
 
     ! Left edge value of the test parabola
-    REAL(fp),  INTENT(INOUT) :: al(lenx)
+    REAL(fp), INTENT(INOUT) :: al(lenx)
 
     ! Right edge value of the test parabola
-    REAL(fp),  INTENT(INOUT) :: ar(lenx)
+    REAL(fp), INTENT(INOUT) :: ar(lenx)
 
     ! 0.5 * mismatch
-    REAL(fp),  INTENT(INOUT) :: dc(lenx)
+    REAL(fp), INTENT(INOUT) :: dc(lenx)
 
     ! Cell-averaged value
-    REAL(fp),  INTENT(INOUT) :: qa(lenx)
+    REAL(fp), INTENT(INOUT) :: qa(lenx)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -4069,18 +4132,18 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: il
-    REAL(fp)  :: a6da
-    REAL(fp)  :: da1, da2
-    REAL(fp)  :: fmin, ftmp
-    REAL(fp)  :: r12
+    INTEGER  :: il
+    REAL(fp) :: a6da
+    REAL(fp) :: da1, da2
+    REAL(fp) :: fmin, ftmp
+    REAL(fp) :: r12
 
 
 !   ----------------
 !   Begin execution.
 !   ----------------
 
-    r12 = 1.0e+0_fp / 12.0e+0_fp
+    r12 = 1.0_fp / 12.0_fp
 
 
 !   =============
@@ -4093,9 +4156,9 @@ CONTAINS
 
        do il = 1, lenx
 
-          if (dc(il) == 0.0e+0_fp) then
+          if (dc(il) == 0.0_fp) then
 
-             a6(il) = 0.0e+0_fp
+             a6(il) = 0.0_fp
              al(il) = qa(il)
              ar(il) = qa(il)
 
@@ -4107,12 +4170,12 @@ CONTAINS
 
              if (a6da < -da2) then
 
-                a6(il) = 3.0e+0_fp * (al(il) - qa(il))
+                a6(il) = 3.0_fp * (al(il) - qa(il))
                 ar(il) = al(il) - a6(il)
 
              else if (a6da > da2) then
 
-                a6(il) = 3.0e+0_fp * (ar(il) - qa(il))
+                a6(il) = 3.0_fp * (ar(il) - qa(il))
                 al(il) = ar(il) - a6(il)
 
              end if
@@ -4136,18 +4199,18 @@ CONTAINS
 
              if ((qa(il) < ar(il)) .and. (qa(il) < al(il))) then
 
-                a6(il) = 0.0e+0_fp
+                a6(il) = 0.0_fp
                 al(il) = qa(il)
                 ar(il) = qa(il)
 
              else if (ar(il) > al(il)) then
 
-                a6(il) = 3.0e+0_fp * (al(il) - qa(il))
+                a6(il) = 3.0_fp * (al(il) - qa(il))
                 ar(il) = al(il) - a6(il)
 
              else
 
-                a6(il) = 3.0e+0_fp * (ar(il) - qa(il))
+                a6(il) = 3.0_fp * (ar(il) - qa(il))
                 al(il) = ar(il) - a6(il)
 
              end if
@@ -4168,25 +4231,25 @@ CONTAINS
              ftmp = ar(il) - al(il)
 
              fmin = qa(il) +  &
-                    0.25e+0_fp * (ftmp * ftmp) / a6(il) +  &
+                    0.25_fp * (ftmp * ftmp) / a6(il) +  &
                     a6(il) * r12
 
-             if (fmin < 0.0e+0_fp) then
+             if (fmin < 0.0_fp) then
 
                 if ((qa(il) < ar(il)) .and. (qa(il) < al(il))) then
 
-                   a6(il) = 0.0e+0_fp
+                   a6(il) = 0.0_fp
                    al(il) = qa(il)
                    ar(il) = qa(il)
 
                 else if (ar(il) > al(il)) then
 
-                   a6(il) = 3.0e+0_fp * (al(il) - qa(il))
+                   a6(il) = 3.0_fp * (al(il) - qa(il))
                    ar(il) = al(il) - a6(il)
 
                 else
 
-                   a6(il) = 3.0e+0_fp * (ar(il) - qa(il))
+                   a6(il) = 3.0_fp * (ar(il) - qa(il))
                    al(il) = ar(il) - a6(il)
 
                 end if
@@ -4224,58 +4287,58 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)    :: J1P,    J2P
+    INTEGER,  INTENT(IN)    :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)    :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)    :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)    :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)    :: I1,     I2
-    INTEGER, INTENT(IN)    :: JU1,    J2
+    INTEGER,  INTENT(IN)    :: I1,     I2
+    INTEGER,  INTENT(IN)    :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: ILO,    IHI
-    INTEGER, INTENT(IN)    :: JULO,   JHI
+    INTEGER,  INTENT(IN)    :: ILO,    IHI
+    INTEGER,  INTENT(IN)    :: JULO,   JHI
 
     ! ???
-    INTEGER, INTENT(IN)    :: ilong
+    INTEGER,  INTENT(IN)    :: ilong
 
     ! Controls various options in N-S advection
-    INTEGER, INTENT(IN)    :: jlmt
+    INTEGER,  INTENT(IN)    :: jlmt
 
     ! N-S transport scheme (see module header for more info)
-    INTEGER, INTENT(IN)    :: jord
+    INTEGER,  INTENT(IN)    :: jord
 
     ! special geometrical factor (geofac) for Polar cap
-    REAL(fp),  INTENT(IN)    :: geofac_pc
+    REAL(fp), INTENT(IN)    :: geofac_pc
 
     ! geometrical factor for meridional advection; geofac uses correct
     ! spherical geometry, and replaces acosp as the  meridional geometrical
     ! factor in tpcore
-    REAL(fp),  INTENT(IN)    :: geofac(JU1_GL:J2_GL)
+    REAL(fp), INTENT(IN)    :: geofac(JU1_GL:J2_GL)
 
     ! Courant number in N-S direction
-    REAL(fp),  INTENT(IN)    :: cry(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)    :: cry(ILO:IHI, JULO:JHI)
 
     ! Concentration contribution from E-W advection [mixing ratio]
-    REAL(fp),  INTENT(IN)    :: qqu(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)    :: qqu(ILO:IHI, JULO:JHI)
 
     ! Horizontal mass flux in N-S direction [hPa]
-    REAL(fp),  INTENT(IN)    :: ymass(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)    :: ymass(ILO:IHI, JULO:JHI)
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
     ! Species density [hPa]
-    REAL(fp),  INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI)
 
     ! Concentration contribution from N-S advection [mixing ratio]
-    REAL(fp),  INTENT(INOUT) :: qqv(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(INOUT) :: qqv(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! N-S flux [mixing ratio]
-    REAL(fp),  INTENT(OUT)   :: fy(ILO:IHI, JULO:JHI+1)
+    REAL(fp), INTENT(OUT)   :: fy(ILO:IHI, JULO:JHI+1)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -4294,21 +4357,22 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: il, ij
-    INTEGER :: jv
-    REAL(fp)  :: rj1p
+    INTEGER  :: il, ij
+    INTEGER  :: jv
+    REAL(fp) :: rj1p
 
     ! Arrays
-    REAL(fp)  :: dcy(ilo:ihi, julo:jhi)
-
+    REAL(fp) :: dcy(ilo:ihi, julo:jhi)
 
 !   ----------------
 !   Begin execution.
 !   ----------------
 
-    dcy(:,:) = 0.0e+0_fp
-    fy(:,:) = 0.0e+0_fp
+    ! Zero output argument for safety's sake
+    fy   = 0.0_fp
 
+    ! Zero/initialize local variables for safety's sake
+    dcy  = 0.0_fp
     rj1p = j1p
 
 
@@ -4356,7 +4420,7 @@ CONTAINS
 
                    qqv(il,ij) =  &
                         qqu(il,jv) +  &
-                        ((Sign (1.0e+0_fp, cry(il,ij)) - cry(il,ij)) *  &
+                        ((Sign (1.0_fp, cry(il,ij)) - cry(il,ij)) *  &
                         dcy(il,jv))
 
                 end do
@@ -4414,31 +4478,31 @@ CONTAINS
     ! Global latitude index at the edge of the South polar cap
     ! J1P=JU1_GL+1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P
+    INTEGER,  INTENT(IN)  :: J1P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! The "order" of the accuracy in the computed linear "slope"
     ! (or mismatch, Lin et al. 1994); it is either 2 or 4.
-    INTEGER, INTENT(IN)  :: id
+    INTEGER,  INTENT(IN)  :: id
 
     ! Concentration contribution from E-W advection (mixing ratio)
-    REAL(fp),  INTENT(IN)  :: qqu(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: qqu(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Slope of concentration distribution in N-S direction [mixing ratio]
-    REAL(fp),  INTENT(OUT) :: dcy(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: dcy(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -4457,10 +4521,10 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: il, ij
-    REAL(fp)  :: pmax, pmin
-    REAL(fp)  :: r24
-    REAL(fp)  :: tmp
+    INTEGER  :: il, ij
+    REAL(fp) :: pmax, pmin
+    REAL(fp) :: r24
+    REAL(fp) :: tmp
 
     ! Arrays
     ! I suppose the values for these indexes are 0.
@@ -4472,10 +4536,17 @@ CONTAINS
 !   Begin execution.
 !   ----------------
 
-    r24  = 1.0e+0_fp / 24.0e+0_fp
+    ! Zero output arguments for safety's sake
+    dcy  = 0.0_fp
+
+    ! Zero/initialize local variables for safety's sake
+    qtmp = 0.0_fp
+    pmax = 0.0_fp
+    pmin = 0.0_fp
+    tmp  = 0.0_fp
+    r24  = 1.0_fp / 24.0_fp
 
     ! Populate qtmp
-    qtmp = 0.
     do ij=ju1,j2
        qtmp(:,ij) = qqu(:,ij)
     enddo
@@ -4487,7 +4558,7 @@ CONTAINS
           do ij = ju1 - 1, j2 - 1
              do il = i1, i2
 
-                tmp  = 0.25e+0_fp * (qtmp(il,ij+2) - qtmp(il,ij))
+                tmp  = 0.25_fp * (qtmp(il,ij+2) - qtmp(il,ij))
 
                 pmax =  &
                   Max (qtmp(il,ij), qtmp(il,ij+1), qtmp(il,ij+2)) -  &
@@ -4516,7 +4587,7 @@ CONTAINS
           do ij = ju1 - 2, j2 - 2
              do il = i1, i2
 
-                tmp  = ((8.0e+0_fp * (qtmp(il,ij+3) - qtmp(il,ij+1))) +  &
+                tmp  = ((8.0_fp * (qtmp(il,ij+3) - qtmp(il,ij+1))) +  &
                          qtmp(il,ij) - qtmp(il,ij+4)) *  &
                          r24
 
@@ -4567,24 +4638,24 @@ CONTAINS
     ! Global min & max longitude (I) and latitude (J) indices
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! Concentration contribution from E-W advection [mixing ratio]
-    REAL(fp),  INTENT(IN)  :: qqu(ILO:IHI, JULO-2:JHI+2)
+    REAL(fp), INTENT(IN)  :: qqu(ILO:IHI, JULO-2:JHI+2)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Slope of concentration distribution in N-S direction [mixing ratio]
-    REAL(fp), INTENT(OUT)  :: dcy(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: dcy(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -4602,20 +4673,26 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER :: i2d2
-    INTEGER :: il
-    REAL(fp)  :: pmax, pmin
-    REAL(fp)  :: r24
-    REAL(fp)  :: tmp
+    INTEGER  :: i2d2
+    INTEGER  :: il
+    REAL(fp) :: pmax, pmin
+    REAL(fp) :: r24
+    REAL(fp) :: tmp
 
 
 !   ----------------
 !   Begin execution.
 !   ----------------
 
-    i2d2 = i2_gl / 2
+    ! Zero output argument for safety's sake
+    dcy  = 0.0_fp
 
-    r24  = 1.0e+0_fp / 24.0e+0_fp
+    ! Zero/initialize local variables for safety's sake
+    pmax = 0.0_fp
+    pmin = 0.0_fp
+    tmp  = 0.0_fp
+    i2d2 = i2_gl / 2
+    r24  = 1.0_fp / 24.0_fp
 
 
 !   ==================
@@ -4625,7 +4702,7 @@ CONTAINS
           do il = i1, i2d2
 
              tmp  =  &
-                  ((8.0e+0_fp * (qqu(il,ju1+2) - qqu(il,ju1))) +  &
+                  ((8.0_fp * (qqu(il,ju1+2) - qqu(il,ju1))) +  &
                   qqu(il+i2d2,ju1+1) - qqu(il,ju1+3)) *  &
                   r24
 
@@ -4645,7 +4722,7 @@ CONTAINS
           do il = i1 + i2d2, i2
 
              tmp  =  &
-                  ((8.0e+0_fp * (qqu(il,ju1+2) - qqu(il,ju1))) +  &
+                  ((8.0_fp * (qqu(il,ju1+2) - qqu(il,ju1))) +  &
                   qqu(il-i2d2,ju1+1) - qqu(il,ju1+3)) *  &
                   r24
 
@@ -4674,7 +4751,7 @@ CONTAINS
           do il = i1, i2d2
 
              tmp  =  &
-                  ((8.0e+0_fp * (qqu(il,j2) - qqu(il,j2-2))) +  &
+                  ((8.0_fp * (qqu(il,j2) - qqu(il,j2-2))) +  &
                   qqu(il,j2-3) - qqu(il+i2d2,j2-1)) *  &
                   r24
 
@@ -4694,7 +4771,7 @@ CONTAINS
          do il = i1 + i2d2, i2
 
              tmp  =  &
-                  ((8.0e+0_fp * (qqu(il,j2) - qqu(il,j2-2))) +  &
+                  ((8.0_fp * (qqu(il,j2) - qqu(il,j2-2))) +  &
                   qqu(il,j2-3) - qqu(il-i2d2,j2-1)) *  &
                   r24
 
@@ -4739,27 +4816,27 @@ CONTAINS
     ! Global latitude index at the edge of the South polar cap
     ! J1P=JU1_GL+1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P
+    INTEGER,  INTENT(IN)  :: J1P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! Concentration contribution from E-W advection [mixing ratio]
-    REAL(fp),  INTENT(IN)  :: qqu(ILO:IHI, JULO-2:JHI+2)
+    REAL(fp), INTENT(IN)  :: qqu(ILO:IHI, JULO-2:JHI+2)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Slope of concentration distribution in N-S direction [mixing ratio]
-    REAL(fp),  INTENT(OUT) :: dcy(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: dcy(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -4778,15 +4855,22 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: i2d2
-    INTEGER :: il
-    REAL(fp)  :: pmax, pmin
-    REAL(fp)  :: tmp
+    INTEGER  :: i2d2
+    INTEGER  :: il
+    REAL(fp) :: pmax, pmin
+    REAL(fp) :: tmp
 
 !   ----------------
 !   Begin execution.
 !   ----------------
 
+    ! Zero output argument for safety's sake
+    dcy  = 0.0_fp
+
+    ! Zero/initialize local variables for safety's sake
+    pmin = 0.0_fp
+    pmax = 0.0_fp
+    tmp  = 0.0_fp
     i2d2 = i2_gl / 2
 
 
@@ -4796,7 +4880,7 @@ CONTAINS
 
        if (j1p /= ju1_gl+1) then
 
-          dcy(i1:i2,ju1) = 0.0e+0_fp
+          dcy(i1:i2,ju1) = 0.0_fp
 
        else
 
@@ -4807,7 +4891,7 @@ CONTAINS
              do il = i1, i2d2
 
                 tmp  =  &
-                     0.25e+0_fp *  &
+                     0.25_fp *  &
                      (qqu(il,ju1+1) - qqu(il+i2d2,ju1+1))
 
                 pmax =  &
@@ -4842,7 +4926,7 @@ CONTAINS
 
        if (j1p /= ju1_gl+1) then
 
-          dcy(i1:i2,j2) = 0.0e+0_fp
+          dcy(i1:i2,j2) = 0.0_fp
 
        else
 
@@ -4853,7 +4937,7 @@ CONTAINS
              do il = i1, i2d2
 
                 tmp  =  &
-                     0.25e+0_fp *  &
+                     0.25_fp *  &
                      (qqu(il+i2d2,j2-1) - qqu(il,j2-1))
 
                 pmax =  &
@@ -4907,39 +4991,39 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)  :: J1P,    J2P
+    INTEGER,  INTENT(IN)  :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)  :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)  :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)  :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)  :: I1,     I2
-    INTEGER, INTENT(IN)  :: JU1,    J2
+    INTEGER,  INTENT(IN)  :: I1,     I2
+    INTEGER,  INTENT(IN)  :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)  :: ILO,    IHI
-    INTEGER, INTENT(IN)  :: JULO,   JHI
+    INTEGER,  INTENT(IN)  :: ILO,    IHI
+    INTEGER,  INTENT(IN)  :: JULO,   JHI
 
     ! ILONG ??
-    INTEGER, INTENT(IN)  :: ilong
+    INTEGER,  INTENT(IN)  :: ilong
 
     ! Controls various options in N-S advection
-    INTEGER, INTENT(IN)  :: jlmt
+    INTEGER,  INTENT(IN)  :: jlmt
 
     ! Courant number in N-S direction
-    REAL(fp),  INTENT(IN)  :: cry(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: cry(ILO:IHI, JULO:JHI)
 
     ! Slope of concentration distribution in N-S direction [mixing ratio]
-    REAL(fp),  INTENT(IN)  :: dcy(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: dcy(ILO:IHI, JULO:JHI)
 
     ! Concentration contribution from E-W advection [mixing ratio]
-    REAL(fp),  INTENT(IN)  :: qqu(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)  :: qqu(ILO:IHI, JULO:JHI)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Concentration contribution from N-S advection [mixing ratio]
-    REAL(fp),  INTENT(OUT) :: qqv(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(OUT) :: qqv(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -4958,20 +5042,20 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: ijm1
-    INTEGER :: il, ij
-    INTEGER :: lenx
-    REAL(fp)  :: r13, r23
+    INTEGER  :: ijm1
+    INTEGER  :: il, ij
+    INTEGER  :: lenx
+    REAL(fp) :: r13, r23
 
     ! Arrays
-    REAL(fp)  :: a61 (ilong*((JHI-1)-(JULO+1)+1))
-    REAL(fp)  :: al1 (ilong*((JHI-1)-(JULO+1)+1))
-    REAL(fp)  :: ar1 (ilong*((JHI-1)-(JULO+1)+1))
-    REAL(fp)  :: dcy1(ilong*((JHI-1)-(JULO+1)+1))
-    REAL(fp)  :: qqu1(ilong*((JHI-1)-(JULO+1)+1))
-    REAL(fp)  :: a6(ILO:IHI, JULO:JHI)
-    REAL(fp)  :: al(ILO:IHI, JULO:JHI)
-    REAL(fp)  :: ar(ILO:IHI, JULO:JHI)
+    REAL(fp) :: a61 (ilong*((JHI-1)-(JULO+1)+1))
+    REAL(fp) :: al1 (ilong*((JHI-1)-(JULO+1)+1))
+    REAL(fp) :: ar1 (ilong*((JHI-1)-(JULO+1)+1))
+    REAL(fp) :: dcy1(ilong*((JHI-1)-(JULO+1)+1))
+    REAL(fp) :: qqu1(ilong*((JHI-1)-(JULO+1)+1))
+    REAL(fp) :: a6(ILO:IHI, JULO:JHI)
+    REAL(fp) :: al(ILO:IHI, JULO:JHI)
+    REAL(fp) :: ar(ILO:IHI, JULO:JHI)
 
     ! NOTE: The code was writtein with I1:I2 as the first dimension of AL,
     ! AR, A6, AL1, A61, AR1.  However, the limits should really should be
@@ -4984,16 +5068,26 @@ CONTAINS
 !   Begin execution.
 !   ----------------
 
-    a6(:,:) = 0.0e+0_fp; al(:,:) = 0.0e+0_fp; ar(:,:) = 0.0e+0_fp
+    ! Zero output argument for safety's sake
+    qqv  = 0.0_fp
 
-
-    r13 = 1.0e+0_fp / 3.0e+0_fp
-    r23 = 2.0e+0_fp / 3.0e+0_fp
+    ! Zero/initialize local variables for safety's sake
+    lenx = 0
+    a61  = 0.0_fp
+    al1  = 0.0_fp
+    ar1  = 0.0_fp
+    dcy1 = 0.0_fp
+    qqu1 = 0.0_fp
+    a6   = 0.0_fp
+    al   = 0.0_fp
+    ar   = 0.0_fp
+    r13  = 1.0_fp / 3.0_fp
+    r23  = 2.0_fp / 3.0_fp
 
     do ij = julo+1, jhi
     do il = ilo,    ihi
        al(il,ij) =  &
-            0.5e+0_fp * (qqu(il,ij-1) + qqu(il,ij)) +  &
+            0.5_fp * (qqu(il,ij-1) + qqu(il,ij)) +  &
             (dcy(il,ij-1) - dcy(il,ij)) * r13
        ar(il,ij-1) = al(il,ij)
     end do
@@ -5010,7 +5104,7 @@ CONTAINS
     do il = ilo,    ihi
 
        a6(il,ij) =  &
-            3.0e+0_fp *  &
+            3.0_fp *  &
             (qqu(il,ij) + qqu(il,ij) -  &
             (al(il,ij) + ar(il,ij)))
 
@@ -5067,21 +5161,21 @@ CONTAINS
 
           do il = ilo, ihi
 
-             if (cry(il,ij) > 0.0e+0_fp) then
+             if (cry(il,ij) > 0.0_fp) then
 
                 qqv(il,ij) =  &
                      ar(il,ijm1) +  &
-                     0.5e+0_fp * cry(il,ij) *  &
+                     0.5_fp * cry(il,ij) *  &
                      (al(il,ijm1) - ar(il,ijm1) +  &
-                     (a6(il,ijm1) * (1.0e+0_fp - (r23 * cry(il,ij)))))
+                     (a6(il,ijm1) * (1.0_fp - (r23 * cry(il,ij)))))
 
              else
 
                 qqv(il,ij) =  &
                      al(il,ij) -  &
-                     0.5e+0_fp * cry(il,ij) *  &
+                     0.5_fp * cry(il,ij) *  &
                      (ar(il,ij) - al(il,ij) +  &
-                     (a6(il,ij) * (1.0e+0_fp + (r23 * cry(il,ij)))))
+                     (a6(il,ij) * (1.0_fp + (r23 * cry(il,ij)))))
 
              end if
 
@@ -5112,22 +5206,22 @@ CONTAINS
 ! !INPUT PARAMETERS:
 !
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)    :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)    :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)    :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)    :: I1,     I2
-    INTEGER, INTENT(IN)    :: JU1,    J2
+    INTEGER,  INTENT(IN)    :: I1,     I2
+    INTEGER,  INTENT(IN)    :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: ILO,    IHI
-    INTEGER, INTENT(IN)    :: JULO,   JHI
+    INTEGER,  INTENT(IN)    :: ILO,    IHI
+    INTEGER,  INTENT(IN)    :: JULO,   JHI
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Left (al) and right (ar) edge values of the test parabola
-    REAL(fp),  INTENT(INOUT) :: al(ILO:IHI, JULO:JHI)
-    REAL(fp),  INTENT(INOUT) :: ar(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(INOUT) :: al(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(INOUT) :: ar(ILO:IHI, JULO:JHI)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -5190,33 +5284,33 @@ CONTAINS
     ! Global latitude indices at the edges of the S/N polar caps
     ! J1P=JU1_GL+1; J2P=J2_GL-1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2; J2P=J2_GL-2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)    :: J1P,    J2P
+    INTEGER,  INTENT(IN)    :: J1P,    J2P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: I1_GL,  I2_GL
-    INTEGER, INTENT(IN)    :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)    :: I1_GL,  I2_GL
+    INTEGER,  INTENT(IN)    :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)    :: I1,     I2
-    INTEGER, INTENT(IN)    :: JU1,    J2
+    INTEGER,  INTENT(IN)    :: I1,     I2
+    INTEGER,  INTENT(IN)    :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: ILO,    IHI
-    INTEGER, INTENT(IN)    :: JULO,   JHI
+    INTEGER,  INTENT(IN)    :: ILO,    IHI
+    INTEGER,  INTENT(IN)    :: JULO,   JHI
 
     ! Special geometrical factor (geofac) for Polar cap
-    REAL(fp),  INTENT(IN)    :: geofac_pc
+    REAL(fp), INTENT(IN)    :: geofac_pc
 
     ! Concentration contribution from N-S advection [mixing ratio]
-    REAL(fp),  INTENT(IN)    :: qqv(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(IN)    :: qqv(ILO:IHI, JULO:JHI)
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
     ! Species density [hPa]
-    REAL(fp),  INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI)
+    REAL(fp), INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI)
 
     ! N-S mass flux [mixing ratio]
-    REAL(fp),  INTENT(INOUT) :: fy (ILO:IHI, JULO:JHI+1)
+    REAL(fp), INTENT(INOUT) :: fy (ILO:IHI, JULO:JHI+1)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -5235,30 +5329,30 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: il, ik
-    REAL(fp)  :: ri2
+    INTEGER  :: il, ik
+    REAL(fp) :: ri2
+    REAL(fp) :: dq_np
+    REAL(fp) :: dq_sp
+    REAL(fp) :: sumnp
+    REAL(fp) :: sumsp
 
     ! Arrays
-    REAL(fp)  :: dq_np
-    REAL(fp)  :: dq_sp
-    REAL(fp)  :: dqik(2)  ! 2 elements array for each pole value.
-    REAL(fp)  :: sumnp
-    REAL(fp)  :: sumsp
-
+    REAL(fp) :: dqik(2)  ! 2 elements array for each pole value.
 
 !   ----------------
 !   Begin execution.
 !   ----------------
 
-    ri2 = i2_gl
-
-    dqik(:) = 0.0e+0_fp
+    ! Zero/initialize local variables for safety's sake
+    dq_np = 0.0_fp
+    dq_sp = 0.0_fp
+    sumnp = 0.0_fp
+    sumsp = 0.0_fp
+    dqik  = 0.0_fp
+    ri2   = i2_gl
 
 
 !... Integrate N-S flux around polar cap lat circle for each level
-
-          sumsp = 0.0e+0_fp
-          sumnp = 0.0e+0_fp
 
           do il = i1, i2
              sumsp = sumsp + qqv(il,j1p)
@@ -5332,46 +5426,46 @@ CONTAINS
     ! Global latitude index at the edges of the South polar cap
     ! J1P=JU1_GL+1 for a polar cap of 1 latitude band
     ! J1P=JU1_GL+2 for a polar cap of 2 latitude bands
-    INTEGER, INTENT(IN)    :: J1P
+    INTEGER,  INTENT(IN)    :: J1P
 
     ! Global min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: JU1_GL, J2_GL
+    INTEGER,  INTENT(IN)    :: JU1_GL, J2_GL
 
     ! Local min & max longitude (I), latitude (J), altitude (K) indices
-    INTEGER, INTENT(IN)    :: I1,     I2
-    INTEGER, INTENT(IN)    :: JU1,    J2
-    INTEGER, INTENT(IN)    :: K1,     K2
+    INTEGER,  INTENT(IN)    :: I1,     I2
+    INTEGER,  INTENT(IN)    :: JU1,    J2
+    INTEGER,  INTENT(IN)    :: K1,     K2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)    :: ILO,    IHI
-    INTEGER, INTENT(IN)    :: JULO,   JHI
+    INTEGER,  INTENT(IN)    :: ILO,    IHI
+    INTEGER,  INTENT(IN)    :: JULO,   JHI
 
     ! Dimensions in longitude & altitude ???
-    INTEGER, INTENT(IN)    :: ilong,  ivert
+    INTEGER,  INTENT(IN)    :: ilong,  ivert
 
     ! Controls various options in vertical advection
-    INTEGER, INTENT(IN)    :: klmt
+    INTEGER,  INTENT(IN)    :: klmt
 
     ! Pressure thickness, the pseudo-density in a
     ! hydrostatic system at t1 [hPa]
-    REAL(fp),  INTENT(IN)    :: delp1(ILO:IHI, JULO:JHI, K1:K2)
+    REAL(fp), INTENT(IN)    :: delp1(ILO:IHI, JULO:JHI, K1:K2)
 
     ! Large scale mass flux (per time step tdt) in the vertical
     ! direction as diagnosed from the hydrostatic relationship [hPa]
-    REAL(fp),  INTENT(IN)    :: wz(I1:I2, JU1:J2, K1:K2)
+    REAL(fp), INTENT(IN)    :: wz(I1:I2, JU1:J2, K1:K2)
 
     ! Species concentration [mixing ratio]
-    REAL(fp),  INTENT(IN)    :: qq1(:,:,:)
+    REAL(fp), INTENT(IN)    :: qq1(:,:,:)
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
     ! Species density [hPa]
-    REAL(fp),  INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI, K1:K2)
+    REAL(fp), INTENT(INOUT) :: dq1(ILO:IHI, JULO:JHI, K1:K2)
 !
 ! !OUTPUT PARAMETERS:
 !
     ! Vertical flux [mixing ratio]
-    REAL(fp),  INTENT(OUT)   :: fz(ILO:IHI, JULO:JHI,  K1:K2)
+    REAL(fp), INTENT(OUT)   :: fz(ILO:IHI, JULO:JHI,  K1:K2)
 !
 ! !AUTHOR:
 !   Original code from Shian-Jiann Lin, DAO
@@ -5390,10 +5484,10 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: il, ij, ik
-    INTEGER :: k1p1, k1p2
-    INTEGER :: k2m1, k2m2
-    INTEGER :: lenx
+    INTEGER   :: il, ij, ik
+    INTEGER   :: k1p1, k1p2
+    INTEGER   :: k2m1, k2m2
+    INTEGER   :: lenx
     REAL(fp)  :: a1, a2
     REAL(fp)  :: aa, bb
     REAL(fp)  :: c0, c1, c2
@@ -5422,29 +5516,34 @@ CONTAINS
     ! Work array
     REAL(fp)  :: dpi(I1:I2, JU1:J2, K1:K2)
 
-
-
 !     ----------------
 !     Begin execution.
 !     ----------------
 
-    a6(:,:) = 0.0e+0_fp
-    al(:,:) = 0.0e+0_fp
-    ar(:,:) = 0.0e+0_fp
-    dc(:,:,:) = 0.0e+0_fp
-!.sds... diagnostic vertical flux for species - set top to 0.0
-    fz(:,:,:) = 0.0
+    ! Zero output arguent for safety's sake
+    fz    = 0.0_fp
 
-
-    k1p1 = k1 + 1
-    k1p2 = k1 + 2
-
-    k2m1 = k2 - 1
-    k2m2 = k2 - 2
-
-    r13  = 1.0e+0_fp / 3.0e+0_fp
-    r23  = 2.0e+0_fp / 3.0e+0_fp
-
+    ! Zero/initialize local variables for safety's sake
+    a61   = 0.0_fp
+    al1   = 0.0_fp
+    ar1   = 0.0_fp
+    dca1  = 0.0_fp
+    qq1a1 = 0.0_fp
+    a6    = 0.0_fp
+    al    = 0.0_fp
+    ar    = 0.0_fp
+    dca   = 0.0_fp
+    dlp1a = 0.0_fp
+    qq1a  = 0.0_fp
+    wza   = 0.0_fp
+    dc    = 0.0_fp
+    dpi   = 0.0_fp
+    k1p1  = k1     + 1
+    k1p2  = k1     + 2
+    k2m1  = k2     - 1
+    k2m2  = k2     - 2
+    r13   = 1.0_fp / 3.0_fp
+    r23   = 2.0_fp / 3.0_fp
 
 !   -------------------
 !   Compute dc for PPM.
@@ -5464,10 +5563,10 @@ CONTAINS
                   (delp1(il,ij,ik-1) + delp1(il,ij,ik) +  &
                   delp1(il,ij,ik+1))
 
-             c1 = (delp1(il,ij,ik-1) + (0.5e+0_fp * delp1(il,ij,ik))) /  &
+             c1 = (delp1(il,ij,ik-1) + (0.5_fp * delp1(il,ij,ik))) /  &
                   (delp1(il,ij,ik+1) + delp1(il,ij,ik))
 
-             c2 = (delp1(il,ij,ik+1) + (0.5e+0_fp * delp1(il,ij,ik))) /  &
+             c2 = (delp1(il,ij,ik+1) + (0.5_fp * delp1(il,ij,ik))) /  &
                   (delp1(il,ij,ik-1) + delp1(il,ij,ik))
 
              tmp = c0 *  &
@@ -5544,16 +5643,16 @@ CONTAINS
           fac2 = (dlp1a(il,k1p1) + dlp1a(il,k1p2)) *  &
                  (dlp1a(il,k1) + dlp1a(il,k1p1) + dlp1a(il,k1p2))
 
-          aa = 3.0e+0_fp * fac1 / fac2
+          aa = 3.0_fp * fac1 / fac2
 
           bb =  &
-               2.0e+0_fp * dpi(il,ij,k1) / (dlp1a(il,k1) + dlp1a(il,k1p1)) -  &
-               r23 * aa * (2.0e+0_fp * dlp1a(il,k1) + dlp1a(il,k1p1))
+               2.0_fp * dpi(il,ij,k1) / (dlp1a(il,k1) + dlp1a(il,k1p1)) -  &
+               r23 * aa * (2.0_fp * dlp1a(il,k1) + dlp1a(il,k1p1))
 
           al(il,k1) = qq1a(il,k1) -  &
                dlp1a(il,k1) *  &
                (r13 * aa * dlp1a(il,k1) +  &
-               0.5e+0_fp * bb)
+               0.5_fp * bb)
 
           al(il,k1p1) = dlp1a(il,k1) * (aa * dlp1a(il,k1) + bb) +  &
                al(il,k1)
@@ -5562,10 +5661,10 @@ CONTAINS
 !         Check if change sign.
 !         ---------------------
 
-          if ((qq1a(il,k1) * al(il,k1)) <= 0.0e+0_fp) then
+          if ((qq1a(il,k1) * al(il,k1)) <= 0.0_fp) then
 
-             al (il,k1) = 0.0e+0_fp
-             dca(il,k1) = 0.0e+0_fp
+             al (il,k1) = 0.0_fp
+             dca(il,k1) = 0.0_fp
 
           else
 
@@ -5587,13 +5686,13 @@ CONTAINS
 
           fac1 = dpi(il,ij,k2m1) * (dlp1a(il,k2) * dlp1a(il,k2)) /  &
                  ((dlp1a(il,k2) + dlp1a(il,k2m1)) *  &
-                 (2.0e+0_fp * dlp1a(il,k2) + dlp1a(il,k2m1)))
+                 (2.0_fp * dlp1a(il,k2) + dlp1a(il,k2m1)))
 
           ar(il,k2) = qq1a(il,k2) + fac1
           al(il,k2) = qq1a(il,k2) - (fac1 + fac1)
 
-          if ((qq1a(il,k2) * ar(il,k2)) <= 0.0e+0_fp) then
-             ar(il,k2) = 0.0e+0_fp
+          if ((qq1a(il,k2) * ar(il,k2)) <= 0.0_fp) then
+             ar(il,k2) = 0.0_fp
           end if
 
           dca(il,k2) = ar(il,k2) - qq1a(il,k2)
@@ -5611,15 +5710,15 @@ CONTAINS
              c1 = (dpi(il,ij,ik-1) * dlp1a(il,ik-1)) /  &
                   (dlp1a(il,ik-1) + dlp1a(il,ik))
 
-             c2 = 2.0e+0_fp /  &
+             c2 = 2.0_fp /  &
                   (dlp1a(il,ik-2) + dlp1a(il,ik-1) +  &
                   dlp1a(il,ik)   + dlp1a(il,ik+1))
 
              a1 = (dlp1a(il,ik-2) + dlp1a(il,ik-1)) /  &
-                  (2.0e+0_fp * dlp1a(il,ik-1) + dlp1a(il,ik))
+                  (2.0_fp * dlp1a(il,ik-1) + dlp1a(il,ik))
 
              a2 = (dlp1a(il,ik) + dlp1a(il,ik+1)) /  &
-                  (2.0e+0_fp * dlp1a(il,ik) + dlp1a(il,ik-1))
+                  (2.0_fp * dlp1a(il,ik) + dlp1a(il,ik-1))
 
              al(il,ik) =  &
                   qq1a(il,ik-1) + c1 +  &
@@ -5647,7 +5746,7 @@ CONTAINS
           do il = i1, i2
 
              a6(il,ik) =  &
-                  3.0e+0_fp * (qq1a(il,ik) + qq1a(il,ik) -  &
+                  3.0_fp * (qq1a(il,ik) + qq1a(il,ik) -  &
                   (al(il,ik)  + ar(il,ik)))
           end do
 
@@ -5665,7 +5764,7 @@ CONTAINS
           do il = i1, i2
 
              a6(il,ik) =  &
-                  3.0e+0_fp * (qq1a(il,ik) + qq1a(il,ik) -  &
+                  3.0_fp * (qq1a(il,ik) + qq1a(il,ik) -  &
                   (al(il,ik)  + ar(il,ik)))
           end do
 
@@ -5704,9 +5803,9 @@ CONTAINS
 !             Right edges.
 !             ------------
 
-                qmp   = qq1a(il,ik) + (2.0e+0_fp * dpi(il,ij,ik-1))
+                qmp   = qq1a(il,ik) + (2.0_fp * dpi(il,ij,ik-1))
                 lac   = qq1a(il,ik) +  &
-                     (1.5e+0_fp * dca(il,ik-1)) + (0.5e+0_fp * dpi(il,ij,ik-1))
+                     (1.5_fp * dca(il,ik-1)) + (0.5_fp * dpi(il,ij,ik-1))
                 qmin  = Min (qq1a(il,ik), qmp, lac)
                 qmax  = Max (qq1a(il,ik), qmp, lac)
 
@@ -5716,9 +5815,9 @@ CONTAINS
 !             Left edges.
 !             -----------
 
-                qmp   = qq1a(il,ik) - (2.0e+0_fp * dpi(il,ij,ik))
+                qmp   = qq1a(il,ik) - (2.0_fp * dpi(il,ij,ik))
                 lac   = qq1a(il,ik) +  &
-                        (1.5e+0_fp * dca(il,ik+1)) - (0.5e+0_fp * dpi(il,ij,ik))
+                        (1.5_fp * dca(il,ik+1)) - (0.5_fp * dpi(il,ij,ik))
                 qmin  = Min (qq1a(il,ik), qmp, lac)
                 qmax  = Max (qq1a(il,ik), qmp, lac)
 
@@ -5729,7 +5828,7 @@ CONTAINS
 !             -------------
 
                 a6(il,ik) =  &
-                     3.0e+0_fp * (qq1a(il,ik) + qq1a(il,ik) -  &
+                     3.0_fp * (qq1a(il,ik) + qq1a(il,ik) -  &
                      (ar(il,ik)  + al(il,ik)))
              end do
           end do
@@ -5751,7 +5850,7 @@ CONTAINS
                 dca1 (lenx) = dca (il,ik)
                 qq1a1(lenx) = qq1a(il,ik)
 
-                a61  (lenx) = 3.0e+0_fp * (qq1a1(lenx) + qq1a1(lenx) -  &
+                a61  (lenx) = 3.0_fp * (qq1a1(lenx) + qq1a1(lenx) -  &
                              (al1(lenx)  + ar1(lenx)))
              end do
           end do
@@ -5784,15 +5883,15 @@ CONTAINS
        do ik = k1, k2m1
           do il = i1, i2
 
-             if (wza(il,ik) > 0.0e+0_fp) then
+             if (wza(il,ik) > 0.0_fp) then
 
                 cm = wza(il,ik) / dlp1a(il,ik)
 
                 dca(il,ik+1) =  &
                      ar(il,ik) +  &
-                     0.5e+0_fp * cm *  &
+                     0.5_fp * cm *  &
                      (al(il,ik) - ar(il,ik) +  &
-                     a6(il,ik) * (1.0e+0_fp - r23 * cm))
+                     a6(il,ik) * (1.0_fp - r23 * cm))
 
              else
 
@@ -5800,9 +5899,9 @@ CONTAINS
 
                 dca(il,ik+1) =  &
                      al(il,ik+1) +  &
-                     0.5e+0_fp * cp *  &
+                     0.5_fp * cp *  &
                      (al(il,ik+1) - ar(il,ik+1) -  &
-                     a6(il,ik+1) * (1.0e+0_fp + r23 * cp))
+                     a6(il,ik+1) * (1.0_fp + r23 * cp))
 
              end if
 
@@ -5858,15 +5957,15 @@ CONTAINS
 ! !INPUT PARAMETERS:
 !
     ! Local min & max longitude (I), latitude (J)
-    INTEGER, INTENT(IN)   :: I1,     I2
-    INTEGER, INTENT(IN)   :: JU1,    J2
+    INTEGER,  INTENT(IN)   :: I1,     I2
+    INTEGER,  INTENT(IN)   :: JU1,    J2
 
     ! Local min & max longitude (I) and latitude (J) indices
-    INTEGER, INTENT(IN)   :: ILO,    IHI
-    INTEGER, INTENT(IN)   :: JULO,   JHI
+    INTEGER,  INTENT(IN)   :: ILO,    IHI
+    INTEGER,  INTENT(IN)   :: JULO,   JHI
 
     ! Surface area of grid box
-    REAL(fp),  INTENT(IN)   :: AREA_1D(JU1:J2)
+    REAL(fp), INTENT(IN)   :: AREA_1D(JU1:J2)
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -5893,7 +5992,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    INTEGER :: I, J
+    INTEGER   :: I, J
     REAL(fp)  :: meanp
     REAL(fp)  :: REL_AREA(JU1:J2)
     REAL(fp)  :: SUM_AREA
@@ -5918,7 +6017,7 @@ CONTAINS
     SUM_AREA = SUM( rel_area( JU1:JU1+1 ) ) * DBLE( I2 )
 
     ! Zero
-    meanp = 0.e+0_fp
+    meanp = 0.0_fp
 
     ! Sum pressure * surface area over the S. Polar cap
     DO J = JU1, JU1+1
@@ -5938,7 +6037,7 @@ CONTAINS
     SUM_AREA = SUM( rel_area( J2-1:J2 ) ) * DBLE( I2 )
 
     ! Zero
-    meanp = 0.e+0_fp
+    meanp = 0.0_fp
 
     ! Sum pressure * surface area over the N. Polar cap
     DO J = J2-1, J2

--- a/GeosCore/vdiff_mod.F90
+++ b/GeosCore/vdiff_mod.F90
@@ -1126,7 +1126,7 @@ CONTAINS
              zp(i) = pblh(i)
           end if
           if( zm(i) < pblh(i) ) then
-             zmzp = 0.5e_fp*(zm(i) + zp(i))
+             zmzp = 0.5_fp*(zm(i) + zp(i))
              zh(i) = zmzp/pblh(i)
              zl(i) = zmzp/obklen(i)
              if( zh(i) <= 1.0_fp ) then

--- a/GeosCore/vdiff_mod.F90
+++ b/GeosCore/vdiff_mod.F90
@@ -52,7 +52,7 @@ MODULE Vdiff_Mod
   REAL(fp), PARAMETER   :: rh2o   = Rv
   REAL(fp), PARAMETER   :: g      = G0
   REAL(fp), PARAMETER   :: gravit = g0
-  REAL(fp), PARAMETER   :: zvir   = rh2o/rair - 1 !.0_fp
+  REAL(fp), PARAMETER   :: zvir   = rh2o/rair - 1.0_fp
   REAL(fp), PARAMETER   :: cappa  = Rd/cpair
   REAL(fp), PARAMETER   :: r_g    = Rdg0
 
@@ -64,8 +64,8 @@ MODULE Vdiff_Mod
   REAL(fp), PARAMETER   :: fakn   = 7.20_fp  ! For turbulent prandtl number
   REAL(fp), PARAMETER   :: ricr   = 0.3_fp   ! For critical richardson number
   REAL(fp), PARAMETER   :: sffrac = 0.1_fp   ! For surface layer fraction of BL
-  REAL(fp), PARAMETER   :: vk     = VON_KARMAN 
-  
+  REAL(fp), PARAMETER   :: vk     = VON_KARMAN
+
   ! Derived constants
   REAL(fp), PARAMETER   :: ccon   = fak    * sffrac * vk
   REAL(fp), PARAMETER   :: binm   = betam  * sffrac
@@ -73,9 +73,9 @@ MODULE Vdiff_Mod
   REAL(fp), PARAMETER   :: onet   = 1.0_fp / 3.0_fp
 
   ! Options
-  LOGICAL,  PARAMETER   :: divdiff = .TRUE. 
+  LOGICAL,  PARAMETER   :: divdiff = .TRUE.
   LOGICAL,  PARAMETER   :: arvdiff = .FALSE.
-  LOGICAL,  PARAMETER   :: pblh_ar = .true.
+  LOGICAL,  PARAMETER   :: pblh_ar = .TRUE.
 !
 ! !PRIVATE DATA MEMBERS:
 !
@@ -83,7 +83,7 @@ MODULE Vdiff_Mod
   INTEGER               :: nspcmix           ! # of species for mixing
   INTEGER               :: plev              ! # of levels
   INTEGER               :: plevp             ! # of level edges
-  INTEGER               :: ntopfl            ! top level to which vertical 
+  INTEGER               :: ntopfl            ! top level to which vertical
                                              !  diffusion is applied.
   INTEGER               :: npbl              ! max # of levels in pbl
   REAL(fp)              :: zkmin             ! minimum kneutral*f(ri)
@@ -287,36 +287,64 @@ CONTAINS
     ! Assume success
     RC = GC_SUCCESS
 
-    ! Initialize
+    ! Zero/initialize local variables for safety's sake
+    indx     = 0
+    adjust   = .FALSE.
     sum_qp0  = 0.0_fp
     sum_qp1  = 0.0_fp
+    cah      = 0.0_fp
+    cam      = 0.0_fp
+    cch      = 0.0_fp
+    ccm      = 0.0_fp
+    cgh      = 0.0_fp
+    cgq      = 0.0_fp
+    cgs      = 0.0_fp
+    cgsh     = 0.0_fp
+    kvf      = 0.0_fp
+    potbar   = 0.0_fp
+    tmp1     = 0.0_fp
+    dubot    = 0.0_fp
+    dvbot    = 0.0_fp
+    dtbot    = 0.0_fp
+    dqbot    = 0.0_fp
+    dshbot   = 0.0_fp
+    thx      = 0.0_fp
+    thv      = 0.0_fp
+    qmx      = 0.0_fp
+    shmx     = 0.0_fp
+    zeh      = 0.0_fp
+    zem      = 0.0_fp
+    termh    = 0.0_fp
+    termm    = 0.0_fp
+    taux     = 0.0_fp
+    tauy     = 0.0_fp
+    ustar    = 0.0_fp
+    qp0      = 0.0_fp
+    um1      = uwnd(:,lat,:)
+    vm1      = vwnd(:,lat,:)
+    tm1      = tadv(:,lat,:)
+    pmidm1   = pmid(:,lat,:)
+    pintm1   = pint(:,lat,:)
+    rpdel    = rpdel_arg(:,lat,:)
+    rpdeli   = rpdeli_arg(:,lat,:)
+    zm       = zm_arg(:,lat,:)
+    shflx    = shflx_arg(:,lat)
+    cflx     = sflx(:,lat,:)
+    wvflx    = wvflx_arg(:,lat)
+    qp1      = as2(:,lat,:,:)
+    qp0      = as2(:,lat,:,:)
+    shp1     = shp(:,lat,:)
+    thp      = thp_arg(:,lat,:)
+    kvh      = kvh_arg(:,lat,:)
+    kvm      = kvm_arg(:,lat,:)
+    tpert    = tpert_arg(:,lat)
+    qpert    = qpert_arg(:,lat)
+    cgs      = cgs_arg(:,lat,:)
+    pblh     = pblh_arg(:,lat)
 
     !### Debug
     IF ( prtDebug .and. ip < 5 .and. lat < 5 ) &
          CALL DEBUG_MSG( '### VDIFF: vdiff begins' )
-
-    !Populate local variables with values from arguments.(ccc, 11/17/09)
-    um1    = uwnd(:,lat,:)
-    vm1    = vwnd(:,lat,:)
-    tm1    = tadv(:,lat,:)
-    pmidm1 = pmid(:,lat,:)
-    pintm1 = pint(:,lat,:)
-    rpdel  = rpdel_arg(:,lat,:)
-    rpdeli = rpdeli_arg(:,lat,:)
-    zm     = zm_arg(:,lat,:)
-    shflx  = shflx_arg(:,lat)
-    cflx   = sflx(:,lat,:)
-    wvflx  = wvflx_arg(:,lat)
-    qp1    = as2(:,lat,:,:)
-    qp0    = as2(:,lat,:,:)
-    shp1   = shp(:,lat,:)
-    thp    = thp_arg(:,lat,:)
-    kvh    = kvh_arg(:,lat,:)
-    kvm    = kvm_arg(:,lat,:)
-    tpert  = tpert_arg(:,lat)
-    qpert  = qpert_arg(:,lat)
-    cgs    = cgs_arg(:,lat,:)
-    pblh   = pblh_arg(:,lat)
 
     IF (PRESENT(taux_arg )) taux  = taux_arg(:,lat)
     IF (PRESENT(tauy_arg )) tauy  = tauy_arg(:,lat)
@@ -325,7 +353,7 @@ CONTAINS
 !-----------------------------------------------------------------------
 ! 	... convert the surface fluxes to lowest level tendencies
 !-----------------------------------------------------------------------
-    rcpair = 1.e+0_fp/cpair
+    rcpair = 1.0_fp/cpair
     do i = 1,plonl
        tmp1(i)      = ztodt*gravit*rpdel(i,plev)
        ! simplified treatment -- dubot and dvbot are not used under current PBL scheme, anyway
@@ -336,7 +364,7 @@ CONTAINS
        endif
        dshbot(i)    = wvflx(i)*tmp1(i)
        dtbot(i)     = shflx(i)*tmp1(i)*rcpair
-       kvf(i,plevp) = 0.e+0_fp
+       kvf(i,plevp) = 0.0_fp
     end do
     do m = 1,nspcmix
        dqbot(:plonl,m) = cflx(:plonl,m)*tmp1(:plonl)
@@ -350,7 +378,7 @@ CONTAINS
 ! 	... set the vertical diffusion coefficient above the top diffusion level
 !-----------------------------------------------------------------------
     do k = 1,ntopfl
-       kvf(:plonl,k) = 0.e+0_fp
+       kvf(:plonl,k) = 0.0_fp
     end do
 
 !-----------------------------------------------------------------------
@@ -385,19 +413,19 @@ CONTAINS
 !-----------------------------------------------------------------------
 ! 	... static stability (use virtual potential temperature)
 !-----------------------------------------------------------------------
-          sstab = gravit*2.e+0_fp*(thv(i,k) - thv(i,k+1))/((thv(i,k) &
+          sstab = gravit*2.0_fp*(thv(i,k) - thv(i,k+1))/((thv(i,k) &
                  + thv(i,k+1))*dz)
 !-----------------------------------------------------------------------
 ! 	... richardson number, stable and unstable modifying functions
 !-----------------------------------------------------------------------
           rinub = sstab/dvdz2
-          fstab = 1.0e+0_fp/(1.0e+0_fp + 10.0e+0_fp*rinub*(1.0e+0_fp &
-                 + 8.0e+0_fp*rinub))
-          funst = max( 1.e+0_fp - 18.e+0_fp*rinub,0.e+0_fp )
+          fstab = 1.0_fp/(1.0_fp + 10.0_fp*rinub*(1.0_fp &
+                                 + 8.0_fp*rinub))
+          funst = max( 1.0_fp - 18.0_fp*rinub,0.0_fp )
 !-----------------------------------------------------------------------
 ! 	... select the appropriate function of the richardson number
 !-----------------------------------------------------------------------
-          if( rinub < 0.e+0_fp ) then
+          if( rinub < 0.0_fp ) then
              fstab = sqrt( funst )
           end if
 !-----------------------------------------------------------------------
@@ -467,7 +495,7 @@ CONTAINS
     end do
     do k = 2,plev
        do i = 1,plonl
-          potbar(i,k) = pintm1(i,k)/(.5e+0_fp*(tm1(i,k) + tm1(i,k-1)))
+          potbar(i,k) = pintm1(i,k)/(0.5_fp*(tm1(i,k) + tm1(i,k-1)))
        end do
     end do
     do i = 1,plonl
@@ -537,7 +565,7 @@ CONTAINS
 !-----------------------------------------------------------------------
 ! 	... 1.e-12 is the value of qmin (=qmincg) used in ccm2.
 !-----------------------------------------------------------------------
-          if( shmx(i,k) < 1.d-12 ) then
+          if( shmx(i,k) < 1.0e-12_fp ) then
              adjust(i) = .true.
           end if
        end do
@@ -579,8 +607,8 @@ CONTAINS
 ! 	... the last element of the upper diagonal is zero.
 !-----------------------------------------------------------------------
     do i = 1,plonl
-       cah(i,plev) = 0.e+0_fp
-       cam(i,plev) = 0.e+0_fp
+       cah(i,plev) = 0.0_fp
+       cam(i,plev) = 0.0_fp
     end do
 
 !-----------------------------------------------------------------------
@@ -588,17 +616,22 @@ CONTAINS
 !           required in solution of tridiagonal matrix defined by implicit diffusion eqn.
 !-----------------------------------------------------------------------
     do i = 1,plonl
-       termh(i,ntopfl) = 1.e+0_fp/(1.e+0_fp + cah(i,ntopfl))
-       termm(i,ntopfl) = 1.e+0_fp/(1.e+0_fp + cam(i,ntopfl))
+       termh(i,ntopfl) = 1.0_fp/(1.0_fp + cah(i,ntopfl))
+       termm(i,ntopfl) = 1.0_fp/(1.0_fp + cam(i,ntopfl))
        zeh(i,ntopfl)   = cah(i,ntopfl)*termh(i,ntopfl)
        zem(i,ntopfl)   = cam(i,ntopfl)*termm(i,ntopfl)
     end do
     do k = ntopfl+1,plev-1
        do i = 1,plonl
-          termh(i,k) = 1.e+0_fp/(1.e+0_fp + cah(i,k) + cch(i,k) &
-                      - cch(i,k)*zeh(i,k-1))
-          termm(i,k) = 1.e+0_fp/(1.e+0_fp + cam(i,k) + ccm(i,k) &
-                      - ccm(i,k)*zem(i,k-1))
+! Suspect that these lines lead to numerical instability
+!         termh(i,k) = 1.e+0_fp/(1.e+0_fp + cah(i,k) + cch(i,k) &
+!                     - cch(i,k)*zeh(i,k-1))
+!         termm(i,k) = 1.e+0_fp/(1.e+0_fp + cam(i,k) + ccm(i,k) &
+!                     - ccm(i,k)*zem(i,k-1))
+          termh(i,k) =                                                       &
+            1.0_fp / ( 1.0_fp + cah(i,k) + cch(i,k)*( 1.0_fp - zeh(i,k-1) ) )
+          termm(i,k) =                                                       &
+            1.0_fp / ( 1.0_fp + cam(i,k) + ccm(i,k)*( 1.0_fp - zem(i,k-1) ) )
           zeh(i,k)   = cah(i,k)*termh(i,k)
           zem(i,k)   = cam(i,k)*termm(i,k)
        end do
@@ -620,8 +653,8 @@ CONTAINS
 !-----------------------------------------------------------------------
 !      call qneg3( 'vdiff   ', lat, qp1, plonl )
 ! just use a simplified treatment
-    where (qp1 < 0.e+0_fp)
-       qp1 = 0.e+0_fp
+    where (qp1 < 0.0_fp)
+       qp1 = 0.0_fp
     endwhere
 
 !-----------------------------------------------------------------------
@@ -664,7 +697,7 @@ CONTAINS
 !      call shneg( 'vdiff:sh', lat, shp1, plonl )
 ! just use a simplified treatment
     where (shp1 < 1.d-12)
-       shp1 = 0.e+0_fp
+       shp1 = 0.0_fp
     endwhere
 
 !-----------------------------------------------------------------------
@@ -772,7 +805,7 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    real(fp), parameter :: tiny = 1.e-36_fp      ! lower bound for wind magnitude
+    real(fp), parameter :: tiny = 1.0e-20_fp  !e-36    ! lower bound for wind magnitude
 
     integer :: &
          i, &                 ! longitude index
@@ -825,6 +858,39 @@ CONTAINS
     ! pbldif begins here!
     !=================================================================
 
+    ! Zero/initialize local variables if they are not initialized below
+    unstbl  = .FALSE.
+    stblev  = .FALSE.
+    unslev  = .FALSE.
+    unssrf  = .FALSE.
+    unsout  = .FALSE.
+    check   = .FALSE.
+    thvref  = 0.0_fp
+    tkv     = 0.0_fp
+    phiminv = 0.0_fp
+    phihinv = 0.0_fp
+    vvk     = 0.0_fp
+    zm      = 0.0_fp
+    zp      = 0.0_fp
+    khfs    = 0.0_fp
+    kqfs    = 0.0_fp
+    kshfs   = 0.0_fp
+    zmzp    = 0.0_fp
+    rino    = 0.0_fp
+    tlv     = 0.0_fp
+    fak1    = 0.0_fp
+    fak2    = 0.0_fp
+    pblk    = 0.0_fp
+    pr      = 0.0_fp
+    zl      = 0.0_fp
+    zzh     = 0.0_fp
+    wstr    = 0.0_fp
+    rrho    = 0.0_fp
+    ustr    = 0.0_fp
+    term    = 0.0_fp
+    fac     = 0.0_fp
+    pblmin  = 0.0_fp
+
 !------------------------------------------------------------------------
 ! 	... compute kinematic surface fluxes
 !------------------------------------------------------------------------
@@ -832,7 +898,7 @@ CONTAINS
        rrho(i)  = rair*t(i,plev)/pmid(i,plev)
        if (present(taux) .and. present(tauy)) then
           ustr     = sqrt( sqrt( taux(i)**2 + tauy(i)**2 )*rrho(i) )
-          ustar(i) = max( ustr,.01e+0_fp )
+          ustar(i) = max( ustr, 0.01_fp )
        endif
        khfs(i)  = shflx(i)*rrho(i)/cpair
        kshfs(i) = wvflx(i)*rrho(i)
@@ -847,13 +913,13 @@ CONTAINS
     do k = 1,plevp
        kvm(:,k)  = kvf(:,k)
        kvh(:,k)  = kvf(:,k)
-       cgh(:,k)  = 0.e+0_fp
-       cgsh(:,k) = 0.e+0_fp
-       cgs(:,k)  = 0.e+0_fp
+       cgh(:,k)  = 0.0_fp
+       cgsh(:,k) = 0.0_fp
+       cgs(:,k)  = 0.0_fp
     end do
     do m = 1,nspcmix
        do k = 1,plevp
-          cgq(:,k,m) = 0.e+0_fp
+          cgq(:,k,m) = 0.0_fp
        end do
     end do
 
@@ -861,27 +927,27 @@ CONTAINS
 ! 	... compute various arrays for use later:
 !------------------------------------------------------------------------
     do i = 1,plonl
-       thvsrf(i) = th(i,plev)*(1.0e+0_fp + 0.61e+0_fp*q(i,plev))
-       heatv(i)  = khfs(i) + 0.61e+0_fp*th(i,plev)*kshfs(i)
-       wm(i)     = 0.e+0_fp
-       therm(i)  = 0.e+0_fp
-       qpert(i)  = 0.e+0_fp
-       tpert(i)  = 0.e+0_fp
-       fak3(i)   = 0.e+0_fp
-       zh(i)     = 0.e+0_fp
+       thvsrf(i) = th(i,plev)*(1.0_fp + 0.61_fp*q(i,plev))
+       heatv(i)  = khfs(i) + 0.61_fp*th(i,plev)*kshfs(i)
+       wm(i)     = 0.0_fp
+       therm(i)  = 0.0_fp
+       qpert(i)  = 0.0_fp
+       tpert(i)  = 0.0_fp
+       fak3(i)   = 0.0_fp
+       zh(i)     = 0.0_fp
        obklen(i) = -thvsrf(i)*ustar(i)**3 &
-                   /(g*vk*(heatv(i) + sign( 1.d-10,heatv(i) )))
+                   /(g*vk*(heatv(i) + sign( 1.0e-10_fp, heatv(i) )))
     end do
 
     if (pblh_ar) then  ! use archived PBLH
 
        do i = 1,plonl
-          if( heatv(i) > 0.e+0_fp ) then
+          if( heatv(i) > 0.0_fp ) then
              unstbl(i) = .true.
           else
              unstbl(i) = .false.
           end if
-          thvref(i) = th(i,plev)*(1.0e+0_fp + 0.61e+0_fp*q(i,plev))
+          thvref(i) = th(i,plev)*(1.0_fp + 0.61_fp*q(i,plev))
        end do
 
     else ! use derived PBLH
@@ -891,16 +957,16 @@ CONTAINS
 !           calculate virtual potential temperature first level
 !           and initialize pbl height to z1
 !------------------------------------------------------------------------
-       fac = 100.
+       fac = 100.0_fp
        do i = 1,plonl
-          thvref(i) = th(i,plev)*(1.0e+0_fp + 0.61e+0_fp*q(i,plev))
+          thvref(i) = th(i,plev)*(1.0_fp + 0.61_fp*q(i,plev))
           pblh(i)   = z(i,plev)
           check(i)  = .true.
 !------------------------------------------------------------------------
 ! 	... initialization of lowest level ri number
 !           (neglected in initial holtslag implementation)
 !------------------------------------------------------------------------
-          rino(i,plev) = 0.e+0_fp
+          rino(i,plev) = 0.0_fp
        end do
 
 !------------------------------------------------------------------------
@@ -914,7 +980,7 @@ CONTAINS
                 vvk = (u(i,k) - u(i,plev))**2 + (v(i,k) - v(i,plev))**2 + &
                       fac*ustar(i)**2
                 vvk = max( vvk,tiny )
-                tkv = th(i,k)*(1. + .61e+0_fp*q(i,k))
+                tkv = th(i,k)*(1.0_fp + 0.61_fp*q(i,k))
                 rino(i,k) = g*(tkv - thvref(i))*(z(i,k)-z(i,plev))/ &
                             (thvref(i)*vvk)
                 if( rino(i,k) >= ricr ) then
@@ -942,7 +1008,7 @@ CONTAINS
 !           find unstable points (virtual heat flux is positive):
 !------------------------------------------------------------------------
        do i = 1,plonl
-          if( heatv(i) > 0.e+0_fp ) then
+          if( heatv(i) > 0.0_fp ) then
              unstbl(i) = .true.
              check(i)  = .true.
           else
@@ -957,10 +1023,10 @@ CONTAINS
 !------------------------------------------------------------------------
        do i = 1,plonl
           if( check(i) ) then
-             phiminv(i)   = (1.e+0_fp - binm*pblh(i)/obklen(i))**onet
+             phiminv(i)   = (1.0_fp - binm*pblh(i)/obklen(i))**onet
              wm(i)        = ustar(i)*phiminv(i)
              therm(i)     = heatv(i)*fak/wm(i)
-             rino(i,plev) = 0.e+0_fp
+             rino(i,plev) = 0.0_fp
              tlv(i)       = thvref(i) + therm(i)
           end if
        end do
@@ -975,7 +1041,7 @@ CONTAINS
                 vvk = (u(i,k) - u(i,plev))**2 + (v(i,k) - v(i,plev))**2 &
                       + fac*ustar(i)**2
                 vvk = max( vvk,tiny )
-                tkv = th(i,k)*(1. + 0.61e+0_fp*q(i,k))
+                tkv = th(i,k)*(1. + 0.61_fp*q(i,k))
                 rino(i,k) = g*(tkv - tlv(i))*(z(i,k)-z(i,plev)) &
                             /(thvref(i)*vvk)
                 if( rino(i,k) >= ricr ) then
@@ -1010,7 +1076,7 @@ CONTAINS
 ! latitude value for f so that c = 0.07/f = 700.
 !------------------------------------------------------------------------
        do i = 1,plonl
-          pblmin  = 700.e+0_fp*ustar(i)
+          pblmin  = 700.0_fp*ustar(i)
           pblh(i) = max( pblh(i),pblmin )
        end do
 
@@ -1020,24 +1086,24 @@ CONTAINS
 ! 	... pblh is now available; do preparation for diffusivity calculation:
 !------------------------------------------------------------------------
     do i = 1,plonl
-       pblk(i) = 0.e+0_fp
+       pblk(i) = 0.0_fp
        fak1(i) = ustar(i)*pblh(i)*vk
 !------------------------------------------------------------------------
 ! 	... do additional preparation for unstable cases only, set temperature
 !           and moisture perturbations depending on stability.
 !------------------------------------------------------------------------
        if( unstbl(i) ) then
-          phiminv(i) = (1.e+0_fp - binm*pblh(i)/obklen(i))**onet
-          phihinv(i) = sqrt(1.e+0_fp - binh*pblh(i)/obklen(i))
+          phiminv(i) = (1.0_fp - binm*pblh(i)/obklen(i))**onet
+          phihinv(i) = sqrt(1.0_fp - binh*pblh(i)/obklen(i))
           wm(i)      = ustar(i)*phiminv(i)
           fak2(i)    = wm(i)*pblh(i)*vk
           wstr(i)    = (heatv(i)*g*pblh(i)/thvref(i))**onet
           fak3(i)    = fakn*wstr(i)/wm(i)
-          tpert(i)   = max( khfs(i)*fak/wm(i),0.e+0_fp )
-          qpert(i)   = max( kshfs(i)*fak/wm(i),0.e+0_fp )
+          tpert(i)   = max( khfs(i)*fak/wm(i),0.0_fp )
+          qpert(i)   = max( kshfs(i)*fak/wm(i),0.0_fp )
        else
-          tpert(i)   = max( khfs(i)*fak/ustar(i),0.e+0_fp )
-          qpert(i)   = max( kshfs(i)*fak/ustar(i),0.e+0_fp )
+          tpert(i)   = max( khfs(i)*fak/ustar(i),0.0_fp )
+          qpert(i)   = max( kshfs(i)*fak/ustar(i),0.0_fp )
        end if
     end do
 
@@ -1053,17 +1119,20 @@ CONTAINS
           stblev(i) = .false.
           zm(i) = z(i,k)
           zp(i) = z(i,k-1)
-          if( zkmin == 0.e+0_fp .and. zp(i) > pblh(i) ) then
+! NOTE: Do not test for floating-point equality, which due to roundoff
+! may never occur. 
+!          if( zkmin == 0.0_fp .and. zp(i) > pblh(i) ) then
+          if ( ( .not. ABS( zkmin ) > 0.0_fp ) .and. ( zp(i) > pblh(i) ) ) then
              zp(i) = pblh(i)
           end if
           if( zm(i) < pblh(i) ) then
-             zmzp = 0.5e+0_fp*(zm(i) + zp(i))
+             zmzp = 0.5e_fp*(zm(i) + zp(i))
              zh(i) = zmzp/pblh(i)
              zl(i) = zmzp/obklen(i)
-             if( zh(i) <= 1.e+0_fp ) then
-                zzh(i) = (1.e+0_fp - zh(i))**2
+             if( zh(i) <= 1.0_fp ) then
+                zzh(i) = (1.0_fp - zh(i))**2
              else
-                zzh(i) = 0.e+0_fp
+                zzh(i) = 0.0_fp
              end if
 !------------------------------------------------------------------------
 ! 	... stblev for points zm < plbh and stable and neutral
@@ -1083,7 +1152,7 @@ CONTAINS
 !------------------------------------------------------------------------
        do i = 1,plonl
           if( stblev(i) ) then
-             if( zl(i) <= 1.e+0_fp ) then
+             if( zl(i) <= 1.0_fp ) then
                 pblk(i) = fak1(i)*zh(i)*zzh(i)/(1. + betas*zl(i))
              else
                 pblk(i) = fak1(i)*zh(i)*zzh(i)/(betas + zl(i))
@@ -1114,9 +1183,9 @@ CONTAINS
 !------------------------------------------------------------------------
        do i = 1,plonl
           if( unssrf(i) ) then
-             term    = (1.e+0_fp - betam*zl(i))**onet
+             term    = (1.0_fp - betam*zl(i))**onet
              pblk(i) = fak1(i)*zh(i)*zzh(i)*term
-             pr(i)   = term/sqrt(1.e+0_fp - betah*zl(i))
+             pr(i)   = term/sqrt(1.0_fp - betah*zl(i))
           end if
        end do
 
@@ -1168,7 +1237,7 @@ CONTAINS
 ! !INTERFACE:
 !
   subroutine qvdiff( ncnst, qm1, qflx, cc, ze, &
-	             term, qp1, plonl )
+	             term, qp1, plonl, lat )
 !
 ! !USES:
 !
@@ -1185,6 +1254,7 @@ CONTAINS
          qflx(plonl,ncnst), &     ! sfc q flux into lowest model level
          cc(plonl,plev), &        ! -lower diag coeff.of tri-diag matrix
          term(plonl,plev)         ! 1./(1. + ca(k) + cc(k) - cc(k)*ze(k-1))
+    integer, optional :: lat
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -1214,10 +1284,20 @@ CONTAINS
     integer :: &
          i, k, &               ! longitude,vertical indices
          m                     ! constituent index
+    logical :: doPrt
 
     !=================================================================
     ! qvdiff begins here!
     !=================================================================
+    doPrt = .FALSE.
+    if ( present( lat ) ) doPrt = ( lat == 6 )
+
+    ! Zero output arguments for safety's sake
+    qp1   = 0.0_fp
+
+    ! Zero local variables for safety's sake
+    zfq   = 0.0_fp
+    tmp1d = 0.0_fp
 
 !-----------------------------------------------------------------------
 ! 	... calculate fq(k).  terms fq(k) and e(k) are required in solution of
@@ -1227,11 +1307,12 @@ CONTAINS
 !-----------------------------------------------------------------------
     do m = 1,ncnst
        do i = 1,plonl
-          zfq(i,ntopfl,m) = qm1(i,ntopfl,m)*term(i,ntopfl)
+          zfq(i,ntopfl,m) = qm1(i,ntopfl,m) * term(i,ntopfl)
        end do
        do k = ntopfl+1,plev-1
           do i = 1,plonl
-             zfq(i,k,m) = (qm1(i,k,m) + cc(i,k)*zfq(i,k-1,m))*term(i,k)
+             zfq(i,k,m) = (qm1(i,k,m) + ( cc(i,k) * zfq(i,k-1,m) ) )         &
+                        * term(i,k)
           end do
        end do
     end do
@@ -1239,13 +1320,17 @@ CONTAINS
 ! 	... bottom level: (includes  surface fluxes)
 !-----------------------------------------------------------------------
     do i = 1,plonl
-       tmp1d(i) = 1.e+0_fp/(1.e+0_fp + cc(i,plev) - cc(i,plev)*ze(i,plev-1))
-       ze(i,plev) = 0.e+0_fp
+! Suspect that this line leads to numerical instability
+!       tmp1d(i) = 1.0_fp /                                                   &
+!                 (1.0_fp + cc(i,plev) - ( cc(i,plev) * ze(i,plev-1) ) )
+       tmp1d(i) = 1.0_fp / ( 1.0_fp + cc(i,plev) * ( 1.0_fp - ze(i,plev-1) ) )
+       ze(i,plev) = 0.0_fp
     end do
     do m = 1,ncnst
        do i = 1,plonl
-          zfq(i,plev,m) = (qm1(i,plev,m) + qflx(i,m) &
-                          + cc(i,plev)*zfq(i,plev-1,m))*tmp1d(i)
+          zfq(i,plev,m) =                                                    &
+               (qm1(i,plev,m) + qflx(i,m) + cc(i,plev)*zfq(i,plev-1,m))      &
+               * tmp1d(i)
        end do
     end do
 !-----------------------------------------------------------------------
@@ -1257,7 +1342,7 @@ CONTAINS
        end do
        do k = plev-1,ntopfl,-1
           do i = 1,plonl
-             qp1(i,k,m) = zfq(i,k,m) + ze(i,k)*qp1(i,k+1,m)
+             qp1(i,k,m) = zfq(i,k,m) + ( ze(i,k) * qp1(i,k+1,m) )
           end do
        end do
     end do
@@ -1352,7 +1437,18 @@ CONTAINS
     ! vdiffar begins here!
     !=================================================================
 
-    !Populate local variables with values from arguments (ccc, 11/17/09)
+    ! Zero/initialize local variables for safety's sake
+    indx   = 0
+    ilogic = 0
+    cah    = 0.0_fp
+    cch    = 0.0_fp
+    cgq    = 0.0_fp
+    potbar = 0.0_fp
+    tmp1   = 0.0_fp
+    dqbot  = 0.0_fp
+    qmx    = 0.0_fp
+    zeh    = 0.0_fp
+    termh  = 0.0_fp
     tm1    = tadv(:,lat,:)
     pmidm1 = pmid(:,lat,:)
     pintm1 = pint(:,lat,:)
@@ -1362,7 +1458,6 @@ CONTAINS
     kvh    = kvh_arg(:,lat,:)
     cgs    = cgs_arg(:,lat,:)
     qp1    = as2(:,lat,:,:)
-
 
 !-----------------------------------------------------------------------
 ! 	... convert the surface fluxes to lowest level tendencies
@@ -1395,7 +1490,7 @@ CONTAINS
        end do
     end do
     do k = 2,plev
-       potbar(:,k) = pintm1(:,k)/(.5e+0_fp*(tm1(:,k) + tm1(:,k-1)))
+       potbar(:,k) = pintm1(:,k)/(0.5_fp*(tm1(:,k) + tm1(:,k-1)))
     end do
     potbar(:,plevp) = pintm1(:,plevp)/tm1(:,plev)
 
@@ -1466,7 +1561,7 @@ CONTAINS
 ! 	... the last element of the upper diagonal is zero.
 !-----------------------------------------------------------------------
     do i = 1,plonl
-       cah(i,plev) = 0.e+0_fp
+       cah(i,plev) = 0.0_fp
     end do
 !-----------------------------------------------------------------------
 ! 	... calculate e(k) for heat vertical diffusion.  this term is
@@ -1474,12 +1569,12 @@ CONTAINS
 !           diffusion eqn.
 !-----------------------------------------------------------------------
     do i = 1,plonl
-       termh(i,ntopfl) = 1.e+0_fp/(1.e+0_fp + cah(i,ntopfl))
+       termh(i,ntopfl) = 1.0_fp/(1.0_fp + cah(i,ntopfl))
        zeh(i,ntopfl) = cah(i,ntopfl)*termh(i,ntopfl)
     end do
     do k = ntopfl+1,plev-1
        do i = 1,plonl
-          termh(i,k) = 1.e+0_fp/(1.e+0_fp + cah(i,k) + cch(i,k) &
+          termh(i,k) = 1.0_fp/(1.0_fp + cah(i,k) + cch(i,k) &
                       - cch(i,k)*zeh(i,k-1))
           zeh(i,k) = cah(i,k)*termh(i,k)
        end do
@@ -1494,8 +1589,8 @@ CONTAINS
 !-----------------------------------------------------------------------
 !      call qneg3( 'vdiff   ', lat, qp1(1,1,1), plonl )
 !     simplified treatment
-    where (qp1 < 0.e+0_fp)
-       qp1 = 0.e+0_fp
+    where (qp1 < 0.0_fp)
+       qp1 = 0.0_fp
     endwhere
 
     !Output values from local variables to arguments.(ccc, 11/17/09)
@@ -1557,6 +1652,13 @@ CONTAINS
     ! pbldifar begins here!
     !=================================================================
 
+    ! Zero output arguments for safety's sake
+    cgq  = 0.0_fp
+
+    ! Zero local variables for safety's sake
+    rrho = 0.0_fp
+    kqfs = 0.0_fp
+
 !------------------------------------------------------------------------
 ! 	... compute kinematic surface fluxes
 !------------------------------------------------------------------------
@@ -1569,7 +1671,7 @@ CONTAINS
 !------------------------------------------------------------------------
     do m = 1,nspcmix
        do k = 1,plevp
-          cgq(:,k,m) = 0.e+0_fp
+          cgq(:,k,m) = 0.0_fp
        end do
     end do
 !------------------------------------------------------------------------
@@ -1676,19 +1778,19 @@ CONTAINS
     USE State_Grid_Mod, ONLY : GrdState
     USE State_Met_Mod,  ONLY : MetState
 !
-! !INPUT PARAMETERS: 
+! !INPUT PARAMETERS:
 !
     TYPE(OptInput), INTENT(IN)  :: Input_Opt
     TYPE(GrdState), INTENT(IN)  :: State_Grid
     TYPE(MetState), INTENT(IN)  :: State_Met
 !
-! !OUTPUT PARAMETERS: 
+! !OUTPUT PARAMETERS:
 !
     INTEGER,        INTENT(OUT) :: RC
 !
 ! !REMARKS:
 !  This routine contains code that was originally in Init_Vdiff.  But it
-!  has to be separated so that it can be called after the initial met fields 
+!  has to be separated so that it can be called after the initial met fields
 !  are read from disk.  This allows us to use the surface pressure field
 !  instead of referencing the Ap and Bp parameters directly.
 !
@@ -1733,11 +1835,11 @@ CONTAINS
     thisLoc         = &
      ' -> at Max_PblHt_for_Vdiff (in module GeosCore/vdiff_mod.F90)'
 
-    ! Now use the average initial surface pressure per layer instead of 
+    ! Now use the average initial surface pressure per layer instead of
     ! having to reference the Ap and Bp.  This should make it easier
     ! to interface to external models such as CESM.
     DO k = 1, plev
-       ref_pmid(plev-k+1) = SUM( State_Met%PMid(:,:,K) ) / cells_per_layer 
+       ref_pmid(plev-k+1) = SUM( State_Met%PMid(:,:,K) ) / cells_per_layer
     ENDDO
 
     ! Derived constants
@@ -1757,7 +1859,7 @@ CONTAINS
        WRITE(6,*) 'Top is ',ref_pmid(plevp-npbl),' hpa'
     ENDIF
 
-    ! Set the ntopfl  
+    ! Set the ntopfl
     IF ( plev == 1 ) THEN
        ntopfl = 0
     ELSE
@@ -1899,7 +2001,7 @@ CONTAINS
     IF ( prtDebug ) CALL DEBUG_MSG( '### VDIFFDR: VDIFFDR begins' )
 
     ! Initialize
-    RC       =  GC_SUCCESS               
+    RC       =  GC_SUCCESS
     nAdvect  =  State_Chm%nAdvect
     ErrMsg   = ''
     ThisLoc  = ' -> at VDIFF (in module GeosCore/vdiff_mod.F90)'
@@ -1921,7 +2023,7 @@ CONTAINS
 
 !$OMP PARALLEL DO        &
 !$OMP DEFAULT( SHARED )  &
-!$OMP PRIVATE( I, J, L ) 
+!$OMP PRIVATE( I, J, L )
     DO J = 1, State_Grid%NY
     DO I = 1, State_Grid%NX
 
@@ -1930,7 +2032,7 @@ CONTAINS
           ! Convert PMID and PEDGE from hPa to Pa
           pmid(I,J,L) = State_Met%PMID(I,J,L)  * 100.0_fp
           pint(I,J,L) = State_Met%PEDGE(I,J,L) * 100.0_fp
-          
+
           ! Potential temperature [K]
           thp(I,J,L) = State_Met%T(I,J,L)*(p0/pmid(I,J,L))**cappa
        ENDDO
@@ -1951,9 +2053,9 @@ CONTAINS
        enddo
 
        !rpdeli(I,J,1) = 1.e+0_fp / (PS(I,J) - pmid(I,J,1))
-       rpdeli(I,J,1) = 0.e+0_fp ! follow mozart setup (shown in mo_physlic.F90)
+       rpdeli(I,J,1) = 0.0_fp ! follow mozart setup (shown in mo_physlic.F90)
        do L = 2, State_Grid%NZ
-          rpdeli(I,J,L) = 1.e+0_fp / (pmid(I,J,L-1) - pmid(I,J,L))
+          rpdeli(I,J,L) = 1.0_fp / (pmid(I,J,L-1) - pmid(I,J,L))
        enddo
 
     enddo
@@ -1984,7 +2086,7 @@ CONTAINS
     p_kvm    => kvm                (:, :, State_Grid%NZ+1:1:-1           )
     p_cgs    => cgs                (:, :, State_Grid%NZ+1:1:-1           )
     p_as2    => State_Chm%Species  (:, :, State_Grid%NZ  :1:-1, 1:nAdvect)
-    
+
     ! Convert v/v -> m/m (i.e., kg/kg)
     DO NA = 1, nAdvect
        p_as2(:,:,:,NA) = p_as2(:,:,:,NA)                                     &
@@ -2022,7 +2124,7 @@ CONTAINS
     ENDDO
 
     ! Convert kg/kg -> g/kg
-    p_shp    = p_shp * 1.e+3_fp
+    p_shp    = p_shp * 1.0e+3_fp
 
     ! Nullify pointers
     p_sflx   => NULL()
@@ -2185,7 +2287,7 @@ CONTAINS
     !=======================================================================
     ! PBL mixing
     !=======================================================================
-    
+
     ! Do non-local PBL mixing
     CALL VDIFFDR( Input_Opt,  State_Chm, State_Diag,                         &
                   State_Grid, State_Met, RC                                 )
@@ -2205,7 +2307,7 @@ CONTAINS
     !=======================================================================
     ! Update airmass etc. and mixing ratios
     !=======================================================================
-    
+
     ! Update air quantities and species concentrations with updated
     ! specific humidity (ewl, 10/28/15)
     !
@@ -2230,7 +2332,7 @@ CONTAINS
     !=======================================================================
     ! Unit conversion #2
     !=======================================================================
-    
+
     ! Convert species back to the original units
     CALL Convert_Spc_Units( Input_Opt, State_Chm, State_Grid,                &
                             State_Met, OrigUnit,  RC                        )
@@ -2299,7 +2401,7 @@ CONTAINS
 !
     USE ErrCode_Mod
 !
-! !OUTPUT PARAMETERS: 
+! !OUTPUT PARAMETERS:
 !
     INTEGER, INTENT(OUT) :: RC
 !

--- a/GeosUtil/regrid_a2a_mod.F90
+++ b/GeosUtil/regrid_a2a_mod.F90
@@ -54,22 +54,36 @@ MODULE Regrid_A2A_Mod
 !------------------------------------------------------------------------------
 !BOC
 !
+! !PRIVATE TYPES:
+!
+
+  !---------------------------------------------------------------------------
+  ! These are now kept locally, to "shadow" variables from other parts of
+  ! GEOS-Chem.  This avoids depending on GEOS-Chem code within the core
+  ! HEMCO modules. (bmy, 7/14/14)
+  !---------------------------------------------------------------------------
+  CHARACTER(LEN=255)    :: NC_DIR        ! Directory w/ netCDF files
+  INTEGER               :: OUTNX         ! # of longitudes (x-dimension) in grid
+  INTEGER               :: OUTNY         ! # of latitudes  (y-dimension) in grid
+  REAL(fp), ALLOCATABLE :: OUTLON (:  )  ! Longitude on output grid
+  REAL(fp), ALLOCATABLE :: OUTSIN (:  )  ! Sines of latitudes on output grid
+  REAL(fp), ALLOCATABLE :: OUTAREA(:,:)  ! Surface areas on output grid
+!
 ! !DEFINED PARAMETERS:
 !
   !---------------------------------------------------------------------------
-  ! These were taken from CMN_GCTM_mod.F90.  This helps us to avoid depending
-  ! on GEOS-Chem modules in the core HEMCO modules.  (bmy, 7/14/14)
-  ! NOTE: CMN_GCTM_mod.F90 is now physconstants.F90 (ewl, 1/8/2016)
+  ! Physical constants taken from the GEOS-Chem "physconstants.F90" module,
+  ! which uses values from NIST 2014. (ewl, bmy, 03 Mar 2022)
   !---------------------------------------------------------------------------
-  REAL(fp), PARAMETER :: PI =   3.14159265358979323e+0_fp   ! Pi
-  REAL(fp), PARAMETER :: Re =   6.375d6                 ! Earth radius [m]
+  REAL(fp), PARAMETER :: PI = 3.14159265358979323_fp        ! Pi
+  REAL(fp), PARAMETER :: Re = 6.3710072e+6_fp               ! Earth radius [m]
 
   !---------------------------------------------------------------------------
   ! Tiny numbers for single and double precision. These are being used for
   ! skipping missing values. miss_r4 and miss_r8 are the default missing values
   ! for single and double precision, respectively. (ckeller, 4/8/2017)
   !---------------------------------------------------------------------------
-  REAL*4, PARAMETER   :: tiny_r4 = 1.0e-20
+  REAL*4, PARAMETER   :: tiny_r4 = 1.0e-30  !1.0e-20
   REAL*4, PARAMETER   :: miss_r4 = 0.0e0
   REAL*8, PARAMETER   :: tiny_r8 = 1.0d-40
   REAL*8, PARAMETER   :: miss_r8 = 0.0d0
@@ -755,7 +769,7 @@ CONTAINS
           endif
 100    continue
 !123    q2(i,j) = qsum / ( sin2(j+1) - sin2(j) )
-123    if ( dlat /= 0.0d0 ) q2(i,j) = qsum / dlat
+123    if ( ABS( dlat ) > 0.0d0 ) q2(i,j) = qsum / dlat
 555    continue
 1000 continue
      !$OMP END PARALLEL DO
@@ -952,7 +966,7 @@ CONTAINS
              endif
           endif
 100    continue
-123    if ( dlat /= 0.0d0 ) q2(i,j) = qsum / dlat
+123    if ( ABS( dlat ) > 0.0d0 ) q2(i,j) = qsum / dlat
 555    continue
 1000 continue
      !$OMP END PARALLEL DO
@@ -1150,7 +1164,7 @@ CONTAINS
              endif
           endif
 100    continue
-123    if ( dlat /= 0.0d0 ) q2(i,j) = qsum / dlat
+123    if ( ABS( dlat ) > 0.0d0 ) q2(i,j) = qsum / dlat
 555    continue
 1000 continue
      !$OMP END PARALLEL DO
@@ -1348,7 +1362,7 @@ CONTAINS
           endif
 100    continue
 !123    q2(i,j) = qsum / ( sin2(j+1) - sin2(j) )
-123    if ( dlat /= 0.0 ) q2(i,j) = qsum / dlat
+123    if ( ABS( dlat ) > 0.0e0 ) q2(i,j) = qsum / dlat
 555    continue
 1000 continue
      !$OMP END PARALLEL DO
@@ -1680,7 +1694,7 @@ CONTAINS
              endif
           endif
 100    continue
-123    if ( dlon /= 0.0d0 ) q2(i,j) = qsum / dlon
+123    if ( ABS( dlon ) > 0.0d0 ) q2(i,j) = qsum / dlon
 555    continue
 1000 continue
      !$OMP END PARALLEL DO
@@ -1692,7 +1706,7 @@ CONTAINS
   END SUBROUTINE xmap_r8r8
 !EOC
 !------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
+!                   Harmonized Emissions Component (HEMCO)                    !
 !------------------------------------------------------------------------------
 !BOP
 !
@@ -1976,7 +1990,7 @@ CONTAINS
              endif
           endif
 100    continue
-123    if( dlon > 0.0 ) q2(i,j) = qsum / dlon
+123    if( ABS( dlon ) > 0.0e0 ) q2(i,j) = qsum / dlon
 555    continue
 1000 continue
      !$OMP END PARALLEL DO
@@ -2260,7 +2274,7 @@ CONTAINS
              endif
           endif
 100    continue
-123    if ( dlon /= 0.0d0 ) q2(i,j) = qsum / dlon
+123    if ( ABS( dlon ) > 0.0d0 ) q2(i,j) = qsum / dlon
 555    continue
 1000 continue
      !$OMP END PARALLEL DO
@@ -2544,7 +2558,7 @@ CONTAINS
              endif
           endif
 100    continue
-123    if( dlon /= 0.0 ) q2(i,j) = qsum / dlon
+123    if( ABS( dlon ) > 0.0e0 ) q2(i,j) = qsum / dlon
 555    continue
 1000 continue
      !$OMP END PARALLEL DO

--- a/GeosUtil/regrid_a2a_mod.F90
+++ b/GeosUtil/regrid_a2a_mod.F90
@@ -54,21 +54,6 @@ MODULE Regrid_A2A_Mod
 !------------------------------------------------------------------------------
 !BOC
 !
-! !PRIVATE TYPES:
-!
-
-  !---------------------------------------------------------------------------
-  ! These are now kept locally, to "shadow" variables from other parts of
-  ! GEOS-Chem.  This avoids depending on GEOS-Chem code within the core
-  ! HEMCO modules. (bmy, 7/14/14)
-  !---------------------------------------------------------------------------
-  CHARACTER(LEN=255)    :: NC_DIR        ! Directory w/ netCDF files
-  INTEGER               :: OUTNX         ! # of longitudes (x-dimension) in grid
-  INTEGER               :: OUTNY         ! # of latitudes  (y-dimension) in grid
-  REAL(fp), ALLOCATABLE :: OUTLON (:  )  ! Longitude on output grid
-  REAL(fp), ALLOCATABLE :: OUTSIN (:  )  ! Sines of latitudes on output grid
-  REAL(fp), ALLOCATABLE :: OUTAREA(:,:)  ! Surface areas on output grid
-!
 ! !DEFINED PARAMETERS:
 !
   !---------------------------------------------------------------------------
@@ -1706,7 +1691,7 @@ CONTAINS
   END SUBROUTINE xmap_r8r8
 !EOC
 !------------------------------------------------------------------------------
-!                   Harmonized Emissions Component (HEMCO)                    !
+!                  GEOS-Chem Global Chemical Transport Model                  !
 !------------------------------------------------------------------------------
 !BOP
 !


### PR DESCRIPTION
## Overview

This PR adds several fixes to improve numerical stability in GEOS-Chem:

  1. In `GeosCore/regrid_a2a_mod.F90`:
     - Use the same values of` PI` and `Re` as in `Headers/physconstants.F90`, which are taken from NIST 2014
     - Change `TINY_R4` to from 1e-20 to 1e-30
     - Now use `IF ( ABS( x ) > 0.0d0 )` instead of `IF ( x == 0.0d0 )`; Due to roundoff, the equality condition may never be met

  2. In `GeosCore/drydep_mod.F90`:
     - Initialize `DRYCOEFF = 0`.  `DRYCOEFF` is used in the HEMCO soil NOx extension, and will have undefined "junk" values if dry deposition is turned off.

  3. In `GeosCore/aerosol_mod.F90`:
     - Do not save TotalOC aerosol diagnostic unless OPOA1 and OPOA2 are defined.  This will avoid a segmentation fault.

  4. In `GeosCore/modis_lai_mod.F90`:
     -  Set the `LANDFRAC` variable to 0 at the start of the loop where it is defined

  5. In `GeosCore/olson_landmap_mod.F90`:
     - Set `State_Met%LandTypeFrac` to zero at the start of the loop where it is defined
     
  6. In `GeosCore/hco_utilities_mod.F90`:
     - Updated comments for clarity

  7. In `KPP/fullchem/fullchem_SulfurChemFuncs.F90`:
     - Reorganize IF blocks to avoid useless computations
     - Replace `State_Het%xRadi(11)` with `State_Chm%AeroRadi(I,J,L,11)`
     - Replace `State_Het%xRadi(12)` with `State_Chm%AeroRadi(I,J,L,12)`
     - Move `USE gckpp_Global` and `USE rateLawUtilFuncs` into the routines where they are referenced

  8. In `GeosCore/fullchem_mod.F90`: 
     - Fix parallelization errors caused by the wrong sequence of routine calls.  See 72c8866ee68a60639be743255bfad2454357af7e for details.

  9. In `GeosCore/hco_interface_gc_mod.F90`:
     - Bug fix: Do not set pointer `Trgt3D => NULL()` in the same line where it is declared.
     - This will make it a global SAVEd variable but we just want it to be a locally-defined automatic variable.

  10. In `GeosCore/tpcore_fvdas_mod.F90`:
      - Make sure that local variables are zeroed before they are used
      - Make sure that arguments declared as `INTENT(OUT)` are zeroed before they are used
      - Removed variables that were not being used in parallel loops
      - Cosmetic changes, updated comments, trimmed trailing whitespace
    
## Related Issues
See: #132, #133, https://github.com/geoschem/geos-chem/issues/1157, https://github.com/geoschem/geos-chem/issues/1103

## Related Pull Requests
  - This PR should be merged before #1166.
  - This PR should be merged concurrently with https://github.com/geoschem/HEMCO/pull/134
