### PR TITLE
Update Restart collection in HISTORY.rc to include BXHEIGHT and TROPLEV for all simulations

### DIFF
--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
@@ -58,6 +58,8 @@ COLLECTIONS: 'Restart',
   Restart.mode:               'instantaneous'
   Restart.fields:             'SpeciesRst_?ALL?               ',
                               'Met_DELPDRY                    ',
+                              'Met_BXHEIGHT                   ',
+                              'Met_TropLev                    ',
 ::
 #==============================================================================
 # %%%%% THE Metrics COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -68,7 +68,10 @@ COLLECTIONS: 'Restart',
   SpeciesConc.frequency:      ${RUNDIR_HIST_TIME_AVG_FREQ}
   SpeciesConc.duration:       ${RUNDIR_HIST_TIME_AVG_DUR}
   SpeciesConc.mode:           'time-averaged'
-  SpeciesConc.fields:         'SpeciesConc_?ADV?             ',
+  SpeciesConc.fields:         'SpeciesConc_?ADV?              ',
+                              'Met_DELPDRY                    ',
+                              'Met_BXHEIGHT                   ',
+                              'Met_TropLev                    ',
 ::
 #==============================================================================
 # %%%%% THE Budget COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.POPs
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.POPs
@@ -59,6 +59,8 @@ COLLECTIONS: 'Restart',
   Restart.mode:               'instantaneous'
   Restart.fields:             'SpeciesRst_?ALL?               ',
                               'Met_DELPDRY                    ',
+                              'Met_BXHEIGHT                   ',
+                              'Met_TropLev                    ',
 ::
 #==============================================================================
 # %%%%% THE SpeciesConc COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -59,6 +59,8 @@ COLLECTIONS: 'Restart',
   Restart.mode:               'instantaneous'
   Restart.fields:             'SpeciesRst_?ALL?               ',
                               'Met_DELPDRY                    ',
+                              'Met_BXHEIGHT                   ',
+                              'Met_TropLev                    ',
 ::
 #==============================================================================
 # %%%%% THE SpeciesConc COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
@@ -67,6 +67,8 @@ COLLECTIONS: 'Restart',
                               'Chem_DryDepNitrogen            ',
                               'Chem_WetDepNitrogen            ',
                               'Met_DELPDRY                    ',
+                              'Met_BXHEIGHT                   ',
+                              'Met_TropLev                    ',
 ::
 #==============================================================================
 # %%%%% THE SpeciesConc COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
@@ -57,6 +57,8 @@ COLLECTIONS: 'Restart',
   Restart.mode:               'instantaneous'
   Restart.fields:             'SpeciesRst_?ALL?               ',
                               'Met_DELPDRY                    ',
+                              'Met_BXHEIGHT                   ',
+                              'Met_TropLev                    ',
 ::
 #==============================================================================
 # %%%%% THE SpeciesConc COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCH4
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCH4
@@ -57,6 +57,8 @@ COLLECTIONS: 'Restart',
   Restart.mode:               'instantaneous'
   Restart.fields:             'SpeciesRst_?ALL?               ',
                               'Met_DELPDRY                    ',
+                              'Met_BXHEIGHT                   ',
+                              'Met_TropLev                    ',
 ::
 #==============================================================================
 # %%%%% THE SpeciesConc COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
@@ -57,6 +57,8 @@ COLLECTIONS: 'Restart',
   Restart.mode:               'instantaneous'
   Restart.fields:             'SpeciesRst_?ALL?               ', 
                               'Met_DELPDRY                    ', 
+                              'Met_BXHEIGHT                   ',
+                              'Met_TropLev                    ',
 ::
 #==============================================================================
 # %%%%% THE SpeciesConc COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
@@ -58,6 +58,8 @@ COLLECTIONS: 'Restart',
   Restart.mode:               'instantaneous'
   Restart.fields:             'SpeciesRst_?ALL?               ',
                               'Met_DELPDRY                    ',
+                              'Met_BXHEIGHT                   ',
+                              'Met_TropLev                    ',
 ::
 #==============================================================================
 # %%%%% THE SpeciesConc COLLECTION %%%%%


### PR DESCRIPTION
The BXHEIGHT and TROPLEV fields are required in the GEOS-Chem restart file when generating global mass tables with GCPy. Previously, these fields were only enabled in the Restart collection for the fullchem and Hg simulations. We now include them for all GEOS-Chem Classic simulation types for consistency.