### PR TITLE
[PULL REQUEST] Remove goto 9999 statement from chemistry_mod.F90

### DIFF
--- a/GeosCore/chemistry_mod.F90
+++ b/GeosCore/chemistry_mod.F90
@@ -310,7 +310,6 @@ CONTAINS
           IF ( Input_Opt%useTimers ) THEN
              CALL Timer_End( "=> FlexChem", RC )
           ENDIF
-goto 9999
 
           !------------------------------------------------------------------
           ! Linearized chemistry above chemistry grid
@@ -565,7 +564,6 @@ goto 9999
              CALL Timer_End( "=> Aerosol chem", RC )
           ENDIF
 
-9999 continue
        !=====================================================================
        ! Aerosol-only simulation
        !=====================================================================


### PR DESCRIPTION
This PR fixes a bug that was introduced via PR #1190 (tagged with 13.4.0-alpha.24). Debug `goto 9999` and `9999 continue` statements were inadvertently left in chemistry_mod.F90 and this caused large changes in many species concentrations as seen in the 13.4.0-rc.3 benchmark:

     ###################################################################################
     ### Global mass (Gg) at end of simulation (Trop only)                           ###
     ### Ref = GCC_13.3.0-rc.1; Dev = GCC_13.4.0-rc.3                                ###
     ###################################################################################
                                         Ref                 Dev     Dev - Ref    % diff
     ASOA1              :           6.746987            0.574392     -6.172596   -91.487
     ASOA2              :           2.236734            0.142172     -2.094562   -93.644
     ASOA3              :           5.067490            0.748983     -4.318506   -85.220
     ASOAN              :          59.332920            2.164097    -57.168823   -96.353
     ASOG1              :           4.739317            0.492503     -4.246814   -89.608
     ASOG2              :           5.983962            0.612297     -5.371665   -89.768
     ASOG3              :          90.603188           14.338389    -76.264801   -84.175
     ...
     BCPI               :          99.370918           22.931009    -76.439911   -76.924
     BCPO               :          20.421244          208.796158    188.374908   922.446
     ...
     DST1               :        2418.661621         2464.097656     45.436035     1.879
     DST2               :        1518.937622         1704.108032    185.170410    12.191
     DST3               :        2106.957275         2977.925293    870.968018    41.338
     DST4               :        1102.301636         3045.754883   1943.453247   176.309

With this fix, species concentrations are restored back to reasonable values. For example, now when comparing to 13.3.0-rc.1, we get:

     ###################################################################################
     ### Global mass (Gg) at end of simulation (Trop only)                           ###
     ### Ref = GCC_13.3.0-rc.1; Dev = GCC_13.4.0-rc.3+chem_mod_fix                   ###
     ###################################################################################
     ASOA1              :           6.746987            6.579333     -0.167654    -2.485
     ASOA2              :           2.236734            2.156800     -0.079935    -3.574
     ASOA3              :           5.067490            4.738415     -0.329074    -6.494
     ASOAN              :          59.332920           57.085258     -2.247662    -3.788
     ASOG1              :           4.739317            4.800664      0.061347     1.294
     ASOG2              :           5.983962            5.936092     -0.047870    -0.800
     ASOG3              :          90.603188           89.896545     -0.706642    -0.780
     ...
     BCPI               :          99.370918           97.939789     -1.431129    -1.440
     BCPO               :          20.421244           20.372309     -0.048935    -0.240
     ...
     DST1               :        2418.661621         2343.679688    -74.981934    -3.100
     DST2               :        1518.937622         1492.575684    -26.361938    -1.736
     DST3               :        2106.957275         2087.034180    -19.923096    -0.946
     DST4               :        1102.301636         1105.905884      3.604248     0.327
