### PR TITLE
Bug fix: Only write dry-run header to HEMCO.log if it has a unit number

### DIFF
--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -2724,11 +2724,18 @@ CONTAINS
     ! Initialize
     RC = GC_SUCCESS
 
-    ! For dry-run simulations, Write the dry-run header to
-    ! stdout (aka GEOS-Chem log file) and the HEMCO log file.
+    ! Skip if not a dry-run simulation
     IF ( Input_Opt%DryRun ) THEN
+
+       ! Print dry-run header to stdout
+       ! (which is usually redirected to the dryrun log file)
        CALL Print_Dry_Run_Warning( 6 )
-       CALL Print_Dry_Run_Warning( HcoState%Config%Err%LUN )
+
+       ! Print dry-run header to HEMCO.log file
+       ! (if HEMCO output is not already being sent to stdout)
+       IF ( HcoState%Config%Err%LUN > 0 ) THEN
+          CALL Print_Dry_Run_Warning( HcoState%Config%Err%LUN )
+       ENDIF
     ENDIF
 
   END SUBROUTINE Cleanup_Dry_Run


### PR DESCRIPTION
This is the corresponding PR to #1475.  We now only print the dry-run informational header, that is:

```console
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!! GEOS-CHEM IS IN DRY-RUN MODE!
!!!
!!! You will NOT get output for this run!
!!! Use this command to validate a GEOS-Chem run configuration:
!!!   ./gcclassic --dryrun > log
!!!
!!! REMOVE THE --dryrun ARGUMENT FROM THE COMMAND LINE
!!! BEFORE RUNNING A GEOS-Chem PRODUCTION SIMULATION!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!! Start Date       : ... # the start date of your simulation
!!! End Date         : ... # the end date of your simulation
!!! Simulation       : ... # the type of your simulation
!!! Meteorology      : ... # the met fields your simulation uses
!!! Grid Resolution  : ... # the grid your simulation uses  
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

to the HEMCO.log file only if HEMCO output is not already being sent to stdout (which is redirected to the GEOS-Chem log file).