### PR TITLE
Apply work-around for GFAS pFe bug in GC-Classic and GCHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Added HTAPv3 inventory as a global emissions option (off by default)
   - Added carbon simulation and KPP mechanism for CO-CO2-CH4-OCS
   - Added GCHP run script and environment file for UCI Australia cluster Gadi
+  - Added GFAS entries in GCHP config file ExtData.rc
 
 ### Changed
   - Moved in-module variables in global_ch4_mod.F90 to State_Chm
@@ -42,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Fixed bug in logic that caused restart files not to be linked to the Restarts/ folder of the GCHP tagO3 run directory
   - Fixed timestamp for GCClassic History diagnostic so time-averaged collections match the reference time
   - Fixed double-titration of seasalt alkalinity
+  - Fixed bug in GFAS pFe by applying work-around in config files
 
 ### Removed
   - Removed LRED_JNO2 and AERO_HG2_PARTITON switches from HEMCO_Config.rc (and related code)

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -1659,7 +1659,7 @@ Warnings:                    1
 0 GFAS_OCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPI 72/75  5 3
 0 GFAS_OCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ocfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s OCPO 73/75  5 3
 0 GFAS_SO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SO2  75     5 3
-0 GFAS_pFe   -                                          -             -                     - -             -       pFe  75/66  5 3
+0 GFAS_pFe   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s pFe  75/66  5 3
 0 GFAS_NH3   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc nh3fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NH3  75     5 3
 0 GFAS_DMS   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6sfire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s DMS  75     5 3
 )))GFAS

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3008,7 +3008,7 @@ Warnings:                    1
 0 GFAS_CO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc co2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO2  75       5 3
 0 GFAS_CH4   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch4fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH4  75       5 3
 0 GFAS_SO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SO2  75       5 3
-0 GFAS_pFe   -                                          -             -                     - -             -       pFe  75/66    5 3
+0 GFAS_pFe   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s pFe  75/66    5 3
 0 GFAS_NH3   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc nh3fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NH3  75       5 3
 0 GFAS_ACET  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ACET 75       5 3
 0 GFAS_ALD2  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALD2 75       5 3

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -1544,7 +1544,34 @@ EOH_PLANTDECAY  kgC/m2/s Y Y F1985-%m2-01T00:00:00 none none HET_RESP ./HcoDir/A
 # --- GFAS biomass burning (GFAS) ---
 # GFAS is off by default in HEMCO_Config.rc; fill in this section if turning on
 #==============================================================================
-#
+#GFAS_CO    kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none cofire        ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_SOAP  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none cofire        ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_NO    kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none noxfire       ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_BCPI  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none bcfire        ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_BCPO  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none bcfire        ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_OCPI  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none ocfire        ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_OCPO  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none ocfire        ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_CO2   kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none co2fire       ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_CH4   kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none ch4fire       ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_SO2   kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none so2fire       ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_pFe   kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none so2fire       ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_NH3   kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none nh3fire       ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_ACET  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c3h6ofire     ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_ALD2  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c2h4ofire     ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_ALK4  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none hialkanesfire ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_PRPE1 kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none hialkenesfire ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_PRPE2 kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c3h6fire      ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_C2H6  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c2h6fire      ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_C3H8  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c3h8fire      ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_CH2O  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none ch2ofire      ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_C2H4  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c2h4fire      ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_ISOP  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c5h8fire      ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_DMS   kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c2h6sfire     ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_TOLU  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c7h8fire      ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_BENZ  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c6h6fire      ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_XYLE  kg/m2/s N Y F%y4-%m2-%d2T00:00:00 none none c8h10fire     ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+#GFAS_EMITL m       N Y F%y4-%m2-%d2T00:00:00 none none mami          ./HcoDir/GFAS/v2018-09/%y4/GFAS_%y4%m2.nc
+
 #==============================================================================
 # --- Anthropogenic dust emissions (AFCID)---
 #==============================================================================

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3007,7 +3007,7 @@ Warnings:                    1
 0 GFAS_CO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc co2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO2  75       5 3
 0 GFAS_CH4   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch4fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CH4  75       5 3
 0 GFAS_SO2   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SO2  75       5 3
-0 GFAS_pFe   -                                          -             -                     - -             -       pFe  75/66    5 3
+0 GFAS_pFe   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc so2fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s pFe  75/66    5 3
 0 GFAS_NH3   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc nh3fire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NH3  75       5 3
 0 GFAS_ACET  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c3h6ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ACET 75       5 3
 0 GFAS_ALD2  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h4ofire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s ALD2 75       5 3


### PR DESCRIPTION
This update applies a work-around for GFAS when running GC-Classic and GCHP. Previously the model would crash with a HEMCO vertical level error when computing emissions for `GFAS_pFe`. The underlying issue is still under investigation (see https://github.com/geoschem/HEMCO/issues/173). The bug only impacts GFAS when using the vertical injection height scalings (option `xyL=1:scal300` in `HEMCO_Config.rc`, which is default).

The temporary fix is to replace the `GFAS_pFe` entry dash symbols in `HEMCO_Config.rc` with read information for `GFAS_SO2`. The SO2 data is still scaled for pFe. For GCHP an entry for `GFAS_pFe` is also added. Normally the dashes would enable reusing the same data as used for `GFAS_SO2` but for some reason that is not working in HEMCO for `GFAS_pFe` and the vertical injection level option.

This update also adds `ExtData.rc` entries for the GFAS inventory. Previously it was left to the user to add these entries if turning on GFAS. The new section is commented out by default.