### PR TITLE
Update KPP diagnostics archive flags

### DIFF
--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1028,12 +1028,12 @@ CONTAINS
           ENDIF
 
           ! # of accepted internal timesteps
-          IF ( State_Diag%Archive_KppTotSteps ) THEN
+          IF ( State_Diag%Archive_KppAccSteps ) THEN
              State_Diag%KppAccSteps(I,J,L) = ISTATUS(4)
           ENDIF
 
           ! # of rejected internal timesteps
-          IF ( State_Diag%Archive_KppTotSteps ) THEN
+          IF ( State_Diag%Archive_KppRejSteps ) THEN
              State_Diag%KppRejSteps(I,J,L) = ISTATUS(5)
           ENDIF
 
@@ -1116,13 +1116,13 @@ CONTAINS
              ENDIF
 
              ! # of accepted internal timesteps
-             IF ( State_Diag%Archive_KppTotSteps ) THEN
+             IF ( State_Diag%Archive_KppAccSteps ) THEN
                 State_Diag%KppAccSteps(I,J,L) =                              &
                 State_Diag%KppAccSteps(I,J,L) + ISTATUS(4)
              ENDIF
 
              ! # of rejected internal timesteps
-             IF ( State_Diag%Archive_KppTotSteps ) THEN
+             IF ( State_Diag%Archive_KppRejSteps ) THEN
                 State_Diag%KppRejSteps(I,J,L) =                              &
                 State_Diag%KppRejSteps(I,J,L) + ISTATUS(5)
              ENDIF


### PR DESCRIPTION
Some KPP diagnostics are queried using the wrong archive flag. This can lead to seg faults if only some KPP diagnostics are being requested. This change is a bug fix and a zero-diff change.