### PR TITLE
Fix units of RxnRate diagnostic in Get_MetaData_State_Diag routine

### DIFF
--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -10971,7 +10971,7 @@ CONTAINS
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'RXNRATE' ) THEN
        IF ( isDesc    ) Desc  = 'KPP equation reaction rates'
-       IF ( isUnits   ) Units = 's-1'
+       IF ( isUnits   ) Units = 'molec cm-3 s-1'
        IF ( isRank    ) Rank  = 3
        IF ( isTagged  ) TagId = 'RXN'
 


### PR DESCRIPTION
This is the corresponding PR for #1459.  This fixes an error in the metadata for the RxnRate units string, which should be "molec cm-3 s-1" instead of "s-1".

Integration tests to follow.

Closes #1459.