### PR TITLE
[PULL REQUEST] Update createdRunDir.sh for 14.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents all notable changes to the GEOS-Chem repository since versio
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased 14.0.0]
+## [14.0.0] - 2022-10-25
 ### Added
 - Added user registration with dynamodb database during run directory creation
 - Added Hg simulation with KPP
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed 4D State_Chm%Species array to vector of 3D concentration arrays
 - Renamed GCHP config file runConfig.sh to setCommonRunSettings.sh
 - Moved restart file location in run directory to Restarts subdirectory
+- Updated sample restart files copied to run directories to 14.0.0 1-year benchmark output
 
 ### Removed
 - Removed TMPU1, SPHU1, PS1_WET, and PS1_DRY from GC-Classic restart file

--- a/run/GCClassic/README.md
+++ b/run/GCClassic/README.md
@@ -1,6 +1,6 @@
 # This run directory is for GEOS-Chem Classic.
 
-## Instructions on setting up, compiling, and running GEOS-Chem Classic:
+## For instructions on setting up, compiling, and running GEOS-Chem Classic, see:
 
   - https://geos-chem.readthedocs.org
 

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -1038,34 +1038,18 @@ if [[ ${met} = "merra2" ]] || [[ ${met} = "geosfp" ]]; then
           "x${sim_name}" == "xaerosol"      ||
           "x${sim_name}" == "xtagO3"    ]]; then
 
-        # NOTE: We need to read the fullchem restart files from the v2021-09/
-        # folder and TOMAS restart files from the v2021-12/ folder.  These
-        # restart files contain extra species (e.g HMS, HSO3m, SO3mm), for
-        # chemistry updates that were added in 13.3.0 and 13.4.0.  This is
-        # necessary to avoid GEOS-Chem Classic simulations from halting if
-        # these species are not found in the restart file (i.e. with time
-        # cycle flag "EFYO").
-        #   -- Bob Yantosca (14 Jan 2022)
-        #
-        # Aerosol-only simulations can use the fullchem restart since all
-        # of the aerosol species are included.
-	#
-	# For TagO3, we now use the same restart file as the fullchem
-	# to ensure that we start with the same initial conditions.
-	#  -- Bob Yantosca (02 Mar 2022)
-	#
 	if [[ "x${sim_extra_option}" == "xTOMAS15" ]]; then
 	    sample_rst=${rst_root}/v2021-12/GEOSChem.Restart.TOMAS15.${startdate}_0000z.nc4
 	elif [[ "x${sim_extra_option}" == "xTOMAS40" ]]; then
 	    sample_rst=${rst_root}/v2021-12/GEOSChem.Restart.TOMAS40.${startdate}_0000z.nc4
 	else
-	    sample_rst=${rst_root}/v2021-09/GEOSChem.Restart.fullchem.${startdate}_0000z.nc4
+	    sample_rst=${rst_root}/GC_14.0.0/1yr_benchmark/GEOSChem.Restart.fullchem.${startdate}_0000z.nc4
 	fi
 
     elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
 
 	# For TransportTracers, use restart from latest benchmark
-	sample_rst=${rst_root}/GC_13.0.0/GEOSChem.Restart.TransportTracers.${startdate}_0000z.nc4
+	sample_rst=${rst_root}/GC_14.0.0/GEOSChem.Restart.TransportTracers.${startdate}_0000z.nc4
 
     elif [[ "x${sim_name}" == "xHg" ]]; then
 

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -830,7 +830,7 @@ cp ${gcdir}/run/shared/download_data.py     ${rundir}
 cp ${gcdir}/run/shared/download_data.yml    ${rundir}
 cp ./getRunInfo                             ${rundir}
 cp ./archiveRun.sh                          ${rundir}
-cp ./README                                 ${rundir}
+cp ./README.md                              ${rundir}
 cp ./gitignore                              ${rundir}/.gitignore
 
 # Use data downloader that points to GCAP2 restart files

--- a/run/GCHP/README
+++ b/run/GCHP/README
@@ -1,7 +1,0 @@
-This directory is for GEOS-Chem (GCHP) with high performance option. For instructions
-on usage, please see the README at https://github.com/geoschem/gchpctm, also located
-in the top-level directory of your GCHPctm download.
-
-For more information, see the GEOS-Chem High Performance wiki page at
-http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_HP
-or contact the GEOS-Chem Support Team (geos-chem-support@g.harvard.edu).

--- a/run/GCHP/README.md
+++ b/run/GCHP/README.md
@@ -1,0 +1,11 @@
+# This run directory is for GCHP.
+
+## For instructions on setting up, compiling, and running GCHP, see:
+
+  - https://gchp.readthedocs.org
+
+## For help with GCHP, see:
+
+  - https://gchp.readthedocs.io/en/latest/reference/SUPPORT.html
+
+  - https://gchp.readthedocs.io/en/latest/reference/CONTRIBUTING.html

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -424,7 +424,7 @@ mkdir -p ${rundir_config}
 cp ${gcdir}/run/shared/cleanRunDir.sh ${rundir}
 cp ./archiveRun.sh                    ${rundir}
 cp ./logging.yml                      ${rundir}
-cp ./README                           ${rundir}
+cp ./README.md                        ${rundir}
 cp ./setEnvironmentLink.sh            ${rundir}
 cp ./setRestartLink.sh                ${rundir}
 cp ./checkRunSettings.sh              ${rundir}

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -471,14 +471,14 @@ printf "To build GCHP type:\n   cmake ../CodeDir\n   cmake . -DRUNDIR=..\n   mak
 restarts=${GC_DATA_ROOT}/GEOSCHEM_RESTARTS
 if [[ ${sim_name} = "fullchem" ]]; then
     start_date='20190701'
-    restart_dir='v2021-09'
+    restart_dir='GC_14.0.0/1yr_benchmark'
 elif [[ ${sim_name} = "TransportTracers" ]]; then
     start_date='20190101'
-    restart_dir='GC_13.0.0'
+    restart_dir='GC_14.0.0'
 fi
 for N in 24 48 90 180 360
 do
-    old_prefix="GCHP.Restart.${sim_name}"
+    old_prefix="GEOSChem.Restart.${sim_name}"
     new_prefix="GEOSChem.Restart"
     echo "${start_date} 000000" > ${rundir}/cap_restart
     initial_rst="${restarts}/${restart_dir}/${old_prefix}.${start_date}_0000z.c${N}.nc4"


### PR DESCRIPTION
This PR includes the following items in preparation for the 14.0.0 release:

* Update the sample restart files for full-chemistry and transport tracer simulations to use output from the 14.0.0-rc.3 1-year benchmarks 
* Fix typo in GCClassic/createRunDir.sh to copy README.md instead of README
* Convert README for GCHP run directories to markdown format, update contents within, and modify GCHP/createRunDir.sh to copy this file