### PR TITLE
[PULL REQUEST] Save boundary conditions on first timestep

### DIFF
--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -2556,6 +2556,12 @@ CONTAINS
        ! Test if the "UpdateAlarm" is ringing
        DoUpdate = ( ( Container%UpdateAlarm - Container%ElapsedSec ) < EPS )
 
+       IF ( TRIM(Container%Name) .eq. 'BoundaryConditions'   .and.   &
+            Container%ElapsedSec .eq. 0.0 ) THEN
+          Container%UpdateAlarm = 0.0
+          DoUpdate = .TRUE.
+       ENDIF
+
        ! Skip to next collection if it isn't
        IF ( .not. DoUpdate ) THEN
           Container  => NULL()
@@ -2749,7 +2755,7 @@ CONTAINS
        ! Prepare to go to the next collection
        !------------------------------------------------------------------
 
-       ! Recompute the update alarm interval if it 1 month or longer,
+       ! Recompute the update alarm interval if it is 1 month or longer,
        ! as we will have to take into account leap years, etc.
        IF ( Container%UpdateYmd >= 000100 ) THEN
           CALL HistContainer_UpdateIvalSet( Input_Opt, Container, RC )
@@ -2793,7 +2799,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE History_Write( Input_Opt, Spc_Units, RC )
+  SUBROUTINE History_Write( Input_Opt, Spc_Units, State_Diag, State_Chm, RC )
 !
 ! !USES:
 !
@@ -2805,12 +2811,17 @@ CONTAINS
     USE Input_Opt_Mod,         ONLY : OptInput
     USE MetaHistContainer_Mod, ONLY : MetaHistContainer
     USE MetaHistItem_Mod,      ONLY : MetaHistItem
+    USE PhysConstants,         ONLY : AIRMW
     USE Registry_Params_Mod
+    USE State_Chm_Mod,         ONLY : ChmState
+    USE State_Diag_Mod,        ONLY : DgnMap, DgnState
 !
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput),   INTENT(IN)  :: Input_Opt   ! Input Options object
+    TYPE(DgnState),   INTENT(IN)  :: State_Diag   ! Diagnsotics State object
     CHARACTER(LEN=*), INTENT(IN)  :: Spc_Units   ! Units of SC%Species array
+    TYPE(ChmState),   INTENT(IN)  :: State_Chm    ! Chemistry State object
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -2832,6 +2843,7 @@ CONTAINS
     ! Scalars
     LOGICAL                          :: DoClose
     LOGICAL                          :: DoWrite
+    INTEGER                          :: S, N
 
     ! Strings
     CHARACTER(LEN=20)                :: TmpUnits
@@ -2842,6 +2854,7 @@ CONTAINS
     TYPE(MetaHistContainer), POINTER :: Collection
     TYPE(HistContainer),     POINTER :: Container
     TYPE(MetaHistItem),      POINTER :: Current
+    TYPE(DgnMap),            POINTER :: mapData
 
     !=======================================================================
     ! Initialize
@@ -2868,6 +2881,17 @@ CONTAINS
        ! Point to the HISTORY CONTAINER object in this COLLECTION
        Container => Collection%Container
 
+       ! Force define write alarm for creating and saving boundary
+       ! conditions to ensure first file of the simulation has the
+       ! correct file name and number of entries.
+       IF ( Container%ElapsedSec .eq. 0.0 ) THEN
+          IF ( TRIM(Container%Name) .eq. 'BoundaryConditions' ) THEN
+             Container%FileWriteAlarm = 0.0
+          ELSE
+             RETURN
+          ENDIF
+       ENDIF             
+
        !====================================================================
        ! Test if it is time to close/repopen the file or to write data
        !====================================================================
@@ -2878,6 +2902,33 @@ CONTAINS
        ! Test if the "FileWriteAlarm" is ringing
        DoWrite = ( ( Container%FileWriteAlarm - Container%ElapsedSec ) < EPS )
 
+       ! If it's the first timestep of the simulation, map SpeciesConc
+       ! values to BC diagnostic values to output instantaneous values
+       ! at start of simulation.
+       IF ( Container%ElapsedSec .eq. 0.0 .and. &
+            TRIM(Container%Name) .eq. 'BoundaryConditions' ) THEN
+
+          ! Point to mapping obj specific to species boundary conditions
+          mapData => State_Diag%Map_SpeciesBC
+
+          !$OMP PARALLEL DO       &
+          !$OMP DEFAULT( SHARED ) &
+          !$OMP PRIVATE( N, S   )
+          DO S = 1, mapData%nSlots
+             N = mapData%slot2id(S)
+             State_Diag%SpeciesBC(:,:,:,S) = State_Chm%Species(:,:,:,N) *  &
+                               ( AIRMW / State_Chm%SpcData(N)%Info%MW_g )
+          ENDDO
+          !$OMP END PARALLEL DO
+
+          ! Free pointer
+          mapData => NULL()
+
+          ! Update each HISTORY ITEM from its data source
+          CALL History_Update( Input_Opt, RC )
+
+       ENDIF
+          
        !====================================================================
        ! %%% GEOS-Chem "Classic" %%%
        !
@@ -2912,7 +2963,7 @@ CONTAINS
           !-----------------------------------------------------------------
           CALL History_Netcdf_Define( Input_Opt = Input_Opt,                &
                                       Container = Container,                &
-                                      RC        = RC                       )
+                                         RC = RC  )
 
           ! Trap error
           IF ( RC /= GC_SUCCESS ) THEN
@@ -2925,7 +2976,7 @@ CONTAINS
           ! Update "FileClose" alarm for next interval
           !-----------------------------------------------------------------
 
-          ! Recompute the file close alarm interval if it 1 month or longer,
+          ! Recompute the file close alarm interval if it is 1 month or longer,
           ! as we will have to take into account leap years, etc.
           IF ( Container%FileCloseYmd >= 000100 ) THEN
              CALL HistContainer_FileCloseIvalSet( Input_Opt, Container, RC )
@@ -2962,7 +3013,7 @@ CONTAINS
           ! Update "FileWrite" alarm for next interval
           !-----------------------------------------------------------------
 
-          ! Recompute the file write alarm interval if it 1 month or longer,
+          ! Recompute the file write alarm interval if it's 1 month or longer,
           ! as we will have to take into account leap years, etc.
           IF ( Container%FileWriteYmd >= 000100 ) THEN
              CALL HistContainer_FileWriteIvalSet( Input_Opt, Container, RC )

--- a/History/history_netcdf_mod.F90
+++ b/History/history_netcdf_mod.F90
@@ -350,7 +350,8 @@ CONTAINS
        !---------------------------------------------------------------------
        IF ( Container%Operation      == COPY_FROM_SOURCE            .and.    &
             Container%UpdateIvalSec  == Container%FileCloseIvalSec  .and.    &
-            Container%FileCloseAlarm == 0.0                        ) THEN
+            Container%FileCloseAlarm == 0.0                         .and.    &
+            TRIM(Container%Name) .ne. 'BoundaryConditions' )  THEN
           RETURN
 
        ELSE

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -934,6 +934,19 @@ PROGRAM GEOS_Chem
              CALL Error_Stop( ErrMsg, ThisLoc )
           ENDIF
 
+          ! Write HISTORY ITEMS in each diagnostic collection to disk
+          ! (or skip writing if it is not the proper output time.
+          ! Appears at start of run to output instantaneous boundary conditions
+          ! at the start of the simulation with the correct time:
+          CALL History_Write( Input_Opt, State_Chm%Spc_Units, State_Diag, &
+                              State_Chm, RC )
+
+          ! Trap potential errors
+          IF ( RC /= GC_SUCCESS ) THEN
+             ErrMsg = 'Error encountered before timestepping in "History_Write"!'
+             CALL Error_Stop( ErrMsg, ThisLoc )
+          ENDIF
+
           IF ( Input_Opt%useTimers ) THEN
              CALL Timer_End( "All diagnostics",           RC )
              CALL Timer_End( "=> History (netCDF diags)", RC )
@@ -2079,7 +2092,7 @@ PROGRAM GEOS_Chem
 
           ! Write HISTORY ITEMS in each diagnostic collection to disk
           ! (or skip writing if it is not the proper output time.
-          CALL History_Write( Input_Opt, State_Chm%Spc_Units, RC )
+          CALL History_Write( Input_Opt, State_Chm%Spc_Units, State_Diag, State_Chm, RC )
 
           ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN


### PR DESCRIPTION
This is the PR for https://github.com/geoschem/geos-chem/issues/1187. It applies the patch file provided by @eamarais containing:

>Code updates to create correct file name (GEOSChem.BoundaryConditions.YYYYMMDD_0000z.nc4) and complete number of entries (8 rather than 7) for the first BCs file created at the start of each simulation.

