### PR TITLE
Fix GCHP bug where fraction snow all zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Fixed products in HOBr + SO2 and HOCl + SO2 reactions
   - Changed MW_g value of CH4 from 16.05 to 16.04
   - Added "WD_CoarseAer:true" for SO4s and NITs in species_database.yml
-  -Fixed bug in computing State_Met surface type logicals (IsLand, IsWater, etc)
+  - Fixed bug in computing State_Met surface type logicals (IsLand, IsWater, etc)
+  - Fixed bug where State_Met%FRSNO (fraction snow) was all zeros in GCHP
 
 
 ## [14.0.2] - 2022-11-29

--- a/Interfaces/GCHP/Includes_Before_Run.H
+++ b/Interfaces/GCHP/Includes_Before_Run.H
@@ -37,6 +37,7 @@
   State_Met%FRLAKE              = FRLAKE                     ! 1
   State_Met%FRLANDIC            = FRLANDIC                   ! 1
   State_Met%FRSEAICE            = FRSEAICE                   ! 1
+  State_Met%FRSNO               = FRSNO                      ! 1
   State_Met%QV2M                = QV2M                       ! 1
   State_Met%PHIS                = PHIS / 9.80665d0           ! m
   State_Met%GWETROOT            = GWETROOT                   ! 1


### PR DESCRIPTION
This pull request fixes a bug in GCHP in which snow fraction stored in `State_Met%FRSNO` is all zeros. With this update the field is assigned values from import `FRSNO` at the start of every timestep. Previously that code was erroneously missing.

Closes https://github.com/geoschem/GCHP/issues/277