### PR TITLE
GCHP fix: move setup_wetscav so C_H2O is not all zeros in first timestep

### DIFF
--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -876,11 +876,6 @@ CONTAINS
     ! Zero out certain State_Diag arrays
     CALL Zero_Diagnostics_StartOfTimestep( Input_Opt, State_Diag, RC )
 
-    ! Eventually initialize/reset wetdep
-    IF ( DoConv .OR. DoChem .OR. DoWetDep ) THEN
-       CALL SETUP_WETSCAV( Input_Opt, State_Chm, State_Grid, State_Met, RC )
-    ENDIF
-
     ! Pass time values obtained from the ESMF environment to GEOS-Chem
     CALL Accept_External_Date_Time( value_NYMD     = nymd,       &
                                     value_NHMS     = nhms,       &
@@ -940,6 +935,11 @@ CONTAINS
        CALL AirQnt( Input_Opt, State_Chm, State_Grid, State_Met, RC, scaleMR )
     ENDIF
 #endif
+
+    ! Initialize/reset wetdep after air quantities computed
+    IF ( DoConv .OR. DoChem .OR. DoWetDep ) THEN
+       CALL SETUP_WETSCAV( Input_Opt, State_Chm, State_Grid, State_Met, RC )
+    ENDIF
 
     ! Cap the polar tropopause pressures at 200 hPa, in order to avoid
     ! tropospheric chemistry from happening too high up (cf. J. Logan)


### PR DESCRIPTION
This PR removes the differences in H2O2 concentrations introduced in wet scavenging when breaking up a GCHP run into multiple segments. Before this fix the call to setup_wetscav was before the first call to AIRQNT, when State_Met%PMID was still zero. State_Met%C_H2O is calculated from PMID in setup_wetscav, and thus was all zeros when wet scavenging was first called in the run.

This fix does not impact GEOS-Chem Classic, but it will introduce small differences in the GCHP benchmark. The differences introduced by this bug are very small. Below is a comparison of the 1-hr average H2O2 concentrations in the 2nd hour of a 2-hr standard simulation with only wet scavenging on. Ref was a 2 hr simulation run as a single job. Dev was the same simulation split up into two 1-hr jobs. This fix removes all differences shown.

<img width="1081" alt="Screen Shot 2022-03-17 at 9 32 00 PM" src="https://user-images.githubusercontent.com/651947/158920412-6b4ff246-8db9-4d0a-ba08-b0daa1ba36d4.png">


