### PR TITLE
Fix typos and add explanatory comments for Hg simulation emissions

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.Hg
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.Hg
@@ -139,6 +139,7 @@ Warnings:                    1
 # --- GMA 2018 emissions ---
 #
 #  NOTE: HgP emissions are added to Hg2 emissions!
+#  NOTE: Hg2 and HgP emissions are 0 everywhere for ASGM source
 #==============================================================================
 (((GMA_ASGM
 0 GMA_ASGM_HG0     $ROOT/MERCURY/v2022-10/GMA_emissions_Hg.0.25x0.25.2015.nc emi_hg_0_asgm 2015/1/1/0 C xy kg/m2/s Hg0    - 8 1

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.Hg
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.Hg
@@ -23,18 +23,20 @@
 ###############################################################################
 EmisHg0_Total      Hg0     -1    -1   -1   2   kg/m2/s  Hg0_emission_flux_from_all_sectors
 EmisHg0_Anthro     Hg0      0     1   -1   2   kg/m2/s  Hg0_emission_flux_from_anthropogenic
-EmisHg0_Artisanal  Hg0      0     8   -1   2   kg/m2/s  Hg0_emission_flux_from_artisinal_mining
+EmisHg0_ASGM       Hg0      0     8   -1   2   kg/m2/s  Hg0_emission_flux_from_ASGM
 EmisHg0_BioBurn    Hg0      111  -1   -1   2   kg/m2/s  Hg0_emission_flux_from_biomass_burning
 EmisHg0_Natural    Hg0      0     3   -1   2   kg/m2/s  Hg0_emission_flux_from_natural_sources
 
 ###############################################################################
 #####   Hg2 emissions                                                     #####
 ###############################################################################
+# Note ASGM Hg2 emissions are 0, so anthro=total in default configuration
 EmisHgCl2_Anthro   HgCl2    0    -1   -1   2  kg/m2/s  HgCl2_emission_flux_from_anthropogenic
 
 ###############################################################################
-#####   Hg2 emissions                                                     #####
+#####   HgP emissions                                                     #####
 ###############################################################################
+# Note ASGM Hg2 emissions are 0, so anthro=total in default configuration
 EmisHg2ClP_Anthro  Hg2ClP   0    -1   -1   2  kg/m2/s  Hg2ClP_emission_flux_from_anthropogenic
 
 #EOC


### PR DESCRIPTION
Hi GCST,

My first pull request! (still learning these new-fangled techniques, lol). I did this off the dev/14.1.0 branch as I knew that was the one with the other Hg fixes.

These are just some minor changes to HEMCO files for the Hg simulation to fix typos (artisanal was misspelled and in any case ASGM is the more standard terminology these days) and add some comments about the GMA emissions.

One question... Currently the simulation has the following block in HEMCO_Config:
```
(((GMA_ASGM
0 GMA_ASGM_HG0     $ROOT/MERCURY/v2022-10/GMA_emissions_Hg.0.25x0.25.2015.nc emi_hg_0_asgm 2015/1/1/0 C xy kg/m2/s Hg0    - 8 1 
0 GMA_ASGM_HG2     $ROOT/MERCURY/v2022-10/GMA_emissions_Hg.0.25x0.25.2015.nc emi_hg_2_asgm 2015/1/1/0 C xy *       HgCl2  - 8 1 
0 GMA_ASGM_HGP     $ROOT/MERCURY/v2022-10/GMA_emissions_Hg.0.25x0.25.2015.nc emi_hg_p_asgm 2015/1/1/0 C xy *       Hg2ClP - 8 1 
)))GMA_ASGM
```
However, the latter two (`emi_hg_2_asgm` and `emi_hg_p_asgm`) are just filled with zeros. They've been left in the HEMCO_Config.rc for now because they are present in the netcdf file and were present in the original files that the netcdf file was created from - it may confuse people if it appears the data contains fields we aren't actually using. 

Will this unnecessary data read slow things down much? If so, we could comment them out in HEMCO_Config (but leave the lines there probably to avoid the confusion). I did add a comment to this section to inform that the emissions are supposed to be 0 for these species, as I went to the trouble of adding them to the diagnostics, saw they were zero, and thought there was a bug initially - so trying to avoid someone else doing the same!

Cheers,
Jenny

P.S. Let me know if I've done any of this pull request stuff wrong!