### PR TITLE
Update README.md and AUTHORS.txt for 14.0.0

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,4 +1,5 @@
-List of Developers for GEOS-Chem, HEMCO, and Related Software (04 Jan 2021)
+List of Developers for GEOS-Chem, GCHP, HEMCO, and Related Software
+(26 Oct 2022)
 ===============================================================================
 
 Peter Adams
@@ -30,6 +31,7 @@ Beata Bukosa
 Christopher Butenhoff
 Karen Cady-Pereira
 Philip Cameron-Smith
+Patrick Campbell
 Liangzhong Cao
 Guofeng Cao
 Yi Cao
@@ -47,6 +49,7 @@ Xin Chen
 Yang Chen
 Yunsoo Choi
 Kenneth Christian
+Tom Clune
 Matt Cooper
 Bess Corbitt
 Betty Croft
@@ -66,10 +69,12 @@ Bryan Duncan
 Sebastian Eastham
 Raluca Ellis
 Joseph Enberg
+Lucas Estrada
 Mathew Evans
 T. Duncan Fairlie
 Sal Farina
 Vivian Faye
+Ari Feinberg
 Brendan Field
 Arlene Fiore
 Emily Fischer
@@ -89,6 +94,7 @@ Cui Ge
 Jeffrey Geddes
 Amanda Giang
 Christos Giannakopoulos
+Harriet Gounia
 Edward Graef
 Jesse Greenslade
 Xiaoguang Gu
@@ -112,7 +118,9 @@ Andy Jacobson
 Marc Jacobson
 Lyatt Jaegle
 Ruud Jansen
+Weiyuan Jiang
 Zhe Jiang
+Lixu Jin
 Matthew Johnson
 Dylan Jones
 Jaegun Jung
@@ -138,6 +146,7 @@ David Lary
 Robyn Latimer
 Philippe Le Sager
 Chulkyu Lee
+Colin Lee
 Meemong Lee
 Ralph Lehmann
 Eric Leibensperger
@@ -148,6 +157,7 @@ Chi Li
 Ke Li
 Qinbin Li
 Xianglan Li
+Yanshun Li
 K. J. Liao
 Qing Liang
 Hong Liao
@@ -164,6 +174,7 @@ Yang Liu
 Ying Liu
 Jennifer Logan
 Mike Long
+Xiao Lu
 Lizzie Lundgren
 Gan Luo
 J.D. (Bram) Maasakkers
@@ -219,6 +230,7 @@ Will Porter
 Ryan Pound
 Michael Prather
 Anna Protonatariou
+Bill Putman
 Havala Pye
 Asif Qureshi
 Emily Ramnarine
@@ -255,6 +267,7 @@ Dominick Spracklen
 Ilya Stanevich
 Stephen Steenrod
 Rebecca Stern
+Robin Stevens
 David Streets
 Sarah Strode
 Flora Su
@@ -263,6 +276,7 @@ Minmin Sun
 Elsie Sunderland
 Parvada Suntharalingam
 Luke Surl
+Bethany Sutherland
 Kimito Suto
 Monika Szelag
 Amos Tai
@@ -270,6 +284,7 @@ Hiroshi Tanimoto
 John Tannahill
 Shu Tao
 Colin Thackray
+Matt Thompson
 Thibaud Thonat
 Rong Tian
 Maria Tombrou
@@ -310,6 +325,7 @@ Ingo Wohltmann
 Shiliang Wu
 Shiliang Wu
 Yaping Xiao
+Junwei Xu
 Yingying Yan
 Matt Yannetti
 Bob Yantosca
@@ -320,6 +336,7 @@ Fangqun Yu
 Xu Yue
 Xuyan Yue
 Maria Zatko
+Shixian Zhai
 Shuting Zhai
 Bo Zhang
 Chi Zhang

--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ This repository contains the __GEOS-Chem science codebase__.  Included in this r
 
 ### Version 12.9.3 and prior
 
-GEOS-Chem 12.9.3 was the last version in which this "Science Codebase" repository was used in a standalone manner.  For this reason, the latest release is frozen at 12.9.3. 
+GEOS-Chem 12.9.3 was the last version in which this "Science Codebase" repository was used in a standalone manner.
 
 ### Version 13.0.0 and later
 
 GEOS-Chem 13.0.0 and later versions use this "Science Codebase" repository as a  submodule within the [GCClassic](https://github.com/geoschem/GCClassic) and [GCHP](https://github.com/geoschem/GCHP) repositories.
 
-Releases for GEOS-Chem 13.0.0 and later versions will be issued at the [GCClassic](https://github.com/geoschem/GCClassic) and [GCHP](https://github.com/geoschem/GCHP) Github repositories.
+Releases for GEOS-Chem 13.0.0 and later versions will be issued at the [GCClassic](https://github.com/geoschem/GCClassic) and [GCHP](https://github.com/geoschem/GCHP) Github repositories. We will also tag and release the corresponding versions at this repository for the sake of completeness.
 
 ## User Manuals
 
 Each implementation of GEOS-Chem has its own manual page.  For more information, please see:
 
-* __GEOS-Chem "Classic":__ [http://wiki.geos-chem.org/Getting_Started_with_GEOS-Chem](http://wiki.geos-chem.org/Getting_Started_with_GEOS-Chem)
+* __GEOS-Chem "Classic":__ [https://geos-chem.readthedocs.io](https://geos-chem.readthedocs.io)
 
 * __GCHP:__ [https://gchp.readthedocs.io](https://gchp.readthedocs.io)
 

--- a/REVISIONS
+++ b/REVISIONS
@@ -1,5 +1,0 @@
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%% NOTE: It is recommended to use the gitk viewer to examine the source    %%%
-%%%       code modifications that have been added to GEOS-Chem!             %%%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-


### PR DESCRIPTION
This PR includes the following updates:

- README.md now points to GEOS-Chem user manual at geos-chem.readthedocs.io and includes updated text about releases for this repository.
- AUTHORS.txt has been updated to include developers for 13.0.1 through 14.0.0. This file will also be copied to and updated in the GCClassic, GCHP, and HEMCO repositories.