### PR TITLE
Fix typo preventing the ND51 satellite diagnostic from turning on

### DIFF
--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -3868,7 +3868,7 @@ CONTAINS
     !------------------------------------------------------------------------
     ! Turn on ND51 diagnostic
     !------------------------------------------------------------------------
-    key    = "extra_diagnostics%ND51_satellite%activate"
+    key    = "extra_diagnostics%legacy_bpch%ND51_satellite%activate"
     v_bool = MISSING_BOOL
     CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN


### PR DESCRIPTION
The line for turning on the ND51 satellite diagnostic in GeosCore/input_mod.F90 was missing "%legacy_bpch". This prevented the diagnostic from ever turning on despite the settings in geoschem_config.yml.

Closes #1467