### PR TITLE
Update offline biogenic VOC and soil NOx emissions

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -137,11 +137,11 @@ Warnings:                    1
 # update ExtNr and Cat in HEMCO_Diagn.rc to properly save out emissions for
 # any affected species.
 #------------------------------------------------------------------------------
-    --> OFFLINE_DUST           :       ${RUNDIR_OFFLINE_DUST}    # 1980-2021
-    --> OFFLINE_BIOGENICVOC    :       ${RUNDIR_OFFLINE_BIOVOC}    # 1980-2021
-    --> OFFLINE_SEASALT        :       ${RUNDIR_OFFLINE_SEASALT}    # 1980-2021
+    --> OFFLINE_DUST           :       ${RUNDIR_OFFLINE_DUST}    # 1980-2019
+    --> OFFLINE_BIOGENICVOC    :       ${RUNDIR_OFFLINE_BIOVOC}    # 1980-2020
+    --> OFFLINE_SEASALT        :       ${RUNDIR_OFFLINE_SEASALT}    # 1980-2019
     -->  CalcBrSeasalt         :       false
-    --> OFFLINE_SOILNOX        :       ${RUNDIR_OFFLINE_SOILNOX}    # 1980-2021
+    --> OFFLINE_SOILNOX        :       ${RUNDIR_OFFLINE_SOILNOX}    # 1980-2020
 # ----- NON-EMISSIONS DATA ----------------------------------------------------
     --> UVALBEDO               :       true     # 1985
     --> OMOC_RATIO             :       false    # 2010
@@ -1664,10 +1664,10 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_DUST
 (((.not.DustDead.or.DustGinoux
-0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2021/1-12/1-31/* C xy kg/m2/s DST1 - 3 2
-0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2021/1-12/1-31/* C xy kg/m2/s DST2 - 3 2
-0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2021/1-12/1-31/* C xy kg/m2/s DST3 - 3 2
-0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2021/1-12/1-31/* C xy kg/m2/s DST4 - 3 2
+0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2022/1-12/1-31/* EY xy kg/m2/s DST1 - 3 2
+0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2022/1-12/1-31/* EY xy kg/m2/s DST2 - 3 2
+0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2022/1-12/1-31/* EY xy kg/m2/s DST3 - 3 2
+0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2022/1-12/1-31/* EY xy kg/m2/s DST4 - 3 2
 ))).not.DustDead.or.DustGinoux
 )))OFFLINE_DUST
 
@@ -1675,26 +1675,27 @@ Warnings:                    1
 # --- Offline biogenic VOC emissions ---
 #==============================================================================
 (((OFFLINE_BIOGENICVOC
-0 BIOGENIC_ACET      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ACET_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s ACET 40  4 2
-0 BIOGENIC_ALD2      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ALD2_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s ALD2 41  4 2
-0 BIOGENIC_C2H4      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc C2H4_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s C2H4 44  4 2
-0 BIOGENIC_EOH       $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EOH_MEGAN     1980-2021/1-12/1-31/* C xy kgC/m2/s EOH  47  4 2
-0 BIOGENIC_ISOP      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ISOP_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s ISOP 61  4 2
-0 BIOGENIC_ISOP_SOAP -                                                                                   -             -                     - -  -        SOAP 610 4 2
-0 BIOGENIC_ISOP_SOAS -                                                                                   -             -                     - -  -        SOAS 610 4 2
-0 BIOGENIC_LIMO      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc LIMO_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s LIMO -   4 2
-0 BIOGENIC_LIMO_SOAP -                                                                                   -             -                     - -  -        SOAP 611 4 2
-0 BIOGENIC_LIMO_SOAS -                                                                                   -             -                     - -  -        SOAS 611 4 2
-0 BIOGENIC_MTPA      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPA_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s MTPA -   4 2
-0 BIOGENIC_MTPA_SOAP -                                                                                   -             -                     - -  -        SOAP 611 4 2
-0 BIOGENIC_MTPA_SOAS -                                                                                   -             -                     - -  -        SOAS 611 4 2
-0 BIOGENIC_MTPO      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPO_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s MTPO -   4 2
-0 BIOGENIC_MTPO_SOAP -                                                                                   -             -                     - -  -        SOAP 611 4 2
-0 BIOGENIC_MTPO_SOAS -                                                                                   -             -                     - -  -        SOAS 611 4 2
-0 BIOGENIC_PRPE      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc PRPE_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s PRPE 49  4 2
-0 BIOGENIC_SESQ      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SESQ_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s SESQ -   4 2
-0 BIOGENIC_SESQ_SOAP -                                                                                   -             -                     - -  -        SOAP 612 4 2
-0 BIOGENIC_SESQ_SOAS -                                                                                   -             -                     - -  -        SOAS 612 4 2
+0 BIOGENIC_ACET      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ACET_MEGAN    1980-2022/1-12/1-31/* EY xy kg/m2/s ACET -   4 2
+0 BIOGENIC_ALD2      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ALD2_MEGAN    1980-2022/1-12/1-31/* EY xy kg/m2/s ALD2 -   4 2
+0 BIOGENIC_C2H4      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc C2H4_MEGAN    1980-2022/1-12/1-31/* EY xy kg/m2/s C2H4 -   4 2
+0 BIOGENIC_EOH       $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EOH_MEGAN     1980-2022/1-12/1-31/* EY xy kg/m2/s EOH  -   4 2
+0 BIOGENIC_ISOP      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ISOP_MEGAN    1980-2022/1-12/1-31/* EY xy kg/m2/s ISOP -   4 2
+0 BIOGENIC_ISOP_SOAP -                                                                                                            -             -                     -  -  -       SOAP 610 4 2
+0 BIOGENIC_ISOP_SOAS -                                                                                                            -             -                     -  -  -       SOAS 610 4 2
+0 BIOGENIC_LIMO      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc LIMO_MEGAN    1980-2022/1-12/1-31/* EY xy kg/m2/s LIMO -   4 2
+0 BIOGENIC_LIMO_SOAP -                                                                                                            -             -                     -  -  -       SOAP 611 4 2
+0 BIOGENIC_LIMO_SOAS -                                                                                                            -             -                     -  -  -       SOAS 611 4 2
+0 BIOGENIC_MOH       $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MOH_MEGAN     1980-2022/1-12/1-31/* EF xy kg/m2/s MOH  -   4 2
+0 BIOGENIC_MTPA      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPA_MEGAN    1980-2022/1-12/1-31/* EY xy kg/m2/s MTPA -   4 2
+0 BIOGENIC_MTPA_SOAP -                                                                                                            -             -                     -  -  -       SOAP 611 4 2
+0 BIOGENIC_MTPA_SOAS -                                                                                                            -             -                     -  -  -       SOAS 611 4 2
+0 BIOGENIC_MTPO      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPO_MEGAN    1980-2022/1-12/1-31/* EY xy kg/m2/s MTPO -   4 2
+0 BIOGENIC_MTPO_SOAP -                                                                                                            -             -                     -  -  -       SOAP 611 4 2
+0 BIOGENIC_MTPO_SOAS -                                                                                                            -             -                     -  -  -       SOAS 611 4 2
+0 BIOGENIC_PRPE      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc PRPE_MEGAN    1980-2022/1-12/1-31/* EY xy kg/m2/s PRPE -   4 2
+0 BIOGENIC_SESQ      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SESQ_MEGAN    1980-2022/1-12/1-31/* EY xy kg/m2/s SESQ -   4 2
+0 BIOGENIC_SESQ_SOAP -                                                                                                            -             -                     -  -  -       SOAP 612 4 2
+0 BIOGENIC_SESQ_SOAS -                                                                                                            -             -                     -  -  -       SOAS 612 4 2
 )))OFFLINE_BIOGENICVOC
 
 #==============================================================================
@@ -1702,17 +1703,17 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_SEASALT
 (((.not.SeaSalt
-0 SEASALT_SALA    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALA_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALA    -   3 2
-0 SEASALT_SALAAL  -                                                                                     -            -                     - -  -       SALAAL  615 3 2
-0 SEASALT_SALACL  -                                                                                     -            -                     - -  -       SALACL  616 3 2
+0 SEASALT_SALA    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALA_TOTAL   1980-2022/1-12/1-31/* EY xy kg/m2/s SALA    -   3 2
+0 SEASALT_SALAAL  -                                                                                                              -            -                     -  -  -       SALAAL  615 3 2
+0 SEASALT_SALACL  -                                                                                                              -            -                     -  -  -       SALACL  616 3 2
 (((CalcBrSeasalt
-0 SEASALT_BrSALA  -                                                                                     -            -                     - -  -       BrSALA  617 3 2
+0 SEASALT_BrSALA  -                                                                                                              -            -                     -  -  -       BrSALA  617 3 2
 )))CalcBrSeasalt
-0 SEASALT_SALC    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALC_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALC    -   3 2
-0 SEASALT_SALCAL  -                                                                                     -            -                     - -  -       SALCAL  615 3 2
-0 SEASALT_SALCCL  -                                                                                     -            -                     - -  -       SALCCL  616 3 2
+0 SEASALT_SALC    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALC_TOTAL   1980-2022/1-12/1-31/* EY xy kg/m2/s SALC    -   3 2
+0 SEASALT_SALCAL  -                                                                                                              -            -                     -  -  -       SALCAL  615 3 2
+0 SEASALT_SALCCL  -                                                                                                              -            -                     -  -  -       SALCCL  616 3 2
 (((CalcBrSeasalt
-0 SEASALT_BrSALC  -                                                                                     -            -                     - -  -       BrSALC  617 3 2
+0 SEASALT_BrSALC  -                                                                                                              -            -                     -  -  -       BrSALC  617 3 2
 )))CalcBrSeasalt
 ))).not.SeaSalt
 )))OFFLINE_SEASALT

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -138,7 +138,6 @@ Warnings:                    1
 # corresponding HEMCO extension to 'on':
 #   OFFLINE_DUST        - DustDead or DustGinoux
 #   OFFLINE_BIOGENICVOC - MEGAN
-#    - Note: MEGAN must always be on for species not in OFFLINE_BIOGENICVOC
 #   OFFLINE_SEASALT     - SeaSalt
 #   OFFLINE_SOILNOX     - SoilNOx
 #
@@ -146,11 +145,11 @@ Warnings:                    1
 # update ExtNr and Cat in HEMCO_Diagn.rc to properly save out emissions for
 # any affected species.
 #------------------------------------------------------------------------------
-    --> OFFLINE_DUST           :       ${RUNDIR_OFFLINE_DUST}    # 1980-2021
-    --> OFFLINE_BIOGENICVOC    :       ${RUNDIR_OFFLINE_BIOVOC}    # 1980-2021
-    --> OFFLINE_SEASALT        :       ${RUNDIR_OFFLINE_SEASALT}    # 1980-2021
+    --> OFFLINE_DUST           :       ${RUNDIR_OFFLINE_DUST}    # 1980-2019
+    --> OFFLINE_BIOGENICVOC    :       ${RUNDIR_OFFLINE_BIOVOC}    # 1980-2020
+    --> OFFLINE_SEASALT        :       ${RUNDIR_OFFLINE_SEASALT}    # 1980-2019
     -->  CalcBrSeasalt         :       false
-    --> OFFLINE_SOILNOX        :       ${RUNDIR_OFFLINE_SOILNOX}    # 1980-2021
+    --> OFFLINE_SOILNOX        :       ${RUNDIR_OFFLINE_SOILNOX}    # 1980-2020
 # ----- NON-EMISSIONS DATA ----------------------------------------------------
     --> UVALBEDO               :       true     # 1985
     --> CCM_STRAT_Bry          :       true     # 2007
@@ -239,7 +238,7 @@ Warnings:                    1
 ### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
-# ExtNrName sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
+# ExtNr	Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
 
 (((EMISSIONS
 
@@ -2786,10 +2785,10 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_DUST
 (((.not.DustDead.or.DustGinoux
-0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2021/1-12/1-31/* C xy kg/m2/s DST1 - 3 2
-0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2021/1-12/1-31/* C xy kg/m2/s DST2 - 3 2
-0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2021/1-12/1-31/* C xy kg/m2/s DST3 - 3 2
-0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2021/1-12/1-31/* C xy kg/m2/s DST4 - 3 2
+0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2022/1-12/1-31/* EF xy kg/m2/s DST1 - 3 2
+0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2022/1-12/1-31/* EF xy kg/m2/s DST2 - 3 2
+0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2022/1-12/1-31/* EF xy kg/m2/s DST3 - 3 2
+0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2022/1-12/1-31/* EF xy kg/m2/s DST4 - 3 2
 ))).not.DustDead.or.DustGinoux
 )))OFFLINE_DUST
 
@@ -2797,26 +2796,27 @@ Warnings:                    1
 # --- Offline biogenic VOC emissions ---
 #==============================================================================
 (((OFFLINE_BIOGENICVOC
-0 BIOGENIC_ACET      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ACET_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s ACET 40  4 2
-0 BIOGENIC_ALD2      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ALD2_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s ALD2 41  4 2
-0 BIOGENIC_C2H4      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc C2H4_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s C2H4 44  4 2
-0 BIOGENIC_EOH       $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EOH_MEGAN     1980-2021/1-12/1-31/* C xy kgC/m2/s EOH  47  4 2
-0 BIOGENIC_ISOP      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ISOP_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s ISOP 61  4 2
-0 BIOGENIC_ISOP_SOAP -                                                                                   -             -                     - -  -        SOAP 610 4 2
-0 BIOGENIC_ISOP_SOAS -                                                                                   -             -                     - -  -        SOAS 610 4 2
-0 BIOGENIC_LIMO      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc LIMO_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s LIMO -   4 2
-0 BIOGENIC_LIMO_SOAP -                                                                                   -             -                     - -  -        SOAP 611 4 2
-0 BIOGENIC_LIMO_SOAS -                                                                                   -             -                     - -  -        SOAS 611 4 2
-0 BIOGENIC_MTPA      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPA_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s MTPA -   4 2
-0 BIOGENIC_MTPA_SOAP -                                                                                   -             -                     - -  -        SOAP 611 4 2
-0 BIOGENIC_MTPA_SOAS -                                                                                   -             -                     - -  -        SOAS 611 4 2
-0 BIOGENIC_MTPO      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPO_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s MTPO -   4 2
-0 BIOGENIC_MTPO_SOAP -                                                                                   -             -                     - -  -        SOAP 611 4 2
-0 BIOGENIC_MTPO_SOAS -                                                                                   -             -                     - -  -        SOAS 611 4 2
-0 BIOGENIC_PRPE      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc PRPE_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s PRPE 49  4 2
-0 BIOGENIC_SESQ      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SESQ_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s SESQ -   4 2
-0 BIOGENIC_SESQ_SOAP -                                                                                   -             -                     - -  -        SOAP 612 4 2
-0 BIOGENIC_SESQ_SOAS -                                                                                   -             -                     - -  -        SOAS 612 4 2
+0 BIOGENIC_ACET      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ACET_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s ACET -   4 2
+0 BIOGENIC_ALD2      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ALD2_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s ALD2 -   4 2
+0 BIOGENIC_C2H4      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc C2H4_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s C2H4 -   4 2
+0 BIOGENIC_EOH       $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EOH_MEGAN     1980-2022/1-12/1-31/* EF xy kg/m2/s EOH  -   4 2
+0 BIOGENIC_ISOP      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ISOP_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s ISOP -   4 2
+0 BIOGENIC_ISOP_SOAP -                                                                                                            -             -                     -  -  -       SOAP 610 4 2
+0 BIOGENIC_ISOP_SOAS -                                                                                                            -             -                     -  -  -       SOAS 610 4 2
+0 BIOGENIC_LIMO      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc LIMO_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s LIMO -   4 2
+0 BIOGENIC_LIMO_SOAP -                                                                                                            -             -                     -  -  -       SOAP 611 4 2
+0 BIOGENIC_LIMO_SOAS -                                                                                                            -             -                     -  -  -       SOAS 611 4 2
+0 BIOGENIC_MOH       $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MOH_MEGAN     1980-2022/1-12/1-31/* EF xy kg/m2/s MOH  -   4 2
+0 BIOGENIC_MTPA      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPA_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s MTPA -   4 2
+0 BIOGENIC_MTPA_SOAP -                                                                                                            -             -                     -  -  -       SOAP 611 4 2
+0 BIOGENIC_MTPA_SOAS -                                                                                                            -             -                     -  -  -       SOAS 611 4 2
+0 BIOGENIC_MTPO      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPO_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s MTPO -   4 2
+0 BIOGENIC_MTPO_SOAP -                                                                                                            -             -                     -  -  -       SOAP 611 4 2
+0 BIOGENIC_MTPO_SOAS -                                                                                                            -             -                     -  -  -       SOAS 611 4 2
+0 BIOGENIC_PRPE      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc PRPE_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s PRPE -   4 2
+0 BIOGENIC_SESQ      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SESQ_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s SESQ -   4 2
+0 BIOGENIC_SESQ_SOAP -                                                                                                            -             -                     -  -  -       SOAP 612 4 2
+0 BIOGENIC_SESQ_SOAS -                                                                                                            -             -                     -  -  -       SOAS 612 4 2
 )))OFFLINE_BIOGENICVOC
 
 #==============================================================================
@@ -2824,17 +2824,17 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_SEASALT
 (((.not.SeaSalt
-0 SEASALT_SALA    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALA_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALA    -   3 2
-0 SEASALT_SALAAL  -                                                                                     -            -                     - -  -       SALAAL  615 3 2
-0 SEASALT_SALACL  -                                                                                     -            -                     - -  -       SALACL  616 3 2
+0 SEASALT_SALA    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALA_TOTAL   1980-2022/1-12/1-31/* EF xy kg/m2/s SALA    -   3 2
+0 SEASALT_SALAAL  -                                                                                                              -            -                     -  -  -       SALAAL  615 3 2
+0 SEASALT_SALACL  -                                                                                                              -            -                     -  -  -       SALACL  616 3 2
 (((CalcBrSeasalt
-0 SEASALT_BrSALA  -                                                                                     -            -                     - -  -       BrSALA  617 3 2
+0 SEASALT_BrSALA  -                                                                                                              -            -                     -  -  -       BrSALA  617 3 2
 )))CalcBrSeasalt
-0 SEASALT_SALC    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALC_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALC    -   3 2
-0 SEASALT_SALCAL  -                                                                                     -            -                     - -  -       SALCAL  615 3 2
-0 SEASALT_SALCCL  -                                                                                     -            -                     - -  -       SALCCL  616 3 2
+0 SEASALT_SALC    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALC_TOTAL   1980-2022/1-12/1-31/* EF xy kg/m2/s SALC    -   3 2
+0 SEASALT_SALCAL  -                                                                                                              -            -                     -  -  -       SALCAL  615 3 2
+0 SEASALT_SALCCL  -                                                                                                              -            -                     -  -  -       SALCCL  616 3 2
 (((CalcBrSeasalt
-0 SEASALT_BrSALC  -                                                                                     -            -                     - -  -       BrSALC  617 3 2
+0 SEASALT_BrSALC  -                                                                                                              -            -                     -  -  -       BrSALC  617 3 2
 )))CalcBrSeasalt
 ))).not.SeaSalt
 )))OFFLINE_SEASALT
@@ -2844,7 +2844,7 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_SOILNOX
 (((.not.SoilNOx
-0 SOILNOX_NO  $ROOT/OFFLINE_SOILNOX/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/soilnox_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SOIL_NOx 1980-2021/1-12/1-31/* C xy kg/m2/s NO - 3 2
+0 SOILNOX_NO  $ROOT/OFFLINE_SOILNOX/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/soilnox_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SOIL_NOx 1980-2022/1-12/1-31/* EF xy kg/m2/s NO - 3 2
 ))).not.SoilNOx
 )))OFFLINE_SOILNOX
 

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -1538,20 +1538,19 @@ EMIS_DST4 kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none EMIS_DST4 ./HcoDir/OFFLINE
 #==============================================================================
 # --- Offline biogenic VOC emissions (OFFLINE_BIOGENICVOC) ---
 #==============================================================================
-BIOGENIC_ACET kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none ACET_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_ALD2 kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none ALD2_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_C2H4 kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none C2H4_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_EOH  kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none EOH_MEGAN  ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_ISOP kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none ISOP_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_PRPE kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none PRPE_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_SOAP kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none SOAP_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_SOAS kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none SOAS_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_MTPA kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none MTPA_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_MTPO kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none MTPO_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_LIMO kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none LIMO_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-BIOGENIC_SESQ kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none SESQ_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
-#
-BIOGENIC_CO   kgC/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none BIOGENIC_CO ./HcoDir/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_ACET kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none ACET_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_ALD2 kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none ALD2_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_C2H4 kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none C2H4_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_EOH  kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none EOH_MEGAN  ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_ISOP kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none ISOP_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_PRPE kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none PRPE_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_SOAP kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none SOAP_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_SOAS kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none SOAS_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_MOH  kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none MOH_MEGAN  ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_MTPA kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none MTPA_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_MTPO kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none MTPO_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_LIMO kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none LIMO_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+BIOGENIC_SESQ kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none SESQ_MEGAN ./HcoDir/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/biovoc_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
 #
 #==============================================================================
 # --- Offline sea salt emissions (OFFLINE_SEASALT) ---
@@ -1566,7 +1565,7 @@ SEASALT_SALC kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none SALC_TOTAL ./HcoDir/OFF
 #==============================================================================
 # --- Offline soil NOx emissions (OFFLINE_SOILNOX) ---
 #==============================================================================
-SOILNOX_NO kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none SOIL_NOx ./HcoDir/OFFLINE_SOILNOX/v2019-01/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/soilnox_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
+SOILNOX_NO kg/m2/s N Y %y4-%m2-%d2T%h2:00:00 none none SOIL_NOx ./HcoDir/OFFLINE_SOILNOX/v2021-12/${RUNDIR_MET_NATIVE_RES}/%y4/%m2/soilnox_${RUNDIR_MET_LAT_RES}.%y4%m2%d2.nc
 #
 ###############################################################################
 ###

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -137,7 +137,6 @@ Warnings:                    1
 # corresponding HEMCO extension to 'on':
 #   OFFLINE_DUST        - DustDead or DustGinoux
 #   OFFLINE_BIOGENICVOC - MEGAN
-#    - Note: MEGAN must always be on for species not in OFFLINE_BIOGENICVOC
 #   OFFLINE_SEASALT     - SeaSalt
 #   OFFLINE_SOILNOX     - SoilNOx
 #
@@ -145,11 +144,11 @@ Warnings:                    1
 # update ExtNr and Cat in HEMCO_Diagn.rc to properly save out emissions for
 # any affected species.
 #------------------------------------------------------------------------------
-    --> OFFLINE_DUST           :       ${RUNDIR_OFFLINE_DUST}    # 1980-2021
-    --> OFFLINE_BIOGENICVOC    :       ${RUNDIR_OFFLINE_BIOVOC}    # 1980-2021
-    --> OFFLINE_SEASALT        :       ${RUNDIR_OFFLINE_SEASALT}    # 1980-2021
+    --> OFFLINE_DUST           :       ${RUNDIR_OFFLINE_DUST}    # 1980-2019
+    --> OFFLINE_BIOGENICVOC    :       ${RUNDIR_OFFLINE_BIOVOC}    # 1980-2020
+    --> OFFLINE_SEASALT        :       ${RUNDIR_OFFLINE_SEASALT}    # 1980-2019
     -->  CalcBrSeasalt         :       false
-    --> OFFLINE_SOILNOX        :       ${RUNDIR_OFFLINE_SOILNOX}    # 1980-2021
+    --> OFFLINE_SOILNOX        :       ${RUNDIR_OFFLINE_SOILNOX}    # 1980-2020
 # ----- NON-EMISSIONS DATA ----------------------------------------------------
     --> UVALBEDO               :       true     # 1985
     --> CCM_STRAT_Bry          :       true     # 2007
@@ -2475,7 +2474,7 @@ Warnings:                    1
 )))CEDSv2_SHIP
 
 (((CEDS_GBDMAPS_SHIP
-0 CEDS_NO_SHP $ROOT/CEDS/v2020-08/$YYYY/NO-em-total-anthro_CEDS_$YYYY.nc NO_shp 1970-2017/1-12/1/0 C xy kg/m2/s NO 25 10 5
+0 CEDS_NO_SHP $ROOT/CEDS/v2020-08/$YYYY/NO-em-total-anthro_CEDS_$YYYY.nc      NO_shp 1970-2017/1-12/1/0 C xy kg/m2/s NO 25   10 5
 )))CEDS_GBDMAPS_SHIP
 
 (((CMIP6_SHIP
@@ -2487,32 +2486,32 @@ Warnings:                    1
 )))SHIP
 
 #==============================================================================
-# --- AEIC 2019 aircraft emissions ---
+# --- AEIC 2019 aircraft emissions (daily & monthly mean) ---
 #
 # Data files are for 2019, but scale factors from 1990-2019 can be applied
 # in order to get year-specific emissions.  See the notes in the AEIC2019
 # scale factor section below for more information.
 #==============================================================================
 (((AEIC2019_DAILY
-0 AEIC19_DAILY_NO   $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc NO       2019/1-12/1-31/0 C xyz kg/m2/s NO   241/240     20 1
-0 AEIC19_DAILY_NO2  $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc NO2      2019/1-12/1-31/0 C xyz kg/m2/s NO2  241/240     20 1
-0 AEIC19_DAILY_HONO $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc HONO     2019/1-12/1-31/0 C xyz kg/m2/s HNO2 241/240     20 1
-0 AEIC19_DAILY_CO   $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc CO       2019/1-12/1-31/0 C xyz kg/m2/s CO   241         20 1
-0 AEIC19_DAILY_SOAP -                                                             -        -                - -   -       SOAP 241/280     20 1
-0 AEIC19_DAILY_SO2  $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc FUELBURN 2019/1-12/1-31/0 C xyz kg/m2/s SO2  241/111     20 1
-0 AEIC19_DAILY_SO4  -                                                             -        -                - -   -       SO4  241/112     20 1
-0 AEIC19_DAILY_H2O  -                                                             -        -                - -   -       H2O  241/120     20 1
-0 AEIC19_DAILY_BCPI $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc BC       2019/1-12/1-31/0 C xyz kg/m2/s BCPI 241         20 1
-0 AEIC19_DAILY_OCPI $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc OC       2019/1-12/1-31/0 C xyz kg/m2/s OCPI 241         20 1
-0 AEIC19_DAILY_ACET $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc HC       2019/1-12/1-31/0 C xyz kg/m2/s ACET 241/114/101 20 1
-0 AEIC19_DAILY_ALD2 -                                                             -        -                - -   -       ALD2 241/114/102 20 1
-0 AEIC19_DAILY_ALK4 -                                                             -        -                - -   -       ALK4 241/114/103 20 1
-0 AEIC19_DAILY_C2H6 -                                                             -        -                - -   -       C2H6 241/114/104 20 1
-0 AEIC19_DAILY_C3H8 -                                                             -        -                - -   -       C3H8 241/114/105 20 1
-0 AEIC19_DAILY_CH2O -                                                             -        -                - -   -       CH2O 241/114/106 20 1
-0 AEIC19_DAILY_PRPE -                                                             -        -                - -   -       PRPE 241/114/107 20 1
-0 AEIC19_DAILY_MACR -                                                             -        -                - -   -       MACR 241/114/108 20 1
-0 AEIC19_DAILY_RCHO -                                                             -        -                - -   -       RCHO 241/114/109 20 1
+0 AEIC19_DAILY_NO   $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc NO       2019/1-12/1-31/0 C xyz kg/m2/s NO   241/240     20 1
+0 AEIC19_DAILY_NO2  $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc NO2      2019/1-12/1-31/0 C xyz kg/m2/s NO2  241/240     20 1
+0 AEIC19_DAILY_HONO $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc HONO     2019/1-12/1-31/0 C xyz kg/m2/s HNO2 241/240     20 1
+0 AEIC19_DAILY_CO   $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc CO       2019/1-12/1-31/0 C xyz kg/m2/s CO   241         20 1
+0 AEIC19_DAILY_SOAP -                                                                 -        -                - -   -       SOAP 241/280     20 1
+0 AEIC19_DAILY_SO2  $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc FUELBURN 2019/1-12/1-31/0 C xyz kg/m2/s SO2  241/111     20 1
+0 AEIC19_DAILY_SO4  -                                                                 -        -                - -   -       SO4  241/112     20 1
+0 AEIC19_DAILY_H2O  -                                                                 -        -                - -   -       H2O  241/120     20 1
+0 AEIC19_DAILY_BCPI $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc BC       2019/1-12/1-31/0 C xyz kg/m2/s BCPI 241         20 1
+0 AEIC19_DAILY_OCPI $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc OC       2019/1-12/1-31/0 C xyz kg/m2/s OCPI 241         20 1
+0 AEIC19_DAILY_ACET $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc HC       2019/1-12/1-31/0 C xyz kg/m2/s ACET 241/114/101 20 1
+0 AEIC19_DAILY_ALD2 -                                                                 -        -                - -   -       ALD2 241/114/102 20 1
+0 AEIC19_DAILY_ALK4 -                                                                 -        -                - -   -       ALK4 241/114/103 20 1
+0 AEIC19_DAILY_C2H6 -                                                                 -        -                - -   -       C2H6 241/114/104 20 1
+0 AEIC19_DAILY_C3H8 -                                                                 -        -                - -   -       C3H8 241/114/105 20 1
+0 AEIC19_DAILY_CH2O -                                                                 -        -                - -   -       CH2O 241/114/106 20 1
+0 AEIC19_DAILY_PRPE -                                                                 -        -                - -   -       PRPE 241/114/107 20 1
+0 AEIC19_DAILY_MACR -                                                                 -        -                - -   -       MACR 241/114/108 20 1
+0 AEIC19_DAILY_RCHO -                                                                 -        -                - -   -       RCHO 241/114/109 20 1
 )))AEIC2019_DAILY
 (((AEIC2019_MONMEAN
 0 AEIC19_MONMEAN_NO   $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc NO       2019/1-12/1/0 C xyz kg/m2/s NO   241/240     20 1
@@ -2785,10 +2784,10 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_DUST
 (((.not.DustDead.or.DustGinoux
-0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2021/1-12/1-31/* C xy kg/m2/s DST1 - 3 2
-0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2021/1-12/1-31/* C xy kg/m2/s DST2 - 3 2
-0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2021/1-12/1-31/* C xy kg/m2/s DST3 - 3 2
-0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2021/1-12/1-31/* C xy kg/m2/s DST4 - 3 2
+0 EMIS_DST1 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST1 1980-2022/1-12/1-31/* EF xy kg/m2/s DST1 - 3 2
+0 EMIS_DST2 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST2 1980-2022/1-12/1-31/* EF xy kg/m2/s DST2 - 3 2
+0 EMIS_DST3 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST3 1980-2022/1-12/1-31/* EF xy kg/m2/s DST3 - 3 2
+0 EMIS_DST4 $ROOT/OFFLINE_DUST/v2021-08/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/dust_emissions_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EMIS_DST4 1980-2022/1-12/1-31/* EF xy kg/m2/s DST4 - 3 2
 ))).not.DustDead.or.DustGinoux
 )))OFFLINE_DUST
 
@@ -2796,26 +2795,27 @@ Warnings:                    1
 # --- Offline biogenic VOC emissions ---
 #==============================================================================
 (((OFFLINE_BIOGENICVOC
-0 BIOGENIC_ACET      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ACET_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s ACET 40  4 2
-0 BIOGENIC_ALD2      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ALD2_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s ALD2 41  4 2
-0 BIOGENIC_C2H4      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc C2H4_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s C2H4 44  4 2
-0 BIOGENIC_EOH       $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EOH_MEGAN     1980-2021/1-12/1-31/* C xy kgC/m2/s EOH  47  4 2
-0 BIOGENIC_ISOP      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ISOP_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s ISOP 61  4 2
-0 BIOGENIC_ISOP_SOAP -                                                                                   -             -                     - -  -        SOAP 610 4 2
-0 BIOGENIC_ISOP_SOAS -                                                                                   -             -                     - -  -        SOAS 610 4 2
-0 BIOGENIC_LIMO      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc LIMO_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s LIMO -   4 2
-0 BIOGENIC_LIMO_SOAP -                                                                                   -             -                     - -  -        SOAP 611 4 2
-0 BIOGENIC_LIMO_SOAS -                                                                                   -             -                     - -  -        SOAS 611 4 2
-0 BIOGENIC_MTPA      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPA_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s MTPA -   4 2
-0 BIOGENIC_MTPA_SOAP -                                                                                   -             -                     - -  -        SOAP 611 4 2
-0 BIOGENIC_MTPA_SOAS -                                                                                   -             -                     - -  -        SOAS 611 4 2
-0 BIOGENIC_MTPO      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPO_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s MTPO -   4 2
-0 BIOGENIC_MTPO_SOAP -                                                                                   -             -                     - -  -        SOAP 611 4 2
-0 BIOGENIC_MTPO_SOAS -                                                                                   -             -                     - -  -        SOAS 611 4 2
-0 BIOGENIC_PRPE      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc PRPE_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s PRPE 49  4 2
-0 BIOGENIC_SESQ      $ROOT/OFFLINE_BIOVOC/v2019-10/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SESQ_MEGAN    1980-2021/1-12/1-31/* C xy kgC/m2/s SESQ -   4 2
-0 BIOGENIC_SESQ_SOAP -                                                                                   -             -                     - -  -        SOAP 612 4 2
-0 BIOGENIC_SESQ_SOAS -                                                                                   -             -                     - -  -        SOAS 612 4 2
+0 BIOGENIC_ACET      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ACET_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s ACET -   4 2
+0 BIOGENIC_ALD2      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ALD2_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s ALD2 -   4 2
+0 BIOGENIC_C2H4      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc C2H4_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s C2H4 -   4 2
+0 BIOGENIC_EOH       $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc EOH_MEGAN     1980-2022/1-12/1-31/* EF xy kg/m2/s EOH  -   4 2
+0 BIOGENIC_ISOP      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc ISOP_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s ISOP -   4 2
+0 BIOGENIC_ISOP_SOAP -                                                                                                            -             -                     -  -  -       SOAP 610 4 2
+0 BIOGENIC_ISOP_SOAS -                                                                                                            -             -                     -  -  -       SOAS 610 4 2
+0 BIOGENIC_LIMO      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc LIMO_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s LIMO -   4 2
+0 BIOGENIC_LIMO_SOAP -                                                                                                            -             -                     -  -  -       SOAP 611 4 2
+0 BIOGENIC_LIMO_SOAS -                                                                                                            -             -                     -  -  -       SOAS 611 4 2
+0 BIOGENIC_MOH       $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MOH_MEGAN     1980-2022/1-12/1-31/* EF xy kg/m2/s MOH  -   4 2
+0 BIOGENIC_MTPA      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPA_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s MTPA -   4 2
+0 BIOGENIC_MTPA_SOAP -                                                                                                            -             -                     -  -  -       SOAP 611 4 2
+0 BIOGENIC_MTPA_SOAS -                                                                                                            -             -                     -  -  -       SOAS 611 4 2
+0 BIOGENIC_MTPO      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc MTPO_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s MTPO -   4 2
+0 BIOGENIC_MTPO_SOAP -                                                                                                            -             -                     -  -  -       SOAP 611 4 2
+0 BIOGENIC_MTPO_SOAS -                                                                                                            -             -                     -  -  -       SOAS 611 4 2
+0 BIOGENIC_PRPE      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc PRPE_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s PRPE -   4 2
+0 BIOGENIC_SESQ      $ROOT/OFFLINE_BIOVOC/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/biovoc_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SESQ_MEGAN    1980-2022/1-12/1-31/* EF xy kg/m2/s SESQ -   4 2
+0 BIOGENIC_SESQ_SOAP -                                                                                                            -             -                     -  -  -       SOAP 612 4 2
+0 BIOGENIC_SESQ_SOAS -                                                                                                            -             -                     -  -  -       SOAS 612 4 2
 )))OFFLINE_BIOGENICVOC
 
 #==============================================================================
@@ -2823,17 +2823,17 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_SEASALT
 (((.not.SeaSalt
-0 SEASALT_SALA    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALA_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALA    -   3 2
-0 SEASALT_SALAAL  -                                                                                     -            -                     - -  -       SALAAL  615 3 2
-0 SEASALT_SALACL  -                                                                                     -            -                     - -  -       SALACL  616 3 2
+0 SEASALT_SALA    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALA_TOTAL   1980-2022/1-12/1-31/* EF xy kg/m2/s SALA    -   3 2
+0 SEASALT_SALAAL  -                                                                                                              -            -                     -  -  -       SALAAL  615 3 2
+0 SEASALT_SALACL  -                                                                                                              -            -                     -  -  -       SALACL  616 3 2
 (((CalcBrSeasalt
-0 SEASALT_BrSALA  -                                                                                     -            -                     - -  -       BrSALA  617 3 2
+0 SEASALT_BrSALA  -                                                                                                              -            -                     -  -  -       BrSALA  617 3 2
 )))CalcBrSeasalt
-0 SEASALT_SALC    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALC_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALC    -   3 2
-0 SEASALT_SALCAL  -                                                                                     -            -                     - -  -       SALCAL  615 3 2
-0 SEASALT_SALCCL  -                                                                                     -            -                     - -  -       SALCCL  616 3 2
+0 SEASALT_SALC    $ROOT/OFFLINE_SEASALT/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/seasalt_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SALC_TOTAL   1980-2022/1-12/1-31/* EF xy kg/m2/s SALC    -   3 2
+0 SEASALT_SALCAL  -                                                                                                              -            -                     -  -  -       SALCAL  615 3 2
+0 SEASALT_SALCCL  -                                                                                                              -            -                     -  -  -       SALCCL  616 3 2
 (((CalcBrSeasalt
-0 SEASALT_BrSALC  -                                                                                     -            -                     - -  -       BrSALC  617 3 2
+0 SEASALT_BrSALC  -                                                                                                              -            -                     -  -  -       BrSALC  617 3 2
 )))CalcBrSeasalt
 ))).not.SeaSalt
 )))OFFLINE_SEASALT
@@ -2843,7 +2843,7 @@ Warnings:                    1
 #==============================================================================
 (((OFFLINE_SOILNOX
 (((.not.SoilNOx
-0 SOILNOX_NO  $ROOT/OFFLINE_SOILNOX/v2019-01/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/soilnox_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SOIL_NOx 1980-2021/1-12/1-31/* C xy kg/m2/s NO - 3 2
+0 SOILNOX_NO  $ROOT/OFFLINE_SOILNOX/v2021-12/${RUNDIR_MET_NATIVE_RES}/$YYYY/$MM/soilnox_${RUNDIR_MET_LAT_RES}.$YYYY$MM$DD.nc SOIL_NOx 1980-2022/1-12/1-31/* EF xy kg/m2/s NO - 3 2
 ))).not.SoilNOx
 )))OFFLINE_SOILNOX
 
@@ -3088,6 +3088,10 @@ Warnings:                    1
 * DRYDEP_N       ./GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_DryDepNitrogen $YYYY/$MM/$DD/$HH EY   xy  1 * - 1 1
 * SO2_AFTERCHEM  ./GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_SO2AfterChem   $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
 * H2O2_AFTERCHEM ./GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_H2O2AfterChem  $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
+* AEROH2O_SNA    ./GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_AeroH2OSNA     $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
+* ORVCSESQ       ./GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_ORVCSESQ       $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
+* JOH            ./GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_JOH            $YYYY/$MM/$DD/$HH EY   xy  1 * - 1 1
+* JNO2           ./GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_JNO2           $YYYY/$MM/$DD/$HH EY   xy  1 * - 1 1
 * STATE_PSC      ./GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_StatePSC       $YYYY/$MM/$DD/$HH EY   xyz count * - 1 1
 )))GC_RESTART
 


### PR DESCRIPTION
The entries in HEMCO_Config.rc and ExtData.rc have been updated to use the v2021-12 directories for the OFFLINE_BIOVOC and OFFLINE_SEASALT emissions.

@hongjianweng wrote:

> We have uploaded the new version OFFLINE_BIOVOC and OFFLINE_SOILNOX at native MERRA-2 (0.5 x 0.625, from 1980 to 202012) and GEOS-FP (0.25 x 0.3125, from 2014 to 202009).
> 
> These emissions were generated with GEOS-Chem 13.2.0 and the updates include:
> 
> 1. Use new version Yuan-processed MODIS LAI (v2021-06);
> 2. Fix the unit bug for soil NOx emission;
> 3. Add methanol(MOH) variables for biogenic VOCs emissions;
> 4. All emissions are now all in kg species/m2/s instead of kgN/m2/s or kgC/m2/s before.
> 
> For more information, please see README files, which I have also uploaded to Washu.

In this commit, we also change the time cycle flag in HEMCO_Config.rc from "C" to "EF" to ensure users are aware when running outside of the available data range (because HEMCO will crash with a file-not-found error now). In this case users can opt to use the online emissions, latest available year, or generate a climatology.

HEMCO branch https://github.com/geoschem/HEMCO/tree/feature/update-offline-emissions should also be merged in with this PR.