### PR TITLE
Removal of module variables from ucx_mod

### DIFF
--- a/GeosCore/aerosol_mod.F90
+++ b/GeosCore/aerosol_mod.F90
@@ -186,7 +186,6 @@ CONTAINS
     USE State_Diag_Mod,    ONLY : DgnState
     USE State_Grid_Mod,    ONLY : GrdState
     USE State_Met_Mod,     ONLY : MetState
-    USE UCX_MOD,           ONLY : KG_STRAT_AER
     USE UnitConv_Mod,      ONLY : Convert_Spc_Units
     USE TIME_MOD,          ONLY : GET_MONTH
 #ifdef TOMAS
@@ -250,6 +249,7 @@ CONTAINS
     REAL(fp),      POINTER   :: PMID(:,:,:)
     REAL(fp),      POINTER   :: T(:,:,:)
     REAL(fp),      POINTER   :: SOILDUST(:,:,:,:)
+    REAL(fp),      POINTER   :: KG_STRAT_AER(:,:,:,:)
 
     ! Other variables
     CHARACTER(LEN=63)   :: OrigUnit
@@ -320,6 +320,7 @@ CONTAINS
     PMID     => State_Met%PMID
     T        => State_Met%T
     SOILDUST => State_Chm%SoilDust
+    KG_STRAT_AER => State_Chm%KG_AER
 
     !=================================================================
     ! OM/OC ratio
@@ -1062,7 +1063,6 @@ CONTAINS
     USE TIME_MOD,       ONLY : ITS_A_NEW_MONTH
     USE TIME_MOD,       ONLY : SYSTEM_TIMESTAMP
     USE UCX_MOD,        ONLY : GET_STRAT_OPT
-    USE UCX_MOD,        ONLY : NDENS_AER
     USE Species_Mod,    ONLY : Species
 
     IMPLICIT NONE
@@ -1722,7 +1722,7 @@ CONTAINS
                 !--------------------------------------------------------
 
                 ! Get aerosol effective radius
-                CALL GET_STRAT_OPT(I, J, L, ISTRAT, RAER, REFF, &
+                CALL GET_STRAT_OPT(State_Chm, I, J, L, ISTRAT, RAER, REFF, &
                                    SADSTRAT, XSASTRAT)
 
                 ! SDE 2014-02-04
@@ -1950,7 +1950,7 @@ CONTAINS
        DO I = 1, State_Grid%NX
 
           ! Get aerosol effective radius
-          CALL GET_STRAT_OPT(I,J,L,ISTRAT,RAER,REFF,SADSTRAT,XSASTRAT)
+          CALL GET_STRAT_OPT(State_Chm, I,J,L,ISTRAT,RAER,REFF,SADSTRAT,XSASTRAT)
 
           ! Moved this from a separate loop for clarity
           IF ( State_Met%InChemGrid(I,J,L) ) THEN
@@ -1986,7 +1986,7 @@ CONTAINS
              IF ( IsSLA ) THEN
                 IF ( State_Diag%Archive_AerNumDenSLA ) THEN
                    State_Diag%AerNumDenSLA(I,J,L) = &
-                        NDENS_AER(I,J,L,ISTRAT)*1.d-6
+                        State_Chm%NDENS_AER(I,J,L,ISTRAT)*1.d-6
                 ENDIF
                 IF ( State_Diag%Archive_AODSLAWL1 ) THEN
                    State_Diag%AODSLAWL1(I,J,L) = &
@@ -2003,7 +2003,7 @@ CONTAINS
              ELSEIF ( IsPSC ) THEN
                 IF ( State_Diag%Archive_AerNumDenPSC ) THEN
                    State_Diag%AerNumDenPSC(I,J,L) = &
-                        NDENS_AER(I,J,L,ISTRAT)*1.d-6
+                        State_Chm%NDENS_AER(I,J,L,ISTRAT)*1.d-6
                 ENDIF
                 IF ( State_Diag%Archive_AODPSCWL1 ) THEN
                    State_Diag%AODPSCWL1(I,J,L) = &

--- a/GeosCore/cleanup.F90
+++ b/GeosCore/cleanup.F90
@@ -43,7 +43,6 @@ SUBROUTINE CLEANUP( Input_Opt, State_Grid, ERROR, RC )
   USE SULFATE_MOD,             ONLY : CLEANUP_SULFATE
   USE State_Grid_Mod,          ONLY : GrdState
   USE TAGGED_CO_MOD,           ONLY : CLEANUP_TAGGED_CO
-  USE UCX_MOD,                 ONLY : CLEANUP_UCX
   USE EMISSIONS_MOD,           ONLY : EMISSIONS_FINAL
   USE SFCVMR_MOD,              ONLY : FixSfcVmr_Final
   USE VDiff_Mod,               ONLY : Cleanup_Vdiff
@@ -116,11 +115,6 @@ SUBROUTINE CLEANUP( Input_Opt, State_Grid, ERROR, RC )
      CALL GC_Error( ErrMsg, RC, ThisLoc )
      RETURN
   ENDIF
-
-  ! UCX needs to be cleaned up before emissions, because the UCX
-  ! restart variables needs to be passed to the HEMCO diagnostics
-  ! first.
-  CALL CLEANUP_UCX()
 
   !=================================================================
   ! Cleanup HEMCO

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -586,7 +586,7 @@ CONTAINS
 
           ! Get the fraction of H2SO4 that is available for photolysis
           ! (this is only valid for UCX-enabled mechanisms)
-          SO4_FRAC = SO4_PHOTFRAC( I, J, L )
+          SO4_FRAC = SO4_PHOTFRAC( I, J, L, State_Chm )
 
           ! Adjust certain photolysis rates:
           ! (1) H2SO4 + hv -> SO2 + OH + OH   (UCX-based mechanisms)

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -604,8 +604,11 @@ CONTAINS
     INTEGER,        INTENT(IN)    :: TARG_MONTH
     TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input options
     TYPE(GrdState), INTENT(IN)    :: State_Grid  ! Grid State object
-    TYPE(ChmState), INTENT(IN)    :: State_Chm   ! Chemistry State object
     TYPE(MetState), INTENT(IN)    :: State_Met   ! Meteorology State object
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
 !
 ! !REMARKS:
 !  At some later point we should attempt to rewrite the parallel DO loop so
@@ -1514,7 +1517,11 @@ CONTAINS
 ! !INPUT PARAMETERS:
 !
     INTEGER,  INTENT(IN)  :: I,J,L      ! Location indices
-    TYPE(ChmState), INTENT(IN) :: State_Chm   ! Chemistry State object
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+
+    TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
 !
 ! !OUTPUT VARIABLES:
 !

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -50,7 +50,6 @@ MODULE UCX_MOD
 ! !PUBLIC DATA MEMBERS:
 !
   PUBLIC :: T_STS          ! Max temperature of STS formation (K)
-  PUBLIC :: NDENS_AER      ! See below
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
@@ -61,10 +60,7 @@ MODULE UCX_MOD
   PUBLIC  :: UCX_H2SO4PHOT
   PUBLIC  :: CALC_STRAT_AER
   PUBLIC  :: GET_STRAT_OPT
-  PUBLIC  :: KG_STRAT_AER
-  PUBLIC  :: RHO_STRAT_AER
   PUBLIC  :: INIT_UCX
-  PUBLIC  :: CLEANUP_UCX
 !
 ! PRIVATE MEMBER FUNCTIONS:
 !
@@ -125,20 +121,20 @@ MODULE UCX_MOD
   ! ISR_HOCl           : HOCl MW (inverse sqrt) (kg/kmol)^-0.5
   ! ISR_HOBr           : HOBr MW (inverse sqrt) (kg/kmol)^-0.5
   !
-  ! Arrays
+  ! Arrays (now moved to State_Chm object)
   !
-  ! UCX_PLEVS          : Pressure levels of 2D data (hPa)
-  ! UCX_LATS           : Latitude edges of 2D data (deg)
-  ! RAD_AER            : Strat. aerosol radius (cm)
-  ! KG_AER             : Aerosol mass (kg/box)
-  ! SAD_AER            : Aerosol surface area density (cm2/cm3)
-  ! NDENS_AER          : Aerosol number density (#/m3)
-  ! RHO_AER            : Aerosol mass density (kg/m3 aerosol)
-  ! AERFRAC            : Mass fraction of species in liquid aerosols
-  ! AERFRACIND         : Indices of liquid aerosol species
-  ! NOX_O              : Monthly mean noontime O3P/O1D for NOx calcs
-  ! NOX_J              : Monthly mean noontime J-rates for NOx calcs
-  ! SO4_TOPPHOT        : Photolysis rate at the top of the chemgrid (1/s)
+  ! State_Chm%UCX_PLEVS          : Pressure levels of 2D data (hPa)
+  ! State_Chm%UCX_LATS           : Latitude edges of 2D data (deg)
+  ! State_Chm%RAD_AER            : Strat. aerosol radius (cm)
+  ! State_Chm%KG_AER             : Aerosol mass (kg/box)
+  ! State_Chm%SAD_AER            : Aerosol surface area density (cm2/cm3)
+  ! State_Chm%NDENS_AER          : Aerosol number density (#/m3)
+  ! State_Chm%RHO_AER            : Aerosol mass density (kg/m3 aerosol)
+  ! State_Chm%AERFRAC            : Mass fraction of species in liquid aerosols
+  ! State_Chm%AERFRACIND         : Indices of liquid aerosol species
+  ! State_Chm%NOX_O              : Monthly mean noontime O3P/O1D for NOx calcs
+  ! State_Chm%NOX_J              : Monthly mean noontime J-rates for NOx calcs
+  ! State_Chm%SO4_TOPPHOT        : Photolysis rate at the top of the chemgrid (1/s)
   !
   !=================================================================
 
@@ -155,36 +151,6 @@ MODULE UCX_MOD
   REAL(fp), PARAMETER  :: ISR_N2O5 =1.e+0_fp/sqrt(108.0e+0_fp)
   REAL(fp), PARAMETER  :: ISR_HOCl =1.e+0_fp/sqrt(52.46e+0_fp)
   REAL(fp), PARAMETER  :: ISR_HOBr =1.e+0_fp/sqrt(96.91e+0_fp)
-
-  ! Arrays
-  REAL(fp),DIMENSION(:,:),ALLOCATABLE     :: UCX_REGRID
-  REAL(fp),DIMENSION(:),ALLOCATABLE       :: UCX_PLEVS
-  REAL(fp),DIMENSION(:),ALLOCATABLE       :: UCX_LATS
-  REAL(fp),DIMENSION(:,:,:,:),ALLOCATABLE :: RAD_AER
-  REAL(fp),DIMENSION(:,:,:,:),ALLOCATABLE :: KG_AER
-  REAL(fp),DIMENSION(:,:,:,:),ALLOCATABLE :: SAD_AER
-  REAL(fp),DIMENSION(:,:,:,:),ALLOCATABLE :: NDENS_AER
-  REAL(fp),DIMENSION(:,:,:,:),ALLOCATABLE :: RHO_AER
-  REAL(fp),DIMENSION(:,:,:,:),ALLOCATABLE :: AERFRAC
-  INTEGER,DIMENSION(:),ALLOCATABLE      :: AERFRACIND
-  REAL(fp),DIMENSION(:,:,:,:),ALLOCATABLE :: NOX_O
-  REAL(fp),DIMENSION(:,:,:,:),ALLOCATABLE :: NOX_J
-  REAL(fp),DIMENSION(:,:),ALLOCATABLE     :: SO4_TOPPHOT
-
-  !=================================================================
-  ! Variables to use NOx coefficients in ESMF / grid-independent
-  ! envionment. The NOx coefficients are climatological 2D
-  ! (lat/lev/12 months) data that are currently available for
-  ! horizontal (latitude) resolutions of 2 and 4 degrees. For other
-  ! resolutions, the horizontal data becomes mapped onto the
-  ! simulation grid (see GET_JJNOX).
-  ! Similar to the surface mixing ratio boundary conditions, we now
-  ! read all the NOx coefficients during initialization to avoid
-  ! additional I/O calls during run time (ckeller, 05/12/2014).
-  !=================================================================
-  REAL(fp), ALLOCATABLE, TARGET :: NOXCOEFF(:,:,:,:)
-  REAL(fp), ALLOCATABLE         :: NOXLAT(:)
-  INTEGER                     :: JJNOXCOEFF
 
   !=================================================================
   ! Species ID flags
@@ -335,7 +301,7 @@ CONTAINS
     ! Retrieve monthly mean data if necessary
     IF (LASTMONTH.ne.GET_MONTH()) THEN
        LASTMONTH = GET_MONTH()
-       CALL GET_NOXCOEFF( LASTMONTH, Input_Opt, State_Grid, State_Met)
+       CALL GET_NOXCOEFF( LASTMONTH, Input_Opt, State_Grid, State_Chm, State_Met )
     ENDIF
 
     ! Get chemistry step length in seconds
@@ -476,13 +442,13 @@ CONTAINS
           ! 1:  NO2 + O -> NO + O2
           RRATE(1)  = 5.1e-12_fp*exp(210.e+0_fp*TINV)
           ! 4:  NO2 + hv -> NO + O1D
-          !RRATE(k_JNO2) = NOX_J(I,J,L,JNO2IDX)*DAYFRAC
+          !RRATE(k_JNO2) = State_Chm%NOX_J(I,J,L,JNO2IDX)*DAYFRAC
           RRATE(k_JNO2) = ZPJ(LMINPHOT,RXN_NO2,I,J)
           ! 5:  NO3 + hv -> NO2 + O
-          !RRATE(k_JNO3) = NOX_J(I,J,L,JNO3IDX)*DAYFRAC
+          !RRATE(k_JNO3) = State_Chm%NOX_J(I,J,L,JNO3IDX)*DAYFRAC
           RRATE(k_JNO3) = ZPJ(LMINPHOT,RXN_NO3,I,J)
           ! 6:  NO + hv -> N + O
-          !RRATE(k_JNO ) = NOX_J(I,J,L,JNOIDX)*DAYFRAC
+          !RRATE(k_JNO ) = State_Chm%NOX_J(I,J,L,JNOIDX)*DAYFRAC
           RRATE(k_JNO) = ZPJ(LMINPHOT,RXN_NO,I,J)
           ! 7:  N + NO2 -> N2O + O
           RRATE(7)  = 5.8e-12_fp*exp(220.e+0_fp*TINV)
@@ -495,7 +461,7 @@ CONTAINS
           ! 11:  N2O + O1D -> 2NO
           RRATE(11) = 7.25e-11_fp*exp(20.e+0_fp*TINV)
           ! 12:  N2O + hv -> N2 + O1D
-          !RRATE(k_JN2O) = NOX_J(I,J,L,JN2OIDX)*DAYFRAC
+          !RRATE(k_JN2O) = State_Chm%NOX_J(I,J,L,JN2OIDX)*DAYFRAC
           RRATE(k_JN2O) = ZPJ(LMINPHOT,RXN_N2O,I,J)
 
           ! Sanity check
@@ -503,8 +469,8 @@ CONTAINS
 
           ! Retrieve local O3P/O1D mixing ratios and relevant
           ! j-rates from interpolated 2D arrays
-          LOCALO3P = NOX_O(I,J,L,1)*NDAIR*DAYFRAC
-          LOCALO1D = NOX_O(I,J,L,2)*NDAIR*DAYFRAC
+          LOCALO3P = State_Chm%NOX_O(I,J,L,1)*NDAIR*DAYFRAC
+          LOCALO1D = State_Chm%NOX_O(I,J,L,2)*NDAIR*DAYFRAC
 
           ! Partition NOx into N, NO, NO2 and NO3 based on PSSA
           ! Two cases: Daytime/nighttime
@@ -621,7 +587,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE GET_NOXCOEFF( TARG_MONTH, Input_Opt, State_Grid, State_Met )
+  SUBROUTINE GET_NOXCOEFF( TARG_MONTH, Input_Opt, State_Grid, State_Chm, State_Met )
 !
 ! !USES:
 !
@@ -630,6 +596,7 @@ CONTAINS
     USE FILE_MOD,           ONLY : IOERROR
     USE Input_Opt_Mod,      ONLY : OptInput
     USE State_Grid_Mod,     ONLY : GrdState
+    USE State_Chm_Mod,      ONLY : ChmState
     USE State_Met_Mod,      ONLY : MetState
 !
 ! !INPUT PARAMETERS:
@@ -637,6 +604,7 @@ CONTAINS
     INTEGER,        INTENT(IN)    :: TARG_MONTH
     TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input options
     TYPE(GrdState), INTENT(IN)    :: State_Grid  ! Grid State object
+    TYPE(ChmState), INTENT(IN)    :: State_Chm   ! Chemistry State object
     TYPE(MetState), INTENT(IN)    :: State_Met   ! Meteorology State object
 !
 ! !REMARKS:
@@ -687,13 +655,13 @@ CONTAINS
     prtDebug = ( Input_Opt%LPRT .and. Input_Opt%amIRoot )
 
     ! Clear interpolated arrays
-    NOX_O = 0e+0_fp
-    NOX_J = 0e+0_fp
+    State_Chm%NOX_O = 0e+0_fp
+    State_Chm%NOX_J = 0e+0_fp
 
-    ! All the coefficients are now stored in NOXCOEFF.
+    ! All the coefficients are now stored in State_Chm%NOXCOEFF.
     ! NOXDATA2D points to the desired month slice.
     ! (ckeller, 05/12/14)
-    NOXDATA2D => NOXCOEFF(:,:,:,TARG_MONTH)
+    NOXDATA2D => State_Chm%NOXCOEFF(:,:,:,TARG_MONTH)
 
     ! Scan through target array, element by element
     !$OMP PARALLEL DO       &
@@ -706,7 +674,7 @@ CONTAINS
 
        ! Get corresponding J value in NOXDATA2D. This can be different
        ! from J if the simulation grid is not 2x25 or 4x5.
-       JJNOX = GET_JJNOX( I, J, State_Grid )
+       JJNOX = GET_JJNOX( I, J, State_Grid, State_Chm )
 
        ! Vertcount is the layer count for the input, where layer 1
        ! is at the *top* of the atmosphere
@@ -719,7 +687,7 @@ CONTAINS
 
           ! Pressure at center of cell
           PCENTER = State_Met%PMID(I,J,L)
-          FOUNDLEV = (PCENTER.gt.UCX_PLEVS(VERTCOUNT))
+          FOUNDLEV = (PCENTER.gt.State_Chm%UCX_PLEVS(VERTCOUNT))
           DO WHILE (.not. FOUNDLEV)
              IF (VERTCOUNT.eq.1) THEN
                 ! At top layer; use it anyway
@@ -727,7 +695,7 @@ CONTAINS
                 EXTRAP = .TRUE.
              ELSE
                 VERTCOUNT = VERTCOUNT - 1
-                FOUNDLEV = (PCENTER.gt.UCX_PLEVS(VERTCOUNT))
+                FOUNDLEV = (PCENTER.gt.State_Chm%UCX_PLEVS(VERTCOUNT))
                 EXTRAP = .FALSE.
              ENDIF
           ENDDO
@@ -740,8 +708,8 @@ CONTAINS
                 CURRVAL = NOXDATA2D(JJNOX,VERTCOUNT,ITRAC)
              ELSE
                 ! Interpolate by pressure
-                CURRVAL = (UCX_PLEVS(VERTCOUNT+1)-PCENTER)
-                CURRVAL = CURRVAL/(UCX_PLEVS(VERTCOUNT+1)-UCX_PLEVS(VERTCOUNT))
+                CURRVAL = (State_Chm%UCX_PLEVS(VERTCOUNT+1)-PCENTER)
+                CURRVAL = CURRVAL/(State_Chm%UCX_PLEVS(VERTCOUNT+1)-State_Chm%UCX_PLEVS(VERTCOUNT))
                 CURRVAL = CURRVAL * &
                           (NOXDATA2D(JJNOX,VERTCOUNT+1,ITRAC)- &
                            NOXDATA2D(JJNOX,VERTCOUNT,ITRAC))
@@ -749,10 +717,10 @@ CONTAINS
              ENDIF
              IF (.not.ISRATE) THEN
                 ! Reading in mixing ratios (v/v)
-                NOX_O(I,J,L,ITRAC) = CURRVAL
+                State_Chm%NOX_O(I,J,L,ITRAC) = CURRVAL
              ELSE
                 ! J-rate (no conversion necessary)
-                NOX_J(I,J,L,ITRAC-2) = CURRVAL
+                State_Chm%NOX_J(I,J,L,ITRAC-2) = CURRVAL
              ENDIF
           ENDDO ! ITRAC
        ENDDO ! L
@@ -958,11 +926,11 @@ CONTAINS
              RHO(IBC) = BCDEN
 
              ! Get aerosol properties
-             RWET(ILIQ) = RAD_AER(I,J,L,I_SLA)*1.e-2_fp
-             RHO(ILIQ)  = RHO_AER(I,J,L,I_SLA)
+             RWET(ILIQ) = State_Chm%RAD_AER(I,J,L,I_SLA)*1.e-2_fp
+             RHO(ILIQ)  = State_Chm%RHO_AER(I,J,L,I_SLA)
 
              ! Do we need to sediment NAT?
-             IF (NDENS_AER(I,J,L,I_SPA).gt.TINY(0e+0_fp)) THEN
+             IF (State_Chm%NDENS_AER(I,J,L,I_SPA).gt.TINY(0e+0_fp)) THEN
                 NATCOL = .TRUE.
                 BXMIN  = MIN(BXMIN, State_Met%BXHEIGHT(I,J,L))
                 MINALT = MIN(L,MINALT)
@@ -1032,8 +1000,8 @@ CONTAINS
              ! Now solid PSC particles
              IF (NATCOL) THEN
                 ! sp_Num: Air molecule#/m3
-                VNAT(L) = CALC_FALLVEL(RHO_AER(I,J,L,I_SPA), &
-                          RAD_AER(I,J,L,I_SPA),TEMP,P)
+                VNAT(L) = CALC_FALLVEL(State_Chm%RHO_AER(I,J,L,I_SPA), &
+                          State_Chm%RAD_AER(I,J,L,I_SPA),TEMP,P)
                 IF (VNAT(L).gt.VFALLMAX) VFALLMAX = VNAT(L)
              ELSE
                 VNAT(L) = 0.e+0_fp
@@ -1057,13 +1025,13 @@ CONTAINS
        ! in the aerosol
        DO K = 1,7
           ! Only process transported species
-          IDTCURRENT = AERFRACIND(K)
+          IDTCURRENT = State_Chm%AERFRACIND(K)
           IF (IDTCURRENT.ne.0) THEN
              ! Calculate local phase partitioning
              ! Total upper gridbox mass
              PHASEMASS(3,2) = Spc(IDTCURRENT)%Conc(I,J,L)
              ! Aerosol-phase upper gridbox mass
-             PHASEMASS(2,2) = AERFRAC(I,J,L,K)*PHASEMASS(3,2)
+             PHASEMASS(2,2) = State_Chm%AERFRAC(I,J,L,K)*PHASEMASS(3,2)
              ! Gas-phase upper gridbox mass
              PHASEMASS(1,2) = PHASEMASS(3,2) - PHASEMASS(2,2)
 
@@ -1076,9 +1044,9 @@ CONTAINS
 
              ! Recalculate phase fractions
              IF (PHASEMASS(3,2).gt.TINY(1e+0_fp)) THEN
-                AERFRAC(I,J,L,K) = PHASEMASS(2,2)/PHASEMASS(3,2)
+                State_Chm%AERFRAC(I,J,L,K) = PHASEMASS(2,2)/PHASEMASS(3,2)
              ELSE
-                AERFRAC(I,J,L,K) = 0e+0_fp
+                State_Chm%AERFRAC(I,J,L,K) = 0e+0_fp
              ENDIF
 
              ! Store result
@@ -1093,19 +1061,19 @@ CONTAINS
           DELZ1 = State_Met%BXHEIGHT(I,J,L+1)
 
           DO K=1,7
-             IDTCURRENT = AERFRACIND(K)
+             IDTCURRENT = State_Chm%AERFRACIND(K)
              IF (IDTCURRENT.ne.0) THEN
                 ! Total upper gridbox mass
                 PHASEMASS(3,2) = Spc(IDTCURRENT)%Conc(I,J,L+1)
                 ! Aerosol-phase upper gridbox mass
-                PHASEMASS(2,2) = AERFRAC(I,J,L+1,K)*PHASEMASS(3,2)
+                PHASEMASS(2,2) = State_Chm%AERFRAC(I,J,L+1,K)*PHASEMASS(3,2)
                 ! Gas-phase upper gridbox mass
                 PHASEMASS(1,2) = PHASEMASS(3,2) - PHASEMASS(2,2)
 
                 ! Total lower gridbox mass
                 PHASEMASS(3,1) = Spc(IDTCURRENT)%Conc(I,J,L)
                 ! Aerosol-phase lower gridbox mass
-                PHASEMASS(2,1) = AERFRAC(I,J,L,K)*PHASEMASS(3,1)
+                PHASEMASS(2,1) = State_Chm%AERFRAC(I,J,L,K)*PHASEMASS(3,1)
                 ! Gas-phase lower gridbox mass
                 PHASEMASS(1,1) = PHASEMASS(3,1) - PHASEMASS(2,1)
 
@@ -1120,9 +1088,9 @@ CONTAINS
 
                 ! Recalculate phase fraction
                 IF (PHASEMASS(3,1).gt.TINY(1e+0_fp)) THEN
-                   AERFRAC(I,J,L,K) = PHASEMASS(2,1)/PHASEMASS(3,1)
+                   State_Chm%AERFRAC(I,J,L,K) = PHASEMASS(2,1)/PHASEMASS(3,1)
                 ELSE
-                   AERFRAC(I,J,L,K) = 0e+0_fp
+                   State_Chm%AERFRAC(I,J,L,K) = 0e+0_fp
                 ENDIF
 
                 ! Store result
@@ -1167,7 +1135,7 @@ CONTAINS
                 XNO3_0 = Spc(id_NIT)%Conc(I,J,L) * AIRMW / &
                          ( NIT_MW_G * State_Met%AD(I,J,L) )
                 XNAT_0 = XNO3_0! * 4.e+0_fp
-                XICE_0 = (KG_AER(I,J,L,I_SPA)- &
+                XICE_0 = (State_Chm%KG_AER(I,J,L,I_SPA)- &
                          ( ( NATMW / NIT_MW_G ) * &
                          Spc(id_NIT)%Conc(I,J,L)))*AIRMW/(ICEMW* &
                          State_Met%AD(I,J,L))
@@ -1186,9 +1154,9 @@ CONTAINS
                                 * INVAIR_ABOVE / NIT_MW_G
                    ! NAT = HNO3.3H2O = 4 molecules
                    XNAT_ABOVE = XNO3_ABOVE! * 4.e+0_fp
-                   ! XICE_ABOVE = (KG_AER(I,J,L+1,I_SPA)-Spc(id_NIT)%Conc(I,J,L+1)) &
+                   ! XICE_ABOVE = (State_Chm%KG_AER(I,J,L+1,I_SPA)-Spc(id_NIT)%Conc(I,J,L+1)) &
                    !                            *INVAIR_ABOVE/ICEMW
-                   XICE_ABOVE = (KG_AER(I,J,L+1,I_SPA)- &
+                   XICE_ABOVE = (State_Chm%KG_AER(I,J,L+1,I_SPA)- &
                                 ( ( NATMW / NIT_MW_G ) * &
                                 Spc(id_NIT)%Conc(I,J,L+1)))*INVAIR_ABOVE/ICEMW
                 ENDIF
@@ -1237,7 +1205,7 @@ CONTAINS
                    IF (STATE_PSC(I,J,L+2) >= 2.0e+0_f4 ) THEN
                       XNO3_ABOVE = Spc(id_NIT)%Conc(I,J,L+2)*INVAIR_ABOVE/NIT_MW_G
                       XNAT_ABOVE = XNO3_ABOVE! * 4.e+0_fp
-                      XICE_ABOVE = (KG_AER(I,J,L+2,I_SPA)- &
+                      XICE_ABOVE = (State_Chm%KG_AER(I,J,L+2,I_SPA)- &
                                    ( ( NATMW / NIT_MW_G )* &
                                    Spc(id_NIT)%Conc(I,J,L+2)))*INVAIR_ABOVE/ICEMW
                    ELSE
@@ -1361,9 +1329,9 @@ CONTAINS
                 ! Now correct aerosol totals
                 SEDNAT = SEDNO3 * NATMW / NIT_MW_G
                 SEDPSC = SEDNAT + SEDICE
-                SEDPSC = MIN(SEDPSC,KG_AER(I,J,L+1,I_SPA))
-                KG_AER(I,J,L,I_SPA) = KG_AER(I,J,L,I_SPA) + SEDPSC
-                KG_AER(I,J,L+1,I_SPA)=KG_AER(I,J,L+1,I_SPA)-SEDPSC
+                SEDPSC = MIN(SEDPSC,State_Chm%KG_AER(I,J,L+1,I_SPA))
+                State_Chm%KG_AER(I,J,L,I_SPA) = State_Chm%KG_AER(I,J,L,I_SPA) + SEDPSC
+                State_Chm%KG_AER(I,J,L+1,I_SPA)=State_Chm%KG_AER(I,J,L+1,I_SPA)-SEDPSC
 
              ENDDO SED_LLOOP
           ENDDO SEDSTEPLOOP
@@ -1488,10 +1456,10 @@ CONTAINS
 
        INVAIR  = AIRMW / State_Met%AD(I,J,L)
        IF (PCENTER.ge.1.e+2_fp) THEN
-          AERFRAC(I,J,L,1) = 1e+0_fp
+          State_Chm%AERFRAC(I,J,L,1) = 1e+0_fp
        ELSEIF ( State_Met%InTroposphere(I,J,L) ) THEN
           ! Don't want to interfere with tropospheric aerosols
-          AERFRAC(I,J,L,1) = 1e+0_fp
+          State_Chm%AERFRAC(I,J,L,1) = 1e+0_fp
        ELSE
           H2SO4SUM = Spc(id_SO4)%Conc(I,J,L) * INVAIR / SO4_MW_G
           ! Use approximation from Kumala (1990)
@@ -1505,11 +1473,11 @@ CONTAINS
           GF_PVAP = 1.e-2_fp * EXP(GF_LOGPSULFATE)
           GF_DIFF = (GF_PVAP+GF_THRESHOLD) - GF_PP
           IF (GF_DIFF .lt. 0) THEN
-             AERFRAC(I,J,L,1) = 1.e+0_fp
+             State_Chm%AERFRAC(I,J,L,1) = 1.e+0_fp
           ELSEIF (GF_DIFF .lt. GF_RANGE) THEN
-             AERFRAC(I,J,L,1) = 1.e+0_fp-(GF_DIFF/GF_RANGE)
+             State_Chm%AERFRAC(I,J,L,1) = 1.e+0_fp-(GF_DIFF/GF_RANGE)
           ELSE
-             AERFRAC(I,J,L,1) = 0e+0_fp
+             State_Chm%AERFRAC(I,J,L,1) = 0e+0_fp
           ENDIF
        ENDIF
     ENDDO
@@ -1537,11 +1505,16 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  REAL(fp) FUNCTION SO4_PHOTFRAC(I,J,L)
+  REAL(fp) FUNCTION SO4_PHOTFRAC(I,J,L,State_Chm)
+!
+! !USES:
+!
+    USE State_Chm_Mod,      ONLY : ChmState
 !
 ! !INPUT PARAMETERS:
 !
     INTEGER,  INTENT(IN)  :: I,J,L      ! Location indices
+    TYPE(ChmState), INTENT(IN) :: State_Chm   ! Chemistry State object
 !
 ! !OUTPUT VARIABLES:
 !
@@ -1558,7 +1531,7 @@ CONTAINS
     ! SO4_PHOTFRAC begins here!
     !=================================================================
 
-    SO4_PHOTFRAC = 1.e+0_fp - AERFRAC(I,J,L,1)
+    SO4_PHOTFRAC = 1.e+0_fp - State_Chm%AERFRAC(I,J,L,1)
 
   END FUNCTION SO4_PHOTFRAC
 !EOC
@@ -2041,11 +2014,11 @@ CONTAINS
        ENDIF
 
        ! Store in outer arrays
-       RAD_AER(I,J,L,I_SPA)   = RAD_AER_BOX*1.e+2_fp ! cm
-       RHO_AER(I,J,L,I_SPA)   = RHO_AER_BOX          ! kg/m3
-       KG_AER(I,J,L,I_SPA)    = KG_AER_BOX           ! kg
-       NDENS_AER(I,J,L,I_SPA) = NDENS_AER_BOX        !#/m3
-       SAD_AER(I,J,L,I_SPA)   = SAD_AER_BOX          ! cm2/cm3
+       State_Chm%RAD_AER(I,J,L,I_SPA)   = RAD_AER_BOX*1.e+2_fp ! cm
+       State_Chm%RHO_AER(I,J,L,I_SPA)   = RHO_AER_BOX          ! kg/m3
+       State_Chm%KG_AER(I,J,L,I_SPA)    = KG_AER_BOX           ! kg
+       State_Chm%NDENS_AER(I,J,L,I_SPA) = NDENS_AER_BOX        !#/m3
+       State_Chm%SAD_AER(I,J,L,I_SPA)   = SAD_AER_BOX          ! cm2/cm3
 
        ! Repartition NIT and HNO3 in strat/meso
        IF (LSOLIDPSC.and.IS_STRAT) THEN
@@ -2084,7 +2057,7 @@ CONTAINS
 
        ! H2SO4 gas fraction calculated earlier throughout grid
        ! Consider gaseoues H2SO4 to be unavailable for SLA
-       H2SO4_BOX_L = H2SO4SUM * AERFRAC(I,J,L,1)
+       H2SO4_BOX_L = H2SO4SUM * State_Chm%AERFRAC(I,J,L,1)
        H2SO4_BOX_G = H2SO4SUM - H2SO4_BOX_L
 
        ! Zero local properties
@@ -2190,35 +2163,35 @@ CONTAINS
        H2O_BOX_G = MAX(0e+0_fp,H2O_BOX_G-(H2O_BOX_L+H2O_BOX_S))
 
        ! If very low number density, ignore settling
-       AERFRAC(I,J,L,2) = 0e+0_fp
-       AERFRAC(I,J,L,3) = 0e+0_fp
-       AERFRAC(I,J,L,4) = 0e+0_fp
-       AERFRAC(I,J,L,5) = 0e+0_fp
-       AERFRAC(I,J,L,6) = 0e+0_fp
-       AERFRAC(I,J,L,7) = 0e+0_fp
+       State_Chm%AERFRAC(I,J,L,2) = 0e+0_fp
+       State_Chm%AERFRAC(I,J,L,3) = 0e+0_fp
+       State_Chm%AERFRAC(I,J,L,4) = 0e+0_fp
+       State_Chm%AERFRAC(I,J,L,5) = 0e+0_fp
+       State_Chm%AERFRAC(I,J,L,6) = 0e+0_fp
+       State_Chm%AERFRAC(I,J,L,7) = 0e+0_fp
 
        IF ((HNO3SUM.gt.1e+0_fp).and.(IS_SAFE_DIV(HNO3_BOX_L,HNO3SUM))) THEN
-          AERFRAC(I,J,L,2) = HNO3_BOX_L/HNO3SUM
+          State_Chm%AERFRAC(I,J,L,2) = HNO3_BOX_L/HNO3SUM
        ENDIF
 
        IF ((HClSUM.gt.1e+0_fp).and.(IS_SAFE_DIV(HCl_BOX_L,HClSUM))) THEN
-          AERFRAC(I,J,L,3) = HCl_BOX_L/HClSUM
+          State_Chm%AERFRAC(I,J,L,3) = HCl_BOX_L/HClSUM
        ENDIF
 
        IF ((HOClSUM.gt.1e+0_fp).and. (IS_SAFE_DIV(HOCl_BOX_L,HOClSUM))) THEN
-          AERFRAC(I,J,L,4) = HOCl_BOX_L/HOClSUM
+          State_Chm%AERFRAC(I,J,L,4) = HOCl_BOX_L/HOClSUM
        ENDIF
 
        IF ((HBrSUM.gt.1e+0_fp).and.(IS_SAFE_DIV(HBr_BOX_L,HBrSUM))) THEN
-          AERFRAC(I,J,L,5) = HBr_BOX_L/HBrSUM
+          State_Chm%AERFRAC(I,J,L,5) = HBr_BOX_L/HBrSUM
        ENDIF
 
        IF ((HOBrSUM.gt.1e+0_fp).and.(IS_SAFE_DIV(HOBr_BOX_L,HOBrSUM))) THEN
-          AERFRAC(I,J,L,6) = HOBr_BOX_L/HOBrSUM
+          State_Chm%AERFRAC(I,J,L,6) = HOBr_BOX_L/HOBrSUM
        ENDIF
 
        IF ((H2OSUM.gt.1e+0_fp).and.(IS_SAFE_DIV(H2O_BOX_L,H2OSUM))) THEN
-          AERFRAC(I,J,L,7) = H2O_BOX_L/H2OSUM
+          State_Chm%AERFRAC(I,J,L,7) = H2O_BOX_L/H2OSUM
        ENDIF
 
        ! Send properties to larger array
@@ -2252,11 +2225,11 @@ CONTAINS
        KHETI_SLA(I,J,L,10) = GAMMA_BOX(10)*KHET_SPECIFIC
        KHETI_SLA(I,J,L,11) = GAMMA_BOX(11)*KHET_SPECIFIC
 
-       RAD_AER(I,J,L,I_SLA)  = RAD_AER_BOX*1.e+2_fp ! cm
-       RHO_AER(I,J,L,I_SLA)  = RHO_AER_BOX          ! kg/m3
-       KG_AER(I,J,L,I_SLA)   = KG_AER_BOX           ! kg
-       NDENS_AER(I,J,L,I_SLA)= NDENS_AER_BOX        ! #/m3
-       SAD_AER(I,J,L,I_SLA)  = SAD_AER_BOX          ! cm2/cm3
+       State_Chm%RAD_AER(I,J,L,I_SLA)  = RAD_AER_BOX*1.e+2_fp ! cm
+       State_Chm%RHO_AER(I,J,L,I_SLA)  = RHO_AER_BOX          ! kg/m3
+       State_Chm%KG_AER(I,J,L,I_SLA)   = KG_AER_BOX           ! kg
+       State_Chm%NDENS_AER(I,J,L,I_SLA)= NDENS_AER_BOX        ! #/m3
+       State_Chm%SAD_AER(I,J,L,I_SLA)  = SAD_AER_BOX          ! cm2/cm3
 
     ENDDO
     ENDDO
@@ -2267,82 +2240,6 @@ CONTAINS
     NULLIFY( Spc, STATE_PSC, KHETI_SLA )
 
   END SUBROUTINE CALC_STRAT_AER
-!EOC
-!------------------------------------------------------------------------------
-!               MIT Laboratory for Aviation and the Environment               !
-!------------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE: kg_strat_aer
-!
-! !DESCRIPTION: Function KG\_STRAT\_AER returns the calculated mass of a
-!  stratospheric aerosol. The routine is essentially just an
-!  interface to allow external routines to "see" the arrays.
-!\\
-!\\
-! !INTERFACE:
-!
-  REAL(fp) FUNCTION KG_STRAT_AER (I,J,L,IAER)
-!
-! !INPUT PARAMETERS:
-!
-    INTEGER,INTENT(IN)          :: I,J,L      ! Grid indices
-    INTEGER,INTENT(IN)          :: IAER       ! Aerosol index
-                                              ! 1 = SSA (pure H2SO4)
-                                              ! 2 = STS
-                                              ! 3 = Solid PSC
-!
-! !REVISION HISTORY:
-!  18 Apr 2013 - S. D. Eastham - Initial version
-!  See https://github.com/geoschem/geos-chem for complete history
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-
-    !=================================================================
-    ! KG_STRAT_AER begins here!
-    !=================================================================
-
-    KG_STRAT_AER = KG_AER(I,J,L,IAER)
-
-  END FUNCTION KG_STRAT_AER
-!EOC
-!------------------------------------------------------------------------------
-!               MIT Laboratory for Aviation and the Environment               !
-!------------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE: rho_strat_aer
-!
-! !DESCRIPTION: Function RHO\_STRAT\_AER returns the calculated
-!  stratospheric aerosol mass density.
-!\\
-!\\
-! !INTERFACE:
-!
-  REAL(fp) FUNCTION RHO_STRAT_AER (I,J,L,IAER)
-!
-! !INPUT PARAMETERS:
-!
-    INTEGER,INTENT(IN)          :: I,J,L      ! Grid indices
-    INTEGER,INTENT(IN)          :: IAER       ! Aerosol index:
-                                              ! 1 = Liquid aerosol
-                                              ! 2 = Solid aerosol
-!
-! !REVISION HISTORY:
-!  18 Apr 2013 - S. D. Eastham - Initial version
-!  See https://github.com/geoschem/geos-chem for complete history
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-
-    !=================================================================
-    ! RHO_STRAT_AER begins here!
-    !=================================================================
-
-    RHO_STRAT_AER = RHO_AER(I,J,L,IAER)
-
-  END FUNCTION RHO_STRAT_AER
 !EOC
 !------------------------------------------------------------------------------
 !               MIT Laboratory for Aviation and the Environment               !
@@ -2360,10 +2257,15 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE GET_STRAT_OPT (I,J,L,IAER,RAER,REFF,SAD,XSA)
+  SUBROUTINE GET_STRAT_OPT (State_Chm,I,J,L,IAER,RAER,REFF,SAD,XSA)
+!
+! !USES:
+!
+    USE State_Chm_Mod,      ONLY : ChmState
 !
 ! !INPUT PARAMETERS:
 !
+    TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
     INTEGER,  INTENT(IN)  :: I, J, L    ! Grid indices
     INTEGER,  INTENT(IN)  :: IAER       ! Aerosol index
                                         ! 1 = Liquid aerosols
@@ -2394,7 +2296,7 @@ CONTAINS
     !=================================================================
 
     ! Surface area density [cm2/cm3]
-    SAD  = SAD_AER(I,J,L,IAER)
+    SAD  = State_Chm%SAD_AER(I,J,L,IAER)
 
     ! Add error check: threshold is 1e-14 cm2/cm3 (bmy, 4/7/15)
     IF ( SAD < 1e-14_fp ) THEN
@@ -2415,7 +2317,7 @@ CONTAINS
        !--------------------------------------------------------------
 
        ! For SLA, convert liquid radius to effective optical radius
-       RAER = RAD_AER(I,J,L,IAER)
+       RAER = State_Chm%RAD_AER(I,J,L,IAER)
        IF (IAER.eq.I_SLA) THEN
           REFF = RAER/SLA_RR
        ELSE
@@ -3948,7 +3850,7 @@ CONTAINS
           DO L=LMINPHOT+1,State_Grid%NZ
              ! Apply photolysis to SO4
              ! First retrieve gaseous fraction
-             SO4_IN = Spc(id_SO4)%Conc(I,J,L)*SO4_PHOTFRAC(I,J,L)
+             SO4_IN = Spc(id_SO4)%Conc(I,J,L)*SO4_PHOTFRAC(I,J,L,State_Chm)
              SO4_DELTA = PHOTDELTA*SO4_IN
              ! Remove from SO4
              Spc(id_SO4)%Conc(I,J,L) = Spc(id_SO4)%Conc(I,J,L) - SO4_DELTA
@@ -3980,7 +3882,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE NOXCOEFF_INIT( Input_Opt, State_Grid )
+  SUBROUTINE NOXCOEFF_INIT( Input_Opt, State_Grid, State_Chm )
 !
 ! !USES:
 !
@@ -3989,6 +3891,7 @@ CONTAINS
     USE FILE_MOD,           ONLY : IoError
     USE Input_Opt_Mod,      ONLY : OptInput
     USE State_Grid_Mod,     ONLY : GrdState
+    USE State_Chm_Mod,      ONLY : ChmState
 #if defined( MODEL_CESM )
     USE UNITS,              ONLY : freeUnit
 #if defined( SPMD )
@@ -4000,6 +3903,10 @@ CONTAINS
 !
     TYPE(OptInput),   INTENT(IN) :: Input_Opt          ! Input options
     TYPE(GrdState),   INTENT(IN) :: State_Grid         ! Grid State object
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(ChmState),INTENT(INOUT) :: State_Chm          ! Chemistry State object
 !
 ! !REVISION HISTORY:
 !  05 Dec 2014 - C. Keller - Initial version
@@ -4016,7 +3923,7 @@ CONTAINS
     INTEGER            :: IMON, ITRAC, ILEV
     INTEGER            :: IU_FILE
 #if defined( MODEL_CESM ) && defined( SPMD )
-    INTEGER            :: nSize ! Number of elements in NOXCOEFF
+    INTEGER            :: nSize ! Number of elements in State_Chm%NOXCOEFF
 #endif
 
     ! Strings
@@ -4110,38 +4017,38 @@ CONTAINS
     ! If this is a regular simulation, then read data from files
     !=================================================================
 
-    ! Number of latitude levels of NOXCOEFF array. Data is only
+    ! Number of latitude levels of State_Chm%NOXCOEFF array. Data is only
     ! available for 2x25 and 4x5. Use 2x25 for any different grid
     ! and map NOx coeffs onto simulation grid when calling
     ! GET_NOXCOEFF.
     IF ( TRIM(State_Grid%GridRes) == '4.0x5.0' .or. &
          TRIM(State_Grid%GridRes) == '2.0x2.5' ) THEN
-       JJNOXCOEFF = State_Grid%NY
+       State_Chm%JJNOXCOEFF = State_Grid%NY
     ELSE
-       JJNOXCOEFF = 91
+       State_Chm%JJNOXCOEFF = 91
     ENDIF
 
     ! Fill NOx latitudes
-    ALLOCATE(NOXLAT(JJNOXCOEFF+1), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'NOXLAT' )
+    ALLOCATE(State_Chm%NOXLAT(State_Chm%JJNOXCOEFF+1), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%NOXLAT' )
 
     ! Fill manually
-    NOXLAT(2) = -89.0e+0_fp
-    DO I = 3,JJNOXCOEFF
-       NOXLAT(I) = NOXLAT(I-1) + 2e+0_fp
+    State_Chm%NOXLAT(2) = -89.0e+0_fp
+    DO I = 3,State_Chm%JJNOXCOEFF
+       State_Chm%NOXLAT(I) = State_Chm%NOXLAT(I-1) + 2e+0_fp
     ENDDO
-    ! Overshoot to make sure that a latitude of 90.0 will be properl
-    ! matched onto JJNOXCOEFF.
-    NOXLAT(JJNOXCOEFF+1) = 90.5e+0_fp
+    ! Overshoot to make sure that a latitude of 90.0 will be properly
+    ! matched onto State_Chm%JJNOXCOEFF.
+    State_Chm%NOXLAT(State_Chm%JJNOXCOEFF+1) = 90.5e+0_fp
 
-    ! Initialize the NOXCOEFF array. This array holds monthly NOx
+    ! Initialize the State_Chm%NOXCOEFF array. This array holds monthly NOx
     ! coefficients on 51 levels and for 6 species.
-    ALLOCATE(NOXCOEFF(JJNOXCOEFF,UCX_NLEVS,6,12), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'NOXCOEFF' )
-    NOXCOEFF = 0.0e+0_fp
+    ALLOCATE(State_Chm%NOXCOEFF(State_Chm%JJNOXCOEFF,UCX_NLEVS,6,12), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%NOXCOEFF' )
+    State_Chm%NOXCOEFF = 0.0e+0_fp
 
 #if defined( MODEL_CESM )
-    nSize = JJNOXCOEFF * UCX_NLEVS * 6 * 12
+    nSize = State_Chm%JJNOXCOEFF * UCX_NLEVS * 6 * 12
     IF ( Input_Opt%amIRoot ) THEN
 #endif
     ! Fill array
@@ -4199,11 +4106,11 @@ CONTAINS
        DO ILEV = 1,UCX_NLEVS
 
           IF ( TRIM(State_Grid%GridRes) =='4.0x5.0' ) THEN
-             READ(IU_FILE, 110, IOSTAT=IOS ) NOXCOEFF(:,ILEV,ITRAC,IMON)
+             READ(IU_FILE, 110, IOSTAT=IOS ) State_Chm%NOXCOEFF(:,ILEV,ITRAC,IMON)
 110          FORMAT(46E10.3)
           ELSE
              ! Use 2x25 as default
-             READ(IU_FILE, 120, IOSTAT=IOS ) NOXCOEFF(:,ILEV,ITRAC,IMON)
+             READ(IU_FILE, 120, IOSTAT=IOS ) State_Chm%NOXCOEFF(:,ILEV,ITRAC,IMON)
 120          FORMAT(91E10.3)
           ENDIF
           IF ( IOS /= 0 ) THEN
@@ -4223,7 +4130,7 @@ CONTAINS
 #if defined( MODEL_CESM )
     ENDIF
 #if defined( SPMD )
-    CALL MPIBCAST( NOXCOEFF, nSize, MPIR8, 0, MPICOM )
+    CALL MPIBCAST( State_Chm%NOXCOEFF, nSize, MPIR8, 0, MPICOM )
 #endif
 #endif
 
@@ -4237,7 +4144,7 @@ CONTAINS
 ! !IROUTINE: get_jjnox
 !
 ! !DESCRIPTION: Subroutine GET\_JJNOX maps grid box at location IISIM, JJSIM of
-! the simulation grid onto the latitude grid of the NOXCOEFF array.
+! the simulation grid onto the latitude grid of the State_Chm%NOXCOEFF array.
 !\\
 !\\
 ! This routine simply returns the index of the NOx latitude vector that covers
@@ -4246,21 +4153,23 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  FUNCTION GET_JJNOX( IISIM, JJSIM, State_Grid ) RESULT ( JJNOX )
+  FUNCTION GET_JJNOX( IISIM, JJSIM, State_Grid, State_Chm ) RESULT ( JJNOX )
 !
 ! !USES:
 !
     USE State_Grid_Mod, ONLY : GrdState
+    USE State_Chm_Mod,  ONLY : ChmState
 !
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN) :: IISIM    ! Latitude index on simulation grid
     INTEGER,          INTENT(IN) :: JJSIM    ! Latitude index on simulation grid
     TYPE(GrdState),   INTENT(IN) :: State_Grid ! Grid State object
+    TYPE(ChmState),   INTENT(IN) :: State_Chm   ! Chemistry State object
 !
 ! !OUTPUT VARIABLES:
 !
-    INTEGER                      :: JJNOX    ! Latitude index on NOXCOEFF grid
+    INTEGER                      :: JJNOX    ! Latitude index on State_Chm%NOXCOEFF grid
 !
 ! !REVISION HISTORY:
 !  05 Dec 2014 - C. Keller - Initial version
@@ -4286,8 +4195,8 @@ CONTAINS
 
     ! Loop over all latitudes of the NOx grid until we reach the grid
     ! box where the simulation latitude sits in.
-    DO I = 1,JJNOXCOEFF
-       IF ( LAT < NOXLAT(I+1) ) THEN
+    DO I = 1,State_Chm%JJNOXCOEFF
+       IF ( LAT < State_Chm%NOXLAT(I+1) ) THEN
           JJNOX = I
           EXIT
        ENDIF
@@ -4326,9 +4235,12 @@ CONTAINS
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput), INTENT(IN) :: Input_Opt   ! Input options
-    TYPE(ChmState), INTENT(IN) :: State_Chm   ! Chemistry State object
     TYPE(DgnState), INTENT(IN) :: State_Diag  ! Diagnostics State object
     TYPE(GrdState), INTENT(IN) :: State_Grid  ! Grid State object
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry State object
 !
 ! !REVISION HISTORY:
 !  04 Apr 2013 - S. D. Eastham - Initial version
@@ -4403,7 +4315,7 @@ CONTAINS
     IF ( Input_Opt%DryRun ) THEN
 
        ! Get dry-run output from NOXCOEFF_INIT as well
-       CALL NOXCOEFF_INIT( Input_Opt, State_Grid )
+       CALL NOXCOEFF_INIT( Input_Opt, State_Grid, State_Chm )
 
        ! Exit without doing any computation (dry-run only)
        RETURN
@@ -4414,14 +4326,14 @@ CONTAINS
     !=================================================================
 
     ! Allocate arrays of input pressure levels and lat edges
-    ALLOCATE( UCX_PLEVS( UCX_NLEVS ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'UCX_PLEVS' )
+    ALLOCATE( State_Chm%UCX_PLEVS( UCX_NLEVS ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%UCX_PLEVS' )
 
-    ALLOCATE( UCX_LATS( UCX_NLAT+1 ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'UCX_LATS' )
+    ALLOCATE( State_Chm%UCX_LATS( UCX_NLAT+1 ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%UCX_LATS' )
 
     ! Set input pressure levels (hPa)
-    UCX_PLEVS = (/ 0.2200e+00_fp, 0.2600e+00_fp, &
+    State_Chm%UCX_PLEVS = (/ 0.2200e+00_fp, 0.2600e+00_fp, &
                    0.3100e+00_fp, 0.3600e+00_fp, &
                    0.4300e+00_fp, 0.5100e+00_fp, &
                    0.6000e+00_fp, 0.7100e+00_fp, &
@@ -4449,11 +4361,11 @@ CONTAINS
                    9.2004e+02_fp /)
 
     ! Set input latitude edges (degrees)
-    UCX_LATS(1)  = -90.0e+0_fp
-    UCX_LATS(2)  = (-90.0e+0_fp) + (9.5e+0_fp/2.0e+0_fp)
-    UCX_LATS(20) = 90.0e+0_fp
+    State_Chm%UCX_LATS(1)  = -90.0e+0_fp
+    State_Chm%UCX_LATS(2)  = (-90.0e+0_fp) + (9.5e+0_fp/2.0e+0_fp)
+    State_Chm%UCX_LATS(20) = 90.0e+0_fp
     DO N=2,18
-       UCX_LATS(N+1) = UCX_LATS(N) + 9.5e+0_fp
+       State_Chm%UCX_LATS(N+1) = State_Chm%UCX_LATS(N) + 9.5e+0_fp
     ENDDO
 
     ! Calculate conversion factors for SLA
@@ -4470,41 +4382,41 @@ CONTAINS
     SLA_VR = (0.357e-6_fp)*(10.e+0_fp**(12.e+0_fp*0.249))
 
     ! Initialize NOx coefficient arrays
-    ALLOCATE( NOX_O( State_Grid%NX, State_Grid%NY, State_Grid%NZ, 2 ), &
+    ALLOCATE( State_Chm%NOX_O( State_Grid%NX, State_Grid%NY, State_Grid%NZ, 2 ), &
               STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'NOX_O' )
-    NOX_O = 0e+0_fp
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%NOX_O' )
+    State_Chm%NOX_O = 0e+0_fp
 
-    ALLOCATE( NOX_J( State_Grid%NX, State_Grid%NY, State_Grid%NZ, 4 ), &
+    ALLOCATE( State_Chm%NOX_J( State_Grid%NX, State_Grid%NY, State_Grid%NZ, 4 ), &
               STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'NOX_J' )
-    NOX_J = 0e+0_fp
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%NOX_J' )
+    State_Chm%NOX_J = 0e+0_fp
 
     ! Initialize PSC variables
-    ALLOCATE( RAD_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
+    ALLOCATE( State_Chm%RAD_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
                        NSTRATAER ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'RAD_AER' )
-    RAD_AER = 0e+0_fp
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%RAD_AER' )
+    State_Chm%RAD_AER = 0e+0_fp
 
-    ALLOCATE( KG_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
+    ALLOCATE( State_Chm%KG_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
                       NSTRATAER ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'KG_AER' )
-    KG_AER = 0e+0_fp
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%KG_AER' )
+    State_Chm%KG_AER = 0e+0_fp
 
-    ALLOCATE( SAD_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
+    ALLOCATE( State_Chm%SAD_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
                        NSTRATAER ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'SAD_AER' )
-    SAD_AER = 0e+0_fp
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%SAD_AER' )
+    State_Chm%SAD_AER = 0e+0_fp
 
-    ALLOCATE( NDENS_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
+    ALLOCATE( State_Chm%NDENS_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
                          NSTRATAER ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'NDENS_AER' )
-    NDENS_AER = 0e+0_fp
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%NDENS_AER' )
+    State_Chm%NDENS_AER = 0e+0_fp
 
-    ALLOCATE( RHO_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
+    ALLOCATE( State_Chm%RHO_AER( State_Grid%NX, State_Grid%NY, State_Grid%NZ, &
                        NSTRATAER ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'RHO_AER' )
-    RHO_AER = 0e+0_fp
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%RHO_AER' )
+    State_Chm%RHO_AER = 0e+0_fp
 
     ! Mass fraction of species contained in liquid aerosol
     ! Indices: 1 - SO4
@@ -4514,29 +4426,29 @@ CONTAINS
     !          5 - HBr
     !          6 - HOBr
     !          7 - H2O
-    ALLOCATE( AERFRAC( State_Grid%NX, State_Grid%NY, State_Grid%NZ,7), &
+    ALLOCATE( State_Chm%AERFRAC( State_Grid%NX, State_Grid%NY, State_Grid%NZ,7), &
               STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'AERFRAC' )
-    AERFRAC = 0e+0_fp
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%AERFRAC' )
+    State_Chm%AERFRAC = 0e+0_fp
 
-    ALLOCATE( AERFRACIND( 7 ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'AERFRACIND' )
-    AERFRACIND(1) = id_SO4
-    AERFRACIND(2) = id_HNO3
-    AERFRACIND(3) = id_HCl
-    AERFRACIND(4) = id_HOCl
-    AERFRACIND(5) = id_HBr
-    AERFRACIND(6) = id_HOBr
-    AERFRACIND(7) = id_H2O
+    ALLOCATE( State_Chm%AERFRACIND( 7 ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%AERFRACIND' )
+    State_Chm%AERFRACIND(1) = id_SO4
+    State_Chm%AERFRACIND(2) = id_HNO3
+    State_Chm%AERFRACIND(3) = id_HCl
+    State_Chm%AERFRACIND(4) = id_HOCl
+    State_Chm%AERFRACIND(5) = id_HBr
+    State_Chm%AERFRACIND(6) = id_HOBr
+    State_Chm%AERFRACIND(7) = id_H2O
 
     ! H2SO4 photolysis rate at the top of the chemgrid
-    ALLOCATE( SO4_TOPPHOT( State_Grid%NX,State_Grid%NY ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'SO4_TOPPHOT' )
-    SO4_TOPPHOT = 0.e+0_fp
+    ALLOCATE( State_Chm%SO4_TOPPHOT( State_Grid%NX,State_Grid%NY ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%SO4_TOPPHOT' )
+    State_Chm%SO4_TOPPHOT = 0.e+0_fp
 
-    ALLOCATE( UCX_REGRID( State_Grid%NY, UCX_NLAT ), STAT=AS )
-    IF ( AS /= 0 ) CALL ALLOC_ERR( 'UCX_REGRID' )
-    UCX_REGRID = 0e+0_fp
+    ALLOCATE( State_Chm%UCX_REGRID( State_Grid%NY, UCX_NLAT ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'State_Chm%UCX_REGRID' )
+    State_Chm%UCX_REGRID = 0e+0_fp
 
     ! Calculate the scaling matrix
     ! Note cosine (area-weighted)
@@ -4548,8 +4460,8 @@ CONTAINS
                 - SIN( JMIN_OUT * PI_180 )
        DEG_SUM = 0e+0_fp
        DO JIN=1,UCX_NLAT
-          JMIN_IN = UCX_LATS(JIN)
-          JMAX_IN = UCX_LATS(JIN+1)
+          JMIN_IN = State_Chm%UCX_LATS(JIN)
+          JMAX_IN = State_Chm%UCX_LATS(JIN+1)
           IF ((JMAX_OUT.ge.JMIN_IN).and.(JMIN_OUT.le.JMAX_IN)) THEN
              JMAX_TMP = MIN(JMAX_IN,JMAX_OUT)
              JMIN_TMP = MAX(JMIN_IN,JMIN_OUT)
@@ -4557,7 +4469,7 @@ CONTAINS
                       - SIN( JMIN_TMP * PI_180 )
              IF (IS_SAFE_DIV(JDIF_TMP,JDIF_OUT)) THEN
                 JRATIO = JDIF_TMP/JDIF_OUT
-                UCX_REGRID(JOUT,JIN) = JRATIO
+                State_Chm%UCX_REGRID(JOUT,JIN) = JRATIO
                 DEG_SUM = DEG_SUM + JRATIO
              ENDIF
           ENDIF
@@ -4565,10 +4477,10 @@ CONTAINS
        ! Normalize
        IF (DEG_SUM.gt.0e+0_fp) THEN
           DO JIN=1,UCX_NLAT
-             UCX_REGRID(JOUT,JIN) = UCX_REGRID(JOUT,JIN)/DEG_SUM
+             State_Chm%UCX_REGRID(JOUT,JIN) = State_Chm%UCX_REGRID(JOUT,JIN)/DEG_SUM
           ENDDO
        ELSE
-          UCX_REGRID(JOUT,:) = 0e+0_fp
+          State_Chm%UCX_REGRID(JOUT,:) = 0e+0_fp
        ENDIF
 
        !! Debug
@@ -4582,55 +4494,9 @@ CONTAINS
        !ENDIF
     ENDDO
 
-    ! Initialize NOXCOEFF arrays
-    CALL NOXCOEFF_INIT( Input_Opt, State_Grid )
+    ! Initialize State_Chm%NOXCOEFF arrays
+    CALL NOXCOEFF_INIT( Input_Opt, State_Grid, State_Chm )
 
   END SUBROUTINE INIT_UCX
-!EOC
-!------------------------------------------------------------------------------
-!               MIT Laboratory for Aviation and the Environment               !
-!------------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE: cleanup_ucx
-!
-! !DESCRIPTION: Subroutine CLEANUP\_UCX deallocates module variables.
-!\\
-!\\
-! !INTERFACE:
-!
-  SUBROUTINE CLEANUP_UCX ( )
-!
-! !REVISION HISTORY:
-!  04 Apr 2013 - S. D. Eastham - Initial version
-!  See https://github.com/geoschem/geos-chem for complete history
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-    INTEGER :: N
-
-    !=================================================================
-    ! CLEANUP_UCX begins here!
-    !=================================================================
-
-    IF ( ALLOCATED( RAD_AER    ) ) DEALLOCATE( RAD_AER    )
-    IF ( ALLOCATED( SAD_AER    ) ) DEALLOCATE( SAD_AER    )
-    IF ( ALLOCATED( KG_AER     ) ) DEALLOCATE( KG_AER     )
-    IF ( ALLOCATED( RHO_AER    ) ) DEALLOCATE( RHO_AER    )
-    IF ( ALLOCATED( NDENS_AER  ) ) DEALLOCATE( NDENS_AER  )
-    IF ( ALLOCATED( AERFRAC    ) ) DEALLOCATE( AERFRAC    )
-    IF ( ALLOCATED( AERFRACIND ) ) DEALLOCATE( AERFRACIND )
-    IF ( ALLOCATED( UCX_REGRID ) ) DEALLOCATE( UCX_REGRID )
-    IF ( ALLOCATED( UCX_PLEVS  ) ) DEALLOCATE( UCX_PLEVS  )
-    IF ( ALLOCATED( UCX_LATS   ) ) DEALLOCATE( UCX_LATS   )
-    IF ( ALLOCATED( NOX_O      ) ) DEALLOCATE( NOX_O      )
-    IF ( ALLOCATED( NOX_J      ) ) DEALLOCATE( NOX_J      )
-    IF ( ALLOCATED( SO4_TOPPHOT) ) DEALLOCATE( SO4_TOPPHOT)
-
-    ! Cleanup the NOx coeff arrays
-    IF ( ALLOCATED( NOXCOEFF ) ) DEALLOCATE( NOXCOEFF )
-    IF ( ALLOCATED( NOXLAT   ) ) DEALLOCATE( NOXLAT   )
-
-  END SUBROUTINE CLEANUP_UCX
 !EOC
 END MODULE UCX_MOD


### PR DESCRIPTION
This patch moves in-module variables in UCX_MOD to State_Chm, to facilitate integration of GEOS-Chem into the WRF-GC and CESM models.

This patch might be considered a draft. There are some shortcomings with this patch, namely because the UCX variables are not regularly-sized (not I, J, L), they cannot be allocated using the current implementation of Init_and_Register, and instead are allocated by ucx_mod itself. This may need an alternative implementation of State_Chm_Mod's Init_and_Register to fix.

Hopefully, this patch is mostly self-contained because most of the changes are in `ucx_mod.F90` (not very frequently updated) and only additions to `state_chm_mod.F90` (easy to merge), and little changes everywhere else. So hopefully the PR can be brought forward to future versions easily. I'm opening this up with a preliminary implementation to put this on the radar. After this, I think the other major module that still hasn't migrated to State variables is aerosol_mod.

Thanks,
Haipeng