### PR TITLE
Archive State_Chm%H2SO4_PRDR for production rate of H2SO4 (mol/mol) for CESM-GC

### DIFF
--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1350,6 +1350,29 @@ CONTAINS
 #endif
 #endif
 
+#ifdef MODEL_CESM
+       ! Calculate H2SO4 production rate for coupling to CESM (interface to MAM4 nucleation)
+       DO F = 1, NFAM
+
+          ! Determine dummy species index in KPP
+          KppID =  PL_Kpp_Id(F)
+
+          ! Calculate H2SO4 production rate [mol mol-1] in this timestep (hplin, 1/25/23)
+          IF ( TRIM(FAM_NAMES(F)) == 'PSO4' ) THEN
+             ! mol/mol = molec cm-3 * g * mol(Air)-1 * kg g-1 * m-3 cm3 / (molec mol-1 * kg m-3)
+             !         = mol/molAir
+             State_Chm%H2SO4_PRDR(I,J,L) = C(KppID) * AIRMW * 1e-3_fp * 1.0e+6_fp / &
+                                 (AVO * State_Met%AIRDEN(I,J,L))
+
+             IF ( State_Chm%H2SO4_PRDR(I,J,L) < 0.0d0) THEN
+               write(*,*) "H2SO4_PRDR negative in fullchem_mod.F90!!", &
+                  I, J, L, "was:", State_Chm%H2SO4_PRDR(I,J,L), "  setting to 0.0d0"
+               State_Chm%H2SO4_PRDR(I,J,L) = 0.0d0
+             ENDIF
+          ENDIF
+       ENDDO
+#endif
+
 #ifdef MODEL_GEOS
        !--------------------------------------------------------------------
        ! Archive NOx lifetime [h]

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -272,6 +272,13 @@ MODULE State_Chm_Mod
      LOGICAL                    :: Do_SulfateMod_Cld
      LOGICAL                    :: Do_SulfateMod_SeaSalt
 
+#if defined(MODEL_CESM)
+     !-----------------------------------------------------------------------
+     ! Fields for CESM interface to GEOS-Chem
+     !-----------------------------------------------------------------------
+     REAL(fp),          POINTER :: H2SO4_PRDR (:,:,:  ) ! H2SO4 prod rate [mol/mol]
+#endif
+
      !-----------------------------------------------------------------------
      ! Fields for CH4 specialty simulation
      !-----------------------------------------------------------------------
@@ -497,6 +504,11 @@ CONTAINS
     ! FALSE = use KPP computations
     State_Chm%Do_SulfateMod_Cld     = .FALSE.
     State_Chm%Do_SulfateMod_SeaSalt = .FALSE.
+
+#if defined(MODEL_CESM)
+    ! Quantities for coupling to CESM
+    State_Chm%H2SO4_PRDR        => NULL()
+#endif
 
   END SUBROUTINE Zero_State_Chm
 !EOC
@@ -2055,6 +2067,28 @@ CONTAINS
        RETURN
     ENDIF
 
+#if defined(MODEL_CESM)
+    IF ( Input_Opt%ITS_A_FULLCHEM_SIM ) THEN
+       !---------------------------------------------------------------------
+       ! H2SO4_PRDR: H2SO4 production rate [mol/mol] for MAM4 interface
+       !---------------------------------------------------------------------
+       chmId = 'H2SO4_PRDR'
+       CALL Init_and_Register(                                               &
+            Input_Opt  = Input_Opt,                                          &
+            State_Chm  = State_Chm,                                          &
+            State_Grid = State_Grid,                                         &
+            chmId      = chmId,                                              &
+            Ptr2Data   = State_Chm%H2SO4_PRDR,                               &
+            RC         = RC                                                 )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( chmId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+    ENDIF
+#endif
+
     !=======================================================================
     ! Initialize State_Chm quantities pertinent to Hg simulations
     !=======================================================================
@@ -3398,6 +3432,15 @@ CONTAINS
        State_Chm%TOMS2 => NULL()
     ENDIF
 
+#if defined(MODEL_CESM)
+    IF ( ASSOCIATED( State_Chm%H2SO4_PRDR ) ) THEN
+       DEALLOCATE( State_Chm%H2SO4_PRDR, STAT=RC )
+       CALL GC_CheckVar( 'State_Chm%H2SO4_PRDR', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Chm%H2SO4_PRDR => NULL()
+    ENDIF
+#endif
+
     !-----------------------------------------------------------------------
     ! Template for deallocating more arrays, replace xxx with field name
     !-----------------------------------------------------------------------
@@ -4360,6 +4403,13 @@ CONTAINS
           IF ( isDesc  ) Desc  = 'QQRain'
           IF ( isUnits ) Units = '1'
           IF ( isRank  ) Rank  = 3
+
+#if defined(MODEL_CESM)
+       CASE( 'H2SO4_PRDR' )
+          IF ( isDesc  ) Desc  = 'H2SO4 production rate in timestep'
+          IF ( isUnits ) Units = 'mol mol-1'
+          IF ( isRank  ) Rank  = 3
+#endif
 
        CASE DEFAULT
           Found = .False.


### PR DESCRIPTION
Hi GCST,

This update is for GEOS-Chem coupling with CESM and adds a quantity, `State_Chm%H2SO4_PRDR` which archives the production rate of H2SO4 in mol/mol for interfacing with CESM.

These changes are zero-diff for GEOS-Chem science codebase but the quantity will be used in the CESM-GC interface as part of a science update.

Thanks!
Haipeng