### PR TITLE
Update CH4 lake emission files to correct for wrong time units

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
@@ -353,10 +353,10 @@ Warnings:                    1
 )))SEEPS
 
 #==============================================================================
-# --- Emissions from Lakes (Maasakkers et al., in prep) ---
+# --- Emissions from Lakes (Maasakkers et al., 2019) ---
 #==============================================================================
 (((LAKES
-0 CH4_LAKES $ROOT/CH4/v2017-10/Lakes/Maasakkers_Lakes_$YYYY.01x01.nc emi_ch4 $YYYY/1-12/1/0 C xy molec/cm2/s CH4 - 12 1
+0 CH4_LAKES $ROOT/CH4/v2022-11/Lakes/Maasakkers_Lakes_$YYYY.01x01.nc emi_ch4 $YYYY/1-12/1/0 C xy molec/cm2/s CH4 - 12 1
 )))LAKES
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
@@ -477,11 +477,11 @@ Warnings:                    1
 )))SEEPS
 
 #==============================================================================
-# --- Emissions from Lakes (Maasakkers et al., in prep) ---
+# --- Emissions from Lakes (Maasakkers et al., 2019) ---
 #==============================================================================
 (((LAKES
-0 CH4_LAKES_T $ROOT/CH4/v2017-10/Lakes/Maasakkers_Lakes_$YYYY.01x01.nc emi_ch4 $YYYY/1-12/1/0 C xy molec/cm2/s CH4_LAK - 12 1
-0 CH4_LAKES   $ROOT/CH4/v2017-10/Lakes/Maasakkers_Lakes_$YYYY.01x01.nc emi_ch4 $YYYY/1-12/1/0 C xy molec/cm2/s CH4     - 12 1
+0 CH4_LAKES_T $ROOT/CH4/v2022-11/Lakes/Maasakkers_Lakes_$YYYY.01x01.nc emi_ch4 $YYYY/1-12/1/0 C xy molec/cm2/s CH4_LAK - 12 1
+0 CH4_LAKES   $ROOT/CH4/v2022-11/Lakes/Maasakkers_Lakes_$YYYY.01x01.nc emi_ch4 $YYYY/1-12/1/0 C xy molec/cm2/s CH4     - 12 1
 )))LAKES
 
 #==============================================================================


### PR DESCRIPTION
The original lake emission files in HEMCO/CH4/v2017-10 had the wrong time units as reported in https://github.com/geoschem/geos-chem/issues/1523. Here the CH4_LAKES file paths are updated to use the corrected files.