### PR TITLE
Update units metadata for State_Met%AirNumDen (should be molec cm-3); Closes #1441

### DIFF
--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -4951,7 +4951,7 @@ CONTAINS
 
        CASE ( 'AIRNUMDEN' )
           IF ( isDesc  ) Desc  = 'Dry air density'
-          IF ( isUnits ) Units = 'm-3'
+          IF ( isUnits ) Units = 'molec cm-3'
           IF ( isRank  ) Rank  = 3
           IF ( isVLoc  ) VLoc  = VLocationCenter
 


### PR DESCRIPTION
This is the corresponding PR for #1441.  Here we fix the units metadata for `State_Met$AirNumDen`, which should be `molec cm-3`.

Closes #1441