### PR TITLE
Bug fix: disable analytical inversion by default for CH4 simulations

### DIFF
--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
@@ -75,7 +75,7 @@ ch4_simulation_options:
     TCCON: false
 
   analytical_inversion:
-    activate: true
+    activate: false
     emission_perturbation: 1.0
     state_vector_element_number: 0
     use_emission_scale_factor: false

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
@@ -89,7 +89,7 @@ ch4_simulation_options:
     TCCON: false
 
   analytical_inversion:
-    activate: true
+    activate: false
     emission_perturbation: 1.0
     state_vector_element_number: 0
     use_emission_scale_factor: false


### PR DESCRIPTION
This is the corresponding PR for #1436.  I