### PR TITLE
Bug fix for GCHP transport tracers simulation in 14.0.0-rc.0

### DIFF
--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -669,6 +669,7 @@ CONTAINS
        EOF = IOS < 0
        IF ( EOF ) CALL IOERROR( IOS, IU_GEOS, 'READ_SPECIES_FROM_FILE:3' )
        LINE = ADJUSTL( ADJUSTR( LINE ) )
+       IF ( INDEX( LINE, 'passive_species' ) > 0 ) EXIT
        CALL STRSPLIT( LINE, '-', SUBSTRS, N )
        IF ( INDEX( LINE, '-' ) > 0 ) THEN
           substrs(1) = ADJUSTL( ADJUSTR( substrs(1) ) )


### PR DESCRIPTION
This PR corrects an issue introduced in the transport tracers simulation early in 14.0.0 development. The problem was the advected species list was incorrectly read in when adding species to the MAPL internal state. With the fix a stop criteria is added to prevent continuing to read lines as species in geoschem_config.yml.