### PR TITLE
Turn off GEOS-Chem seasalt emissions in CESM

### DIFF
--- a/run/CESM/HEMCO_Config.rc
+++ b/run/CESM/HEMCO_Config.rc
@@ -172,7 +172,7 @@ Warnings:                    1
 105     DustDead               : off   DST1/DST2/DST3/DST4
     --> Mass tuning factor     :       4.7586e-4
 106     DustGinoux             : off   DST1/DST2/DST3/DST4
-107     SeaSalt                : on    SALA/SALC/SALACL/SALCCL/SALAAL/SALCAL/BRSALA/BRSALC/MOPO/MOPI
+107     SeaSalt                : off   SALA/SALC/SALACL/SALCCL/SALAAL/SALCAL/BRSALA/BRSALC/MOPO/MOPI
     --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5
     --> SALC lower radius      :       0.5


### PR DESCRIPTION
This pull request is a bug fix to turn off seasalt emissions in GEOS-Chem within CESM. Seasalt emissions are handled in CESM external to GEOS-Chem.