### PR TITLE
Add timestep menu back to GCHP geoschem_config.yml templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Added capability to write species metadata to YAML file
   - Added satellite diagnostic (SatDiagn) collection, to archive several fields within a user-defined local-time interval. CAVEAT: For now, only one local-time interval is permitted.
   - Added adaptive solver (`rosenbrock_autoreduce`) option for fullchem mechanism
+  - Added timestep menu to GCHP `geoschem_config.yml` template files
 
 ### Changed
   - Moved in-module variables in global_ch4_mod.F90 to State_Chm

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -1356,6 +1356,7 @@ CONTAINS
                           nhmsE     = nhmsE,      & ! hhmmss   @ end of run
                           tsChem    = tsChem,     & ! Chemical timestep [s]
                           tsDyn     = tsDyn,      & ! Dynamic  timestep [s]
+                          tsRad     = tsRad,      & ! RRTMG    timestep [s]
                           lonCtr    = lonCtr,     & ! Lon centers [radians]
                           latCtr    = latCtr,     & ! Lat centers [radians]
 #if !defined( MODEL_GEOS )

--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -58,7 +58,7 @@ CONTAINS
 !
   SUBROUTINE GCHP_Chunk_Init( nymdB,         nhmsB,      nymdE,           &
                               nhmsE,         tsChem,     tsDyn,           &
-                              lonCtr,        latCtr,                      &
+                              tsRad,         lonCtr,     latCtr,          &
 #if !defined( MODEL_GEOS )
                               GC,            EXPORT,                      &
 #endif
@@ -108,6 +108,7 @@ CONTAINS
     INTEGER,            INTENT(IN)    :: nhmsE       ! hhmmss   @ end of run
     REAL,               INTENT(IN)    :: tsChem      ! Chemistry timestep [s]
     REAL,               INTENT(IN)    :: tsDyn       ! Chemistry timestep [s]
+    REAL,               INTENT(IN)    :: tsRad       ! Chemistry timestep [s]
     REAL(ESMF_KIND_R4), INTENT(IN)    :: lonCtr(:,:) ! Lon centers [radians]
     REAL(ESMF_KIND_R4), INTENT(IN)    :: latCtr(:,:) ! Lat centers [radians]
 !
@@ -200,6 +201,7 @@ CONTAINS
     Input_Opt%TS_EMIS = INT( tsChem )   ! Chemistry timestep [sec]
     Input_Opt%TS_DYN  = INT( tsDyn  )   ! Dynamic   timestep [sec]
     Input_Opt%TS_CONV = INT( tsDyn  )   ! Dynamic   timestep [sec]
+    Input_Opt%TS_RAD  = INT( tsRad  )   ! RRTMG     timestep [sec]
 
     ! Read geoschem_config.yml at very beginning of simulation on every CPU
     CALL Read_Input_File( Input_Opt, State_Grid, RC )

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.CO2
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.CO2
@@ -16,6 +16,13 @@ simulation:
   debug_printout: false
 
 #============================================================================
+# Timesteps settings
+#============================================================================
+timesteps:
+  transport_timestep_in_s: ${RUNDIR_TRANSPORT_TS}
+  chemistry_timestep_in_s: ${RUNDIR_CHEMISTRY_TS}
+
+#============================================================================
 # Settings for GEOS-Chem operations
 #============================================================================
 operations:

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.CO2
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.CO2
@@ -17,6 +17,9 @@ simulation:
 
 #============================================================================
 # Timesteps settings
+#
+# These timesteps are determined in setCommonRunSettings.sh since they are
+# resolution-dependent for GCHP
 #============================================================================
 timesteps:
   transport_timestep_in_s: ${RUNDIR_TRANSPORT_TS}

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
@@ -16,6 +16,13 @@ simulation:
   debug_printout: false
 
 #============================================================================
+# Timesteps settings
+#============================================================================
+timesteps:
+  transport_timestep_in_s: ${RUNDIR_TRANSPORT_TS}
+  chemistry_timestep_in_s: ${RUNDIR_CHEMISTRY_TS}
+
+#============================================================================
 # Settings for GEOS-Chem operations
 #============================================================================
 operations:

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
@@ -17,6 +17,9 @@ simulation:
 
 #============================================================================
 # Timesteps settings
+#
+# These timesteps are determined in setCommonRunSettings.sh since they are
+# resolution-dependent for GCHP
 #============================================================================
 timesteps:
   transport_timestep_in_s: ${RUNDIR_TRANSPORT_TS}

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -16,6 +16,14 @@ simulation:
   debug_printout: false
 
 #============================================================================
+# Timesteps settings
+#============================================================================
+timesteps:
+  transport_timestep_in_s: ${RUNDIR_TRANSPORT_TS}
+  chemistry_timestep_in_s: ${RUNDIR_CHEMISTRY_TS}
+  radiation_timestep_in_s: 10800
+
+#============================================================================
 # Settings for GEOS-Chem operations
 #============================================================================
 operations:

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -17,6 +17,9 @@ simulation:
 
 #============================================================================
 # Timesteps settings
+#
+# These timesteps are determined in setCommonRunSettings.sh since they are
+# resolution-dependent for GCHP
 #============================================================================
 timesteps:
   transport_timestep_in_s: ${RUNDIR_TRANSPORT_TS}


### PR DESCRIPTION
This is the companion PR for https://github.com/geoschem/GCHP/issues/279.  Restoring the timestep menu to the GCHP geoschem_config.yml template files  should fix the issue with the RRTMG timestep being zero.

This PR will not affect any GEOS-Chem Classic simulations

Integration tests pending.