### PR TITLE
Disallow wildcards in HISTORY.rc for CESM model

### DIFF
--- a/Headers/diaglist_mod.F90
+++ b/Headers/diaglist_mod.F90
@@ -686,10 +686,10 @@ CONTAINS
           isWildcard = .FALSE.
           wildcard   = ''
           IF ( INDEX( name, '?' ) > 0 ) THEN
-#if defined( MODEL_GCHPCTM ) || defined( MODEL_GEOS )
+#if defined( MODEL_GCHPCTM ) || defined( MODEL_GEOS ) || defined( MODEL_CESM )
              ! Exit with an error if using GCHP and wildcard is present
              ErrMsg = 'ERROR: HISTORY.rc wildcard handling is not ' // &
-                      'implemented in GCHP: ' // TRIM(name) // '. Replace ' // &
+                      'implemented in GCHP/CESM: ' // TRIM(name) // '. Replace ' // &
                       'wildcard with a specific tag.'
              CALL GC_Error( ErrMsg, RC, ThisLoc )
              RETURN


### PR DESCRIPTION
Hi GCST, this is a simple change accompanying https://github.com/CESM-GC/CAM/pull/11 to disallow wildcards in HISTORY.rc when running within CESM.

We've adopted similar HistoryExports diagnostics to GCHP so when GCHP starts supporting this, the check can be removed for CESM as well. 

Thanks!
Haipeng