### PR TITLE
Add entries for GFAS methanol to HEMCO_Config.rc templates

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -2998,6 +2998,7 @@ Warnings:                    1
 (((GFAS
 0 GFAS_CO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO   75       5 3
 0 GFAS_SOAP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SOAP 75/281   5 3
+0 GFAS_CH3OH $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch3ohfire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s MOH  75       5 3
 0 GFAS_NO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc noxfire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NO   75       5 3
 0 GFAS_BCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPI 70/75    5 3
 0 GFAS_BCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPO 71/75    5 3

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -2997,6 +2997,7 @@ Warnings:                    1
 (((GFAS
 0 GFAS_CO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO   75       5 3
 0 GFAS_SOAP  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s SOAP 75/281   5 3
+0 GFAS_CH3OH $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc ch3ohfire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s MOH  75       5 3
 0 GFAS_NO    $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc noxfire       2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s NO   75       5 3
 0 GFAS_BCPI  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPI 70/75    5 3
 0 GFAS_BCPO  $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc bcfire        2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s BCPO 71/75    5 3


### PR DESCRIPTION
This is the companion PR for issue #1631 (raised by @Twize).  It simply adds entries for GFAS methanol to the HEMCO_Config.rc.fullchem template files for GCHP and GCClassic.  This is a zero-diff update w/r/t benchmark simulations, as the benchmarks use GFED instead of GFAS.

Closes #1631 
