### PR TITLE
rm duplicate species for SO4 in aciduptake.eqn

### DIFF
--- a/KPP/aciduptake/aciduptake.eqn
+++ b/KPP/aciduptake/aciduptake.eqn
@@ -471,7 +471,6 @@ SO4D1      = IGNORE; {SO4 taken up on DST1}
 SO4D2      = IGNORE; {SO4 taken up on DST2}
 SO4D3      = IGNORE; {SO4 taken up on DST3}
 SO4D4      = IGNORE; {SO4 taken up on DST4}
-SO4        = IGNORE; {SO4; Sulfate}
 SO4s       = IGNORE; {SO4 on sea-salt; Sulfate}
 SOAGX      = IGNORE; {CHOCHO; Aerosol-phase glyoxal}
 SOAIE      = IGNORE; {C5H10O3; Aerosol-phase IEPOX}


### PR DESCRIPTION
There are currently two entries for SO4 in the aciduptake branch *.eqn KPP. This commit removes one of these. 