### PR TITLE
Add "WD_CoarseAer:true" for SO4s and NITs in species_database.yml

### DIFF
--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -3316,6 +3316,7 @@ NITs:
   FullName: Inorganic nitrates on surface of seasalt aerosol
   Is_Photolysis: true
   MW_g: 31.4
+  WD_CoarseAer: true
 'NO':
   Background_VV: 4.0e-13
   Formula: 'NO'
@@ -4351,6 +4352,7 @@ SO4s:
   << : *SALCproperties
   FullName: Sulfate on surface of seasalt aerosol
   MW_g: 31.4
+  WD_CoarseAer: true
 SOAGX:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0


### PR DESCRIPTION
This is the corresponding PR for #1414.  We have added the `WD_CoarseAer: true` attribute for SO4s and NITs in the `species_database.yml` file.  SO4s and NITs should behave like coarse aerosol in wet scavenging, although for some reason the `WD_CoarseAer: true` attribute had never been added to their metadata.  

Closes #1414 