### PR TITLE
Fix parsing error for ObsPack diagnostic species in input_mod.F90 -- Closes #1542

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file documents all notable changes to the GEOS-Chem repository since versio
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 14.1.0]
+### Fixed
+  - Now use a string array for reading the list of ObsPack diagnostic
+    species (in `GeosCore/input_mod.F90`)
+
+
 ## [14.0.2] - 2022-11-29
 ### Fixed
   - Added fix for writing dry-run header to log file

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -3746,7 +3746,8 @@ CONTAINS
     !------------------------------------------------------------------------
     key   = "extra_diagnostics%obspack%output_species"
     a_str = MISSING_STR
-    CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
+    CALL QFYAML_Add_Get( Config, TRIM( key ), a_str,                         &
+                         "",     RC,          dynamic_size=.TRUE.           )
     IF ( RC /= GC_SUCCESS ) THEN
        errMsg = 'Error parsing ' // TRIM( key ) // '!'
        CALL GC_Error( errMsg, RC, thisLoc )


### PR DESCRIPTION
This is the corresponding PR for issue #1542.  We have modified `GeosCore/input_mod.F90` so that a string array is used to hold the ObsPack diagnostic species that are read from `geoschem_config.yml`.  (Previously, this was being saved to a scalar string variable which caused the error as described in #1542.)

Closes #1542 