### PR TITLE
Add missing entries for POG1, POG2, and pFe to HEMCO_Config.rc

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -228,8 +228,6 @@ Warnings:                    1
 0 APEI_BCPO $ROOT/APEI/v2016-11/APEI.0.1x0.1.nc EC  1989-2014/1/1/0 RF xy kg/m2/s BCPO 71/1002        1 30
 0 APEI_OCPI $ROOT/APEI/v2016-11/APEI.0.1x0.1.nc OC  1989-2014/1/1/0 RF xy kg/m2/s OCPI 72/1002        1 30
 0 APEI_OCPO $ROOT/APEI/v2016-11/APEI.0.1x0.1.nc OC  1989-2014/1/1/0 RF xy kg/m2/s OCPO 73/1002        1 30
-0 APEI_POG1 -                                       -    -          -  -  -       POG1 74/76/1002     1 30
-0 APEI_POG2 -                                       -    -          -  -  -       POG2 74/77/1002     1 30
 )))APEI
 
 #==============================================================================
@@ -1054,24 +1052,14 @@ Warnings:                    1
 
 0 AF_EDGAR_OCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.POW.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 RF xy kg/m2/s OCPI 1201/1008/72         1 60
 0 AF_EDGAR_OCPO_POW -                                                    -       -               -  -  -       OCPO 1201/1008/73         1 60
-0 AF_EDGAR_POG1_POW -                                                    -       -               -  -  -       POG1 1201/1008/74/76      1 60
-0 AF_EDGAR_POG2_POW -                                                    -       -               -  -  -       POG2 1201/1008/74/77      1 60
 0 AF_EDGAR_OCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.ENG.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 RF xy kg/m2/s OCPI 1202/1008/72         1 60
 0 AF_EDGAR_OCPO_ENG -                                                    -       -               -  -  -       OCPO 1202/1008/73         1 60
-0 AF_EDGAR_POG1_ENG -                                                    -       -               -  -  -       POG1 1202/74/1008/76      1 60
-0 AF_EDGAR_POG2_ENG -                                                    -       -               -  -  -       POG2 1202/1008/74/77      1 60
 0 AF_EDGAR_OCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.IND.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 RF xy kg/m2/s OCPI 1203/1008/72         1 60
 0 AF_EDGAR_OCPO_IND -                                                    -       -               -  -  -       OCPO 1203/1008/73         1 60
-0 AF_EDGAR_POG1_IND -                                                    -       -               -  -  -       POG1 1203/1008/74/76      1 60
-0 AF_EDGAR_POG2_IND -                                                    -       -               -  -  -       POG2 1203/1008/74/77      1 60
 0 AF_EDGAR_OCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.TNG.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 RF xy kg/m2/s OCPI 1205/1008/72         1 60
 0 AF_EDGAR_OCPO_TNG -                                                    -       -               -  -  -       OCPO 1205/1008/73         1 60
-0 AF_EDGAR_POG1_TNG -                                                    -       -               -  -  -       POG1 1205/1008/74/76      1 60
-0 AF_EDGAR_POG2_TNG -                                                    -       -               -  -  -       POG2 1205/1008/74/77      1 60
 0 AF_EDGAR_OCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.SWD.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 RF xy kg/m2/s OCPI 1211/1008/72         1 60
 0 AF_EDGAR_OCPO_SWD -                                                    -       -               -  -  -       OCPO 1211/1008/73         1 60
-0 AF_EDGAR_POG1_SWD -                                                    -       -               -  -  -       POG1 1211/1008/74/76      1 60
-0 AF_EDGAR_POG2_SWD -                                                    -       -               -  -  -       POG2 1211/1008/74/77      1 60
 
 0 AF_EDGAR_SO2_POW  $ROOT/EDGARv43/v2016-11/EDGAR_v43.SO2.POW.0.1x0.1.nc emi_so2 1970-2010/1/1/0 RF xy kg/m2/s SO2  1201/1008            1 60
 0 AF_EDGAR_SO4_POW  -                                                    -       -               -  -  -       SO4  1201/1008/63         1 60
@@ -1324,40 +1312,22 @@ Warnings:                    1
 0  EDGAR_NH3_SWD  $ROOT/EDGARv43/v2016-11/EDGAR_v43.NH3.SWD.0.1x0.1.nc emi_nh3 1970-2010/1/1/0 C xy kg/m2/s NH3  1211            1 2
 0  EDGAR_OCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.POW.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 C xy kg/m2/s OCPI 1201/72         1 2
 0  EDGAR_OCPO_POW -                                                    -       -               - -  -       OCPO 1201/73         1 2
-0  EDGAR_POG1_POW -                                                    -       -               - -  -       POG1 1201/74/76      1 2
-0  EDGAR_POG2_POW -                                                    -       -               - -  -       POG2 1201/74/77      1 2
 0  EDGAR_OCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.ENG.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 C xy kg/m2/s OCPI 1202/72         1 2
 0  EDGAR_OCPO_ENG -                                                    -       -               - -  -       OCPO 1202/73         1 2
-0  EDGAR_POG1_ENG -                                                    -       -               - -  -       POG1 1202/74/76      1 2
-0  EDGAR_POG2_ENG -                                                    -       -               - -  -       POG2 1202/74/77      1 2
 0  EDGAR_OCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.IND.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 C xy kg/m2/s OCPI 1203/72         1 2
 0  EDGAR_OCPO_IND -                                                    -       -               - -  -       OCPO 1203/73         1 2
-0  EDGAR_POG1_IND -                                                    -       -               - -  -       POG1 1203/74/76      1 2
-0  EDGAR_POG2_IND -                                                    -       -               - -  -       POG2 1203/74/77      1 2
 0  EDGAR_OCPI_TRO $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.TRO.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 C xy kg/m2/s OCPI 1204/72         1 2
 0  EDGAR_OCPO_TRO -                                                    -       -               - -  -       OCPO 1204/73         1 2
-0  EDGAR_POG1_TRO -                                                    -       -               - -  -       POG1 1204/74/76      1 2
-0  EDGAR_POG2_TRO -                                                    -       -               - -  -       POG2 1204/74/77      1 2
 0  EDGAR_OCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.TNG.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 C xy kg/m2/s OCPI 1205/72         1 2
 0  EDGAR_OCPO_TNG -                                                    -       -               - -  -       OCPO 1205/73         1 2
-0  EDGAR_POG1_TNG -                                                    -       -               - -  -       POG1 1205/74/76      1 2
-0  EDGAR_POG2_TNG -                                                    -       -               - -  -       POG2 1205/74/77      1 2
 0  EDGAR_OCPI_RCO $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.RCO.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 C xy kg/m2/s OCPI 1206/72         1 2
 0  EDGAR_OCPO_RCO -                                                    -       -               - -  -       OCPO 1206/73         1 2
-0  EDGAR_POG1_RCO -                                                    -       -               - -  -       POG1 1206/74/76      1 2
-0  EDGAR_POG2_RCO -                                                    -       -               - -  -       POG2 1206/74/77      1 2
 #0 EDGAR_OCPI_AWB $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.AWB.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 C xy kg/m2/s OCPI 1209/72         1 2
 #0 EDGAR_OCPO_AWB -                                                    -       -               - -  -       OCPO 1209/73         1 2
-#0 EDGAR_POG1_AWB -                                                    -       -               - -  -       POG1 1209/74/76      1 2
-#0 EDGAR_POG2_AWB -                                                    -       -               - -  -       POG2 1209/74/77      1 2
 0  EDGAR_OCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.SWD.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 C xy kg/m2/s OCPI 1211/72         1 2
 0  EDGAR_OCPO_SWD -                                                    -       -               - -  -       OCPO 1211/73         1 2
-0  EDGAR_POG1_SWD -                                                    -       -               - -  -       POG1 1211/74/76      1 2
-0  EDGAR_POG2_SWD -                                                    -       -               - -  -       POG2 1211/74/77      1 2
 0  EDGAR_OCPI_FFF $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.FFF.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 C xy kg/m2/s OCPI 1212/72         1 2
 0  EDGAR_OCPO_FFF -                                                    -       -               - -  -       OCPO 1212/73         1 2
-0  EDGAR_POG1_FFF -                                                    -       -               - -  -       POG1 1212/74/76      1 2
-0  EDGAR_POG2_FFF -                                                    -       -               - -  -       POG2 1212/74/77      1 2
 0  EDGAR_SO2_POW  $ROOT/EDGARv43/v2016-11/EDGAR_v43.SO2.POW.0.1x0.1.nc emi_so2 1970-2010/1/1/0 C xy kg/m2/s SO2  1201            1 2
 0  EDGAR_SO4_POW  -                                                    -       -               - -  -       SO4  1201/63         1 2
 0  EDGAR_pFe_POW  -                                                    -       -               - -  -       pFe  1201/66         1 2

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -1195,26 +1195,26 @@ Warnings:                    1
 0 CMIP6_SOAP_WST   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_wst            1750-2100/1-12/1/0 C xy kg/m2/s    SOAP  26/280    1 5
 
 0 CMIP6_SO2_AGR    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_agr           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_AGR    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_AGR    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_AGR    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_AGR    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_ENE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_ene           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_ENE    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_ENE    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_ENE    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_ENE    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_IND    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_ind           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_IND    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_IND    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_IND    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_IND    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_TRA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_tra           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_TRA    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_TRA    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_TRA    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_TRA    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_RCO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_rco           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_RCO    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_RCO    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_RCO    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_RCO    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_SLV    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_slv           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_SLV    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_SLV    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_SLV    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_SLV    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_WST    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_wst           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_WST    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_WST    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_WST    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_WST    -                                                                              -                 -                  - -  -          pFe   66        1 5
 
 0 CMIP6_NH3_AGR    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NH3_agr           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         1 5
 0 CMIP6_NH3_ENE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NH3_ene           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         1 5
@@ -1225,34 +1225,34 @@ Warnings:                    1
 0 CMIP6_NH3_WST    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NH3_wst           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         1 5
 
 0 CMIP6_BCPI_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_agr            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_AGR   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_AGR   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_ENE   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_ene            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_ENE   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_ENE   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_IND   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_ind            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_IND   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_IND   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_TRA   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_tra            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_TRA   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_TRA   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_RCO   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_rco            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_RCO   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_RCO   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_SLV   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_slv            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_SLV   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_SLV   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_WST   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_wst            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_WST   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_WST   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 
 0 CMIP6_OCPI_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_agr            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_AGR   -                                                          -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_OCPO_AGR   -                                                                              -                 -                  - -  -          OCPO  73        1 5
 0 CMIP6_OCPI_ENE   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_ene            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_ENE   -                                                          -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_OCPO_ENE   -                                                                              -                 -                  - -  -          OCPO  73        1 5
 0 CMIP6_OCPI_IND   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_ind            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_IND   -                                                          -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_OCPO_IND   -                                                                              -                 -                  - -  -          OCPO  73        1 5
 0 CMIP6_OCPI_TRA   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_tra            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_TRA   -                                                          -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_OCPO_TRA   -                                                                              -                 -                  - -  -          OCPO  73        1 5
 0 CMIP6_OCPI_RCO   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_rco            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_RCO   -                                                          -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_OCPO_RCO   -                                                                              -                 -                  - -  -          OCPO  73        1 5
 0 CMIP6_OCPI_SLV   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_slv            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_SLV   -                                                          -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_OCPO_SLV   -                                                                              -                 -                  - -  -          OCPO  73        1 5
 0 CMIP6_OCPI_WST   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_wst            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_WST   -                                                          -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_OCPO_WST   -                                                                              -                 -                  - -  -          OCPO  73        1 5
 )))CMIP6_SFC_LAND_ANTHRO
 
 #==============================================================================
@@ -1265,7 +1265,8 @@ Warnings:                    1
 (((CMIP6_AIRCRAFT
 0 CMIP6_AIR_SOAP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    CO_air            1750-2100/1-12/1/0 C xyz kg/m2/s   SOAP  280      20 1
 0 CMIP6_AIR_SO2    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    SO2_air           1750-2100/1-12/1/0 C xyz kg/m2/s   SO2   -        20 1
-0 CMIP6_AIR_SO4    -                                                          -                 -                  - -   -         SO4   63       20 1
+0 CMIP6_AIR_SO4    -                                                                                  -                 -                  - -   -         SO4   63       20 1
+0 CMIP6_AIR_pFe    -                                                                                  -                 -                  - -   -         pFe   66       20 1
 0 CMIP6_AIR_NH3    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    NH3_air           1750-2100/1-12/1/0 C xyz kg/m2/s   NH3   -        20 1
 # Assume all BC/OC is BCPI/OCPI
 0 CMIP6_AIR_BCPI   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    BC_air            1750-2100/1-12/1/0 C xyz kg/m2/s   BCPI  -        20 1
@@ -1502,13 +1503,13 @@ Warnings:                    1
 (((CMIP6_SHIP
 0 CMIP6_SOAP_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            CO_shp            1750-2100/1-12/1/0 C xy kg/m2/s    SOAP  26/280    10 5
 0 CMIP6_SO2_SHP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            SO2_shp           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         10 5
-0 CMIP6_SO4_SHP    -                                                   -                 -                  - -  -          SO4   63        10 5
-0 CMIP6_pFe_SHP    -                                                   -                 -                  - -  -          pFe   66        10 5
+0 CMIP6_SO4_SHP    -                                                                       -                 -                  - -  -          SO4   63        10 5
+0 CMIP6_pFe_SHP    -                                                                       -                 -                  - -  -          pFe   66        10 5
 0 CMIP6_NH3_SHP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            NH3_shp           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         10 5
 0 CMIP6_BCPI_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            BC_shp            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        10 5
-0 CMIP6_BCPO_SHP   -                                                   -                 -                  - -  -          BCPO  71        10 5
+0 CMIP6_BCPO_SHP   -                                                                       -                 -                  - -  -          BCPO  71        10 5
 0 CMIP6_OCPI_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            OC_shp            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        10 5
-0 CMIP6_OCPO_SHP   -                                                   -                 -                  - -  -          OCPO  73        10 5
+0 CMIP6_OCPO_SHP   -                                                                       -                 -                  - -  -          OCPO  73        10 5
 )))CMIP6_SHIP
 
 )))SHIP
@@ -1521,15 +1522,17 @@ Warnings:                    1
 # scale factor section below for more information.
 #==============================================================================
 (((AEIC2019_DAILY
-0 AEIC19_DAILY_SOAP $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc CO       2019/1-12/1-31/0 C xyz kg/m2/s SOAP 241/280 20 1
-0 AEIC19_DAILY_SO2  $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc FUELBURN 2019/1-12/1-31/0 C xyz kg/m2/s SO2  241/111 20 1
-0 AEIC19_DAILY_SO4  -                                                             -        -                - -   -       SO4  241/112 20 1
-0 AEIC19_DAILY_BCPI $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc BC       2019/1-12/1-31/0 C xyz kg/m2/s BCPI 241     20 1
-0 AEIC19_DAILY_OCPI $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc OC       2019/1-12/1-31/0 C xyz kg/m2/s OCPI 241     20 1
+0 AEIC19_DAILY_SOAP $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc CO       2019/1-12/1-31/0 C xyz kg/m2/s SOAP 241/280     20 1
+0 AEIC19_DAILY_SO2  $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc FUELBURN 2019/1-12/1-31/0 C xyz kg/m2/s SO2  241/111     20 1
+0 AEIC19_DAILY_pFe  -                                                             -        -                - -   -       pFe  241/111/66  20 1
+0 AEIC19_DAILY_SO4  -                                                             -        -                - -   -       SO4  241/112     20 1
+0 AEIC19_DAILY_BCPI $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc BC       2019/1-12/1-31/0 C xyz kg/m2/s BCPI 241         20 1
+0 AEIC19_DAILY_OCPI $ROOT/AEIC2019/v2022-03/2019/AEIC_2019$MM$DD.0.5x0.625.36L.nc OC       2019/1-12/1-31/0 C xyz kg/m2/s OCPI 241         20 1
 )))AEIC2019_DAILY
 (((AEIC2019_MONMEAN
 0 AEIC19_MONMEAN_SOAP $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc CO       2019/1-12/1/0 C xyz kg/m2/s SOAP 241/280     20 1
 0 AEIC19_MONMEAN_SO2  $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc FUELBURN 2019/1-12/1/0 C xyz kg/m2/s SO2  241/111     20 1
+0 AEIC19_MONMEAN_pFe  -                                                                          -        -             - -   -       pFe  241/111/66  20 1
 0 AEIC19_MONMEAN_SO4  -                                                                          -        -             - -   -       SO4  241/112     20 1
 0 AEIC19_MONMEAN_BCPI $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc BC       2019/1-12/1/0 C xyz kg/m2/s BCPI 241         20 1
 0 AEIC19_MONMEAN_OCPI $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc OC       2019/1-12/1/0 C xyz kg/m2/s OCPI 241         20 1
@@ -1543,6 +1546,7 @@ Warnings:                    1
 0 RCP3PD_BCPO $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_BC_2005-2100_23474.nc  ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO -   1 1
 0 RCP3PD_OCPO $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_OC_2005-2100_23474.nc  ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO -   1 1
 0 RCP3PD_SO2  $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_SO2_2005-2100_23474.nc ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2  -   1 1
+0 RCP3PD_pFe  -                                                             -      -               -  -  -        pFe  66  1 1
 0 RCP3PD_NH3  $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_NH3_2005-2100_23474.nc ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3  -   1 1
 )))RCP_3PD
 
@@ -1551,6 +1555,7 @@ Warnings:                    1
 0 RCP45_BCPO  $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_BC_2005-2100_27424.nc   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO -   1 1
 0 RCP45_OCPO  $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_OC_2005-2100_27424.nc   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO -   1 1
 0 RCP45_SO2   $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_SO2_2005-2100_27424.nc  ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2  -   1 1
+0 RCP45_pFe   -                                                             -      -               -  -  -        pFe  66  1 1
 0 RCP45_NH3   $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_NH3_2005-2100_27424.nc  ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3  -   1 1
 )))RCP_45
 
@@ -1559,6 +1564,7 @@ Warnings:                    1
 0 RCP60_BCPO  $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_BC_2005-2100_43190.nc   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO -   1 1
 0 RCP60_OCPO  $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_OC_2005-2100_43190.nc   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO -   1 1
 0 RCP60_SO2   $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_SO2_2005-2100_43190.nc  ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2  -   1 1
+0 RCP60_pFe   -                                                             -      -               -  -  -        pFe  66  1 1
 0 RCP60_NH3   $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_NH3_2005-2100_43190.nc  ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3  -   1 1
 )))RCP_60
 
@@ -1567,6 +1573,7 @@ Warnings:                    1
 0 RCP85_BCPO  $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_BC_2005-2100_43533.nc   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO -   1 1
 0 RCP85_OCPO  $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_OC_2005-2100_43533.nc   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO -   1 1
 0 RCP85_SO2   $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_SO2_2005-2100_43533.nc  ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2  -   1 1
+0 RCP85_pFe   -                                                             -      -               -  -  -        pFe  66  1 1
 0 RCP85_NH3   $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_NH3_2005-2100_43533.nc  ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3  -   1 1
 )))RCP_85
 
@@ -1587,7 +1594,9 @@ Warnings:                    1
 0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s NH3  75/311        5 2
 0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s NH3  75/312        5 2
 0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_pFe_PBL   -                                                                 -       -                             -  -             -       pFe  75/311/66     5 2
 0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_pFe_FT    -                                                                 -       -                             -  -             -       pF3  75/312/66     5 2
 )))QFED2
 
 #==============================================================================
@@ -1600,6 +1609,7 @@ Warnings:                    1
 0 GFAS_OCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPI 72/75  5 3
 0 GFAS_OCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPO 73/75  5 3
 0 GFAS_SO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SO2  75     5 3
+0 GFAS_pFe   -                                          -             -                     - -             -       pFe  75/66  5 3
 0 GFAS_NH3   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc nh3fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NH3  75     5 3
 0 GFAS_DMS   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6sfire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s DMS  75     5 3
 )))GFAS
@@ -1615,6 +1625,7 @@ Warnings:                    1
 0 CMIP6_BB_OCPI    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPI  72/75  5 3
 0 CMIP6_BB_OCPO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPO  73/75  5 3
 0 CMIP6_BB_SO2     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 SO2_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s SO2   75     5 3
+0 CMIP6_BB_pFe     -                                                            -          -                  - -         -       pFe   75/66  5 3
 0 CMIP6_BB_NH3     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 NH3_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s NH3   75     5 3
 0 CMIP6_BB_DMS     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 DMS_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s DMS   75     5 3
 )))BB4MIPS

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -287,6 +287,9 @@ Warnings:                    1
 0 EPA16_NIT__afdustPNO3          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_OCPI__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
+0 EPA16_POG1__afdustPOC          -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__afdustPOC          -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_SO4__afdustPSO4          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_ACET__agACET             $ROOT/NEI2016/v2021-06/2016fh_16j_ag_0pt1degree_month_$MM.ncf                         ACET       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ACET   26/213/254/1007        1 50
 0 EPA16_ALD2__agALD2             $ROOT/NEI2016/v2021-06/2016fh_16j_ag_0pt1degree_month_$MM.ncf                         ALD2       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ALD2   26/213/254/1007        1 50
@@ -331,6 +334,8 @@ Warnings:                    1
 0 EPA16_NIT__airportsPNO3        $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__airportsPOC        $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__airportsPOC        $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__airportsPOC        -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__airportsPOC        -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__airportsPRPA       $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__airportsPSO4        $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__airportsSO2         $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -367,6 +372,8 @@ Warnings:                    1
 0 EPA16_NIT__nonptPNO3           $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__nonptPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__nonptPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__nonptPOC           -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__nonptPOC           -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__nonptPRPA          $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__nonptPSO4           $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__nonptSO2            $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -401,6 +408,8 @@ Warnings:                    1
 0 EPA16_NIT__nonroadPNO3         $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__nonroadPOC         $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__nonroadPOC         $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__nonroadPOC         -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__nonroadPOC         -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__nonroadPRPA        $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__nonroadPSO4         $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__nonroadSO2          $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -436,6 +445,8 @@ Warnings:                    1
 0 EPA16_NIT__npogPNO3            $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__npogPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__npogPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__npogPOC            -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__npogPOC            -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__npogPRPA           $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__npogPSO4            $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__npogSO2             $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -470,6 +481,8 @@ Warnings:                    1
 0 EPA16_NIT__onroadPNO3          $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__onroadPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__onroadPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__onroadPOC          -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__onroadPOC          -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__onroadPRPA         $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__onroadPSO4          $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__onroadSO2           $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -503,6 +516,8 @@ Warnings:                    1
 0 EPA16_NIT__onroad_caPNO3       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__onroad_caPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__onroad_caPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__onroad_caPOC       -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__onroad_caPOC       -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__onroad_caPRPA      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__onroad_caPSO4       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__onroad_caSO2        $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -536,6 +551,8 @@ Warnings:                    1
 0 EPA16_NIT__railPNO3            $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__railPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__railPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__railPOC            -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__railPOC            -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__railPRPA           $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__railPSO4            $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__railSO2             $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -571,6 +588,8 @@ Warnings:                    1
 0 EPA16_NIT__rwcPNO3             $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__rwcPOC             $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__rwcPOC             $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__rwcPOC             -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__rwcPOC             -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__rwcPRPA            $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__rwcPSO4             $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__rwcSO2              $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -604,6 +623,8 @@ Warnings:                    1
 0 EPA16_NIT__c1c2PNO3            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__c1c2POC            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__c1c2POC            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__clc2POC            -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__clc2POC            -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__c1c2PRPA           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__c1c2PSO4            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__c1c2SO2             $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -637,6 +658,8 @@ Warnings:                    1
 0 EPA16_NIT__c3PNO3              $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__c3POC              $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__c3POC              $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__c3POC              -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__c3POC              -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__c3PRPA             $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__c3PSO4              $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__c3SO2               $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -673,6 +696,8 @@ Warnings:                    1
 0 EPA16_NIT__pteguPNO3           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__pteguPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__pteguPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__pteguPOC           -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__pteguPOC           -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__pteguPRPA          $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__pteguPSO4           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__pteguSO2            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -709,6 +734,8 @@ Warnings:                    1
 0 EPA16_NIT__ptogPNO3            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__ptogPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__ptogPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__ptogPOC            -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__ptogPOC            -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__ptogPRPA           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__ptogPSO4            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__ptogSO2             $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -745,6 +772,8 @@ Warnings:                    1
 0 EPA16_NIT__ptnonipmPNO3        $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__ptnonipmPOC        $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__ptnonipmPOC        $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__ptnonipmPOC        -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__ptnonipmPOC        -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__ptnonipmPRPA       $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__ptnonipmPSO4        $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__ptnonipmSO2         $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -778,6 +807,8 @@ Warnings:                    1
 0 EPA16_NIT__onroad_canPNO3      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__onroad_canPOC      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__onroad_canPOC      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__onroad_canPOC      -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__onroad_canPOC      -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__onroad_canPRPA     $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__onroad_canPSO4      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__onroad_canSO2       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -812,6 +843,8 @@ Warnings:                    1
 0 EPA16_NIT__onroad_mexPNO3      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__onroad_mexPOC      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__onroad_mexPOC      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__onroad_mexPOC      -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__onroad_mexPOC      -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__onroad_mexPRPA     $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__onroad_mexPSO4      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__onroad_mexSO2       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -826,6 +859,8 @@ Warnings:                    1
 0 EPA16_NIT__othafdustPNO3       $ROOT/NEI2016/v2021-06/2016fh_16j_othafdust_adj_0pt1degree_month_$MM.ncf              PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__othafdustPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_othafdust_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__othafdustPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_othafdust_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__othafdustPOC       -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__othafdustPOC       -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_SO4__othafdustPSO4       $ROOT/NEI2016/v2021-06/2016fh_16j_othafdust_adj_0pt1degree_month_$MM.ncf              PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_ACET__otharACET          $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      ACET       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ACET   26/213/254/1007        1 50
 0 EPA16_ALD2__otharALD2          $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      ALD2       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ALD2   26/213/254/1007        1 50
@@ -853,6 +888,8 @@ Warnings:                    1
 0 EPA16_NIT__otharPNO3           $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__otharPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__otharPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__otharPOC           -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__otharPOC           -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__otharPRPA          $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__otharPSO4           $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__otharSO2            $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -867,6 +904,8 @@ Warnings:                    1
 0 EPA16_NIT__othptdustPNO3       $ROOT/NEI2016/v2021-06/2016fh_16j_othptdust_adj_0pt1degree_month_$MM.ncf              PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__othptdustPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_othptdust_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__othptdustPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_othptdust_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__othptdustPOC       -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__othptdustPOC       -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_SO4__othptdustPSO4       $ROOT/NEI2016/v2021-06/2016fh_16j_othptdust_adj_0pt1degree_month_$MM.ncf              PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_ACET__othptACET          $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 ACET       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ACET   26/213/254/1007        1 50
 0 EPA16_ALD2__othptALD2          $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 ALD2       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ALD2   26/213/254/1007        1 50
@@ -894,6 +933,8 @@ Warnings:                    1
 0 EPA16_NIT__othptPNO3           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__othptPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__othptPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__othptPOC           -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__othptPOC           -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__othptPRPA          $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__othptPSO4           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__othptSO2            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -950,6 +991,8 @@ Warnings:                    1
 0 DICE_CARS_BCPO  -                                                                 -       -          - -  -        BCPO  71/1008         1 60
 0 DICE_CARS_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  OC      2013/1/1/0 C xy g/m2/yr  OCPI  72/1008/330     1 60
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
+0 DICE_CARS_POG1  -                                                                 -       -          - -  -        POG1  74/76/1008/330  1 60
+0 DICE_CARS_POG2  -                                                                 -       -          - -  -        POG2  74/77/1008/330  1 60
 
 # ------------------------
 #  Motorcycles
@@ -971,6 +1014,8 @@ Warnings:                    1
 0 DICE_MOTORCYCLES_BCPO  -                                                                        -      -          - -  -        BCPO  71/1008          1 60
 0 DICE_MOTORCYCLES_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  OC     2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
+0 DICE_MOTORCYCLES_POG1  -                                                                        -      -          -  - -        POG1  74/76/1008       1 60
+0 DICE_MOTORCYCLES_POG2  -                                                                        -      -          -  - -        POG2  74/77/1008       1 60
 
 # ------------------------
 #  Backup generators
@@ -996,9 +1041,11 @@ Warnings:                    1
 0 DICE_BACKUPGEN_TOLU  $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  TOLU 2013/1/1/0 C xy g/m2/yr  TOLU  26/1008          1 60
 0 DICE_BACKUPGEN_XYLE  $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  XYLE 2013/1/1/0 C xy g/m2/yr  XYLE  26/1008          1 60
 0 DICE_BACKUPGEN_BCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  BC   2013/1/1/0 C xy g/m2/yr  BCPI  70/1008          1 60
-0 DICE_BACKUPGEN_BCPO  -                                                                          -        -          - -  -    BCPO  71/1008          1 60
+0 DICE_BACKUPGEN_BCPO  -                                                                          -    -          - -  -        BCPO  71/1008          1 60
 0 DICE_BACKUPGEN_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  OC   2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
-0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
+0 DICE_BACKUPGEN_OCPO  -                                                                          -    -          - -  -        OCPO  73/1008          1 60
+0 DICE_BACKUPGEN_POG1  -                                                                          -    -          - -  -        POG1  74/76/1008       1 60
+0 DICE_BACKUPGEN_POG2  -                                                                          -    -          - -  -        POG2  74/77/1008       1 60
 
 # ------------------------
 #  Charcoal production
@@ -1020,6 +1067,8 @@ Warnings:                    1
 0 DICE_CHARCOALPROD_BCPO  -                                                                                -     -          - -  -        BCPO  71/1008/320      1 60
 0 DICE_CHARCOALPROD_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008/320      1 60
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
+0 DICE_CHARCOALPROD_POG1  -                                                                                -     -          - -  -        POG1  74/76/1008/320   1 60
+0 DICE_CHARCOALPROD_POG2  -                                                                                -     -          - -  -        POG2  74/77/1008/320   1 60
 
 # ------------------------
 #  Flaring of natural gas
@@ -1038,6 +1087,8 @@ Warnings:                    1
 0 DICE_GASFLARE_BCPO  -                                                                       -     -          - -  -        BCPO  71/1008          1 60
 0 DICE_GASFLARE_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
+0 DICE_GASFLARE_POG1  -                                                                       -     -          - -  -        POG1  74/76/1008       1 60
+0 DICE_GASFLARE_POG2  -                                                                       -     -          - -  -        POG2  74/77/1008       1 60
 
 # ------------------------------
 #  Ag waste burning for energy
@@ -1075,7 +1126,9 @@ Warnings:                    1
 0 DICE_AGBURNING_BCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  BC    2013/1/1/0 C xy g/m2/yr  BCPI  70/1008          2 60
 0 DICE_AGBURNING_BCPO  -                                                                                       -     -          - -  g/m2/yr  BCPO  71/1008          2 60
 0 DICE_AGBURNING_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          2 60
-0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
+0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  -        OCPO  73/1008          2 60
+0 DICE_AGBURNING_POG1  -                                                                                       -     -          - -  -        POG1  74/76/1008       2 60
+0 DICE_AGBURNING_POG2  -                                                                                       -     -          - -  -        POG2  74/77/1008       2 60
 
 # ------------------------------
 #  Charcoal use
@@ -1096,6 +1149,8 @@ Warnings:                    1
 0 DICE_CHARCOALUSE_BCPO  -                                                                         -     -          - -  -        BCPO  71/1008          2 60
 0 DICE_CHARCOALUSE_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          2 60
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
+0 DICE_CHARCOALUSE_POG1  -                                                                         -     -          - - -         POG1  74/76/1008       2 60
+0 DICE_CHARCOALUSE_POG2  -                                                                         -     -          - - -         POG2  74/77/1008       2 60
 
 # ------------------------------
 #  Kerosene use
@@ -1106,6 +1161,8 @@ Warnings:                    1
 0 DICE_KEROSENE_BCPO  -                                                                         -     -          - -  -        BCPO  71/1008          1 60
 0 DICE_KEROSENE_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
+0 DICE_KEROSENE_POG1  -                                                                         -     -          - -  -        POG1  74/76/1008       1 60
+0 DICE_KEROSENE_POG2  -                                                                         -     -          - -  -        POG2  74/77/1008       1 60
 
 # ------------------------------
 #  Artisanal oil refining
@@ -1131,6 +1188,8 @@ Warnings:                    1
 0 DICE_OILREFINING_BCPO  -                                                                               -     -          - -  -        BCPO  71/1008          1 60
 0 DICE_OILREFINING_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
+0 DICE_OILREFINING_POG1  -                                                                               -     -          - -  -        POG1  74/76/1008       1 60
+0 DICE_OILREFINING_POG2  -                                                                               -     -          - -  -        POG2  74/77/1008       1 60
 
 # --------------------------
 #  Household fuelwood use
@@ -1166,6 +1225,8 @@ Warnings:                    1
 0 DICE_HOUSEFUELWOOD_BCPO  -                                                                                   -     -          - -  -        BCPO  71/1008          2 60
 0 DICE_HOUSEFUELWOOD_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          2 60
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
+0 DICE_HOUSEFUELWOOD_POG1  -                                                                                   -     -          - -  -        POG1  74/76/1008       2 60
+0 DICE_HOUSEFUELWOOD_POG2  -                                                                                   -     -          - -  -        POG2  74/77/1008       2 60
 
 # ---------------------------------
 #  Commercial (other) fuelwood use
@@ -1201,6 +1262,8 @@ Warnings:                    1
 0 DICE_OTHERFUELWOOD_BCPO  -                                                                               -     -          - -  -        BCPO  71/1008          2 60
 0 DICE_OTHERFUELWOOD_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          2 60
 0 DICE_OTHERFUELWOOD_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          2 60
+0 DICE_OTHERFUELWOOD_POG1  -                                                                               -     -          - -  -        POG1  74/76/1008       2 60
+0 DICE_OTHERFUELWOOD_POG2  -                                                                               -     -          - -  -        POG2  74/77/1008       2 60
 
 # ---------------------------------------------------
 #  Efficient Combustion Emissions from EDGAR
@@ -1253,7 +1316,7 @@ Warnings:                    1
 0 AF_EDGAR_POG2_POW -                                                    -       -               -  -  -       POG2 1201/1008/74/77      1 60
 0 AF_EDGAR_OCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.ENG.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 RF xy kg/m2/s OCPI 1202/1008/72         1 60
 0 AF_EDGAR_OCPO_ENG -                                                    -       -               -  -  -       OCPO 1202/1008/73         1 60
-0 AF_EDGAR_POG1_ENG -                                                    -       -               -  -  -       POG1 1202/74/1008/76      1 60
+0 AF_EDGAR_POG1_ENG -                                                    -       -               -  -  -       POG1 1202/1008/74/76      1 60
 0 AF_EDGAR_POG2_ENG -                                                    -       -               -  -  -       POG2 1202/1008/74/77      1 60
 0 AF_EDGAR_OCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.IND.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 RF xy kg/m2/s OCPI 1203/1008/72         1 60
 0 AF_EDGAR_OCPO_IND -                                                    -       -               -  -  -       OCPO 1203/1008/73         1 60
@@ -1365,32 +1428,32 @@ Warnings:                    1
 
 0 CEDS_OCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_agr            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_AGR   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_AGR   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_AGR   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_AGR   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_AGR   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_ENE   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_ENE   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_ENE   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_ENE   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_ENE   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_IND   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_IND   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_IND   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_IND   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_IND   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_tra            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_TRA   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_TRA   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_TRA   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_TRA   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_TRA   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_rco            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_RCO   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_RCO   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_RCO   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_RCO   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_RCO   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_SLV   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_slv            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_SLV   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_SLV   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_SLV   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_SLV   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_SLV   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_WST   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_wst            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_WST   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_WST   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_WST   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_WST   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_WST   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 
 # Comment out CO2 for fullchem simulations: CO2 not advected
 #0 CEDS_CO2_AGR   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_agr           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
@@ -1594,41 +1657,41 @@ Warnings:                    1
 0 CMIP6_NO_WST     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NO_wst            1750-2100/1-12/1/0 C xy kg/m2/s    NO    25        1 5
 
 0 CMIP6_CO_AGR     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_agr            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_AGR   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_AGR   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_ENE     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_ene            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_ENE   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_ENE   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_IND     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_ind            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_IND   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_IND   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_TRA     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_tra            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_TRA   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_TRA   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_RCO     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_rco            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_RCO   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_RCO   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_SLV     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_slv            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_SLV   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_SLV   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_WST     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_wst            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_WST   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_WST   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 
 0 CMIP6_SO2_AGR    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_agr           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_AGR    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_AGR    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_AGR    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_AGR    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_ENE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_ene           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_ENE    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_ENE    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_ENE    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_ENE    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_IND    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_ind           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_IND    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_IND    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_IND    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_IND    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_TRA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_tra           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_TRA    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_TRA    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_TRA    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_TRA    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_RCO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_rco           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_RCO    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_RCO    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_RCO    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_RCO    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_SLV    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_slv           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_SLV    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_SLV    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_SLV    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_SLV    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_WST    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_wst           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_WST    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_WST    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_WST    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_WST    -                                                                              -                 -                  - -  -          pFe   66        1 5
 
 0 CMIP6_NH3_AGR    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NH3_agr           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         1 5
 0 CMIP6_NH3_ENE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NH3_ene           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         1 5
@@ -1639,48 +1702,48 @@ Warnings:                    1
 0 CMIP6_NH3_WST    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NH3_wst           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         1 5
 
 0 CMIP6_BCPI_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_agr            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_AGR   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_AGR   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_ENE   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_ene            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_ENE   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_ENE   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_IND   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_ind            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_IND   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_IND   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_TRA   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_tra            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_TRA   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_TRA   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_RCO   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_rco            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_RCO   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_RCO   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_SLV   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_slv            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_SLV   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_SLV   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_WST   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_wst            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_WST   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_WST   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 
 0 CMIP6_OCPI_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_agr            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_AGR   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_AGR   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_AGR   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_AGR   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_AGR   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_AGR   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_ENE   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_ene            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_ENE   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_ENE   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_ENE   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_ENE   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_ENE   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_ENE   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_IND   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_ind            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_IND   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_IND   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_IND   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_IND   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_IND   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_IND   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_TRA   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_tra            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_TRA   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_TRA   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_TRA   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_TRA   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_TRA   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_TRA   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_RCO   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_rco            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_RCO   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_RCO   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_RCO   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_RCO   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_RCO   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_RCO   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_SLV   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_slv            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_SLV   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_SLV   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_SLV   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_SLV   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_SLV   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_SLV   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_WST   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_wst            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_WST   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_WST   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_WST   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_WST   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_WST   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_WST   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 
 # Comment out CO2 for fullchem simulations: CO2 not advected
 #0 CMIP6_CO2_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO2_agr           1750-2100/1-12/1/0 C xy kg/m2/s    CO2   -         1 5
@@ -1703,26 +1766,26 @@ Warnings:                    1
 
 # NOTE: EOH files in CMIP6/v2021-01 are actually VOC1 (total alchohols) and are split into MOH, EOH, ROH here
 0 CMIP6_MOH_AGR    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_agr           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_AGR    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_AGR    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_AGR    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_AGR    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_ENE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_ene           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_ENE    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_ENE    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_ENE    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_ENE    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_IND    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_ind           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_IND    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_IND    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_IND    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_IND    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_TRA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_tra           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_TRA    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_TRA    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_TRA    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_TRA    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_RCO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_rco           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_RCO    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_RCO    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_RCO    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_RCO    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_SLV    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_slv           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_SLV    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_SLV    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_SLV    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_SLV    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_WST    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_wst           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_WST    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_WST    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_WST    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_WST    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 
 0 CMIP6_C2H6_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   C2H6_agr          1750-2100/1-12/1/0 C xy kg/m2/s    C2H6  26        1 5
 0 CMIP6_C2H6_ENE   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   C2H6_ene          1750-2100/1-12/1/0 C xy kg/m2/s    C2H6  26        1 5
@@ -1855,22 +1918,25 @@ Warnings:                    1
 (((CMIP6_AIRCRAFT
 0 CMIP6_AIR_NO     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    NO_air            1750-2100/1-12/1/0 C xyz kg/m2/s   NO    -        20 1
 0 CMIP6_AIR_CO     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    CO_air            1750-2100/1-12/1/0 C xyz kg/m2/s   CO    -        20 1
-0 CMIP6_AIR_SOAP   -                                                                    -                 -                  - -   -         SOAP  280      20 1
+0 CMIP6_AIR_SOAP   -                                                                                  -                 -                  - -   -         SOAP  280      20 1
 0 CMIP6_AIR_SO2    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    SO2_air           1750-2100/1-12/1/0 C xyz kg/m2/s   SO2   -        20 1
-0 CMIP6_AIR_SO4    -                                                                    -                 -                  - -   -         SO4   63       20 1
-0 CMIP6_AIR_ACET   -                                                                    -                 -                  - -   -         ACET  601      20 1
-0 CMIP6_AIR_ALD2   -                                                                    -                 -                  - -   -         ALD2  602      20 1
-0 CMIP6_AIR_ALK4   -                                                                    -                 -                  - -   -         ALK4  603      20 1
-0 CMIP6_AIR_C2H6   -                                                                    -                 -                  - -   -         C2H6  604      20 1
-0 CMIP6_AIR_C3H8   -                                                                    -                 -                  - -   -         C3H8  605      20 1
-0 CMIP6_AIR_CH2O   -                                                                    -                 -                  - -   -         CH2O  606      20 1
-0 CMIP6_AIR_PRPE   -                                                                    -                 -                  - -   -         PRPE  607      20 1
-0 CMIP6_AIR_MACR   -                                                                    -                 -                  - -   -         MACR  608      20 1
-0 CMIP6_AIR_RCHO   -                                                                    -                 -                  - -   -         RCHO  609      20 1
+0 CMIP6_AIR_SO4    -                                                                                  -                 -                  - -   -         SO4   63       20 1
+0 CMIP6_AIR_pFe    -                                                                                  -                 -                  - -   -         pFe   66       20 1
+0 CMIP6_AIR_ACET   -                                                                                  -                 -                  - -   -         ACET  601      20 1
+0 CMIP6_AIR_ALD2   -                                                                                  -                 -                  - -   -         ALD2  602      20 1
+0 CMIP6_AIR_ALK4   -                                                                                  -                 -                  - -   -         ALK4  603      20 1
+0 CMIP6_AIR_C2H6   -                                                                                  -                 -                  - -   -         C2H6  604      20 1
+0 CMIP6_AIR_C3H8   -                                                                                  -                 -                  - -   -         C3H8  605      20 1
+0 CMIP6_AIR_CH2O   -                                                                                  -                 -                  - -   -         CH2O  606      20 1
+0 CMIP6_AIR_PRPE   -                                                                                  -                 -                  - -   -         PRPE  607      20 1
+0 CMIP6_AIR_MACR   -                                                                                  -                 -                  - -   -         MACR  608      20 1
+0 CMIP6_AIR_RCHO   -                                                                                  -                 -                  - -   -         RCHO  609      20 1
 0 CMIP6_AIR_NH3    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    NH3_air           1750-2100/1-12/1/0 C xyz kg/m2/s   NH3   -        20 1
 # Assume all BC/OC is BCPI/OCPI
 0 CMIP6_AIR_BCPI   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    BC_air            1750-2100/1-12/1/0 C xyz kg/m2/s   BCPI  -        20 1
 0 CMIP6_AIR_OCPI   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    OC_air            1750-2100/1-12/1/0 C xyz kg/m2/s   OCPI  -        20 1
+0 CMIP6_AIR_POG1   -                                                                                  -                 -                  - -  -          POG1  74/76    20 1
+0 CMIP6_AIR_POG2   -                                                                                  -                 -                  - -  -          POG2  74/77    20 1
 
 )))CMIP6_AIRCRAFT
 
@@ -2043,6 +2109,8 @@ Warnings:                    1
 0 TRASH_BCPO  -                                                       -     -          - -  -        BCPO  71    1 2
 0 TRASH_OCPI  $ROOT/TrashEmis/v2015-03/TrashBurn_v2_generic.01x01.nc  OC    2008/1/1/0 C xy kg/m2/s  OCPI  72    1 2
 0 TRASH_OCPO  -                                                       -     -          - -  -        OCPO  73    1 2
+0 TRASH_POG1  -                                                       -     -          - -  -        POG1  74/76 1 2
+0 TRASH_POG2  -                                                       -     -          - -  -        POG2  74/77 1 2
 0 TRASH_NH3   $ROOT/TrashEmis/v2015-03/TrashBurn_v2_generic.01x01.nc  NH3   2008/1/1/0 C xy kg/m2/s  NH3   -     1 2
 
 #==============================================================================
@@ -2356,6 +2424,8 @@ Warnings:                    1
 0 CEDS_BCPO_SHP   -                                                                    -                 -                  - -  -       BCPO  71     10 5
 0 CEDS_OCPI_SHP   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_shp            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72     10 5
 0 CEDS_OCPO_SHP   -                                                                    -                 -                  - -  -       OCPO  73     10 5
+0 CEDS_POG1_SHP   -                                                                    -                 -                  - -  -       POG1  74/76  10 5
+0 CEDS_POG2_SHP   -                                                                    -                 -                  - -  -       POG2  74/77  10 5
 0 CEDS_MOH_SHP    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_shp           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90  10 5
 0 CEDS_EOH_SHP    -                                                                    -                 -                  - -  -       EOH   26/91  10 5
 0 CEDS_ROH_SHP    -                                                                    -                 -                  - -  -       ROH   26/92  10 5
@@ -2396,19 +2466,21 @@ Warnings:                    1
 #==============================================================================
 (((CMIP6_SHIP
 0 CMIP6_CO_SHP     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            CO_shp            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        10 5
-0 CMIP6_SOAP_SHP   -                                                   -                 -                  - -  -          SOAP  26/280    10 5
+0 CMIP6_SOAP_SHP   -                                                                       -                 -                  - -  -          SOAP  26/280    10 5
 0 CMIP6_SO2_SHP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            SO2_shp           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         10 5
-0 CMIP6_SO4_SHP    -                                                   -                 -                  - -  -          SO4   63        10 5
-0 CMIP6_pFe_SHP    -                                                   -                 -                  - -  -          pFe   66        10 5
+0 CMIP6_SO4_SHP    -                                                                       -                 -                  - -  -          SO4   63        10 5
+0 CMIP6_pFe_SHP    -                                                                       -                 -                  - -  -          pFe   66        10 5
 0 CMIP6_NH3_SHP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            NH3_shp           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         10 5
 0 CMIP6_BCPI_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            BC_shp            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        10 5
-0 CMIP6_BCPO_SHP   -                                                   -                 -                  - -  -          BCPO  71        10 5
+0 CMIP6_BCPO_SHP   -                                                                       -                 -                  - -  -          BCPO  71        10 5
 0 CMIP6_OCPI_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            OC_shp            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        10 5
-0 CMIP6_OCPO_SHP   -                                                   -                 -                  - -  -          OCPO  73        10 5
+0 CMIP6_OCPO_SHP   -                                                                       -                 -                  - -  -          OCPO  73        10 5
+0 CMIP6_POG1_SHP   -                                                                       -                 -                  - -  -          POG1  74/76     10 5
+0 CMIP6_POG2_SHP   -                                                                       -                 -                  - -  -          POG2  74/77     10 5
 # NOTE: EOH files in CMIP6/v2021-01 are actually VOC1 (total alchohols) and are split into MOH, EOH, ROH here
 0 CMIP6_MOH_SHP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            EOH_shp           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     10 5
-0 CMIP6_EOH_SHP    -                                                   -                 -                  - -  -          EOH   26/91     10 5
-0 CMIP6_ROH_SHP    -                                                   -                 -                  - -  -          ROH   26/92     10 5
+0 CMIP6_EOH_SHP    -                                                                       -                 -                  - -  -          EOH   26/91     10 5
+0 CMIP6_ROH_SHP    -                                                                       -                 -                  - -  -          ROH   26/92     10 5
 0 CMIP6_C2H6_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            C2H6_shp          1750-2100/1-12/1/0 C xy kg/m2/s    C2H6  26        10 5
 0 CMIP6_C3H8_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            C3H8_shp          1750-2100/1-12/1/0 C xy kg/m2/s    C3H8  26        10 5
 0 CMIP6_C4H10_SHP  $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            ALK4_butanes_shp  1750-2100/1-12/1/0 C xy kg/m2/s    ALK4  26        10 5
@@ -2500,6 +2572,7 @@ Warnings:                    1
 0 AEIC19_DAILY_CO   $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc CO       2019/1-12/1-31/0 C xyz kg/m2/s CO   241         20 1
 0 AEIC19_DAILY_SOAP -                                                                 -        -                - -   -       SOAP 241/280     20 1
 0 AEIC19_DAILY_SO2  $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc FUELBURN 2019/1-12/1-31/0 C xyz kg/m2/s SO2  241/111     20 1
+0 AEIC19_DAILY_pFe  -                                                                 -        -                - -   -       pFe  241/111/66  20 1
 0 AEIC19_DAILY_SO4  -                                                                 -        -                - -   -       SO4  241/112     20 1
 0 AEIC19_DAILY_H2O  -                                                                 -        -                - -   -       H2O  241/120     20 1
 0 AEIC19_DAILY_BCPI $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc BC       2019/1-12/1-31/0 C xyz kg/m2/s BCPI 241         20 1
@@ -2521,6 +2594,7 @@ Warnings:                    1
 0 AEIC19_MONMEAN_CO   $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc CO       2019/1-12/1/0 C xyz kg/m2/s CO   241         20 1
 0 AEIC19_MONMEAN_SOAP -                                                                          -        -             - -   -       SOAP 241/280     20 1
 0 AEIC19_MONMEAN_SO2  $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc FUELBURN 2019/1-12/1/0 C xyz kg/m2/s SO2  241/111     20 1
+0 AEIC19_MONMEAN_pFe  -                                                                          -        -             - -   -       pFe  241/111/66  20 1
 0 AEIC19_MONMEAN_SO4  -                                                                          -        -             - -   -       SO4  241/112     20 1
 0 AEIC19_MONMEAN_H2O  -                                                                          -        -             - -   -       H2O  241/120     20 1
 0 AEIC19_MONMEAN_BCPI $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc BC       2019/1-12/1/0 C xyz kg/m2/s BCPI 241         20 1
@@ -2554,7 +2628,10 @@ Warnings:                    1
 0 RCP3PD_SOAP    -                                                                                        -      -               -  -  -        SOAP  280   1 1
 0 RCP3PD_BCPO    $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_BC_2005-2100_23474.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO  -     1 1
 0 RCP3PD_OCPO    $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_OC_2005-2100_23474.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO  -     1 1
+0 RCP3PD_POG1    -                                                                                        -      -               -  -  -        POG1  74/76 1 1
+0 RCP3PD_POG2    -                                                                                        -      -               -  -  -        POG2  74/77 1 1
 0 RCP3PD_SO2     $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_SO2_2005-2100_23474.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2   -     1 1
+0 RCP3PD_pFe     -                                                                                        -      -               -  -  -        pFe   66    1 1
 0 RCP3PD_NH3     $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_NH3_2005-2100_23474.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3   -     1 1
 0 RCP3PD_C2H2    $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_acetylene_2005-2100_23474_kgC.nc                  ACCMIP 2005-2100/1/1/0 ID xy kgC/m2/s C2H2  59    1 1
 0 RCP3PD_CH2O    $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_formaldehyde_2005-2100_23474.nc                   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  CH2O  -     1 1
@@ -2581,7 +2658,10 @@ Warnings:                    1
 0 RCP45_SOAP    -                                                                                       -      -               -  -  -        SOAP  280   1 1
 0 RCP45_BCPO    $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_BC_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO  -     1 1
 0 RCP45_OCPO    $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_OC_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO  -     1 1
+0 RCP45_POG1    -                                                                                       -      -               -  -  -        POG1  74/76 1 1
+0 RCP45_POG2    -                                                                                       -      -               -  -  -        POG2  74/77 1 1
 0 RCP45_SO2     $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_SO2_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2   -     1 1
+0 RCP45_pFe     -                                                                                       -      -               -  -  -        pFe   66    1 1
 0 RCP45_NH3     $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_NH3_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3   -     1 1
 0 RCP45_C2H2    $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_acetylene_2005-2100_27424_kgC.nc                  ACCMIP 2005-2100/1/1/0 ID xy kgC/m2/s C2H2  59    1 1
 0 RCP45_CH2O    $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_formaldehyde_2005-2100_27424.nc                   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  CH2O  -     1 1
@@ -2608,7 +2688,10 @@ Warnings:                    1
 0 RCP60_SOAP    -                                                                                       -      -               -  -  -        SOAP  280   1 1
 0 RCP60_BCPO    $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_BC_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO  -     1 1
 0 RCP60_OCPO    $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_OC_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO  -     1 1
+0 RCP60_POG1    -                                                                                       -      -               -  -  -        POG1  74/76 1 1
+0 RCP60_POG2    -                                                                                       -      -               -  -  -        POG2  74/77 1 1
 0 RCP60_SO2     $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_SO2_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2   -     1 1
+0 RCP60_pFe     -                                                                                       -      -               -  -  -        pFe   66    1 1
 0 RCP60_NH3     $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_NH3_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3   -     1 1
 0 RCP60_C2H2    $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_acetylene_2005-2100_43190_kgC.nc                  ACCMIP 2005-2100/1/1/0 ID xy kgC/m2/s C2H2  59    1 1
 0 RCP60_CH2O    $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_formaldehyde_2005-2100_43190.nc                   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  CH2O  -     1 1
@@ -2635,7 +2718,10 @@ Warnings:                    1
 0 RCP85_SOAP    -                                                                                       -      -               -  -  -        SOAP  280   1 1
 0 RCP85_BCPO    $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_BC_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO  -     1 1
 0 RCP85_OCPO    $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_OC_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO  -     1 1
+0 RCP85_POG1    -                                                                                       -      -               -  -  -        POG1  74/76 1 1
+0 RCP85_POG2    -                                                                                       -      -               -  -  -        POG2  74/77 1 1
 0 RCP85_SO2     $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_SO2_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2   -     1 1
+0 RCP80_pFe     -                                                                                       -      -               -  -  -        pFe   66    1 1
 0 RCP85_NH3     $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_NH3_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3   -     1 1
 0 RCP85_C2H2    $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_acetylene_2005-2100_43533_kgC.nc                  ACCMIP 2005-2100/1/1/0 ID xy kgC/m2/s C2H2  59    1 1
 0 RCP85_CH2O    $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_formaldehyde_2005-2100_43533.nc                   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  CH2O  -     1 1
@@ -2671,8 +2757,12 @@ Warnings:                    1
 0 QFED_BCPO_FT   -                                                                 -       -                             -  -             -       BCPO 71/75/312     5 2
 0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
 0 QFED_OCPO_PBL  -                                                                 -       -                             -  -             -       OCPO 73/75/311     5 2
+0 QFED_POG1_PBL  -                                                                 -       -                             -  -             -       POG1 74/76/75/311  5 2
+0 QFED_POG2_PBL  -                                                                 -       -                             -  -             -       POG2 74/77/75/311  5 2
 0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
 0 QFED_OCPO_FT   -                                                                 -       -                             -  -             -       OCPO 73/75/312     5 2
+0 QFED_POG1_FT   -                                                                 -       -                             -  -             -       POG1 74/76/75/312  5 2
+0 QFED_POG2_FT   -                                                                 -       -                             -  -             -       POG2 74/77/75/312  5 2
 0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s C2H6 75/311        5 2
 0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2
 0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s C3H8 75/311        5 2
@@ -2694,7 +2784,9 @@ Warnings:                    1
 0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s NO   75/311        5 2
 0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s NO   75/312        5 2
 0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_pFe_FT    -                                                                 -       -                             -  -             -       pFe  75/312/66     5 2
 0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_pFe_FT    -                                                                 -       -                             -  -             -       pF3  75/312/66     5 2
 0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s PRPE 75/311        5 2
 0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2
 )))QFED2
@@ -2703,31 +2795,34 @@ Warnings:                    1
 # --- GFAS biomass burning ---
 #==============================================================================
 (((GFAS
-0 GFAS_CO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO   75     5 3
-0 GFAS_SOAP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SOAP 75/281 5 3
-0 GFAS_NO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc noxfire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NO   75     5 3
-0 GFAS_BCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPI 70/75  5 3
-0 GFAS_BCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPO 71/75  5 3
-0 GFAS_OCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPI 72/75  5 3
-0 GFAS_OCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPO 73/75  5 3
-0 GFAS_CO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc co2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO2  75     5 3
-0 GFAS_CH4   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch4fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH4  75     5 3
-0 GFAS_SO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SO2  75     5 3
-0 GFAS_NH3   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc nh3fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NH3  75     5 3
-0 GFAS_ACET  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ACET 75     5 3
-0 GFAS_ALD2  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALD2 75     5 3
-0 GFAS_ALK4  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc hialkanesfire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALK4 75     5 3
-0 GFAS_PRPE1 $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc hialkenesfire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s PRPE 75     5 3
-0 GFAS_PRPE2 $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s PRPE 75     5 3
-0 GFAS_C2H6  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C2H6 75     5 3
-0 GFAS_C3H8  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C3H8 75     5 3
-0 GFAS_CH2O  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch2ofire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH2O 75     5 3
-0 GFAS_C2H4  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C2H4 75     5 3
-0 GFAS_ISOP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c5h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ISOP 75     5 3
-0 GFAS_DMS   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6sfire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s DMS  75     5 3
-0 GFAS_TOLU  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c7h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s TOLU 75     5 3
-0 GFAS_BENZ  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c6h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BENZ 75     5 3
-0 GFAS_XYLE  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c8h10fire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s XYLE 75     5 3
+0 GFAS_CO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO   75       5 3
+0 GFAS_SOAP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SOAP 75/281   5 3
+0 GFAS_NO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc noxfire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NO   75       5 3
+0 GFAS_BCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPI 70/75    5 3
+0 GFAS_BCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPO 71/75    5 3
+0 GFAS_OCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPI 72/75    5 3
+0 GFAS_OCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPO 73/75    5 3
+0 GFAS_POG1  -                                          -             -                     - -             -       POG1 74/76/75 5 3
+0 GFAS_POG2  -                                          -             -                     - -             -       POG2 74/77/75 5 3
+0 GFAS_CO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc co2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO2  75       5 3
+0 GFAS_CH4   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch4fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH4  75       5 3
+0 GFAS_SO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SO2  75       5 3
+0 GFAS_pFe   -                                          -             -                     - -             -       pFe  75/66    5 3
+0 GFAS_NH3   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc nh3fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NH3  75       5 3
+0 GFAS_ACET  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ACET 75       5 3
+0 GFAS_ALD2  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALD2 75       5 3
+0 GFAS_ALK4  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc hialkanesfire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALK4 75       5 3
+0 GFAS_PRPE1 $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc hialkenesfire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s PRPE 75       5 3
+0 GFAS_PRPE2 $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s PRPE 75       5 3
+0 GFAS_C2H6  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C2H6 75       5 3
+0 GFAS_C3H8  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C3H8 75       5 3
+0 GFAS_CH2O  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch2ofire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH2O 75       5 3
+0 GFAS_C2H4  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C2H4 75       5 3
+0 GFAS_ISOP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c5h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ISOP 75       5 3
+0 GFAS_DMS   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6sfire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s DMS  75       5 3
+0 GFAS_TOLU  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c7h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s TOLU 75       5 3
+0 GFAS_BENZ  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c6h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BENZ 75       5 3
+0 GFAS_XYLE  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c8h10fire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s XYLE 75       5 3
 )))GFAS
 
 #==============================================================================
@@ -2735,39 +2830,42 @@ Warnings:                    1
 #==============================================================================
 (((BB4MIPS
 # 75 is time-of-day scaling
-0 CMIP6_BB_CO      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s CO    75     5 3
-0 CMIP6_BB_SOAP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s SOAP  75/281 5 3
-0 CMIP6_BB_NO      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 NO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s NO    75     5 3
-0 CMIP6_BB_BCPI    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BCPI  70/75  5 3
-0 CMIP6_BB_BCPO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BCPO  71/75  5 3
-0 CMIP6_BB_OCPI    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPI  72/75  5 3
-0 CMIP6_BB_OCPO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPO  73/75  5 3
-0 CMIP6_BB_SO2     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 SO2_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s SO2   75     5 3
-0 CMIP6_BB_NH3     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 NH3_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s NH3   75     5 3
-0 CMIP6_BB_ALD2    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ALD2_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ALD2  75     5 3
-0 CMIP6_BB_ALK4    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ALK4_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ALK4  75     5 3
-0 CMIP6_BB_PRPE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 PRPE_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s PRPE  75     5 3
-0 CMIP6_BB_C2H6    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C2H6_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C2H6  75     5 3
-0 CMIP6_BB_C3H8    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C3H8_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C3H8  75     5 3
-0 CMIP6_BB_CH2O    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CH2O_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s CH2O  75     5 3
-0 CMIP6_BB_C2H4    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C2H4_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C2H4  75     5 3
-0 CMIP6_BB_ISOP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ISOP_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ISOP  75     5 3
-0 CMIP6_BB_DMS     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 DMS_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s DMS   75     5 3
-0 CMIP6_BB_TOLU    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 TOLU_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s TOLU  75     5 3
-0 CMIP6_BB_BENZ    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BENZ_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BENZ  75     5 3
-0 CMIP6_BB_XYLE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 XYLE_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s XYLE  75     5 3
-0 CMIP6_BB_H2      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 H2_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s H2    75     5 3
-0 CMIP6_BB_MTPA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MONOT_bbn  1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MTPA  75     5 3
-#0 CMIP6_BB_MTPO    -                                              -          -                  - -             -   MTPO  75     5 3
-#0 CMIP6_BB_LIMO    -                                              -          -                  - -             -   LIMO  75     5 3
-0 CMIP6_BB_EOH     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 EOH_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s EOH   75     5 3
-0 CMIP6_BB_MOH     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MOH_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MOH   75     5 3
-0 CMIP6_BB_ACET    -                                              -          -                  - -             -   ACET  79/75  5 3
-0 CMIP6_BB_MGLY    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MGLY_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MGLY  75     5 3
-0 CMIP6_BB_ACTA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ACTA_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ACTA  75     5 3
-0 CMIP6_BB_HCN     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 HCN_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s HCN   75     5 3
-0 CMIP6_BB_HCOOH   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 HCOOH_bbn  1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s HCOOH 75     5 3
-0 CMIP6_BB_MEK     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MEK_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MEK   75     5 3
+0 CMIP6_BB_CO      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s CO    75       5 3
+0 CMIP6_BB_SOAP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s SOAP  75/281   5 3
+0 CMIP6_BB_NO      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 NO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s NO    75       5 3
+0 CMIP6_BB_BCPI    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BCPI  70/75    5 3
+0 CMIP6_BB_BCPO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BCPO  71/75    5 3
+0 CMIP6_BB_OCPI    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPI  72/75    5 3
+0 CMIP6_BB_OCPO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPO  73/75    5 3
+0 CMIP6_BB_POG1    -                                                            -          -                  - -         -       POG1  74/76/75 5 3
+0 CMIP6_BB_POG2    -                                                            -          -                  - -         -       POG2  74/77/75 5 3
+0 CMIP6_BB_SO2     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 SO2_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s SO2   75       5 3
+0 CMIP6_BB_pFe     -                                                            -          -                  - -         -       pFe   75/66    5 3
+0 CMIP6_BB_NH3     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 NH3_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s NH3   75       5 3
+0 CMIP6_BB_ALD2    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ALD2_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ALD2  75       5 3
+0 CMIP6_BB_ALK4    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ALK4_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ALK4  75       5 3
+0 CMIP6_BB_PRPE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 PRPE_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s PRPE  75       5 3
+0 CMIP6_BB_C2H6    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C2H6_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C2H6  75       5 3
+0 CMIP6_BB_C3H8    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C3H8_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C3H8  75       5 3
+0 CMIP6_BB_CH2O    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CH2O_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s CH2O  75       5 3
+0 CMIP6_BB_C2H4    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C2H4_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C2H4  75       5 3
+0 CMIP6_BB_ISOP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ISOP_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ISOP  75       5 3
+0 CMIP6_BB_DMS     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 DMS_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s DMS   75       5 3
+0 CMIP6_BB_TOLU    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 TOLU_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s TOLU  75       5 3
+0 CMIP6_BB_BENZ    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BENZ_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BENZ  75       5 3
+0 CMIP6_BB_XYLE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 XYLE_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s XYLE  75       5 3
+0 CMIP6_BB_H2      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 H2_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s H2    75       5 3
+0 CMIP6_BB_MTPA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MONOT_bbn  1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MTPA  75       5 3
+#0 CMIP6_BB_MTPO    -                                                           -          -                  - -             -   MTPO  75       5 3
+#0 CMIP6_BB_LIMO    -                                                           -          -                  - -             -   LIMO  75       5 3
+0 CMIP6_BB_EOH     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 EOH_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s EOH   75       5 3
+0 CMIP6_BB_MOH     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MOH_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MOH   75       5 3
+0 CMIP6_BB_ACET    -                                                            -          -                  - -             -   ACET  79/75    5 3
+0 CMIP6_BB_MGLY    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MGLY_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MGLY  75       5 3
+0 CMIP6_BB_ACTA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ACTA_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ACTA  75       5 3
+0 CMIP6_BB_HCN     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 HCN_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s HCN   75       5 3
+0 CMIP6_BB_HCOOH   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 HCOOH_bbn  1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s HCOOH 75       5 3
+0 CMIP6_BB_MEK     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MEK_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MEK   75       5 3
 )))BB4MIPS
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -2576,6 +2576,8 @@ Warnings:                    1
 0 AEIC19_DAILY_H2O  -                                                                 -        -                - -   -       H2O  241/120     20 1
 0 AEIC19_DAILY_BCPI $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc BC       2019/1-12/1-31/0 C xyz kg/m2/s BCPI 241         20 1
 0 AEIC19_DAILY_OCPI $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc OC       2019/1-12/1-31/0 C xyz kg/m2/s OCPI 241         20 1
+0 AEIC19_DAILY_POG1 -                                                                 -        -                - -   -       POG1 241/74/76   20 1
+0 AEIC19_DAILY_POG2 -                                                                 -        -                - -   -       POG2 241/74/77   20 1
 0 AEIC19_DAILY_ACET $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc HC       2019/1-12/1-31/0 C xyz kg/m2/s ACET 241/114/101 20 1
 0 AEIC19_DAILY_ALD2 -                                                                 -        -                - -   -       ALD2 241/114/102 20 1
 0 AEIC19_DAILY_ALK4 -                                                                 -        -                - -   -       ALK4 241/114/103 20 1
@@ -2598,6 +2600,8 @@ Warnings:                    1
 0 AEIC19_MONMEAN_H2O  -                                                                          -        -             - -   -       H2O  241/120     20 1
 0 AEIC19_MONMEAN_BCPI $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc BC       2019/1-12/1/0 C xyz kg/m2/s BCPI 241         20 1
 0 AEIC19_MONMEAN_OCPI $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc OC       2019/1-12/1/0 C xyz kg/m2/s OCPI 241         20 1
+0 AEIC19_MONMEAN_POG1 -                                                                          -        -             - -   -       POG1 241/74/76   20 1
+0 AEIC19_MONMEAN_POG2 -                                                                          -        -             - -   -       POG2 241/74/77   20 1
 0 AEIC19_MONMEAN_ACET $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc HC       2019/1-12/1/0 C xyz kg/m2/s ACET 241/114/101 20 1
 0 AEIC19_MONMEAN_ALD2 -                                                                          -        -             - -   -       ALD2 241/114/102 20 1
 0 AEIC19_MONMEAN_ALK4 -                                                                          -        -             - -   -       ALK4 241/114/103 20 1
@@ -2783,7 +2787,7 @@ Warnings:                    1
 0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s NO   75/311        5 2
 0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s NO   75/312        5 2
 0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s SO2  75/311        5 2
-0 QFED_pFe_FT    -                                                                 -       -                             -  -             -       pFe  75/312/66     5 2
+0 QFED_pFe_PBL   -                                                                 -       -                             -  -             -       pFe  75/311/66     5 2
 0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
 0 QFED_pFe_FT    -                                                                 -       -                             -  -             -       pF3  75/312/66     5 2
 0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s PRPE 75/311        5 2

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -287,7 +287,6 @@ Warnings:                    1
 0 EPA16_NIT__afdustPNO3          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
-0 EPA16_OCPI__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_POG1__afdustPOC          -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
 0 EPA16_POG2__afdustPOC          -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_SO4__afdustPSO4          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -286,7 +286,6 @@ Warnings:                    1
 0 EPA16_NIT__afdustPNO3          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
-0 EPA16_OCPI__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_POG1__afdustPOC          -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
 0 EPA16_POG2__afdustPOC          -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_SO4__afdustPSO4          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -286,6 +286,9 @@ Warnings:                    1
 0 EPA16_NIT__afdustPNO3          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_OCPI__afdustPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
+0 EPA16_POG1__afdustPOC          -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__afdustPOC          -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_SO4__afdustPSO4          $ROOT/NEI2016/v2021-06/2016fh_16j_afdust_adj_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_ACET__agACET             $ROOT/NEI2016/v2021-06/2016fh_16j_ag_0pt1degree_month_$MM.ncf                         ACET       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ACET   26/213/254/1007        1 50
 0 EPA16_ALD2__agALD2             $ROOT/NEI2016/v2021-06/2016fh_16j_ag_0pt1degree_month_$MM.ncf                         ALD2       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ALD2   26/213/254/1007        1 50
@@ -330,6 +333,8 @@ Warnings:                    1
 0 EPA16_NIT__airportsPNO3        $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__airportsPOC        $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__airportsPOC        $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__airportsPOC        -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__airportsPOC        -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__airportsPRPA       $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__airportsPSO4        $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__airportsSO2         $ROOT/NEI2016/v2021-06/2016fh_16j_airports_0pt1degree_month_$MM.ncf                   SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -366,6 +371,8 @@ Warnings:                    1
 0 EPA16_NIT__nonptPNO3           $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__nonptPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__nonptPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__nonptPOC           -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__nonptPOC           -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__nonptPRPA          $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__nonptPSO4           $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__nonptSO2            $ROOT/NEI2016/v2021-06/2016fh_16j_nonpt_0pt1degree_month_$MM.ncf                      SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -400,6 +407,8 @@ Warnings:                    1
 0 EPA16_NIT__nonroadPNO3         $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__nonroadPOC         $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__nonroadPOC         $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__nonroadPOC         -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__nonroadPOC         -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__nonroadPRPA        $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__nonroadPSO4         $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__nonroadSO2          $ROOT/NEI2016/v2021-06/2016fh_16j_nonroad_0pt1degree_month_$MM.ncf                    SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -435,6 +444,8 @@ Warnings:                    1
 0 EPA16_NIT__npogPNO3            $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__npogPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__npogPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__npogPOC            -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__npogPOC            -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__npogPRPA           $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__npogPSO4            $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__npogSO2             $ROOT/NEI2016/v2021-06/2016fh_16j_np_oilgas_0pt1degree_month_$MM.ncf                  SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -469,6 +480,8 @@ Warnings:                    1
 0 EPA16_NIT__onroadPNO3          $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__onroadPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__onroadPOC          $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__onroadPOC          -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__onroadPOC          -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__onroadPRPA         $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__onroadPSO4          $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__onroadSO2           $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_0pt1degree_month_$MM.ncf                     SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -502,6 +515,8 @@ Warnings:                    1
 0 EPA16_NIT__onroad_caPNO3       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__onroad_caPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__onroad_caPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__onroad_caPOC       -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__onroad_caPOC       -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__onroad_caPRPA      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__onroad_caPSO4       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__onroad_caSO2        $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_ca_adj_0pt1degree_month_$MM.ncf              SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -535,6 +550,8 @@ Warnings:                    1
 0 EPA16_NIT__railPNO3            $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__railPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__railPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__railPOC            -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__railPOC            -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__railPRPA           $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__railPSO4            $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__railSO2             $ROOT/NEI2016/v2021-06/2016fh_16j_rail_0pt1degree_month_$MM.ncf                       SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -570,6 +587,8 @@ Warnings:                    1
 0 EPA16_NIT__rwcPNO3             $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__rwcPOC             $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__rwcPOC             $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__rwcPOC             -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__rwcPOC             -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__rwcPRPA            $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__rwcPSO4             $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__rwcSO2              $ROOT/NEI2016/v2021-06/2016fh_16j_rwc_0pt1degree_month_$MM.ncf                        SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -603,6 +622,8 @@ Warnings:                    1
 0 EPA16_NIT__c1c2PNO3            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__c1c2POC            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__c1c2POC            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__clc2POC            -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__clc2POC            -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__c1c2PRPA           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__c1c2PSO4            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__c1c2SO2             $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c1c2_12_0pt1degree_3D_month_$MM.ncf        SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -636,6 +657,8 @@ Warnings:                    1
 0 EPA16_NIT__c3PNO3              $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__c3POC              $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__c3POC              $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__c3POC              -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__c3POC              -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__c3PRPA             $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__c3PSO4              $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__c3SO2               $ROOT/NEI2016/v2021-06/2016fh_16j_emln_cmv_c3_12_0pt1degree_3D_month_$MM.ncf          SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -672,6 +695,8 @@ Warnings:                    1
 0 EPA16_NIT__pteguPNO3           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__pteguPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__pteguPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__pteguPOC           -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__pteguPOC           -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__pteguPRPA          $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__pteguPSO4           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__pteguSO2            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptegu_0pt1degree_3D_month_$MM.ncf              SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -708,6 +733,8 @@ Warnings:                    1
 0 EPA16_NIT__ptogPNO3            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__ptogPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__ptogPOC            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__ptogPOC            -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__ptogPOC            -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__ptogPRPA           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__ptogPSO4            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__ptogSO2             $ROOT/NEI2016/v2021-06/2016fh_16j_emln_pt_oilgas_allinln_0pt1degree_3D_month_$MM.ncf  SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -744,6 +771,8 @@ Warnings:                    1
 0 EPA16_NIT__ptnonipmPNO3        $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__ptnonipmPOC        $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__ptnonipmPOC        $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__ptnonipmPOC        -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__ptnonipmPOC        -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__ptnonipmPRPA       $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__ptnonipmPSO4        $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__ptnonipmSO2         $ROOT/NEI2016/v2021-06/2016fh_16j_emln_ptnonipm_allinln_0pt1degree_3D_month_$MM.ncf   SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -777,6 +806,8 @@ Warnings:                    1
 0 EPA16_NIT__onroad_canPNO3      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__onroad_canPOC      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__onroad_canPOC      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__onroad_canPOC      -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__onroad_canPOC      -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__onroad_canPRPA     $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__onroad_canPSO4      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__onroad_canSO2       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_can_0pt1degree_month_$MM.ncf                 SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -811,6 +842,8 @@ Warnings:                    1
 0 EPA16_NIT__onroad_mexPNO3      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__onroad_mexPOC      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__onroad_mexPOC      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__onroad_mexPOC      -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__onroad_mexPOC      -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__onroad_mexPRPA     $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__onroad_mexPSO4      $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__onroad_mexSO2       $ROOT/NEI2016/v2021-06/2016fh_16j_onroad_mex_0pt1degree_month_$MM.ncf                 SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -825,6 +858,8 @@ Warnings:                    1
 0 EPA16_NIT__othafdustPNO3       $ROOT/NEI2016/v2021-06/2016fh_16j_othafdust_adj_0pt1degree_month_$MM.ncf              PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__othafdustPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_othafdust_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__othafdustPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_othafdust_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__othafdustPOC       -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__othafdustPOC       -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_SO4__othafdustPSO4       $ROOT/NEI2016/v2021-06/2016fh_16j_othafdust_adj_0pt1degree_month_$MM.ncf              PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_ACET__otharACET          $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      ACET       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ACET   26/213/254/1007        1 50
 0 EPA16_ALD2__otharALD2          $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      ALD2       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ALD2   26/213/254/1007        1 50
@@ -852,6 +887,8 @@ Warnings:                    1
 0 EPA16_NIT__otharPNO3           $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__otharPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__otharPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__otharPOC           -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__otharPOC           -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__otharPRPA          $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__otharPSO4           $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__otharSO2            $ROOT/NEI2016/v2021-06/2016fh_16j_othar_0pt1degree_month_$MM.ncf                      SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -866,6 +903,8 @@ Warnings:                    1
 0 EPA16_NIT__othptdustPNO3       $ROOT/NEI2016/v2021-06/2016fh_16j_othptdust_adj_0pt1degree_month_$MM.ncf              PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__othptdustPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_othptdust_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__othptdustPOC       $ROOT/NEI2016/v2021-06/2016fh_16j_othptdust_adj_0pt1degree_month_$MM.ncf              POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__othptdustPOC       -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__othptdustPOC       -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_SO4__othptdustPSO4       $ROOT/NEI2016/v2021-06/2016fh_16j_othptdust_adj_0pt1degree_month_$MM.ncf              PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_ACET__othptACET          $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 ACET       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ACET   26/213/254/1007        1 50
 0 EPA16_ALD2__othptALD2          $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 ALD2       2002-2020/1-12/1/0 RF xyz  kg/m2/s    ALD2   26/213/254/1007        1 50
@@ -893,6 +932,8 @@ Warnings:                    1
 0 EPA16_NIT__othptPNO3           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 PNO3       2002-2020/1-12/1/0 RF xyz  kg/m2/s    NIT    26/218/255/1007        1 50
 0 EPA16_OCPI__othptPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPI   26/222/256/1007/72     1 50
 0 EPA16_OCPO__othptPOC           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 POC        2002-2020/1-12/1/0 RF xyz  kg/m2/s    OCPO   26/222/256/1007/73     1 50
+0 EPA16_POG1__othptPOC           -                                                                                     -          -                  -  -    -          POG1   26/222/256/1007/74/76  1 50
+0 EPA16_POG2__othptPOC           -                                                                                     -          -                  -  -    -          POG2   26/222/256/1007/74/77  1 50
 0 EPA16_C3H8__othptPRPA          $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 PRPA       2002-2020/1-12/1/0 RF xyz  kg/m2/s    C3H8   26/216/254/1007        1 50
 0 EPA16_SO4__othptPSO4           $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 PSO4       2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO4    26/219/255/1007        1 50
 0 EPA16_SO2__othptSO2            $ROOT/NEI2016/v2021-06/2016fh_16j_emln_othpt_0pt1degree_month_$MM.ncf                 SO2        2002-2020/1-12/1/0 RF xyz  kg/m2/s    SO2    26/218/255/1007        1 50
@@ -949,6 +990,8 @@ Warnings:                    1
 0 DICE_CARS_BCPO  -                                                                 -       -          - -  -        BCPO  71/1008         1 60
 0 DICE_CARS_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  OC      2013/1/1/0 C xy g/m2/yr  OCPI  72/1008/330     1 60
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
+0 DICE_CARS_POG1  -                                                                 -       -          - -  -        POG1  74/76/1008/330  1 60
+0 DICE_CARS_POG2  -                                                                 -       -          - -  -        POG2  74/77/1008/330  1 60
 
 # ------------------------
 #  Motorcycles
@@ -970,6 +1013,8 @@ Warnings:                    1
 0 DICE_MOTORCYCLES_BCPO  -                                                                        -      -          - -  -        BCPO  71/1008          1 60
 0 DICE_MOTORCYCLES_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  OC     2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
+0 DICE_MOTORCYCLES_POG1  -                                                                        -      -          -  - -        POG1  74/76/1008       1 60
+0 DICE_MOTORCYCLES_POG2  -                                                                        -      -          -  - -        POG2  74/77/1008       1 60
 
 # ------------------------
 #  Backup generators
@@ -995,9 +1040,11 @@ Warnings:                    1
 0 DICE_BACKUPGEN_TOLU  $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  TOLU 2013/1/1/0 C xy g/m2/yr  TOLU  26/1008          1 60
 0 DICE_BACKUPGEN_XYLE  $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  XYLE 2013/1/1/0 C xy g/m2/yr  XYLE  26/1008          1 60
 0 DICE_BACKUPGEN_BCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  BC   2013/1/1/0 C xy g/m2/yr  BCPI  70/1008          1 60
-0 DICE_BACKUPGEN_BCPO  -                                                                          -        -          - -  -    BCPO  71/1008          1 60
+0 DICE_BACKUPGEN_BCPO  -                                                                          -    -          - -  -        BCPO  71/1008          1 60
 0 DICE_BACKUPGEN_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  OC   2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
-0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
+0 DICE_BACKUPGEN_OCPO  -                                                                          -    -          - -  -        OCPO  73/1008          1 60
+0 DICE_BACKUPGEN_POG1  -                                                                          -    -          - -  -        POG1  74/76/1008       1 60
+0 DICE_BACKUPGEN_POG2  -                                                                          -    -          - -  -        POG2  74/77/1008       1 60
 
 # ------------------------
 #  Charcoal production
@@ -1019,6 +1066,8 @@ Warnings:                    1
 0 DICE_CHARCOALPROD_BCPO  -                                                                                -     -          - -  -        BCPO  71/1008/320      1 60
 0 DICE_CHARCOALPROD_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008/320      1 60
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
+0 DICE_CHARCOALPROD_POG1  -                                                                                -     -          - -  -        POG1  74/76/1008/320   1 60
+0 DICE_CHARCOALPROD_POG2  -                                                                                -     -          - -  -        POG2  74/77/1008/320   1 60
 
 # ------------------------
 #  Flaring of natural gas
@@ -1037,6 +1086,8 @@ Warnings:                    1
 0 DICE_GASFLARE_BCPO  -                                                                       -     -          - -  -        BCPO  71/1008          1 60
 0 DICE_GASFLARE_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
+0 DICE_GASFLARE_POG1  -                                                                       -     -          - -  -        POG1  74/76/1008       1 60
+0 DICE_GASFLARE_POG2  -                                                                       -     -          - -  -        POG2  74/77/1008       1 60
 
 # ------------------------------
 #  Ag waste burning for energy
@@ -1074,7 +1125,9 @@ Warnings:                    1
 0 DICE_AGBURNING_BCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  BC    2013/1/1/0 C xy g/m2/yr  BCPI  70/1008          2 60
 0 DICE_AGBURNING_BCPO  -                                                                                       -     -          - -  g/m2/yr  BCPO  71/1008          2 60
 0 DICE_AGBURNING_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          2 60
-0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
+0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  -        OCPO  73/1008          2 60
+0 DICE_AGBURNING_POG1  -                                                                                       -     -          - -  -        POG1  74/76/1008       2 60
+0 DICE_AGBURNING_POG2  -                                                                                       -     -          - -  -        POG2  74/77/1008       2 60
 
 # ------------------------------
 #  Charcoal use
@@ -1095,6 +1148,8 @@ Warnings:                    1
 0 DICE_CHARCOALUSE_BCPO  -                                                                         -     -          - -  -        BCPO  71/1008          2 60
 0 DICE_CHARCOALUSE_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          2 60
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
+0 DICE_CHARCOALUSE_POG1  -                                                                         -     -          - - -         POG1  74/76/1008       2 60
+0 DICE_CHARCOALUSE_POG2  -                                                                         -     -          - - -         POG2  74/77/1008       2 60
 
 # ------------------------------
 #  Kerosene use
@@ -1105,6 +1160,8 @@ Warnings:                    1
 0 DICE_KEROSENE_BCPO  -                                                                         -     -          - -  -        BCPO  71/1008          1 60
 0 DICE_KEROSENE_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
+0 DICE_KEROSENE_POG1  -                                                                         -     -          - -  -        POG1  74/76/1008       1 60
+0 DICE_KEROSENE_POG2  -                                                                         -     -          - -  -        POG2  74/77/1008       1 60
 
 # ------------------------------
 #  Artisanal oil refining
@@ -1130,6 +1187,8 @@ Warnings:                    1
 0 DICE_OILREFINING_BCPO  -                                                                               -     -          - -  -        BCPO  71/1008          1 60
 0 DICE_OILREFINING_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          1 60
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
+0 DICE_OILREFINING_POG1  -                                                                               -     -          - -  -        POG1  74/76/1008       1 60
+0 DICE_OILREFINING_POG2  -                                                                               -     -          - -  -        POG2  74/77/1008       1 60
 
 # --------------------------
 #  Household fuelwood use
@@ -1165,6 +1224,8 @@ Warnings:                    1
 0 DICE_HOUSEFUELWOOD_BCPO  -                                                                                   -     -          - -  -        BCPO  71/1008          2 60
 0 DICE_HOUSEFUELWOOD_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          2 60
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
+0 DICE_HOUSEFUELWOOD_POG1  -                                                                                   -     -          - -  -        POG1  74/76/1008       2 60
+0 DICE_HOUSEFUELWOOD_POG2  -                                                                                   -     -          - -  -        POG2  74/77/1008       2 60
 
 # ---------------------------------
 #  Commercial (other) fuelwood use
@@ -1200,6 +1261,8 @@ Warnings:                    1
 0 DICE_OTHERFUELWOOD_BCPO  -                                                                               -     -          - -  -        BCPO  71/1008          2 60
 0 DICE_OTHERFUELWOOD_OCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  OC    2013/1/1/0 C xy g/m2/yr  OCPI  72/1008          2 60
 0 DICE_OTHERFUELWOOD_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          2 60
+0 DICE_OTHERFUELWOOD_POG1  -                                                                               -     -          - -  -        POG1  74/76/1008       2 60
+0 DICE_OTHERFUELWOOD_POG2  -                                                                               -     -          - -  -        POG2  74/77/1008       2 60
 
 # ---------------------------------------------------
 #  Efficient Combustion Emissions from EDGAR
@@ -1252,7 +1315,7 @@ Warnings:                    1
 0 AF_EDGAR_POG2_POW -                                                    -       -               -  -  -       POG2 1201/1008/74/77      1 60
 0 AF_EDGAR_OCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.ENG.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 RF xy kg/m2/s OCPI 1202/1008/72         1 60
 0 AF_EDGAR_OCPO_ENG -                                                    -       -               -  -  -       OCPO 1202/1008/73         1 60
-0 AF_EDGAR_POG1_ENG -                                                    -       -               -  -  -       POG1 1202/74/1008/76      1 60
+0 AF_EDGAR_POG1_ENG -                                                    -       -               -  -  -       POG1 1202/1008/74/76      1 60
 0 AF_EDGAR_POG2_ENG -                                                    -       -               -  -  -       POG2 1202/1008/74/77      1 60
 0 AF_EDGAR_OCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.OC.IND.0.1x0.1.nc  emi_oc  1970-2010/1/1/0 RF xy kg/m2/s OCPI 1203/1008/72         1 60
 0 AF_EDGAR_OCPO_IND -                                                    -       -               -  -  -       OCPO 1203/1008/73         1 60
@@ -1364,32 +1427,32 @@ Warnings:                    1
 
 0 CEDS_OCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_agr            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_AGR   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_AGR   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_AGR   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_AGR   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_AGR   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_ENE   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_ENE   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_ENE   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_ENE   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_ENE   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_IND   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_IND   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_IND   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_IND   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_IND   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_tra            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_TRA   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_TRA   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_TRA   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_TRA   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_TRA   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_rco            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_RCO   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_RCO   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_RCO   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_RCO   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_RCO   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_SLV   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_slv            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_SLV   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_SLV   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_SLV   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_SLV   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_SLV   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 0 CEDS_OCPI_WST   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_wst            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_WST   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_WST   -                                                                    -                 -                  - -  -       POG1  73/74/76  1 5
-0 CEDS_POG2_WST   -                                                                    -                 -                  - -  -       POG2  73/74/77  1 5
+0 CEDS_POG1_WST   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
+0 CEDS_POG2_WST   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
 
 # Comment out CO2 for fullchem simulations: CO2 not advected
 #0 CEDS_CO2_AGR   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_agr           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
@@ -1593,41 +1656,41 @@ Warnings:                    1
 0 CMIP6_NO_WST     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NO_wst            1750-2100/1-12/1/0 C xy kg/m2/s    NO    25        1 5
 
 0 CMIP6_CO_AGR     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_agr            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_AGR   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_AGR   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_ENE     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_ene            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_ENE   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_ENE   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_IND     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_ind            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_IND   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_IND   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_TRA     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_tra            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_TRA   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_TRA   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_RCO     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_rco            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_RCO   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_RCO   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_SLV     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_slv            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_SLV   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_SLV   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 0 CMIP6_CO_WST     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO_wst            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        1 5
-0 CMIP6_SOAP_WST   -                                                          -                 -                  - -  -          SOAP  26/280    1 5
+0 CMIP6_SOAP_WST   -                                                                              -                 -                  - -  -          SOAP  26/280    1 5
 
 0 CMIP6_SO2_AGR    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_agr           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_AGR    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_AGR    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_AGR    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_AGR    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_ENE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_ene           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_ENE    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_ENE    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_ENE    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_ENE    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_IND    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_ind           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_IND    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_IND    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_IND    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_IND    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_TRA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_tra           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_TRA    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_TRA    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_TRA    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_TRA    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_RCO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_rco           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_RCO    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_RCO    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_RCO    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_RCO    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_SLV    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_slv           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_SLV    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_SLV    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_SLV    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_SLV    -                                                                              -                 -                  - -  -          pFe   66        1 5
 0 CMIP6_SO2_WST    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   SO2_wst           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         1 5
-0 CMIP6_SO4_WST    -                                                          -                 -                  - -  -          SO4   63        1 5
-0 CMIP6_pFe_WST    -                                                          -                 -                  - -  -          pFe   66        1 5
+0 CMIP6_SO4_WST    -                                                                              -                 -                  - -  -          SO4   63        1 5
+0 CMIP6_pFe_WST    -                                                                              -                 -                  - -  -          pFe   66        1 5
 
 0 CMIP6_NH3_AGR    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NH3_agr           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         1 5
 0 CMIP6_NH3_ENE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NH3_ene           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         1 5
@@ -1638,48 +1701,48 @@ Warnings:                    1
 0 CMIP6_NH3_WST    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   NH3_wst           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         1 5
 
 0 CMIP6_BCPI_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_agr            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_AGR   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_AGR   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_ENE   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_ene            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_ENE   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_ENE   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_IND   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_ind            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_IND   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_IND   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_TRA   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_tra            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_TRA   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_TRA   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_RCO   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_rco            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_RCO   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_RCO   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_SLV   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_slv            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_SLV   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_SLV   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 0 CMIP6_BCPI_WST   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   BC_wst            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        1 5
-0 CMIP6_BCPO_WST   -                                                          -                 -                  - -  -          BCPO  71        1 5
+0 CMIP6_BCPO_WST   -                                                                              -                 -                  - -  -          BCPO  71        1 5
 
 0 CMIP6_OCPI_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_agr            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_AGR   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_AGR   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_AGR   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_AGR   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_AGR   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_AGR   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_ENE   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_ene            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_ENE   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_ENE   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_ENE   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_ENE   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_ENE   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_ENE   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_IND   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_ind            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_IND   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_IND   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_IND   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_IND   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_IND   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_IND   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_TRA   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_tra            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_TRA   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_TRA   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_TRA   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_TRA   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_TRA   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_TRA   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_RCO   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_rco            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_RCO   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_RCO   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_RCO   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_RCO   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_RCO   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_RCO   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_SLV   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_slv            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_SLV   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_SLV   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_SLV   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_SLV   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_SLV   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_SLV   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 0 CMIP6_OCPI_WST   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   OC_wst            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        1 5
-0 CMIP6_OCPO_WST   -                                                          -                 -                  - -  -          OCPO  73        1 5
-0 CMIP6_POG1_WST   -                                                          -                 -                  - -  -          POG1  73/74/76  1 5
-0 CMIP6_POG2_WST   -                                                          -                 -                  - -  -          POG2  73/74/77  1 5
+0 CMIP6_OCPO_WST   -                                                                              -                 -                  - -  -          OCPO  73        1 5
+0 CMIP6_POG1_WST   -                                                                              -                 -                  - -  -          POG1  74/76     1 5
+0 CMIP6_POG2_WST   -                                                                              -                 -                  - -  -          POG2  74/77     1 5
 
 # Comment out CO2 for fullchem simulations: CO2 not advected
 #0 CMIP6_CO2_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   CO2_agr           1750-2100/1-12/1/0 C xy kg/m2/s    CO2   -         1 5
@@ -1702,26 +1765,26 @@ Warnings:                    1
 
 # NOTE: EOH files in CMIP6/v2021-01 are actually VOC1 (total alchohols) and are split into MOH, EOH, ROH here
 0 CMIP6_MOH_AGR    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_agr           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_AGR    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_AGR    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_AGR    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_AGR    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_ENE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_ene           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_ENE    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_ENE    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_ENE    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_ENE    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_IND    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_ind           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_IND    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_IND    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_IND    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_IND    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_TRA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_tra           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_TRA    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_TRA    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_TRA    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_TRA    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_RCO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_rco           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_RCO    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_RCO    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_RCO    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_RCO    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_SLV    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_slv           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_SLV    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_SLV    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_SLV    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_SLV    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 0 CMIP6_MOH_WST    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   EOH_wst           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     1 5
-0 CMIP6_EOH_WST    -                                                          -                 -                  - -  -          EOH   26/91     1 5
-0 CMIP6_ROH_WST    -                                                          -                 -                  - -  -          ROH   26/92     1 5
+0 CMIP6_EOH_WST    -                                                                              -                 -                  - -  -          EOH   26/91     1 5
+0 CMIP6_ROH_WST    -                                                                              -                 -                  - -  -          ROH   26/92     1 5
 
 0 CMIP6_C2H6_AGR   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   C2H6_agr          1750-2100/1-12/1/0 C xy kg/m2/s    C2H6  26        1 5
 0 CMIP6_C2H6_ENE   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4                   C2H6_ene          1750-2100/1-12/1/0 C xy kg/m2/s    C2H6  26        1 5
@@ -1854,22 +1917,25 @@ Warnings:                    1
 (((CMIP6_AIRCRAFT
 0 CMIP6_AIR_NO     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    NO_air            1750-2100/1-12/1/0 C xyz kg/m2/s   NO    -        20 1
 0 CMIP6_AIR_CO     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    CO_air            1750-2100/1-12/1/0 C xyz kg/m2/s   CO    -        20 1
-0 CMIP6_AIR_SOAP   -                                                                    -                 -                  - -   -         SOAP  280      20 1
+0 CMIP6_AIR_SOAP   -                                                                                  -                 -                  - -   -         SOAP  280      20 1
 0 CMIP6_AIR_SO2    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    SO2_air           1750-2100/1-12/1/0 C xyz kg/m2/s   SO2   -        20 1
-0 CMIP6_AIR_SO4    -                                                                    -                 -                  - -   -         SO4   63       20 1
-0 CMIP6_AIR_ACET   -                                                                    -                 -                  - -   -         ACET  601      20 1
-0 CMIP6_AIR_ALD2   -                                                                    -                 -                  - -   -         ALD2  602      20 1
-0 CMIP6_AIR_ALK4   -                                                                    -                 -                  - -   -         ALK4  603      20 1
-0 CMIP6_AIR_C2H6   -                                                                    -                 -                  - -   -         C2H6  604      20 1
-0 CMIP6_AIR_C3H8   -                                                                    -                 -                  - -   -         C3H8  605      20 1
-0 CMIP6_AIR_CH2O   -                                                                    -                 -                  - -   -         CH2O  606      20 1
-0 CMIP6_AIR_PRPE   -                                                                    -                 -                  - -   -         PRPE  607      20 1
-0 CMIP6_AIR_MACR   -                                                                    -                 -                  - -   -         MACR  608      20 1
-0 CMIP6_AIR_RCHO   -                                                                    -                 -                  - -   -         RCHO  609      20 1
+0 CMIP6_AIR_SO4    -                                                                                  -                 -                  - -   -         SO4   63       20 1
+0 CMIP6_AIR_pFe    -                                                                                  -                 -                  - -   -         pFe   66       20 1
+0 CMIP6_AIR_ACET   -                                                                                  -                 -                  - -   -         ACET  601      20 1
+0 CMIP6_AIR_ALD2   -                                                                                  -                 -                  - -   -         ALD2  602      20 1
+0 CMIP6_AIR_ALK4   -                                                                                  -                 -                  - -   -         ALK4  603      20 1
+0 CMIP6_AIR_C2H6   -                                                                                  -                 -                  - -   -         C2H6  604      20 1
+0 CMIP6_AIR_C3H8   -                                                                                  -                 -                  - -   -         C3H8  605      20 1
+0 CMIP6_AIR_CH2O   -                                                                                  -                 -                  - -   -         CH2O  606      20 1
+0 CMIP6_AIR_PRPE   -                                                                                  -                 -                  - -   -         PRPE  607      20 1
+0 CMIP6_AIR_MACR   -                                                                                  -                 -                  - -   -         MACR  608      20 1
+0 CMIP6_AIR_RCHO   -                                                                                  -                 -                  - -   -         RCHO  609      20 1
 0 CMIP6_AIR_NH3    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    NH3_air           1750-2100/1-12/1/0 C xyz kg/m2/s   NH3   -        20 1
 # Assume all BC/OC is BCPI/OCPI
 0 CMIP6_AIR_BCPI   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    BC_air            1750-2100/1-12/1/0 C xyz kg/m2/s   BCPI  -        20 1
 0 CMIP6_AIR_OCPI   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY_AIR.$GCAP2VERTRESL.nc4    OC_air            1750-2100/1-12/1/0 C xyz kg/m2/s   OCPI  -        20 1
+0 CMIP6_AIR_POG1   -                                                                                  -                 -                  - -  -          POG1  74/76    20 1
+0 CMIP6_AIR_POG2   -                                                                                  -                 -                  - -  -          POG2  74/77    20 1
 
 )))CMIP6_AIRCRAFT
 
@@ -2042,6 +2108,8 @@ Warnings:                    1
 0 TRASH_BCPO  -                                                       -     -          - -  -        BCPO  71    1 2
 0 TRASH_OCPI  $ROOT/TrashEmis/v2015-03/TrashBurn_v2_generic.01x01.nc  OC    2008/1/1/0 C xy kg/m2/s  OCPI  72    1 2
 0 TRASH_OCPO  -                                                       -     -          - -  -        OCPO  73    1 2
+0 TRASH_POG1  -                                                       -     -          - -  -        POG1  74/76 1 2
+0 TRASH_POG2  -                                                       -     -          - -  -        POG2  74/77 1 2
 0 TRASH_NH3   $ROOT/TrashEmis/v2015-03/TrashBurn_v2_generic.01x01.nc  NH3   2008/1/1/0 C xy kg/m2/s  NH3   -     1 2
 
 #==============================================================================
@@ -2355,6 +2423,8 @@ Warnings:                    1
 0 CEDS_BCPO_SHP   -                                                                    -                 -                  - -  -       BCPO  71     10 5
 0 CEDS_OCPI_SHP   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_shp            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72     10 5
 0 CEDS_OCPO_SHP   -                                                                    -                 -                  - -  -       OCPO  73     10 5
+0 CEDS_POG1_SHP   -                                                                    -                 -                  - -  -       POG1  74/76  10 5
+0 CEDS_POG2_SHP   -                                                                    -                 -                  - -  -       POG2  74/77  10 5
 0 CEDS_MOH_SHP    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_shp           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90  10 5
 0 CEDS_EOH_SHP    -                                                                    -                 -                  - -  -       EOH   26/91  10 5
 0 CEDS_ROH_SHP    -                                                                    -                 -                  - -  -       ROH   26/92  10 5
@@ -2395,19 +2465,21 @@ Warnings:                    1
 #==============================================================================
 (((CMIP6_SHIP
 0 CMIP6_CO_SHP     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            CO_shp            1750-2100/1-12/1/0 C xy kg/m2/s    CO    26        10 5
-0 CMIP6_SOAP_SHP   -                                                   -                 -                  - -  -          SOAP  26/280    10 5
+0 CMIP6_SOAP_SHP   -                                                                       -                 -                  - -  -          SOAP  26/280    10 5
 0 CMIP6_SO2_SHP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            SO2_shp           1750-2100/1-12/1/0 C xy kg/m2/s    SO2   -         10 5
-0 CMIP6_SO4_SHP    -                                                   -                 -                  - -  -          SO4   63        10 5
-0 CMIP6_pFe_SHP    -                                                   -                 -                  - -  -          pFe   66        10 5
+0 CMIP6_SO4_SHP    -                                                                       -                 -                  - -  -          SO4   63        10 5
+0 CMIP6_pFe_SHP    -                                                                       -                 -                  - -  -          pFe   66        10 5
 0 CMIP6_NH3_SHP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            NH3_shp           1750-2100/1-12/1/0 C xy kg/m2/s    NH3   -         10 5
 0 CMIP6_BCPI_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            BC_shp            1750-2100/1-12/1/0 C xy kg/m2/s    BCPI  70        10 5
-0 CMIP6_BCPO_SHP   -                                                   -                 -                  - -  -          BCPO  71        10 5
+0 CMIP6_BCPO_SHP   -                                                                       -                 -                  - -  -          BCPO  71        10 5
 0 CMIP6_OCPI_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            OC_shp            1750-2100/1-12/1/0 C xy kg/m2/s    OCPI  72        10 5
-0 CMIP6_OCPO_SHP   -                                                   -                 -                  - -  -          OCPO  73        10 5
+0 CMIP6_OCPO_SHP   -                                                                       -                 -                  - -  -          OCPO  73        10 5
+0 CMIP6_POG1_SHP   -                                                                       -                 -                  - -  -          POG1  74/76     10 5
+0 CMIP6_POG2_SHP   -                                                                       -                 -                  - -  -          POG2  74/77     10 5
 # NOTE: EOH files in CMIP6/v2021-01 are actually VOC1 (total alchohols) and are split into MOH, EOH, ROH here
 0 CMIP6_MOH_SHP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            EOH_shp           1750-2100/1-12/1/0 C xy kg/m2/s    MOH   26/90     10 5
-0 CMIP6_EOH_SHP    -                                                   -                 -                  - -  -          EOH   26/91     10 5
-0 CMIP6_ROH_SHP    -                                                   -                 -                  - -  -          ROH   26/92     10 5
+0 CMIP6_EOH_SHP    -                                                                       -                 -                  - -  -          EOH   26/91     10 5
+0 CMIP6_ROH_SHP    -                                                                       -                 -                  - -  -          ROH   26/92     10 5
 0 CMIP6_C2H6_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            C2H6_shp          1750-2100/1-12/1/0 C xy kg/m2/s    C2H6  26        10 5
 0 CMIP6_C3H8_SHP   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            C3H8_shp          1750-2100/1-12/1/0 C xy kg/m2/s    C3H8  26        10 5
 0 CMIP6_C4H10_SHP  $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4            ALK4_butanes_shp  1750-2100/1-12/1/0 C xy kg/m2/s    ALK4  26        10 5
@@ -2499,6 +2571,7 @@ Warnings:                    1
 0 AEIC19_DAILY_CO   $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc CO       2019/1-12/1-31/0 C xyz kg/m2/s CO   241         20 1
 0 AEIC19_DAILY_SOAP -                                                                 -        -                - -   -       SOAP 241/280     20 1
 0 AEIC19_DAILY_SO2  $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc FUELBURN 2019/1-12/1-31/0 C xyz kg/m2/s SO2  241/111     20 1
+0 AEIC19_DAILY_pFe  -                                                                 -        -                - -   -       pFe  241/111/66  20 1
 0 AEIC19_DAILY_SO4  -                                                                 -        -                - -   -       SO4  241/112     20 1
 0 AEIC19_DAILY_H2O  -                                                                 -        -                - -   -       H2O  241/120     20 1
 0 AEIC19_DAILY_BCPI $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc BC       2019/1-12/1-31/0 C xyz kg/m2/s BCPI 241         20 1
@@ -2520,6 +2593,7 @@ Warnings:                    1
 0 AEIC19_MONMEAN_CO   $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc CO       2019/1-12/1/0 C xyz kg/m2/s CO   241         20 1
 0 AEIC19_MONMEAN_SOAP -                                                                          -        -             - -   -       SOAP 241/280     20 1
 0 AEIC19_MONMEAN_SO2  $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc FUELBURN 2019/1-12/1/0 C xyz kg/m2/s SO2  241/111     20 1
+0 AEIC19_MONMEAN_pFe  -                                                                          -        -             - -   -       pFe  241/111/66  20 1
 0 AEIC19_MONMEAN_SO4  -                                                                          -        -             - -   -       SO4  241/112     20 1
 0 AEIC19_MONMEAN_H2O  -                                                                          -        -             - -   -       H2O  241/120     20 1
 0 AEIC19_MONMEAN_BCPI $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc BC       2019/1-12/1/0 C xyz kg/m2/s BCPI 241         20 1
@@ -2553,7 +2627,10 @@ Warnings:                    1
 0 RCP3PD_SOAP    -                                                                                        -      -               -  -  -        SOAP  280   1 1
 0 RCP3PD_BCPO    $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_BC_2005-2100_23474.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO  -     1 1
 0 RCP3PD_OCPO    $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_OC_2005-2100_23474.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO  -     1 1
+0 RCP3PD_POG1    -                                                                                        -      -               -  -  -        POG1  74/76 1 1
+0 RCP3PD_POG2    -                                                                                        -      -               -  -  -        POG2  74/77 1 1
 0 RCP3PD_SO2     $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_SO2_2005-2100_23474.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2   -     1 1
+0 RCP3PD_pFe     -                                                                                        -      -               -  -  -        pFe   66    1 1
 0 RCP3PD_NH3     $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_NH3_2005-2100_23474.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3   -     1 1
 0 RCP3PD_C2H2    $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_acetylene_2005-2100_23474_kgC.nc                  ACCMIP 2005-2100/1/1/0 ID xy kgC/m2/s C2H2  59    1 1
 0 RCP3PD_CH2O    $ROOT/RCP/v2020-07/RCP_3PD/RCPs_anthro_formaldehyde_2005-2100_23474.nc                   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  CH2O  -     1 1
@@ -2580,7 +2657,10 @@ Warnings:                    1
 0 RCP45_SOAP    -                                                                                       -      -               -  -  -        SOAP  280   1 1
 0 RCP45_BCPO    $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_BC_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO  -     1 1
 0 RCP45_OCPO    $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_OC_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO  -     1 1
+0 RCP45_POG1    -                                                                                       -      -               -  -  -        POG1  74/76 1 1
+0 RCP45_POG2    -                                                                                       -      -               -  -  -        POG2  74/77 1 1
 0 RCP45_SO2     $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_SO2_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2   -     1 1
+0 RCP45_pFe     -                                                                                       -      -               -  -  -        pFe   66    1 1
 0 RCP45_NH3     $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_NH3_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3   -     1 1
 0 RCP45_C2H2    $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_acetylene_2005-2100_27424_kgC.nc                  ACCMIP 2005-2100/1/1/0 ID xy kgC/m2/s C2H2  59    1 1
 0 RCP45_CH2O    $ROOT/RCP/v2020-07/RCP_45/RCPs_anthro_formaldehyde_2005-2100_27424.nc                   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  CH2O  -     1 1
@@ -2607,7 +2687,10 @@ Warnings:                    1
 0 RCP60_SOAP    -                                                                                       -      -               -  -  -        SOAP  280   1 1
 0 RCP60_BCPO    $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_BC_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO  -     1 1
 0 RCP60_OCPO    $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_OC_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO  -     1 1
+0 RCP60_POG1    -                                                                                       -      -               -  -  -        POG1  74/76 1 1
+0 RCP60_POG2    -                                                                                       -      -               -  -  -        POG2  74/77 1 1
 0 RCP60_SO2     $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_SO2_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2   -     1 1
+0 RCP60_pFe     -                                                                                       -      -               -  -  -        pFe   66    1 1
 0 RCP60_NH3     $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_NH3_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3   -     1 1
 0 RCP60_C2H2    $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_acetylene_2005-2100_43190_kgC.nc                  ACCMIP 2005-2100/1/1/0 ID xy kgC/m2/s C2H2  59    1 1
 0 RCP60_CH2O    $ROOT/RCP/v2020-07/RCP_60/RCPs_anthro_formaldehyde_2005-2100_43190.nc                   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  CH2O  -     1 1
@@ -2634,7 +2717,10 @@ Warnings:                    1
 0 RCP85_SOAP    -                                                                                       -      -               -  -  -        SOAP  280   1 1
 0 RCP85_BCPO    $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_BC_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  BCPO  -     1 1
 0 RCP85_OCPO    $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_OC_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  OCPO  -     1 1
+0 RCP85_POG1    -                                                                                       -      -               -  -  -        POG1  74/76 1 1
+0 RCP85_POG2    -                                                                                       -      -               -  -  -        POG2  74/77 1 1
 0 RCP85_SO2     $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_SO2_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  SO2   -     1 1
+0 RCP80_pFe     -                                                                                       -      -               -  -  -        pFe   66    1 1
 0 RCP85_NH3     $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_NH3_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  NH3   -     1 1
 0 RCP85_C2H2    $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_acetylene_2005-2100_43533_kgC.nc                  ACCMIP 2005-2100/1/1/0 ID xy kgC/m2/s C2H2  59    1 1
 0 RCP85_CH2O    $ROOT/RCP/v2020-07/RCP_85/RCPs_anthro_formaldehyde_2005-2100_43533.nc                   ACCMIP 2005-2100/1/1/0 ID xy kg/m2/s  CH2O  -     1 1
@@ -2670,8 +2756,12 @@ Warnings:                    1
 0 QFED_BCPO_FT   -                                                                 -       -                             -  -             -       BCPO 71/75/312     5 2
 0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
 0 QFED_OCPO_PBL  -                                                                 -       -                             -  -             -       OCPO 73/75/311     5 2
+0 QFED_POG1_PBL  -                                                                 -       -                             -  -             -       POG1 74/76/75/311  5 2
+0 QFED_POG2_PBL  -                                                                 -       -                             -  -             -       POG2 74/77/75/311  5 2
 0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
 0 QFED_OCPO_FT   -                                                                 -       -                             -  -             -       OCPO 73/75/312     5 2
+0 QFED_POG1_FT   -                                                                 -       -                             -  -             -       POG1 74/76/75/312  5 2
+0 QFED_POG2_FT   -                                                                 -       -                             -  -             -       POG2 74/77/75/312  5 2
 0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s C2H6 75/311        5 2
 0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2
 0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s C3H8 75/311        5 2
@@ -2693,7 +2783,9 @@ Warnings:                    1
 0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s NO   75/311        5 2
 0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s NO   75/312        5 2
 0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_pFe_FT    -                                                                 -       -                             -  -             -       pFe  75/312/66     5 2
 0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_pFe_FT    -                                                                 -       -                             -  -             -       pF3  75/312/66     5 2
 0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s PRPE 75/311        5 2
 0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2
 )))QFED2
@@ -2702,31 +2794,34 @@ Warnings:                    1
 # --- GFAS biomass burning ---
 #==============================================================================
 (((GFAS
-0 GFAS_CO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO   75     5 3
-0 GFAS_SOAP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SOAP 75/281 5 3
-0 GFAS_NO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc noxfire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NO   75     5 3
-0 GFAS_BCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPI 70/75  5 3
-0 GFAS_BCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPO 71/75  5 3
-0 GFAS_OCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPI 72/75  5 3
-0 GFAS_OCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPO 73/75  5 3
-0 GFAS_CO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc co2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO2  75     5 3
-0 GFAS_CH4   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch4fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH4  75     5 3
-0 GFAS_SO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SO2  75     5 3
-0 GFAS_NH3   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc nh3fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NH3  75     5 3
-0 GFAS_ACET  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ACET 75     5 3
-0 GFAS_ALD2  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALD2 75     5 3
-0 GFAS_ALK4  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc hialkanesfire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALK4 75     5 3
-0 GFAS_PRPE1 $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc hialkenesfire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s PRPE 75     5 3
-0 GFAS_PRPE2 $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s PRPE 75     5 3
-0 GFAS_C2H6  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C2H6 75     5 3
-0 GFAS_C3H8  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C3H8 75     5 3
-0 GFAS_CH2O  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch2ofire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH2O 75     5 3
-0 GFAS_C2H4  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C2H4 75     5 3
-0 GFAS_ISOP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c5h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ISOP 75     5 3
-0 GFAS_DMS   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6sfire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s DMS  75     5 3
-0 GFAS_TOLU  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c7h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s TOLU 75     5 3
-0 GFAS_BENZ  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c6h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BENZ 75     5 3
-0 GFAS_XYLE  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c8h10fire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s XYLE 75     5 3
+0 GFAS_CO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO   75       5 3
+0 GFAS_SOAP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SOAP 75/281   5 3
+0 GFAS_NO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc noxfire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NO   75       5 3
+0 GFAS_BCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPI 70/75    5 3
+0 GFAS_BCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPO 71/75    5 3
+0 GFAS_OCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPI 72/75    5 3
+0 GFAS_OCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPO 73/75    5 3
+0 GFAS_POG1  -                                          -             -                     - -             -       POG1 74/76/75 5 3
+0 GFAS_POG2  -                                          -             -                     - -             -       POG2 74/77/75 5 3
+0 GFAS_CO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc co2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO2  75       5 3
+0 GFAS_CH4   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch4fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH4  75       5 3
+0 GFAS_SO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SO2  75       5 3
+0 GFAS_pFe   -                                          -             -                     - -             -       pFe  75/66    5 3
+0 GFAS_NH3   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc nh3fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NH3  75       5 3
+0 GFAS_ACET  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ACET 75       5 3
+0 GFAS_ALD2  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALD2 75       5 3
+0 GFAS_ALK4  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc hialkanesfire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALK4 75       5 3
+0 GFAS_PRPE1 $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc hialkenesfire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s PRPE 75       5 3
+0 GFAS_PRPE2 $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s PRPE 75       5 3
+0 GFAS_C2H6  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C2H6 75       5 3
+0 GFAS_C3H8  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C3H8 75       5 3
+0 GFAS_CH2O  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch2ofire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH2O 75       5 3
+0 GFAS_C2H4  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s C2H4 75       5 3
+0 GFAS_ISOP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c5h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ISOP 75       5 3
+0 GFAS_DMS   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6sfire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s DMS  75       5 3
+0 GFAS_TOLU  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c7h8fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s TOLU 75       5 3
+0 GFAS_BENZ  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c6h6fire      2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BENZ 75       5 3
+0 GFAS_XYLE  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c8h10fire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s XYLE 75       5 3
 )))GFAS
 
 #==============================================================================
@@ -2734,39 +2829,42 @@ Warnings:                    1
 #==============================================================================
 (((BB4MIPS
 # 75 is time-of-day scaling
-0 CMIP6_BB_CO      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s CO    75     5 3
-0 CMIP6_BB_SOAP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s SOAP  75/281 5 3
-0 CMIP6_BB_NO      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 NO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s NO    75     5 3
-0 CMIP6_BB_BCPI    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BCPI  70/75  5 3
-0 CMIP6_BB_BCPO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BCPO  71/75  5 3
-0 CMIP6_BB_OCPI    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPI  72/75  5 3
-0 CMIP6_BB_OCPO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPO  73/75  5 3
-0 CMIP6_BB_SO2     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 SO2_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s SO2   75     5 3
-0 CMIP6_BB_NH3     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 NH3_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s NH3   75     5 3
-0 CMIP6_BB_ALD2    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ALD2_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ALD2  75     5 3
-0 CMIP6_BB_ALK4    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ALK4_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ALK4  75     5 3
-0 CMIP6_BB_PRPE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 PRPE_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s PRPE  75     5 3
-0 CMIP6_BB_C2H6    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C2H6_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C2H6  75     5 3
-0 CMIP6_BB_C3H8    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C3H8_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C3H8  75     5 3
-0 CMIP6_BB_CH2O    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CH2O_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s CH2O  75     5 3
-0 CMIP6_BB_C2H4    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C2H4_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C2H4  75     5 3
-0 CMIP6_BB_ISOP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ISOP_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ISOP  75     5 3
-0 CMIP6_BB_DMS     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 DMS_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s DMS   75     5 3
-0 CMIP6_BB_TOLU    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 TOLU_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s TOLU  75     5 3
-0 CMIP6_BB_BENZ    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BENZ_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BENZ  75     5 3
-0 CMIP6_BB_XYLE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 XYLE_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s XYLE  75     5 3
-0 CMIP6_BB_H2      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 H2_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s H2    75     5 3
-0 CMIP6_BB_MTPA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MONOT_bbn  1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MTPA  75     5 3
-#0 CMIP6_BB_MTPO    -                                              -          -                  - -             -   MTPO  75     5 3
-#0 CMIP6_BB_LIMO    -                                              -          -                  - -             -   LIMO  75     5 3
-0 CMIP6_BB_EOH     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 EOH_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s EOH   75     5 3
-0 CMIP6_BB_MOH     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MOH_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MOH   75     5 3
-0 CMIP6_BB_ACET    -                                              -          -                  - -             -   ACET  79/75  5 3
-0 CMIP6_BB_MGLY    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MGLY_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MGLY  75     5 3
-0 CMIP6_BB_ACTA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ACTA_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ACTA  75     5 3
-0 CMIP6_BB_HCN     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 HCN_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s HCN   75     5 3
-0 CMIP6_BB_HCOOH   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 HCOOH_bbn  1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s HCOOH 75     5 3
-0 CMIP6_BB_MEK     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MEK_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MEK   75     5 3
+0 CMIP6_BB_CO      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s CO    75       5 3
+0 CMIP6_BB_SOAP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s SOAP  75/281   5 3
+0 CMIP6_BB_NO      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 NO_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s NO    75       5 3
+0 CMIP6_BB_BCPI    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BCPI  70/75    5 3
+0 CMIP6_BB_BCPO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BCPO  71/75    5 3
+0 CMIP6_BB_OCPI    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPI  72/75    5 3
+0 CMIP6_BB_OCPO    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 OC_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s OCPO  73/75    5 3
+0 CMIP6_BB_POG1    -                                                            -          -                  - -         -       POG1  74/76/75 5 3
+0 CMIP6_BB_POG2    -                                                            -          -                  - -         -       POG2  74/77/75 5 3
+0 CMIP6_BB_SO2     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 SO2_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s SO2   75       5 3
+0 CMIP6_BB_pFe     -                                                            -          -                  - -         -       pFe   75/66    5 3
+0 CMIP6_BB_NH3     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 NH3_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s NH3   75       5 3
+0 CMIP6_BB_ALD2    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ALD2_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ALD2  75       5 3
+0 CMIP6_BB_ALK4    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ALK4_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ALK4  75       5 3
+0 CMIP6_BB_PRPE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 PRPE_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s PRPE  75       5 3
+0 CMIP6_BB_C2H6    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C2H6_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C2H6  75       5 3
+0 CMIP6_BB_C3H8    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C3H8_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C3H8  75       5 3
+0 CMIP6_BB_CH2O    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 CH2O_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s CH2O  75       5 3
+0 CMIP6_BB_C2H4    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 C2H4_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s C2H4  75       5 3
+0 CMIP6_BB_ISOP    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ISOP_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ISOP  75       5 3
+0 CMIP6_BB_DMS     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 DMS_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s DMS   75       5 3
+0 CMIP6_BB_TOLU    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 TOLU_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s TOLU  75       5 3
+0 CMIP6_BB_BENZ    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 BENZ_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s BENZ  75       5 3
+0 CMIP6_BB_XYLE    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 XYLE_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s XYLE  75       5 3
+0 CMIP6_BB_H2      $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 H2_bbn     1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s H2    75       5 3
+0 CMIP6_BB_MTPA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MONOT_bbn  1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MTPA  75       5 3
+#0 CMIP6_BB_MTPO    -                                                           -          -                  - -             -   MTPO  75       5 3
+#0 CMIP6_BB_LIMO    -                                                           -          -                  - -             -   LIMO  75       5 3
+0 CMIP6_BB_EOH     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 EOH_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s EOH   75       5 3
+0 CMIP6_BB_MOH     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MOH_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MOH   75       5 3
+0 CMIP6_BB_ACET    -                                                            -          -                  - -             -   ACET  79/75    5 3
+0 CMIP6_BB_MGLY    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MGLY_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MGLY  75       5 3
+0 CMIP6_BB_ACTA    $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 ACTA_bbn   1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s ACTA  75       5 3
+0 CMIP6_BB_HCN     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 HCN_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s HCN   75       5 3
+0 CMIP6_BB_HCOOH   $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 HCOOH_bbn  1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s HCOOH 75       5 3
+0 CMIP6_BB_MEK     $ROOT/CMIP6/v2021-01/$GCAP2SCENARIO/$GCAP2SCENARIO_$YYYY.nc4 MEK_bbn    1750-2100/1-12/1/0 C xyL=1:PBL kg/m2/s MEK   75       5 3
 )))BB4MIPS
 
 #==============================================================================

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -2575,6 +2575,8 @@ Warnings:                    1
 0 AEIC19_DAILY_H2O  -                                                                 -        -                - -   -       H2O  241/120     20 1
 0 AEIC19_DAILY_BCPI $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc BC       2019/1-12/1-31/0 C xyz kg/m2/s BCPI 241         20 1
 0 AEIC19_DAILY_OCPI $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc OC       2019/1-12/1-31/0 C xyz kg/m2/s OCPI 241         20 1
+0 AEIC19_DAILY_POG1 -                                                                 -        -                - -   -       POG1 241/74/76   20 1
+0 AEIC19_DAILY_POG2 -                                                                 -        -                - -   -       POG2 241/74/77   20 1
 0 AEIC19_DAILY_ACET $ROOT/AEIC2019/v2022-03/2019/$MM/AEIC_2019$MM$DD.0.5x0.625.36L.nc HC       2019/1-12/1-31/0 C xyz kg/m2/s ACET 241/114/101 20 1
 0 AEIC19_DAILY_ALD2 -                                                                 -        -                - -   -       ALD2 241/114/102 20 1
 0 AEIC19_DAILY_ALK4 -                                                                 -        -                - -   -       ALK4 241/114/103 20 1
@@ -2597,6 +2599,8 @@ Warnings:                    1
 0 AEIC19_MONMEAN_H2O  -                                                                          -        -             - -   -       H2O  241/120     20 1
 0 AEIC19_MONMEAN_BCPI $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc BC       2019/1-12/1/0 C xyz kg/m2/s BCPI 241         20 1
 0 AEIC19_MONMEAN_OCPI $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc OC       2019/1-12/1/0 C xyz kg/m2/s OCPI 241         20 1
+0 AEIC19_MONMEAN_POG1 -                                                                          -        -             - -   -       POG1 241/74/76   20 1
+0 AEIC19_MONMEAN_POG2 -                                                                          -        -             - -   -       POG2 241/74/77   20 1
 0 AEIC19_MONMEAN_ACET $ROOT/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019$MM.0.5x0.625.36L.nc HC       2019/1-12/1/0 C xyz kg/m2/s ACET 241/114/101 20 1
 0 AEIC19_MONMEAN_ALD2 -                                                                          -        -             - -   -       ALD2 241/114/102 20 1
 0 AEIC19_MONMEAN_ALK4 -                                                                          -        -             - -   -       ALK4 241/114/103 20 1
@@ -2782,7 +2786,7 @@ Warnings:                    1
 0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s NO   75/311        5 2
 0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s NO   75/312        5 2
 0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s SO2  75/311        5 2
-0 QFED_pFe_FT    -                                                                 -       -                             -  -             -       pFe  75/312/66     5 2
+0 QFED_pFe_PBL   -                                                                 -       -                             -  -             -       pFe  75/311/66     5 2
 0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
 0 QFED_pFe_FT    -                                                                 -       -                             -  -             -       pF3  75/312/66     5 2
 0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2022/1-12/1-31/0/+12hour EF xyL=1:PBL     kg/m2/s PRPE 75/311        5 2


### PR DESCRIPTION
Here we fix several issue raised in Github issue #1291 in geoschem/geos-chem, including:

1. Scale factor 73 (OC2OCPO) are removed from the POG1 and POG2 entries for CEDS and CMIP6.
2. Entries for POG1 and POG2 are added for NEI, NEI-Ship, DICE, EDGAR-Trash, CEDS-Ship, RCP, QFED, and GFAS.
3. Entries for pFe are added for CMIP6, AEIC2019, RCP, QFED, and GFAS.

POG1 and POG2 are only included in complexSOA_SVPOA simulations, but this PR will impact benchmark output by changing pFe emissions since AEIC2019 emissions are added for that species. 