### PR TITLE
[PULL REQUEST] Fix incorrect RETURN for deallocation in Cleanup_Vdiff

### DIFF
--- a/GeosCore/vdiff_mod.F90
+++ b/GeosCore/vdiff_mod.F90
@@ -2440,13 +2440,13 @@ CONTAINS
     IF ( ALLOCATED( ml2 ) ) THEN
        DEALLOCATE( ml2, STAT=RC )
        CALL GC_CheckVar( 'vdiff_mod.F90:ML2', 2, RC )
-       RETURN
+       IF ( RC /= GC_SUCCESS ) RETURN
     ENDIF
 
     IF ( ALLOCATED( qmincg ) ) THEN
        DEALLOCATE( qmincg, STAT=RC )
        CALL GC_CheckVar( 'vdiff_mod.F90:QMINCG', 2, RC )
-       RETURN
+       IF ( RC /= GC_SUCCESS ) RETURN
     ENDIF
 
   END SUBROUTINE Cleanup_Vdiff


### PR DESCRIPTION
This fixes a bug where `Cleanup_Vdiff` would not properly deallocate all variables because there was a `RETURN` statement which did not check for a bad RC value and instead was always evaluated.