### PR TITLE
Remove seconds from gchp log filename to match time in new restart filename

### DIFF
--- a/run/GCHP/runScriptSamples/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/gchp.batch_job.sh
@@ -111,7 +111,7 @@ module list
 
 # Define log name to include simulation start date
 start_str=$(sed 's/ /_/g' cap_restart)
-log=gchp.${start_str}z.log
+log=gchp.${start_str:0:13}z.log
 
 # Update config files, set restart symlink, and do sanity checks
 source setCommonRunSettings.sh
@@ -129,15 +129,15 @@ source checkRunSettings.sh
 #
 # Example 1: PBS
 #
-#    mpiexec -n 48 ./gchp > runlog.txt   
+#    mpiexec -n 48 ./gchp > ${log}
 #
 # Example 2: LSF
 #
-#    mpiexec -n 72 ./gchp > runlog.txt
+#    mpiexec -n 72 ./gchp > ${log}
 #
 # Example 3: SLURM
 #
-#    srun -n 48 -N 2 -m plane=24 --mpi=pmix ./gchp
+#    srun -n 48 -N 2 -m plane=24 --mpi=pmix ./gchp > ${log}
 #
 
 #################################################################

--- a/run/GCHP/runScriptSamples/gchp.local.run
+++ b/run/GCHP/runScriptSamples/gchp.local.run
@@ -8,7 +8,7 @@
 
 # Define log name to include simulation start date
 start_str=$(sed 's/ /_/g' cap_restart)
-log=gchp.${start_str}z.log
+log=gchp.${start_str:0:13}z.log
 
 # Load environment
 if [ ! -L gchp.env ] || [ ! -e gchp.env ]; then

--- a/run/GCHP/runScriptSamples/operational_examples/adjoint/gchp.adjoint.run
+++ b/run/GCHP/runScriptSamples/operational_examples/adjoint/gchp.adjoint.run
@@ -25,7 +25,7 @@ set -xe
 
 # Define log name to include simulation start date
 start_str=$(sed 's/ /_/g' cap_restart)
-log=gchp.${start_str}z.log
+log=gchp.${start_str:0:13}z.log
 echo "Writing output to ${log}"
 
 # Assume success until overwritten

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -13,7 +13,7 @@ set -xe
 
 # Define log name to include simulation start date
 start_str=$(sed 's/ /_/g' cap_restart)
-log=gchp.${start_str}z.log
+log=gchp.${start_str:0:13}z.log
 echo "Writing output to ${log}"
 
 # Update config files, set restart symlink, load run env, and do sanity checks

--- a/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
@@ -25,7 +25,7 @@ set -xe
 
 # Define log name to include simulation start date
 start_str=$(sed 's/ /_/g' cap_restart)
-log=gchp.${start_str}z.log
+log=gchp.${start_str:0:13}z.log
 echo "Writing output to ${log}"
 
 # Update config files, set restart symlink, load run env, and do sanity checks


### PR DESCRIPTION
This update simply changes the time string in the main GCHP run log used in sample run scripts to exclude seconds. The time format in the new name will now match the time format used in restart files. Note that the log file contains the start time of the run whereas in previous versions it was simply gchp.log. Using the time in the filename prevents overwriting the log if doing sequential runs.
