### PR TITLE
Adding in dry deposition updates to Hg0 from Feinberg22 ESPI publication + AMAP emissions

### DIFF
--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -1547,6 +1547,8 @@ CONTAINS
                  RSURFC(K,LDT) = 10000.0_f8
              ELSE
                 ! Check latitude and longitude, alter F0 only for Amazon rainforest for Hg0
+                ! (see reference: Feinberg et al., ESPI, 2022: Evaluating atmospheric mercury (Hg) uptake by vegetation in a
+                ! chemistry-transport model)
                 IF (N_SPC .EQ. ID_Hg0) THEN ! Check for Hg0
                    IF ( II .EQ. 6 .AND. & ! if rainforest land type
                         State_Grid%XMid(I,J) > -82 .AND. & ! bounding box of Amazon

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.Hg
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.Hg
@@ -35,6 +35,6 @@ EmisHgCl2_Anthro   HgCl2    0    -1   -1   2  kg/m2/s  HgCl2_emission_flux_from_
 ###############################################################################
 #####   Hg2 emissions                                                     #####
 ###############################################################################
-EmisHg2ClP_Anthro  Hg2ClP   0    -1   -1   2  kg/m1/a  Hg2ClP_emission_flux_from_anthropogenic
+EmisHg2ClP_Anthro  Hg2ClP   0    -1   -1   2  kg/m2/s  Hg2ClP_emission_flux_from_anthropogenic
 
 #EOC

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -1359,7 +1359,7 @@ HCOOH:
   MW_g: 46.03
   WD_RetFactor: 2.0e-2
 Hg0_PROP: &Hg0properties
-  DD_F0: 1.0e-5
+  DD_F0: 3.0e-5
   DD_Hstar: 0.11
   Formula: 'Hg'
   Is_Advected: true

--- a/run/shared/species_database_hg.yml
+++ b/run/shared/species_database_hg.yml
@@ -34,7 +34,7 @@ CO:
   Is_Gas: true
   MW_g: 28.01
 Hg0:
-  DD_F0: 1.0e-5
+  DD_F0: 3.0e-5
   DD_Hstar: 0.11
   Formula: 'Hg'
   FullName: Elemental mercury


### PR DESCRIPTION
This code includes the changes to the dry deposition of Hg0, based on the publication: A. Feinberg, T. Dlamini, M. Jiskra, V. Shah, N. E. Selin, 2022. Evaluating atmospheric mercury (Hg) uptake by vegetation in a chemistry-transport model. Environ. Sci. Process. Impacts. https://doi.org/10.1039/d2em00032f.

The main change is that Hg0 dry deposition reactivity (f0) is set to 3.0e-5 everywhere except for the Amazon rainforest, where it is increased to 0.2. These changes yield improved agreement with observations of Hg0 vegetation uptake, Hg0 seasonality in the Northern midlatitudes, and Hg0 levels in the Southern Hemisphere.

Note that in order to balance the dry deposition changes and maintain good agreement with levels of Hg0 in the Northern Hemisphere, the photo-reduction of Hg(II) in organic aerosol needed to be re-calibrated (HG2ORGP factor increased from 0.004 to 0.010). The altered `FJX_j2j.dat` file is attached here. 

I also attach a benchmark file showing the resulting differences for the Hg concentrations, fluxes, and budget. This compares a run for 2015 from the patch/14.0.1 with the new version including revised Hg0 dry deposition.
 
[FJX_j2j.dat.txt](https://github.com/geoschem/geos-chem/files/9473544/FJX_j2j.dat.txt)
[benchmark_0208_0209.pdf](https://github.com/geoschem/geos-chem/files/9473558/benchmark_0208_0209.pdf)

