### PR TITLE
Fix bug in computing State_Met fields IsLand, IsWater, IsOcean, IsIce

### DIFF
--- a/GeosCore/calc_met_mod.F90
+++ b/GeosCore/calc_met_mod.F90
@@ -292,15 +292,16 @@ CONTAINS
        IsLocNoon(I,J) = ( LocTimeSec(I,J)          <= 43200  .and. &
                           LocTimeSec(I,J) + Dt_Sec >= 43200 )
 
-       FRLAND_NOSNO_NOICE = State_Met%FRLAND(I,J) - State_Met%FRSNO(I,J) - State_Met%FRLANDIC(I,J)
+       ! Land without snow or ice
+       FRLAND_NOSNO_NOICE = State_Met%FRLAND(I,J) - State_Met%FRSNO(I,J)
 
        ! Water without sea ice
        FRWATER = State_Met%FRLAKE(I,J) + State_Met%FROCEAN(I,J) - State_Met%FRSEAICE(I,J)
       
-       ! Land and sea ice 
+       ! Land ice and sea ice
        FRICE = State_Met%FRLANDIC(I,J) + State_Met%FRSEAICE(I,J)
       
-       ! Land snow
+       ! Snow
        FRSNO = State_Met%FRSNO(I,J)
       
        ! Set IsLand, IsWater, IsIce, IsSnow based on max fractional area


### PR DESCRIPTION
This PR is a minor bug fix for computing `State_Met%IsLand`, `State_Met%IsWater`, `State_Met%IsOcean`, and `State_Met%IsIce`. These logical masks are computed based on fraction land with no snow or ice. 
https://github.com/geoschem/geos-chem/blob/412ba5906b2aa9dcd72a2188c76c50220c3697b7/GeosCore/calc_met_mod.F90#L306-L310

The masks are determined based in part on fraction of land without snow or ice. However, this quantity is calculated by subtracting fraction land ice from fraction land when input met-field for fraction land does not include land ice.
https://github.com/geoschem/geos-chem/blob/412ba5906b2aa9dcd72a2188c76c50220c3697b7/GeosCore/calc_met_mod.F90#L295

I verified that FRLANDIC is indeed separate from FRLAND by printing out the fractions per grid box. Here is an example of printed fractions of a single all land ice grid cell:

>  Constants file
>     => FRLAND    :    0.0000000000000000     
>     => FRLANDIC  :    1.0000000000000000     
>     => FRLAKE    :    0.0000000000000000     
>     => FROCEAN   :    0.0000000000000000     
>  A1 file
>     => FRSEAICE  :    0.0000000000000000     
>     => FRSNO     :    0.0000000000000000     
>  Computed values
>     => FRLAND_NoSno_NoIce :   -1.0000000000000000     
>     => FrWater             :    0.0000000000000000     
>     => FrIce               :    1.0000000000000000     
>     => FrSnow              :    0.0000000000000000 

The result is that land fraction is underestimated (and potentially negative) for cells in which both land and land ice are present. The fix is to remove the subtraction of FRLANDIC from FRLAND.