### PR TITLE
Add reminders to compile with CMake options to createRunDir.sh scripts

### DIFF
--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -881,10 +881,6 @@ fi
 ln -s ${wrapperdir} ${rundir}/CodeDir
 ln -s ${wrapperdir}/run/GCHP/runScriptSamples ${rundir}/runScriptSamples
 
-# Create build directory
-mkdir ${rundir}/build
-printf "To build GEOS-Chem type:\n   cmake ../CodeDir\n   cmake . -DRUNDIR=..\n   make -j\n   make install\n" >> ${rundir}/build/README
-
 #--------------------------------------------------------------------
 # Navigate to run directory and set up input files
 #--------------------------------------------------------------------
@@ -1227,14 +1223,34 @@ done
 #---------------------------------------------------------------------------
 hdr="\n>>>> REMINDER: You must compile with options:"
 ftr="<<<<\n"
-[[ "x${sim_name}" == "xcarbon" ]] && printf "${hdr} -DMECH=carbon ${ftr}"
-[[ "x${sim_name}" == "xHg"     ]] && printf "${hdr} -DMECH=Hg ${ftr}"
+
+EXTRA_CMAKE_OPTIONS=""
+[[ "x${sim_name}" == "xcarbon" ]] && EXTRA_CMAKE_OPTIONS="-DMECH=carbon"
+[[ "x${sim_name}" == "xHg"     ]] && EXTRA_CMAKE_OPTIONS="-DMECH=Hg"
 if [[ "x${sim_name}" == "xfullchem" ]]; then
-    [[ "x${sim_extra_option}" == "xAPM"     ]] && printf "${hdr} -DAPM=y ${ftr}"
-    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && printf "${hdr} -DRRTMG=y ${ftr}"
-    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && printf "${hdr} -DTOMAS=y -DTOMAS_BINS=15 ${ftr}"
-    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && printf "${hdr} -DTOMAS=y -DTOMAS_BINS=40 ${ftr}"
+    [[ "x${sim_extra_option}" == "xAPM"     ]] && EXTRA_CMAKE_OPTIONS="-DAPM=y"
+    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && EXTRA_CMAKE_OPTIONS="-DRRTMG=y"
+    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=15"
+    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=40"
 fi
+
+# Add to RUNDIR_VARS
+RUNDIR_VARS+="EXTRA_CMAKE_OPTIONS=${EXTRA_CMAKE_OPTIONS}"
+
+# Print a reminder to compile with extra CMake options, if necessary
+[[ "x${EXTRA_CMAKE_OPTIONS}" != "x" ]] && printf "${hdr} ${EXTRA_CMAKE_OPTIONS} ${ftr}"
+
+#---------------------------------------------------------------------------
+# Create build directory README file
+#---------------------------------------------------------------------------
+mkdir -p "${rundir}/build"
+msg="To build GEOS-Chem, type:\n\n"
+msg+="$ cmake ../CodeDir\n"
+msg+="$ cmake . -DRUNDIR=.. ${EXTRA_CMAKE_OPTIONS}\n"
+msg+="$ make -j\n"
+msg+="$ make install\n"
+printf "${msg}" > ${rundir}/build/README
+unset msg
 
 #-----------------------------------------------------------------
 # Add the version info to the top of the rundir configuration log

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -241,7 +241,6 @@ if [[ ${sim_name} = "fullchem" ]]; then
 	    sim_extra_option="APM"
 	elif [[ ${sim_option} = "8" ]]; then
 	    sim_extra_option="RRTMG"
-            printf "*** IMPORTANT: You must manually specify -DRRTMG=y when compiling the model. ***\n"
 	else
 	    valid_sim_option=0
 	    printf "Invalid simulation option. Try again.\n"
@@ -1222,6 +1221,20 @@ while [ "$valid_response" -eq 0 ]; do
 	printf "Input not recognized. Try again.\n"
     fi
 done
+
+#---------------------------------------------------------------------------
+# Add reminders to compile with CMake options for simulations that need them
+#---------------------------------------------------------------------------
+hdr="\n>>>> REMINDER: You must compile with options:"
+ftr="<<<<\n"
+[[ "x${sim_name}" == "xcarbon" ]] && printf "${hdr} -DMECH=carbon ${ftr}"
+[[ "x${sim_name}" == "xHg"     ]] && printf "${hdr} -DMECH=Hg ${ftr}"
+if [[ "x${sim_name}" == "xfullchem" ]]; then
+    [[ "x${sim_extra_option}" == "xAPM"     ]] && printf "${hdr} -DAPM=y ${ftr}"
+    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && printf "${hdr} -DRRTMG=y ${ftr}"
+    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && printf "${hdr} -DTOMAS=y -DTOMAS_BINS=15 ${ftr}"
+    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && printf "${hdr} -DTOMAS=y -DTOMAS_BINS=40 ${ftr}"
+fi
 
 #-----------------------------------------------------------------
 # Add the version info to the top of the rundir configuration log

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -220,7 +220,6 @@ if [[ ${sim_name} = "fullchem" ]]; then
 	    sim_extra_option="APM"
 	elif [[ ${sim_option} = "8" ]]; then
 	    sim_extra_option="RRTMG"
-            printf "*** IMPORTANT: You must manually specify -DRRTMG=y when compiling the model. ***\n"
 	else
 	    valid_sim_option=0
 	    printf "Invalid simulation option. Try again.\n"
@@ -651,5 +650,20 @@ printf "\n  -- See build/README for compilation instructions"
 printf "\n  -- Example run scripts are in the runScriptSamples subdirectory"
 printf "\n  -- For more information visit the GCHP user guide at"
 printf "\n     https://readthedocs.org/projects/gchp/\n\n"
+
+#---------------------------------------------------------------------------
+# Add reminders to compile with CMake options for simulations that need them
+#---------------------------------------------------------------------------
+hdr="\n>>>> REMINDER: You must compile with options:"
+ftr="<<<<\n"
+[[ "x${sim_name}" == "xcarbon" ]] && printf "${hdr} -DMECH=carbon ${ftr}"
+## FUTURE-PROOFING: Hg may be added eventually (bmy, 03 Feb 2023)
+#[[ "x${sim_name}" == "xHg" ]] && printf "${hdr} -DMECH=Hg ${ftr}"
+if [[ "x${sim_name}" == "xfullchem" ]]; then
+    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && printf "${hdr} -DRRTMG=y ${ftr}"
+# FUTURE-PROOFING: TOMAS will be added soon (bmy, 03 Feb 2023)
+#    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && printf "${hdr} -DTOMAS=y -DTOMAS_BINS=15 ${ftr}"
+#    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && printf "${hdr} -DTOMAS=y -DTOMAS_BINS=40 ${ftr}"
+fi
 
 exit 0

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -466,10 +466,6 @@ fi
 ln -s ${wrapperdir} ${rundir}/CodeDir
 ln -s ${wrapperdir}/run/runScriptSamples ${rundir}/runScriptSamples
 
-# Create build directory
-mkdir ${rundir}/build
-printf "To build GCHP type:\n   cmake ../CodeDir\n   cmake . -DRUNDIR=..\n   make -j\n   make install\n" >> ${rundir}/build/README
-
 #--------------------------------------------------------------------
 # Link to initial restart files, set start in cap_restart
 #--------------------------------------------------------------------
@@ -656,14 +652,38 @@ printf "\n     https://readthedocs.org/projects/gchp/\n\n"
 #---------------------------------------------------------------------------
 hdr="\n>>>> REMINDER: You must compile with options:"
 ftr="<<<<\n"
-[[ "x${sim_name}" == "xcarbon" ]] && printf "${hdr} -DMECH=carbon ${ftr}"
-## FUTURE-PROOFING: Hg may be added eventually (bmy, 03 Feb 2023)
-#[[ "x${sim_name}" == "xHg" ]] && printf "${hdr} -DMECH=Hg ${ftr}"
+
+EXTRA_CMAKE_OPTIONS=""
+[[ "x${sim_name}" == "xcarbon" ]] && EXTRA_CMAKE_OPTIONS="-DMECH=carbon"
+[[ "x${sim_name}" == "xHg"     ]] && EXTRA_CMAKE_OPTIONS="-DMECH=Hg"
 if [[ "x${sim_name}" == "xfullchem" ]]; then
-    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && printf "${hdr} -DRRTMG=y ${ftr}"
-# FUTURE-PROOFING: TOMAS will be added soon (bmy, 03 Feb 2023)
-#    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && printf "${hdr} -DTOMAS=y -DTOMAS_BINS=15 ${ftr}"
-#    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && printf "${hdr} -DTOMAS=y -DTOMAS_BINS=40 ${ftr}"
+    [[ "x${sim_extra_option}" == "xAPM"     ]] && EXTRA_CMAKE_OPTIONS="-DAPM=y"
+    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && EXTRA_CMAKE_OPTIONS="-DRRTMG=y"
+    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=15"
+    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=40"
 fi
+
+# Add to RUNDIR_VARS
+RUNDIR_VARS+="EXTRA_CMAKE_OPTIONS=${EXTRA_CMAKE_OPTIONS}"
+
+# Print a reminder to compile with extra CMake options, if necessary
+[[ "x${EXTRA_CMAKE_OPTIONS}" != "x" ]] && printf "${hdr} ${EXTRA_CMAKE_OPTIONS} ${ftr}"
+
+#---------------------------------------------------------------------------
+# Create build directory README file
+#---------------------------------------------------------------------------
+mkdir -p "${rundir}/build"
+msg="To build GEOS-Chem, type:\n\n"
+msg+="$ cmake ../CodeDir\n"
+msg+="$ cmake . -DRUNDIR=.. ${EXTRA_CMAKE_OPTIONS}\n"
+msg+="$ make -j\n"
+msg+="$ make install\n"
+printf "${msg}" > ${rundir}/build/README
+unset msg
+
+#-----------------------------------------------------------------
+# Done!
+#-----------------------------------------------------------------
+printf "\nCreated ${rundir}\n"
 
 exit 0


### PR DESCRIPTION
This PR prints out reminders to compile with certain CMake options at the end of the GCClassic and GCHP run directory creation process.  For example, if you were creating a GCClassic or GCHP run directory for a TOMAS15 simulation, you would see this text:

```console
... etc. not shown ...
-----------------------------------------------------------
Do you want to track run directory changes with git? (y/n)
-----------------------------------------------------------
n

>>>> REMINDER: You must compile with options: -DTOMAS=y -DTOMAS_BINS=15 <<<<

Created /path/to/tomas/run/dir
```

The reminders are printed just before the `createRunDir.sh` script stops executing so that the options remain prominent and visible to the user.

I have labeled this as a bug fix because reminders had been printed for some simulations but not for all relevant simulations, as they are now.