### PR TITLE
Include nitrate aerosol photolysis in the troposphere

### DIFF
--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -578,8 +578,8 @@ CONTAINS
           ! (1) H2SO4 + hv -> SO2 + OH + OH   (UCX-based mechanisms)
           ! (2) O3    + hv -> O2  + O         (UCX-based mechanisms)
           ! (2) O3    + hv -> OH  + OH        (trop-only mechanisms)
-          CALL PHOTRATE_ADJ( Input_Opt, State_Diag, State_Met, I,            &
-                             J,         L,          SO4_FRAC,  IERR         )
+          CALL PHOTRATE_ADJ( Input_Opt, State_Chm,  State_Diag, State_Met,  &
+                             I,         J,          L,          SO4_FRAC,  IERR )
 
           ! Loop over the FAST-JX photolysis species
           DO N = 1, JVN_

--- a/run/CESM/geoschem_config.yml
+++ b/run/CESM/geoschem_config.yml
@@ -53,9 +53,9 @@ operations:
       use_column_O3_from_met: true
       use_TOMS_SBUV_O3: false
     photolyze_nitrate_aerosol:
-      activate: false
-      NITs_Jscale_JHNO3: 0.0
-      NIT_Jscale_JHNO2: 0.0
+      activate: true
+      NITs_Jscale_JHNO3: 100.0
+      NIT_Jscale_JHNO2: 100.0
       percent_channel_A_HONO: 66.667
       percent_channel_B_NO2: 33.333
 

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -79,9 +79,9 @@ operations:
       use_column_O3_from_met: true
       use_TOMS_SBUV_O3: false
     photolyze_nitrate_aerosol:
-      activate: false
-      NITs_Jscale_JHNO3: 0.0
-      NIT_Jscale_JHNO2: 0.0
+      activate: true
+      NITs_Jscale_JHNO3: 100.0
+      NIT_Jscale_JHNO2: 100.0
       percent_channel_A_HONO: 66.667
       percent_channel_B_NO2: 33.333
 

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -51,9 +51,9 @@ operations:
       use_column_O3_from_met: true
       use_TOMS_SBUV_O3: false
     photolyze_nitrate_aerosol:
-      activate: false
-      NITs_Jscale_JHNO3: 0.0
-      NIT_Jscale_JHNO2: 0.0
+      activate: true
+      NITs_Jscale_JHNO3: 100.0
+      NIT_Jscale_JHNO2: 100.0
       percent_channel_A_HONO: 66.667
       percent_channel_B_NO2: 33.333
 

--- a/run/GEOS/geoschem_config.yml
+++ b/run/GEOS/geoschem_config.yml
@@ -51,9 +51,9 @@ operations:
       use_column_O3_from_met: true
       use_TOMS_SBUV_O3: false
     photolyze_nitrate_aerosol:
-      activate: false
-      NITs_Jscale_JHNO3: 0.0
-      NIT_Jscale_JHNO2: 0.0
+      activate: true
+      NITs_Jscale_JHNO3: 100.0
+      NIT_Jscale_JHNO2: 100.0
       percent_channel_A_HONO: 66.667
       percent_channel_B_NO2: 33.333
 


### PR DESCRIPTION
Include nitrate aerosol photolysis in the troposphere as described in:

> Shah, V., Jacob, D. J., Dang, R., Lamsal, L. N., Strode, S. A., Steenrod, S. D., Boersma, K. F., Eastham, S. D., Fritz, T. M., Thompson, C., Peischl, J., Bourgeois, I., Pollack, I. B., Nault, B. A., Cohen, R. C., Campuzano-Jost, P., Jimenez, J. L., Andersen, S. T., Carpenter, L. J., Sherwen, T., and Evans, M. J.: Nitrogen oxides in the free troposphere: implications for tropospheric oxidants and the interpretation of satellite NO2 measurements, Atmospheric Chemistry and Physics, 23, 1227–1257, https://doi.org/10.5194/acp-23-1227-2023, 2023.
