### PR TITLE
Fix logic error in GCHP createRunDir.sh for tagO3 simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Fixed HCFC141b and HCFC142b names in GCHP HISTORY.rc
   - Fixed list of complex SOA species checked in input_mod.F90
   - Now use a string array for reading the list of ObsPack diagnostic species (in `GeosCore/input_mod.F90`)
+  - Fixed bug in logic that caused restart files not to be linked to the Restarts/ folder of the GCHP tagO3 run directory
 
 ### Removed
   - Removed LRED_JNO2 and AERO_HG2_PARTITON switches from HEMCO_Config.rc (and related code)

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -472,16 +472,23 @@ printf "To build GCHP type:\n   cmake ../CodeDir\n   cmake . -DRUNDIR=..\n   mak
 # Link to initial restart files, set start in cap_restart
 #--------------------------------------------------------------------
 restarts=${GC_DATA_ROOT}/GEOSCHEM_RESTARTS
-if [[ ${sim_name} = "fullchem" || ${sim_name} = "tagO3" ]]; then
+if [[ "x${sim_name}" == "xfullchem" ]]; then
     start_date='20190701'
     restart_dir='GC_14.0.0'
-elif [[ ${sim_name} = "TransportTracers" ]]; then
+    restart_name="${sim_name}"
+elif [[ "x${sim_name}" == "xtagO3" ]]; then
+    # NOTE: we use the fullchem restart file for tagO3
+    start_date='20190701'
+    restart_dir='GC_14.0.0'
+    restart_name="fullchem"
+elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
     start_date='20190101'
     restart_dir='GC_14.0.0'
+    restart_name="${sim_name}"
 fi
 for N in 24 48 90 180 360
 do
-    old_prefix="GEOSChem.Restart.${sim_name}"
+    old_prefix="GEOSChem.Restart.${restart_name}"
     new_prefix="GEOSChem.Restart"
     echo "${start_date} 000000" > ${rundir}/cap_restart
     initial_rst="${restarts}/${restart_dir}/${old_prefix}.${start_date}_0000z.c${N}.nc4"


### PR DESCRIPTION
We have fixed a logic error in the `run/GCHP/createRunDir.sh` script.  When creating a GCHP run directory for the tagO3 simulation, we use the proper path to the fullchem restart file.

