### PR TITLE
Change Harvard Cannon "huce_cascade" partition name to "seas_compute" in sample run scripts

### DIFF
--- a/run/GCClassic/runScriptSamples/geoschem.benchmark.run
+++ b/run/GCClassic/runScriptSamples/geoschem.benchmark.run
@@ -3,7 +3,7 @@
 #SBATCH -c 48
 #SBATCH -N 1
 #SBATCH -t 0-5:00
-#SBATCH -p huce_cascade
+#SBATCH -p seas_compute
 #SBATCH --mem=16000
 #SBATCH --mail-type=END
 

--- a/run/GCClassic/runScriptSamples/geoschem.run
+++ b/run/GCClassic/runScriptSamples/geoschem.run
@@ -3,7 +3,7 @@
 #SBATCH -c 8
 #SBATCH -N 1
 #SBATCH -t 0-12:00
-#SBATCH -p huce_intel
+#SBATCH -p seas_compute
 #SBATCH --mem=15000
 #SBATCH --mail-type=END
 

--- a/run/GCHP/runScriptSamples/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/gchp.batch_job.sh
@@ -48,7 +48,7 @@
 #SBATCH -n 60
 #SBATCH -N 2
 #SBATCH -t 2:00:00
-#SBATCH -p huce_intel
+#SBATCH -p seas_compute
 #SBATCH --mem=110G
 #SBATCH --mail-type=ALL
 #

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -4,7 +4,7 @@
 #SBATCH -N 2
 #SBATCH --exclusive
 #SBATCH -t 0-8:00
-#SBATCH -p huce_cascade
+#SBATCH -p seas_compute
 #SBATCH --mem=180000
 #SBATCH --mail-type=END
 


### PR DESCRIPTION
In June 2023, the `huce_cascade` SLURM partition on the Harvard Cannon cluster will be retired.  The replacement partition name is `seas_compute` (which is active as of 01 Jan 2023).

In this PR we have changed all instances of `huce_cascade` in sample run scripts (both GC-Classic and GCHP) to `seas_compute`.

This is a zero-diff PR as no source code files are touched.