### PR TITLE
Close GEOS-Chem Classic restart files to disk immediately after writing -- Closes #1464

### DIFF
--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -890,6 +890,36 @@ PROGRAM GEOS_Chem
     ! Get dynamic timestep in seconds
     N_DYN  = GET_TS_DYN()
 
+    !---------------------------------------------------------------------
+    ! %%%%% HISTORY (netCDF diagnostics) %%%%%
+    !
+    ! Write HISTORY ITEMS in each diagnostic collection to disk
+    ! Appears at start of run to output instantaneous boundary conditions
+    ! at the start of the simulation with the correct time:
+    !---------------------------------------------------------------------
+    IF ( notDryRun ) THEN
+       IF ( Input_Opt%useTimers ) THEN
+          CALL Timer_Start( "All diagnostics",           RC )
+          CALL Timer_Start( "=> History (netCDF diags)", RC )
+       ENDIF
+
+       ! Write collections (such as BoundaryConditions) that need
+       ! to be defined at the start of the run
+       CALL History_Write( Input_Opt, State_Chm%Spc_Units, State_Diag, &
+                           State_Chm, RC )
+
+       ! Trap potential errors
+       IF ( RC /= GC_SUCCESS ) THEN
+          ErrMsg = 'Error encountered before timestepping in "History_Write"!'
+          CALL Error_Stop( ErrMsg, ThisLoc )
+       ENDIF
+
+       IF ( Input_Opt%useTimers ) THEN
+          CALL Timer_End( "All diagnostics",           RC )
+          CALL Timer_End( "=> History (netCDF diags)", RC )
+       ENDIF
+    ENDIF
+
     !========================================================================
     !         ***** D Y N A M I C   T I M E S T E P   L O O P *****
     !         *****    a k a   H E A R T B E A T   L O O P    *****
@@ -933,19 +963,6 @@ PROGRAM GEOS_Chem
           CALL Zero_Diagnostics_StartOfTimestep( Input_Opt, State_Diag, RC )
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Zero_Diagnostics_StartOfTimestep!"'
-             CALL Error_Stop( ErrMsg, ThisLoc )
-          ENDIF
-
-          ! Write HISTORY ITEMS in each diagnostic collection to disk
-          ! (or skip writing if it is not the proper output time.
-          ! Appears at start of run to output instantaneous boundary conditions
-          ! at the start of the simulation with the correct time:
-          CALL History_Write( Input_Opt, State_Chm%Spc_Units, State_Diag, &
-                              State_Chm, RC )
-
-          ! Trap potential errors
-          IF ( RC /= GC_SUCCESS ) THEN
-             ErrMsg = 'Error encountered before timestepping in "History_Write"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
           ENDIF
 


### PR DESCRIPTION
This is the companion PR to #1464.  We have modified `History/history_netcdf_mod.F90` so that restart files (i.e. belonging to the `Restart` collection of GEOS-Chem Classic History diagnostics) will be closed immediately after writing.  This will make sure that the latest restart file will be properly flushed to disk in case an abnormal exit necessitates a restarting of the simulation.

This is more of a quick fix than a permanent fix.  A more general method of ensuring proper file flushing for other diagnostic collection files will have to be implemented at a later date.

Integration tests pending.

Closes #1464