### PR TITLE
Fix list of Complex SOA species checked in input_mod.F90

### DIFF
--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -5905,7 +5905,14 @@ CONTAINS
         MAX( Ind_('ASOA1','A'), 0 ) + &
         MAX( Ind_('ASOA2','A'), 0 ) + &
         MAX( Ind_('ASOA3','A'), 0 ) + &
-        MAX( Ind_('ASOAN','A'), 0 )
+        MAX( Ind_('ASOAN','A'), 0 ) + &
+        MAX( Ind_('ASOG1','A'), 0 ) + &
+        MAX( Ind_('ASOG2','A'), 0 ) + &
+        MAX( Ind_('ASOG3','A'), 0 ) + &
+        MAX( Ind_('TSOG0','A'), 0 ) + &
+        MAX( Ind_('TSOG1','A'), 0 ) + &
+        MAX( Ind_('TSOG2','A'), 0 ) + &
+        MAX( Ind_('TSOG3','A'), 0 )
 
     IF ( Input_Opt%LSOA ) THEN
        IF ( I == 0 ) THEN


### PR DESCRIPTION
Hi GCST,

This is a minor change to `input_mod.F90` to update the list of Complex SOA species checked in a safety check in `input_mod.F90` to be consistent with the run directory creation process.

The original check only included some of the species; the `createRunDir.sh` script has the full list:
```
	# Add complex SOA species ASOA* and ASOG* following ALK4
        prev_line='      - ALK4'
        new_line='\      - ASOA1\
      - ASOA2\
      - ASOA3\
      - ASOAN\
      - ASOG1\
      - ASOG2\
      - ASOG3
'
        insert_text "${prev_line}" "${new_line}" geoschem_config.yml

	# Add complex SOA species TSOA* and TSOG* following TOLU
        prev_line='      - TOLU'
        new_line='\      - TSOA0\
      - TSOA1\
      - TSOA2\
      - TSOA3\
      - TSOG0\
      - TSOG1\
      - TSOG2\
      - TSOG3
```

So I updated `input_mod.F90`'s failsafe check to include all of these species, so that the error reporting is more robust.

This update introduces no differences and should have no effect on existing, correctly-built simulations.
