### PR TITLE
The 1st time slice in GCC HISTORY files now matches the reference datetime (for time-averaged data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Fixed list of complex SOA species checked in input_mod.F90
   - Now use a string array for reading the list of ObsPack diagnostic species (in `GeosCore/input_mod.F90`)
   - Fixed bug in logic that caused restart files not to be linked to the Restarts/ folder of the GCHP tagO3 run directory
+  - Fixed timestamp for GCClassic History diagnostic so time-averaged collections match the reference time
 
 ### Removed
   - Removed LRED_JNO2 and AERO_HG2_PARTITON switches from HEMCO_Config.rc (and related code)

--- a/History/history_netcdf_mod.F90
+++ b/History/history_netcdf_mod.F90
@@ -784,9 +784,7 @@ CONTAINS
     ! For time-averaged collections, we need to subtract the file write
     ! interval from the current time.  This will make sure that time[0] = 0,
     ! or in other words, that the first time slice matches up to the
-    ! reference datetime.  This will allow GEOS-Chem Classic diagnostic
-    ! files to be read by GCHP (since GCHP cannot read any netCDF files
-    ! where time[0] != 0).   -- Bob Yantosca (13 Jan 2023)
+    ! reference datetime.  -- Bob Yantosca (13 Jan 2023)
     IF ( Container%Operation == ACCUM_FROM_SOURCE ) THEN
        Container%TimeStamp = Container%TimeStamp - Container%FileWriteIvalSec
     ENDIF

--- a/History/history_netcdf_mod.F90
+++ b/History/history_netcdf_mod.F90
@@ -781,11 +781,14 @@ CONTAINS
                                TimeBaseJsec = Container%ReferenceJsec,       &
                                ElapsedSec   = Container%TimeStamp           )
 
-    ! For time-averaged collections, offset the timestamp
-    ! by 1/2 of the file averaging interval in minutes
+    ! For time-averaged collections, we need to subtract the file write
+    ! interval from the current time.  This will make sure that time[0] = 0,
+    ! or in other words, that the first time slice matches up to the
+    ! reference datetime.  This will allow GEOS-Chem Classic diagnostic
+    ! files to be read by GCHP (since GCHP cannot read any netCDF files
+    ! where time[0] != 0).   -- Bob Yantosca (13 Jan 2023)
     IF ( Container%Operation == ACCUM_FROM_SOURCE ) THEN
-       Container%TimeStamp = Container%TimeStamp -                           &
-                             ( Container%FileWriteIvalSec * 0.5_f8 )
+       Container%TimeStamp = Container%TimeStamp - Container%FileWriteIvalSec
     ENDIF
 
     ! Convert to minutes since the reference time


### PR DESCRIPTION
This PR addresses an issue in GEOS-Chem Classic History diagnostics where the first time slice of a time-averaged collection did not match the reference time.

For example, a `GEOSChem.SpeciesConc.20190101_0000z.nc4` file (which is a time-averaged collection) has a reference time (i.e. the date & time specified in `time;units`) of:

```console
        double time(time) ;
                time:long_name = "Time" ;
                time:units = "minutes since 2019-01-01 00:00:00" ;
```

But the first time slice in the file is offset from the reference time by 1/2 of the file write interval.  For a 1-day output this means that the first time in the file is:
```console
data:

 time = "2019-01-01 12" ;
```

We have now changed this behavior so that the first time value (for time-averaged collections) matches the reference date; that is, it is zero minutes since the reference date, as shown below:

```console
data:

 time = "2019-01-01" ;
```

This was done in order to be compatible with GCHP, which uses the same behavior,  It will also allow netCDF files created by GEOS-Chem Classic History diagnostics (e.g. prod & loss data) to be read into GCHP without error.