### PR TITLE
Remove dry air from AIRVOL and BXHEIGHT long names for diagnostics -- Closes #1487

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated EDGAR v6 CH4 emission files to correct timestamp issue
 - Fixed indentation error in the `legacy_bpch` section of
   `geoschem_config.yml` template files
+- Removed "dry air" from the metadata of fields `State_Met%AIRVOL` and
+  `State_Met%BXHEIGHT`
 
 ## [14.0.1] - 2022-10-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This file documents all notable changes to the GEOS-Chem repository since versio
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 14.0.2]
+### Fixed
+- Added fix for writing dry-run header to log file
+- Updated KPP diagnostics archive flags
+- Rewrote code to avoid memory leaks (identified by the code sanitizer)
+- Updated EDGAR v6 CH4 emission files to correct timestamp issue
+- Fixed indentation error in the `legacy_bpch` section of
+  `geoschem_config.yml` template files
+
 ## [14.0.1] - 2022-10-31
 ### Fixed
 - Corrected units in metadata for State_Met%AirNumDen and State_Met%PHIS

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1028,12 +1028,12 @@ CONTAINS
           ENDIF
 
           ! # of accepted internal timesteps
-          IF ( State_Diag%Archive_KppTotSteps ) THEN
+          IF ( State_Diag%Archive_KppAccSteps ) THEN
              State_Diag%KppAccSteps(I,J,L) = ISTATUS(4)
           ENDIF
 
           ! # of rejected internal timesteps
-          IF ( State_Diag%Archive_KppTotSteps ) THEN
+          IF ( State_Diag%Archive_KppRejSteps ) THEN
              State_Diag%KppRejSteps(I,J,L) = ISTATUS(5)
           ENDIF
 
@@ -1116,13 +1116,13 @@ CONTAINS
              ENDIF
 
              ! # of accepted internal timesteps
-             IF ( State_Diag%Archive_KppTotSteps ) THEN
+             IF ( State_Diag%Archive_KppAccSteps ) THEN
                 State_Diag%KppAccSteps(I,J,L) =                              &
                 State_Diag%KppAccSteps(I,J,L) + ISTATUS(4)
              ENDIF
 
              ! # of rejected internal timesteps
-             IF ( State_Diag%Archive_KppTotSteps ) THEN
+             IF ( State_Diag%Archive_KppRejSteps ) THEN
                 State_Diag%KppRejSteps(I,J,L) =                              &
                 State_Diag%KppRejSteps(I,J,L) + ISTATUS(5)
              ENDIF

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -1212,6 +1212,13 @@ CONTAINS
        Input_Opt%FAM_NAME => NULL()
     ENDIF
 
+    IF ( ASSOCIATED( Input_Opt%FAM_TYPE ) ) THEN
+       DEALLOCATE( Input_Opt%FAM_TYPE, STAT=RC )
+       CALL GC_CheckVar( 'Input_Opt%FAM_TYPE', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       Input_Opt%FAM_TYPE => NULL()
+    ENDIF
+
     IF ( ASSOCIATED( Input_Opt%LINOZ_TPARM ) ) THEN
        DEALLOCATE( Input_Opt%LINOZ_TPARM, STAT=RC )
        CALL GC_CheckVar( 'Input_Opt%LINOZ_TPARM', 2, RC )
@@ -1224,6 +1231,34 @@ CONTAINS
        CALL GC_CheckVar( 'Input_Opt%LSPECRADMENU', 2, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
        Input_Opt%LSPECRADMENU => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( Input_Opt%LSKYRAD ) ) THEN
+       DEALLOCATE( Input_Opt%LSKYRAD, STAT=RC )
+       CALL GC_CheckVar( 'Input_Opt%LSKYRAD', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       Input_Opt%LSKYRAD => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( Input_Opt%WVSELECT ) ) THEN
+       DEALLOCATE( Input_Opt%WVSELECT, STAT=RC )
+       CALL GC_CheckVar( 'Input_Opt%WVSELECT', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       Input_Opt%WVSELECT => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( Input_Opt%STRWVSELECT ) ) THEN
+       DEALLOCATE( Input_Opt%STRWVSELECT, STAT=RC )
+       CALL GC_CheckVar( 'Input_Opt%STRWVSELECT', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       Input_Opt%STRWVSELECT => NULL()
+    ENDIF
+
+    IF ( ASSOCIATED( Input_Opt%ObsPack_SpcName ) ) THEN
+       DEALLOCATE( Input_Opt%ObsPack_SpcName, STAT=RC )
+       CALL GC_CheckVar( 'Input_Opt%ObsPack_SpcName', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       Input_Opt%ObsPack_SpcName => NULL()
     ENDIF
 
 #ifdef MODEL_GEOS

--- a/Headers/registry_mod.F90
+++ b/Headers/registry_mod.F90
@@ -406,6 +406,10 @@ CONTAINS
        RETURN
     ENDIF
 
+    ! Free Item once we have attached it to the Registry linked list
+    DEALLOCATE( Item )
+    Item => NULL()
+
   END SUBROUTINE Registry_AddField
 !EOC
 !------------------------------------------------------------------------------

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -10971,7 +10971,7 @@ CONTAINS
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'RXNRATE' ) THEN
        IF ( isDesc    ) Desc  = 'KPP equation reaction rates'
-       IF ( isUnits   ) Units = 's-1'
+       IF ( isUnits   ) Units = 'molec cm-3 s-1'
        IF ( isRank    ) Rank  = 3
        IF ( isTagged  ) TagId = 'RXN'
 

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -4956,7 +4956,7 @@ CONTAINS
           IF ( isVLoc  ) VLoc  = VLocationCenter
 
        CASE ( 'AIRVOL' )
-          IF ( isDesc  ) Desc  = 'Volume of dry air in grid box'
+          IF ( isDesc  ) Desc  = 'Volume of grid box'
           IF ( isUnits ) Units = 'm3'
           IF ( isRank  ) Rank  = 3
           IF ( isVLoc  ) VLoc  = VLocationCenter
@@ -4968,7 +4968,7 @@ CONTAINS
           IF ( isVLoc  ) VLoc  = VLocationCenter
 
        CASE ( 'BXHEIGHT' )
-          IF ( isDesc  ) Desc  = 'Grid box height (w/r/t dry air)'
+          IF ( isDesc  ) Desc  = 'Grid box height'
           IF ( isUnits ) Units = 'm'
           IF ( isRank  ) Rank  = 3
           IF ( isVLoc  ) VLoc  = VLocationCenter

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -1631,7 +1631,7 @@ CONTAINS
                    ! Increment the item count
                    ItemCount   = ItemCount + 1
 
-                  ! Create the a HISTORY ITEM object for this diagnostic
+                   ! Create the a HISTORY ITEM object for this diagnostic
                    ! and add it to the given DIAGNOSTIC COLLECTION
                    CALL History_AddItemToCollection(                         &
                             Input_Opt    = Input_Opt,                        &
@@ -1770,7 +1770,6 @@ CONTAINS
              RETURN
           ENDIF
        ENDIF
-
     ENDDO
 
     !=======================================================================
@@ -2344,6 +2343,10 @@ CONTAINS
 
     ! Increment number of HISTORY ITEMS in this collection
     Collection%nHistItems = Collection%nHistItems + 1
+
+    ! Free Item (we have added it to the container and don't need it anymore)
+    DEALLOCATE( Item )
+    Item => NULL()
 
     ! Free pointers
     Ptr0d   => NULL()

--- a/History/history_netcdf_mod.F90
+++ b/History/history_netcdf_mod.F90
@@ -93,7 +93,7 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    TYPE(MetaHIstItem), POINTER :: Current
+    TYPE(MetaHistItem), POINTER :: Current
 
     !=======================================================================
     ! Initialize
@@ -1677,6 +1677,10 @@ CONTAINS
           CALL GC_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
+
+       ! Free Item now that we have added it to IndexVarList
+       DEALLOCATE( Item )
+       Item => NULL()
     ENDDO
 
   END SUBROUTINE IndexVarList_Create

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -739,6 +739,7 @@ PROGRAM GEOS_Chem
 
   ! Run HEMCO phase 0 as simplfied phase 1 to get initial met fields
   ! and restart file fields
+  TimeForEmis = .FALSE.
   CALL Emissions_Run( Input_Opt, State_Chm,   State_Diag, State_Grid,  &
                       State_Met, TimeForEmis, 0,          RC )
 
@@ -2724,11 +2725,18 @@ CONTAINS
     ! Initialize
     RC = GC_SUCCESS
 
-    ! For dry-run simulations, Write the dry-run header to
-    ! stdout (aka GEOS-Chem log file) and the HEMCO log file.
+    ! Skip if not a dry-run simulation
     IF ( Input_Opt%DryRun ) THEN
+
+       ! Print dry-run header to stdout
+       ! (which is usually redirected to the dryrun log file)
        CALL Print_Dry_Run_Warning( 6 )
-       CALL Print_Dry_Run_Warning( HcoState%Config%Err%LUN )
+
+       ! Print dry-run header to HEMCO.log file
+       ! (if HEMCO output is not already being sent to stdout)
+       IF ( HcoState%Config%Err%LUN > 0 ) THEN
+          CALL Print_Dry_Run_Warning( HcoState%Config%Err%LUN )
+       ENDIF
     ENDIF
 
   END SUBROUTINE Cleanup_Dry_Run

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
@@ -260,40 +260,40 @@ Warnings:                    1
 #==============================================================================
 (((EDGARv6
 ### Oil ###
-0 CH4_OIL__1B2a          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_OIL.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 1 1
+0 CH4_OIL__1B2a          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_OIL.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 1 1
 
 ### Gas ###
-0 CH4_OIL__1B2c          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_GAS.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 2 1
+0 CH4_OIL__1B2c          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_GAS.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 2 1
 
 ### Coal ###
-0 CH4_COAL__1B1a         $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_COAL.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 3 1
+0 CH4_COAL__1B1a         $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_COAL.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 3 1
 
 ### Livestock ###
-0 CH4_LIVESTOCK__4A      $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENF.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 4 1
-0 CH4_LIVESTOCK__4B      $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_MNM.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 4 1
+0 CH4_LIVESTOCK__4A      $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENF.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 4 1
+0 CH4_LIVESTOCK__4B      $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_MNM.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 4 1
 
 ### Landfills ###
-0 CH4_LANDFILLS__6A_6D   $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_LDF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 5 1
+0 CH4_LANDFILLS__6A_6D   $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_LDF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 5 1
 
 ### Wastewater ###
-0 CH4_WASTEWATER__6B     $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_WWT.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 6 1
+0 CH4_WASTEWATER__6B     $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_WWT.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 6 1
 
 ### Other Anthro ###
-0 CH4_OTHER__1A1_1B1_1B2 $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_REF_TRF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__1A1a        $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__1A2         $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IND.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__1A3a_CDS    $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CDS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__1A3a_CRS    $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CRS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__1A3a_LTO    $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_LTO.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__1A3b        $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TRO_noRES.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__1A3c_1A3e   $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Other.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__1A3d_1C2    $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Ship.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__1A4         $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_RCO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__2B          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_CHE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__2C          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IRO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__4F          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AWB.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__4C_4D       $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AGS.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
-0 CH4_OTHER__6C          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_INC.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A1_1B1_1B2 $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_REF_TRF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A1a        $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A2         $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IND.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A3a_CDS    $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CDS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A3a_CRS    $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CRS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A3a_LTO    $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_LTO.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A3b        $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TRO_noRES.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A3c_1A3e   $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Other.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A3d_1C2    $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Ship.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__1A4         $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_RCO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__2B          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_CHE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__2C          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IRO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__4F          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AWB.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__4C_4D       $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AGS.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
+0 CH4_OTHER__6C          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_INC.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4 - 8 1
 )))EDGARv6
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
@@ -349,62 +349,62 @@ Warnings:                    1
 #==============================================================================
 (((EDGARv6
 ### Oil ###
-0 CH4_OIL__1B2a_T          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_OIL.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OIL - 1 1
-0 CH4_OIL__1B2a            $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_OIL.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 1 1
+0 CH4_OIL__1B2a_T          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_OIL.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OIL - 1 1
+0 CH4_OIL__1B2a            $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_OIL.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 1 1
 
 ### Gas ###
-0 CH4_OIL__1B2c_T          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_GAS.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_GAS - 2 1
-0 CH4_OIL__1B2c            $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_GAS.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 2 1
+0 CH4_OIL__1B2c_T          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_GAS.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_GAS - 2 1
+0 CH4_OIL__1B2c            $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_GAS.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 2 1
 
 ### Coal ###
-0 CH4_COAL__1B1a_T         $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_COAL.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_COL - 3 1
-0 CH4_COAL__1B1a           $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_COAL.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 3 1
+0 CH4_COAL__1B1a_T         $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_COAL.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_COL - 3 1
+0 CH4_COAL__1B1a           $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_PRO_COAL.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 3 1
 
 ### Livestock ###
-0 CH4_LIVESTOCK__4A_T      $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENF.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_LIV - 4 1
-0 CH4_LIVESTOCK__4A        $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENF.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 4 1
-0 CH4_LIVESTOCK__4B_T      $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_MNM.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_LIV - 4 1
-0 CH4_LIVESTOCK__4B        $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_MNM.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 4 1
+0 CH4_LIVESTOCK__4A_T      $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENF.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_LIV - 4 1
+0 CH4_LIVESTOCK__4A        $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENF.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 4 1
+0 CH4_LIVESTOCK__4B_T      $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_MNM.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_LIV - 4 1
+0 CH4_LIVESTOCK__4B        $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_MNM.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 4 1
 
 ### Landfills ###
-0 CH4_LANDFILLS__6A_6D_T   $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_LDF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_LDF - 5 1
-0 CH4_LANDFILLS__6A_6D     $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_LDF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 5 1
+0 CH4_LANDFILLS__6A_6D_T   $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_LDF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_LDF - 5 1
+0 CH4_LANDFILLS__6A_6D     $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_LDF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 5 1
 
 ### Wastewater ###
-0 CH4_WASTEWATER__6B_T     $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_WWT.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_WST - 6 1
-0 CH4_WASTEWATER__6B       $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_WWT.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 6 1
+0 CH4_WASTEWATER__6B_T     $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_WWT.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_WST - 6 1
+0 CH4_WASTEWATER__6B       $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_WWT.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 6 1
 
 ### Other Anthro ###
-0 CH4_OTHER__1A1_1B1_1B2_T $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_REF_TRF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A1_1B1_1B2   $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_REF_TRF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__1A1a_T        $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A1a          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__1A2_T         $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IND.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A2           $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IND.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__1A3a_CDS_T    $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CDS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A3a_CDS      $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CDS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__1A3a_CRS_T    $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CRS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A3a_CRS      $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CRS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__1A3a_LTO_T    $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_LTO.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A3a_LTO      $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_LTO.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__1A3b_T        $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TRO_noRES.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A3b          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TRO_noRES.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__1A3c_1A3e_T   $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Other.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A3c_1A3e     $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Other.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__1A3d_1C2_T    $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Ship.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A3d_1C2      $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Ship.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__1A4_T         $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_RCO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__1A4           $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_RCO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__2B_T          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_CHE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__2B            $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_CHE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__2C_T          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IRO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__2C            $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IRO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__4F_T          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AWB.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__4F            $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AWB.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__4C_4D_T       $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AGS.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__4C_4D         $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AGS.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
-0 CH4_OTHER__6C_T          $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_INC.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
-0 CH4_OTHER__6C            $ROOT/CH4/v2022-01/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_INC.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A1_1B1_1B2_T $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_REF_TRF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A1_1B1_1B2   $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_REF_TRF.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A1a_T        $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A1a          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_ENE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A2_T         $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IND.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A2           $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IND.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A3a_CDS_T    $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CDS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A3a_CDS      $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CDS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A3a_CRS_T    $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CRS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A3a_CRS      $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_CRS.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A3a_LTO_T    $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_LTO.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A3a_LTO      $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Aviation_LTO.0.1x0.1.nc emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A3b_T        $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TRO_noRES.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A3b          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TRO_noRES.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A3c_1A3e_T   $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Other.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A3c_1A3e     $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Other.0.1x0.1.nc        emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A3d_1C2_T    $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Ship.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A3d_1C2      $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_TNR_Ship.0.1x0.1.nc         emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__1A4_T         $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_RCO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__1A4           $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_RCO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__2B_T          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_CHE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__2B            $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_CHE.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__2C_T          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IRO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__2C            $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_IRO.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__4F_T          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AWB.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__4F            $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AWB.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__4C_4D_T       $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AGS.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__4C_4D         $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_AGS.0.1x0.1.nc              emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
+0 CH4_OTHER__6C_T          $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_INC.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4_OTA - 8 1
+0 CH4_OTHER__6C            $ROOT/CH4/v2022-11/EDGARv6/$YYYY/v6.0_CH4_$YYYY_SWD_INC.0.1x0.1.nc          emi_ch4 2000-2018/1-12/1/0 C xy kg/m2/s CH4     - 8 1
 )))EDGARv6
 
 #==============================================================================

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
@@ -100,19 +100,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CO2
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CO2
@@ -106,19 +106,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
@@ -140,19 +140,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.POPs
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.POPs
@@ -110,19 +110,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
@@ -152,19 +152,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
@@ -148,19 +148,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -386,19 +386,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.metals
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.metals
@@ -116,19 +116,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
@@ -114,19 +114,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCO
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCO
@@ -109,19 +109,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagO3
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagO3
@@ -99,19 +99,19 @@ extra_diagnostics:
     output_file: plane.log.YYYYMMDD
 
   legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
+    output_menu:             # 1234567890123456789012345678901
+      schedule_output_for_JAN: 3000000000000000000000000000000
+      schedule_output_for_FEB: 30000000000000000000000000000
+      schedule_output_for_MAR: 3000000000000000000000000000000
+      schedule_output_for_APR: 300000000000000000000000000000
+      schedule_output_for_MAY: 3000000000000000000000000000000
+      schedule_output_for_JUN: 300000000000000000000000000000
+      schedule_output_for_JUL: 3000000000000000000000000000000
+      schedule_output_for_AUG: 3000000000000000000000000000000
+      schedule_output_for_SEP: 300000000000000000000000000000
+      schedule_output_for_OCT: 3000000000000000000000000000000
+      schedule_output_for_NOV: 300000000000000000000000000000
+      schedule_output_for_DEC: 3000000000000000000000000000000
 
     gamap:
       diaginfo_dat_file: ./diaginfo.dat


### PR DESCRIPTION
This is the corresponding PR for #1487, namely to remove "dry air" from the metadata of `State_Met%AIRVOL` and `State_Met%BXHEIGHT`. 

Closes #1487