### PR TITLE
Add GCHP upwards mass flux diagnostic to config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Added capability to write species metadata to YAML file
   - Added satellite diagnostic (SatDiagn) collection, to archive several fields within a user-defined local-time interval. CAVEAT: For now, only one local-time interval is permitted.
   - Added adaptive solver (`rosenbrock_autoreduce`) option for fullchem mechanism
+  - Added upwards mass flux diagnostic to GCHP History collection LevelEdgeDiags
 
 ### Changed
   - Moved in-module variables in global_ch4_mod.F90 to State_Chm

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -188,6 +188,7 @@ COLLECTIONS: 'Emissions',
                                  'Met_PFILSAN        ', 'GCHPchem',
                                  'Met_PFLCU          ', 'GCHPchem',
                                  'Met_PFLLSAN        ', 'GCHPchem',
+                                 'UpwardsMassFlux    ', 'GCHPctmEnv',
 ::
 #==============================================================================
   SpeciesConc_avg.template:       '%y4%m2%d2_%h2%n2z.nc4',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -366,6 +366,7 @@ COLLECTIONS: 'Emissions',
                             'Met_PFILSAN        ', 'GCHPchem',
                             'Met_PFLCU          ', 'GCHPchem',
                             'Met_PFLLSAN        ', 'GCHPchem',
+                            'UpwardsMassFlux    ', 'GCHPctmEnv',
 ::
 #==============================================================================
   RadioNuclide.template:       '%y4%m2%d2_%h2%n2z.nc4',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -4729,6 +4729,8 @@ COLLECTIONS: @#'DefaultCollection',
                                  'Met_PFILSAN                   ', 'GCHPchem',
                                  'Met_PFLCU                     ', 'GCHPchem',
                                  'Met_PFLLSAN                   ', 'GCHPchem',
+                                 'UpwardsMassFlux               ', 'GCHPctmEnv',
+
 ::
 #==============================================================================
 # %%%%% THE ProdLoss COLLECTION %%%%%


### PR DESCRIPTION
The upwards mass flux of air was added as a MAPL export in GCHP in 13.4.0. It is computed within the `GCHPctmEnv` gridded component by calling a subroutine in FV3 to retrieve it. That gridded component is used as an interface between GEOS-Chem and FV3 advection.

Users may be unaware this diagnostics exists or how to use it since the diagnostic is not part of the `GEOSchem` gridded component. This pull request solves this issue by adding it to the GCHP config files by default. It is now part of the `LevelEdgeDiags` collection for all simulations.