### PR TITLE
Improve GCHP crash error message in run scripts

### DIFF
--- a/run/GCHP/runScriptSamples/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/gchp.batch_job.sh
@@ -148,7 +148,7 @@ source checkRunSettings.sh
 # and update restart symlink
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: cap_restart either did not change or is empty."
+   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    

--- a/run/GCHP/runScriptSamples/gchp.local.run
+++ b/run/GCHP/runScriptSamples/gchp.local.run
@@ -34,7 +34,7 @@ time mpirun -np ${nCores} ./gchp 2>&1 | tee -a ${log}
 # Rename and move restart file and update restart symlink if new start time ok
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: cap_restart either did not change or is empty."
+   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -38,7 +38,7 @@ time srun -n ${coreCount} -N ${SLURM_NNODES} -m plane=${planeCount} --mpi=pmix .
 # Rename and move restart file and update restart symlink if new start time ok
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: cap_restart either did not change or is empty."
+   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    

--- a/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
@@ -56,7 +56,7 @@ rc=$?
 # Rename and move restart file and update restart symlink if new start time ok
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: cap_restart either did not change or is empty."
+   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    


### PR DESCRIPTION
This PR makes GCHP run script messages about GCHP crashing easier to understand. Previously the error message stated the problem in the run script, which was that file `cap_restart` either did not change or was empty. The underlying problem, however, is actually that GCHP failed to complete. The error message now states this with direction to look at the log file, which should be less confusing to users.