### PR TITLE
Specify AOD wavelength 999 nm for use in FAST-JX

### DIFF
--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -334,6 +334,7 @@ CONTAINS
     ENDIF
 
     ! Do Photolysis
+    WAVELENGTH = 0
     CALL FAST_JX( WAVELENGTH, Input_Opt,  State_Chm,                         &
                   State_Diag, State_Grid, State_Met, RC                     )
 


### PR DESCRIPTION
This PR fixes a bug in 14.0.0 in which the incorrect AOD wavelength logical is used in subroutine PHOTO_JX. That bug resulted in calculating the 550 nm scaling rather than the 999 nm scaling for aerosol/dust. The fix is simply setting WAVELENGTH=0 prior to calling FAST_JX.

I did a 1-month benchmark comparison of this fix using 14.0. Differences are small. Benchmark tables with ref being 14.0.0-rc.1 and dev being 14.0.0-rc.1 plus the fix are as follows:

[OH_metrics.txt](https://github.com/geoschem/geos-chem/files/9192275/OH_metrics.txt)
[GlobalMass_Trop.txt](https://github.com/geoschem/geos-chem/files/9192281/GlobalMass_Trop.txt)
[GlobalMass_TropStrat.txt](https://github.com/geoschem/geos-chem/files/9192277/GlobalMass_TropStrat.txt)
[Emission_totals.txt](https://github.com/geoschem/geos-chem/files/9192278/Emission_totals.txt)

closes https://github.com/geoschem/geos-chem/issues/1309