### PR TITLE
Feature/user registration: optionally register first time users with dynamodb database

### DIFF
--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -19,6 +19,7 @@ function post_registration() {
     site="$3"
     git_username="$4"
     research_interest="$5"
+    env_name="$6"
     curl --location --request POST "https://gc-dashboard.org/registration" \
         --header "Content-Type: text/plain" \
         --data-raw "{
@@ -27,6 +28,8 @@ function post_registration() {
             \"site\": \"${site}\",
             \"git_username\": \"${git_username}\",
             \"research_interest\": \"${research_interest}\"
+            \"model_type\": \"GCClassic\",
+            \"env_name\": \"${env_name}\"
         }"
 }
 
@@ -101,11 +104,27 @@ if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
     IFS='\n' read -r affiliation
     printf "${thinline}If available, please provide the url for your affiliated \ninstitution (group website, company website, etc.)?${thinline}"
     IFS='\n' read -r site
-    printf "${thinline}If you have one, please provide your github username?${thinline}"
+    printf "${thinline}Please provide your github username (if any) so that we \ncan recognize you in submitted issues and pull requests.${thinline}"
     IFS='\n' read -r git_username
-    printf "${thinline}What is your application for GEOS-Chem?${thinline}"
+    printf "${thinline}How do you plan to run GEOS-Chem?${thinline}"
+    printf "   1. Local Cluster\n"
+    printf "   2. AWS\n"
+    valid_env=0
+    while [ "${valid_env}" -eq 0 ]; do
+        read env_num
+        valid_env=1
+        if [[ ${env_num} = "1" ]]; then
+    	env_name=aws
+        elif [[ ${env_num} = "2" ]]; then
+    	env_name=cluster
+        else
+            valid_env=0
+    	printf "Invalid option. Try again.\n"
+        fi
+    done
+    printf "${thinline}Please briefly describe how you plan on using GEOS-Chem \nso that we can add you to the GEOS-Chem People and Projects \nwebpage (https://geoschem.github.io/geos-chem-people-projects-map/).${thinline}"
     IFS='\n' read -r research_interest
-    post_registration "$email" "$affiliation" "$site" "$git_username" "$research_interest"
+    post_registration "$email" "$affiliation" "$site" "$git_username" "$research_interest" "$env_name"
     fi
     echo "export GC_FIRST_TIME_USER=true" >> ${HOME}/.geoschem/config
     source ${HOME}/.geoschem/config

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -97,7 +97,7 @@ RUNDIR_VARS+="RUNDIR_DATA_ROOT=$GC_DATA_ROOT\n"
 # --------------------------------------------------------------
 # registration for first time users
 # --------------------------------------------------------------
-if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
+if [[ -z "${GC_USER_REGISTERED}" ]]; then
     printf "\nInitiating User Registration: You will only need to fill this out once.\n"
     printf "${thinline}What is your email address?${thinline}"
     read email
@@ -131,7 +131,7 @@ if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
     IFS='\n' read -r research_interest
     post_registration "$email" "$name" "$affiliation" "$site" "$git_username" "$research_interest" "$env_type"
     fi
-    echo "export GC_FIRST_TIME_USER=true" >> ${HOME}/.geoschem/config
+    echo "export GC_USER_REGISTERED=true" >> ${HOME}/.geoschem/config
     source ${HOME}/.geoschem/config
 fi
 

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -19,7 +19,7 @@ function post_registration() {
     site="$3"
     git_username="$4"
     research_interest="$5"
-    env_name="$6"
+    env_type="$6"
     curl --location --request POST "https://gc-dashboard.org/registration" \
         --header "Content-Type: text/plain" \
         --data-raw "{
@@ -27,9 +27,9 @@ function post_registration() {
             \"affiliation\": \"${affiliation}\",
             \"site\": \"${site}\",
             \"git_username\": \"${git_username}\",
-            \"research_interest\": \"${research_interest}\"
-            \"model_type\": \"GCClassic\",
-            \"env_name\": \"${env_name}\"
+            \"research_interest\": \"${research_interest}\",
+            \"model_type\": \"gcc\",
+            \"env_type\": \"${env_type}\"
         }"
 }
 
@@ -114,9 +114,9 @@ if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
         read env_num
         valid_env=1
         if [[ ${env_num} = "1" ]]; then
-    	env_name=aws
+    	env_type="Local Cluster"
         elif [[ ${env_num} = "2" ]]; then
-    	env_name=cluster
+    	env_type=AWS
         else
             valid_env=0
     	printf "Invalid option. Try again.\n"
@@ -124,7 +124,7 @@ if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
     done
     printf "${thinline}Please briefly describe how you plan on using GEOS-Chem \nso that we can add you to the GEOS-Chem People and Projects \nwebpage (https://geoschem.github.io/geos-chem-people-projects-map/).${thinline}"
     IFS='\n' read -r research_interest
-    post_registration "$email" "$affiliation" "$site" "$git_username" "$research_interest" "$env_name"
+    post_registration "$email" "$affiliation" "$site" "$git_username" "$research_interest" "$env_type"
     fi
     echo "export GC_FIRST_TIME_USER=true" >> ${HOME}/.geoschem/config
     source ${HOME}/.geoschem/config

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -12,6 +12,16 @@
 #
 # Initial version: M. Sulprizio, 6/24/2020 (based off GCHP/createRunDir.sh)
 
+function post_registration() {
+    email=$1
+    affiliation=$2
+    research_interest=$3
+    body="{'email': ${email}, 'affiliation': ${affiliation}, 'research_interest': ${research_interest}"
+    curl -X POST https://4uh55iovvv6v5xvpmgxkwiidxm0mdyki.lambda-url.us-east-1.on.aws/registration \
+        -H "Content-Type: application/json" \
+        -d "{'email': ${email}, 'affiliation': ${affiliation}, 'research_interest': ${research_interest}"
+}
+
 srcrundir=$(pwd -P)
 cd ${srcrundir}
 cd ../..
@@ -70,6 +80,29 @@ if [[ -z "${GC_DATA_ROOT}" ]]; then
 fi
 
 RUNDIR_VARS+="RUNDIR_DATA_ROOT=$GC_DATA_ROOT\n"
+
+# --------------------------------------------------------------
+# registration for first time users
+# --------------------------------------------------------------
+printf "${thinline}Are you a first time user? If so, would you like to register with the GEOS-Chem community? (y/n)${thinline}"
+valid_response=0
+while [ "$valid_response" -eq 0 ]; do
+    read enable_registration
+    if [[ ${enable_registration} = "y" ]]; then
+    printf "${thinline}What is your email address (If you would like to be added to our user email list)?${thinline}"
+    read email
+    printf "${thinline}What is your research affiliation (University, Research Group, Government Organization, Company)?${thinline}"
+    read affiliation
+    printf "${thinline}What is your application for GEOS-Chem?${thinline}"
+    read research_interest
+    post_registration $email $affiliation $research_interest
+	valid_response=1
+    elif [[ ${enable_git} = "n" ]]; then
+	valid_response=1
+    else
+	printf "Input not recognized. Try again.\n"
+    fi
+done
 
 #-----------------------------------------------------------------
 # Ask user to select simulation type

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -15,15 +15,17 @@
 # post registration details to api
 function post_registration() {
     email="$1"
-    affiliation="$2"
-    site="$3"
-    git_username="$4"
-    research_interest="$5"
-    env_type="$6"
+    name="$2"
+    affiliation="$3"
+    site="$4"
+    git_username="$5"
+    research_interest="$6"
+    env_type="$7"
     curl --location --request POST "https://gc-dashboard.org/registration" \
         --header "Content-Type: text/plain" \
-        --data-raw "{
+        -d "{
             \"email\": \"${email}\",
+            \"name\": \"${name}\",
             \"affiliation\": \"${affiliation}\",
             \"site\": \"${site}\",
             \"git_username\": \"${git_username}\",
@@ -101,6 +103,8 @@ if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
     read email
     
     if [[ ${email} != "" ]]; then
+    printf "${thinline}What is your name?${thinline}"
+    IFS='\n' read -r name
     printf "${thinline}What is your research affiliation (University, \nResearch Group, Government Organization, Company)?${thinline}"
     IFS='\n' read -r affiliation
     printf "${thinline}If available, please provide the url for your affiliated \ninstitution (group website, company website, etc.)?${thinline}"
@@ -125,7 +129,7 @@ if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
     done
     printf "${thinline}Please briefly describe how you plan on using GEOS-Chem \nso that we can add you to the GEOS-Chem People and Projects \nwebpage (https://geoschem.github.io/geos-chem-people-projects-map/).${thinline}"
     IFS='\n' read -r research_interest
-    post_registration "$email" "$affiliation" "$site" "$git_username" "$research_interest" "$env_type"
+    post_registration "$email" "$name" "$affiliation" "$site" "$git_username" "$research_interest" "$env_type"
     fi
     echo "export GC_FIRST_TIME_USER=true" >> ${HOME}/.geoschem/config
     source ${HOME}/.geoschem/config

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -88,26 +88,30 @@ RUNDIR_VARS+="RUNDIR_DATA_ROOT=$GC_DATA_ROOT\n"
 # --------------------------------------------------------------
 # registration for first time users
 # --------------------------------------------------------------
-printf "${thinline}Are you a first time user? If so, would you like to\nregister with the GEOS-Chem community? (y/n)${thinline}"
-valid_response=0
-while [ "$valid_response" -eq 0 ]; do
-    read enable_registration
-    if [[ ${enable_registration} = "y" ]]; then
-    printf "${thinline}What is your email address?${thinline}"
-    read email
-    printf "${thinline}What is your research affiliation (University, \nResearch Group, Government Organization, Company)?${thinline}"
-    IFS='\n' read -r affiliation
-    printf "${thinline}What is your application for GEOS-Chem?${thinline}"
-    IFS='\n' read -r research_interest
+if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
+    printf "${thinline}Are you a first time user? If so, would you like to\nregister with the GEOS-Chem community? (y/n)${thinline}"
+    valid_response=0
+    while [ "$valid_response" -eq 0 ]; do
+        read enable_registration
+        if [[ ${enable_registration} = "y" ]]; then
+        printf "${thinline}What is your email address?${thinline}"
+        read email
+        printf "${thinline}What is your research affiliation (University, \nResearch Group, Government Organization, Company)?${thinline}"
+        IFS='\n' read -r affiliation
+        printf "${thinline}What is your application for GEOS-Chem?${thinline}"
+        IFS='\n' read -r research_interest
 
-    post_registration "$email" "$affiliation" "$research_interest"
-	valid_response=1
-    elif [[ ${enable_git} = "n" ]]; then
-	valid_response=1
-    else
-	printf "Input not recognized. Try again.\n"
-    fi
-done
+        post_registration "$email" "$affiliation" "$research_interest"
+    	valid_response=1
+        elif [[ ${enable_git} = "n" ]]; then
+    	valid_response=1
+        else
+    	printf "Input not recognized. Try again.\n"
+        fi
+    done
+    echo "export GC_FIRST_TIME_USER=true" >> ${HOME}/.geoschem/config
+    source ${HOME}/.geoschem/config
+fi
 
 #-----------------------------------------------------------------
 # Ask user to select simulation type

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -16,12 +16,16 @@
 function post_registration() {
     email="$1"
     affiliation="$2"
-    research_interest="$3"
+    site="$3"
+    git_username="$4"
+    research_interest="$5"
     curl --location --request POST "https://4uh55iovvv6v5xvpmgxkwiidxm0mdyki.lambda-url.us-east-1.on.aws/registration" \
         --header "Content-Type: text/plain" \
         --data-raw "{
             \"email\": \"${email}\",
             \"affiliation\": \"${affiliation}\",
+            \"site\": \"${site}\",
+            \"git_username\": \"${git_username}\",
             \"research_interest\": \"${research_interest}\"
         }"
 }
@@ -89,26 +93,20 @@ RUNDIR_VARS+="RUNDIR_DATA_ROOT=$GC_DATA_ROOT\n"
 # registration for first time users
 # --------------------------------------------------------------
 if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
-    printf "${thinline}Are you a first time user? If so, would you like to\nregister with the GEOS-Chem community? (y/n)${thinline}"
-    valid_response=0
-    while [ "$valid_response" -eq 0 ]; do
-        read enable_registration
-        if [[ ${enable_registration} = "y" ]]; then
-        printf "${thinline}What is your email address?${thinline}"
-        read email
-        printf "${thinline}What is your research affiliation (University, \nResearch Group, Government Organization, Company)?${thinline}"
-        IFS='\n' read -r affiliation
-        printf "${thinline}What is your application for GEOS-Chem?${thinline}"
-        IFS='\n' read -r research_interest
-
-        post_registration "$email" "$affiliation" "$research_interest"
-    	valid_response=1
-        elif [[ ${enable_git} = "n" ]]; then
-    	valid_response=1
-        else
-    	printf "Input not recognized. Try again.\n"
-        fi
-    done
+    printf "${thinline}What is your email address?${thinline}"
+    read email
+    
+    if [[ ${email} != "" ]]; then
+    printf "${thinline}What is your research affiliation (University, \nResearch Group, Government Organization, Company)?${thinline}"
+    IFS='\n' read -r affiliation
+    printf "${thinline}If available, please provide the url for your affiliated \ninstitution (group website, company website, etc.)?${thinline}"
+    IFS='\n' read -r site
+    printf "${thinline}If you have one, please provide your github username?${thinline}"
+    IFS='\n' read -r git_username
+    printf "${thinline}What is your application for GEOS-Chem?${thinline}"
+    IFS='\n' read -r research_interest
+    post_registration "$email" "$affiliation" "$site" "$git_username" "$research_interest"
+    fi
     echo "export GC_FIRST_TIME_USER=true" >> ${HOME}/.geoschem/config
     source ${HOME}/.geoschem/config
 fi

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -12,14 +12,18 @@
 #
 # Initial version: M. Sulprizio, 6/24/2020 (based off GCHP/createRunDir.sh)
 
+# post registration details to api
 function post_registration() {
-    email=$1
-    affiliation=$2
-    research_interest=$3
-    body="{'email': ${email}, 'affiliation': ${affiliation}, 'research_interest': ${research_interest}"
-    curl -X POST https://4uh55iovvv6v5xvpmgxkwiidxm0mdyki.lambda-url.us-east-1.on.aws/registration \
-        -H "Content-Type: application/json" \
-        -d "{'email': ${email}, 'affiliation': ${affiliation}, 'research_interest': ${research_interest}"
+    email="$1"
+    affiliation="$2"
+    research_interest="$3"
+    curl --location --request POST "https://4uh55iovvv6v5xvpmgxkwiidxm0mdyki.lambda-url.us-east-1.on.aws/registration" \
+        --header "Content-Type: text/plain" \
+        --data-raw "{
+            \"email\": \"${email}\",
+            \"affiliation\": \"${affiliation}\",
+            \"research_interest\": \"${research_interest}\"
+        }"
 }
 
 srcrundir=$(pwd -P)
@@ -84,18 +88,19 @@ RUNDIR_VARS+="RUNDIR_DATA_ROOT=$GC_DATA_ROOT\n"
 # --------------------------------------------------------------
 # registration for first time users
 # --------------------------------------------------------------
-printf "${thinline}Are you a first time user? If so, would you like to register with the GEOS-Chem community? (y/n)${thinline}"
+printf "${thinline}Are you a first time user? If so, would you like to\nregister with the GEOS-Chem community? (y/n)${thinline}"
 valid_response=0
 while [ "$valid_response" -eq 0 ]; do
     read enable_registration
     if [[ ${enable_registration} = "y" ]]; then
-    printf "${thinline}What is your email address (If you would like to be added to our user email list)?${thinline}"
+    printf "${thinline}What is your email address?${thinline}"
     read email
-    printf "${thinline}What is your research affiliation (University, Research Group, Government Organization, Company)?${thinline}"
-    read affiliation
+    printf "${thinline}What is your research affiliation (University, \nResearch Group, Government Organization, Company)?${thinline}"
+    IFS='\n' read -r affiliation
     printf "${thinline}What is your application for GEOS-Chem?${thinline}"
-    read research_interest
-    post_registration $email $affiliation $research_interest
+    IFS='\n' read -r research_interest
+
+    post_registration "$email" "$affiliation" "$research_interest"
 	valid_response=1
     elif [[ ${enable_git} = "n" ]]; then
 	valid_response=1

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -96,6 +96,7 @@ RUNDIR_VARS+="RUNDIR_DATA_ROOT=$GC_DATA_ROOT\n"
 # registration for first time users
 # --------------------------------------------------------------
 if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
+    printf "\nInitiating User Registration: You will only need to fill this out once.\n"
     printf "${thinline}What is your email address?${thinline}"
     read email
     

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -19,7 +19,7 @@ function post_registration() {
     site="$3"
     git_username="$4"
     research_interest="$5"
-    curl --location --request POST "https://4uh55iovvv6v5xvpmgxkwiidxm0mdyki.lambda-url.us-east-1.on.aws/registration" \
+    curl --location --request POST "https://gc-dashboard.org/registration" \
         --header "Content-Type: text/plain" \
         --data-raw "{
             \"email\": \"${email}\",

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -97,7 +97,7 @@ RUNDIR_VARS+="RUNDIR_DATA_ROOT=$GC_DATA_ROOT\n"
 # --------------------------------------------------------------
 # registration for first time users
 # --------------------------------------------------------------
-if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
+if [[ -z "${GC_USER_REGISTERED}" ]]; then
     printf "\nInitiating User Registration: You will only need to fill this out once.\n"
     printf "${thinline}What is your email address?${thinline}"
     read email
@@ -131,7 +131,7 @@ if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
     IFS='\n' read -r research_interest
     post_registration "$email" "$name" "$affiliation" "$site" "$git_username" "$research_interest" "$env_type"
     fi
-    echo "export GC_FIRST_TIME_USER=true" >> ${HOME}/.geoschem/config
+    echo "export GC_USER_REGISTERED=true" >> ${HOME}/.geoschem/config
     source ${HOME}/.geoschem/config
 fi
 

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -12,6 +12,27 @@
 #
 # Initial version: E. Lundgren,10/5/2018
 
+# post registration details to api
+function post_registration() {
+    email="$1"
+    affiliation="$2"
+    site="$3"
+    git_username="$4"
+    research_interest="$5"
+    env_type="$6"
+    curl --location --request POST "https://gc-dashboard.org/registration" \
+        --header "Content-Type: text/plain" \
+        --data-raw "{
+            \"email\": \"${email}\",
+            \"affiliation\": \"${affiliation}\",
+            \"site\": \"${site}\",
+            \"git_username\": \"${git_username}\",
+            \"research_interest\": \"${research_interest}\",
+            \"model_type\": \"gchp\",
+            \"env_type\": \"${env_type}\"
+        }"
+}
+
 srcrundir=$(pwd -P)
 cd ${srcrundir}
 cd ../..
@@ -70,6 +91,45 @@ if [[ -z "${GC_DATA_ROOT}" ]]; then
 fi
 
 RUNDIR_VARS+="RUNDIR_DATA_ROOT=$GC_DATA_ROOT\n"
+
+# --------------------------------------------------------------
+# registration for first time users
+# --------------------------------------------------------------
+if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
+    printf "\nInitiating User Registration: You will only need to fill this out once.\n"
+    printf "${thinline}What is your email address?${thinline}"
+    read email
+    
+    if [[ ${email} != "" ]]; then
+    printf "${thinline}What is your research affiliation (University, \nResearch Group, Government Organization, Company)?${thinline}"
+    IFS='\n' read -r affiliation
+    printf "${thinline}If available, please provide the url for your affiliated \ninstitution (group website, company website, etc.)?${thinline}"
+    IFS='\n' read -r site
+    printf "${thinline}Please provide your github username (if any) so that we \ncan recognize you in submitted issues and pull requests.${thinline}"
+    IFS='\n' read -r git_username
+    printf "${thinline}How do you plan to run GEOS-Chem?${thinline}"
+    printf "   1. Local Cluster\n"
+    printf "   2. AWS\n"
+    valid_env=0
+    while [ "${valid_env}" -eq 0 ]; do
+        read env_num
+        valid_env=1
+        if [[ ${env_num} = "1" ]]; then
+    	env_type="Local Cluster"
+        elif [[ ${env_num} = "2" ]]; then
+    	env_type=AWS
+        else
+            valid_env=0
+    	printf "Invalid option. Try again.\n"
+        fi
+    done
+    printf "${thinline}Please briefly describe how you plan on using GEOS-Chem \nso that we can add you to the GEOS-Chem People and Projects \nwebpage (https://geoschem.github.io/geos-chem-people-projects-map/).${thinline}"
+    IFS='\n' read -r research_interest
+    post_registration "$email" "$affiliation" "$site" "$git_username" "$research_interest" "$env_type"
+    fi
+    echo "export GC_FIRST_TIME_USER=true" >> ${HOME}/.geoschem/config
+    source ${HOME}/.geoschem/config
+fi
 
 #-----------------------------------------------------------------
 # Ask user to select simulation type

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -15,15 +15,17 @@
 # post registration details to api
 function post_registration() {
     email="$1"
-    affiliation="$2"
-    site="$3"
-    git_username="$4"
-    research_interest="$5"
-    env_type="$6"
+    name="$2"
+    affiliation="$3"
+    site="$4"
+    git_username="$5"
+    research_interest="$6"
+    env_type="$7"
     curl --location --request POST "https://gc-dashboard.org/registration" \
         --header "Content-Type: text/plain" \
-        --data-raw "{
+        -d "{
             \"email\": \"${email}\",
+            \"name\": \"${name}\",
             \"affiliation\": \"${affiliation}\",
             \"site\": \"${site}\",
             \"git_username\": \"${git_username}\",
@@ -101,6 +103,8 @@ if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
     read email
     
     if [[ ${email} != "" ]]; then
+    printf "${thinline}What is your name?${thinline}"
+    IFS='\n' read -r name
     printf "${thinline}What is your research affiliation (University, \nResearch Group, Government Organization, Company)?${thinline}"
     IFS='\n' read -r affiliation
     printf "${thinline}If available, please provide the url for your affiliated \ninstitution (group website, company website, etc.)?${thinline}"
@@ -125,7 +129,7 @@ if [[ -z "${GC_FIRST_TIME_USER}" ]]; then
     done
     printf "${thinline}Please briefly describe how you plan on using GEOS-Chem \nso that we can add you to the GEOS-Chem People and Projects \nwebpage (https://geoschem.github.io/geos-chem-people-projects-map/).${thinline}"
     IFS='\n' read -r research_interest
-    post_registration "$email" "$affiliation" "$site" "$git_username" "$research_interest" "$env_type"
+    post_registration "$email" "$name" "$affiliation" "$site" "$git_username" "$research_interest" "$env_type"
     fi
     echo "export GC_FIRST_TIME_USER=true" >> ${HOME}/.geoschem/config
     source ${HOME}/.geoschem/config


### PR DESCRIPTION
This is a workin progress pr that will allow for registration of new users of geoschem. For first time users, few additional questions are asked (email, research interests, affiliation), which are then sent to a dynamodb database via a POST api request. 

A list of registered users is then available from a [GC User dashboard](https://gc-dashboard.org/users), which I have mocked up with some sample data.

Is there additional info that would be useful for registration? FYI, the dashboard currently uses a crazy ephemeral url that I plan to switch to a more static custom domain for the actual pr (eg. geoschem.org), but suggestions for domain names are appreciated!

Here is an example of the `./createrundir` flow for first time users:
<img width="487" alt="Screen Shot 2022-06-27 at 6 06 41 PM" src="https://user-images.githubusercontent.com/63303345/176043699-cab43d57-e6db-42b7-bdb9-fc2240cf514d.png">
