### PR TITLE
Reduce root logging level for MAPL to WARNING

### DIFF
--- a/run/GCHP/logging.yml
+++ b/run/GCHP/logging.yml
@@ -87,7 +87,7 @@ loggers:
    MAPL:
        handlers: [mpi_shared]
        level: WARNING
-       root_level: INFO
+       root_level: WARNING
        
    CAP.EXTDATA:
        handlers: [mpi_shared]


### PR DESCRIPTION
The INFO logging level still generates a large number of messages which are excessive unless performing debugging. I suggest we reduce this to WARNING for MAPL, which results in much cleaner log files.