### PR TITLE
Use modified EDGAR diurnal scale factors file to correctly read data

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -2203,7 +2203,7 @@ ${RUNDIR_TES_CLIM_N2O}
 #==============================================================================
 # --- Diurnal scale factors ---
 #==============================================================================
-25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
+25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.modified.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
@@ -2214,7 +2214,7 @@ ${RUNDIR_TES_CLIM_N2O}
 35 PKU_pow_PM_BC_POC_VOC_CO 0.95/0.93/0.92/0.91/0.90/0.93/0.97/0.97/0.99/1.03/1.04/1.03/1.02/1.03/1.05/1.07/1.07/1.07/1.06/1.04/1.03/1.02/1.00/0.97 - - - xy unitless 1 1009
 
 # These scale factors undo (Oper=-1) the global diurnal scale factors over China (Mask=1009)
-36 EDGAR_TODNOX_UNDO $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless -1 1009
+36 EDGAR_TODNOX_UNDO $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.modified.nc NOXscale 2000/1/1/* C xy unitless -1 1009
 37 GEIA_TOD_FOSSIL_UNDO 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless -1 1009
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3780,7 +3780,7 @@ ${RUNDIR_TES_CLIM_N2O}
 #==============================================================================
 # --- Diurnal scale factors ---
 #==============================================================================
-25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
+25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.modified.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
@@ -3791,7 +3791,7 @@ ${RUNDIR_TES_CLIM_N2O}
 35 PKU_pow_PM_BC_POC_VOC_CO 0.95/0.93/0.92/0.91/0.90/0.93/0.97/0.97/0.99/1.03/1.04/1.03/1.02/1.03/1.05/1.07/1.07/1.07/1.06/1.04/1.03/1.02/1.00/0.97 - - - xy unitless 1 1009
 
 # These scale factors undo (Oper=-1) the global diurnal scale factors over China (Mask=1009)
-36 EDGAR_TODNOX_UNDO $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless -1 1009
+36 EDGAR_TODNOX_UNDO $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.modified.nc NOXscale 2000/1/1/* C xy unitless -1 1009
 37 GEIA_TOD_FOSSIL_UNDO 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless -1 1009
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCO
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCO
@@ -1122,7 +1122,7 @@ ${RUNDIR_GMI_PROD_CO}
 35 PKU_pow_PM_BC_POC_VOC_CO 0.95/0.93/0.92/0.91/0.90/0.93/0.97/0.97/0.99/1.03/1.04/1.03/1.02/1.03/1.05/1.07/1.07/1.07/1.06/1.04/1.03/1.02/1.00/0.97 - - - xy unitless 1 1009
 
 ## These scale factors undo (Oper=-1) the global diurnal scale factors over China (Mask=1009)
-36 EDGAR_TODNOX_UNDO $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless -1 1009
+36 EDGAR_TODNOX_UNDO $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.modified.nc NOXscale 2000/1/1/* C xy unitless -1 1009
 37 GEIA_TOD_FOSSIL_UNDO 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless -1 1009
 
 ==============================================================================

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -2203,8 +2203,8 @@ SOLFUEL_2008_2010 1 N Y F%y4-01-01T00:00:00  none none SO2scalar ./HcoDir/Annual
 #==============================================================================
 # --- Diurnal scale factors ---
 #==============================================================================
-EDGAR_TODNOX 1 N Y F2000-01-01T%h2:00:00 none none NOXscale ./HcoDir/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc
-EDGAR_TODNOX_UNDO 1 N Y F2000-01-01T%h2:00:00 none none NOXscale ./HcoDir/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc
+EDGAR_TODNOX 1 N Y F2000-01-01T%h2:00:00 none none NOXscale ./HcoDir/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.modified.nc
+EDGAR_TODNOX_UNDO 1 N Y F2000-01-01T%h2:00:00 none none NOXscale ./HcoDir/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.modified.nc
 #
 #==============================================================================
 # --- Seasonal scale factors ---

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3770,7 +3770,7 @@ ${RUNDIR_TES_CLIM_N2O}
 #==============================================================================
 # --- Diurnal scale factors ---
 #==============================================================================
-25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
+25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.modified.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
@@ -3781,7 +3781,7 @@ ${RUNDIR_TES_CLIM_N2O}
 35 PKU_pow_PM_BC_POC_VOC_CO 0.95/0.93/0.92/0.91/0.90/0.93/0.97/0.97/0.99/1.03/1.04/1.03/1.02/1.03/1.05/1.07/1.07/1.07/1.06/1.04/1.03/1.02/1.00/0.97 - - - xy unitless 1 1009
 
 # These scale factors undo (Oper=-1) the global diurnal scale factors over China (Mask=1009)
-36 EDGAR_TODNOX_UNDO $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless -1 1009
+36 EDGAR_TODNOX_UNDO $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.modified.nc NOXscale 2000/1/1/* C xy unitless -1 1009
 37 GEIA_TOD_FOSSIL_UNDO 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless -1 1009
 
 #==============================================================================


### PR DESCRIPTION
This PR updates the GC-Classic and GCHP config files to use new file `EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScale.modified.nc`, which is a duplicate of the file currently used but with all missing data removed and replaced with value 1.0.

The currently used file, `EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScale.nc`, uses missing values and `_FillValue` attribute value of 1 to indicate where scale factors are 1.0. This causes a silent bug in GC-Classic where near-zero values are used instead of 1.0 since HEMCO treats all missing values as 0 rather than using the _FillValue (see [here](https://github.com/geoschem/HEMCO/blob/4a66bae48f33e6dc22cda5ec9d4633192dee2f73/src/Core/hco_error_mod.F90#L94-L97), [here](https://github.com/geoschem/HEMCO/blob/4a66bae48f33e6dc22cda5ec9d4633192dee2f73/src/Core/hcoio_read_std_mod.F90#L766-L782), [here](https://github.com/geoschem/HEMCO/blob/4a66bae48f33e6dc22cda5ec9d4633192dee2f73/src/Shared/NcdfUtil/hco_ncdf_mod.F90#L646-L648), and [here](https://github.com/geoschem/HEMCO/blob/4a66bae48f33e6dc22cda5ec9d4633192dee2f73/src/Shared/NcdfUtil/hco_ncdf_mod.F90#L1185-L1201).

This also causes a run fail in GCHP if a new `_FillValue` update is enabled in the new version of MAPL we just updated to. This is because data with values equivalent to `_FillValue` are now treated as missing and not included in regridding. For this reason that fix is currently disabled MAPL inGCHP. We will enable it following this update (https://github.com/geoschem/MAPL/pull/21).

This update causes small differences in GC-Classic. No differences are expected for GCHP.