### PR TITLE
Fix bug where writing species metadata yaml file always attempted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased 14.1.1]
 ### Added
 - New integration test functions in `test/GCClassic/integration` and `test/GCHP/integration`
 - New parallelization test functions in `test/GCClassic/parallel`
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Integration test run directories are created with the default names assigned by `createRunDir.sh`
 - Several bash functions in `test/shared/commonFunctionsForTests.sh` have been combined so that they will work for both GCClassic and GCHP integration tests
 - `./cleanRunDir.sh` functions now take an argument for non-interactive execution (facilitates integration & parallelization tests)
+
+### Fixed
+- Fixed bug in where writing species metadata yaml file write was always attempted
 
 ### Removed
 - Removed `intTest*_slurm.sh`, `intTest_*lsf.sh`, and `intTest*_interactive.sh` integration test scripts

--- a/Headers/species_database_mod.F90
+++ b/Headers/species_database_mod.F90
@@ -835,22 +835,19 @@ CONTAINS
     !=======================================================================
     ! Print metadata for only the species that are defined in this
     ! simulation (but not the entire species database) to a YAML file.
-    !
-    ! Also note: Input_Opt%amIRoot is always set to False in MODEL_CESM
-    ! so we will need to block out the test for it for CESM only.
+    ! This file may be used for pre-processing files in other models
+    ! when updating GEOS-Chem versions, such as in WRF and CESM. It
+    ! should not be generated when running those models. Output file is
+    ! set in simulation%species_metadata_output_file in geoschem_config.yml.
     !=======================================================================
-    IF ( TRIM( Input_Opt%SpcMetaDataOutFile ) /= "none" ) THEN
-#ifndef MODEL_CESM
+    IF ( LEN(TRIM( Input_Opt%SpcMetaDataOutFile )) > 0 ) THEN
        IF ( Input_Opt%amIRoot ) THEN
-#endif
           CALL QFYAML_Print( yml        = yml,                               &
                              fileName   = Input_Opt%SpcMetaDataOutFile,      &
                              searchKeys = species_names,                     &
                              RC         = RC                                )
 
-#ifndef MODEL_CESM
        ENDIF
-#endif
     ENDIF
 
     !=======================================================================


### PR DESCRIPTION
This PR fixes a bug in which the model crashes if `species_metadata_output_file` is excluded from the `simulation` settings in `geoschem_config.yml`. It does this by changing the criteria to skip file write. Previously the criteria was that the output file path was equal to 'none'. This did not work since the output file path is initialized to an empty string. The new criteria is that the string length is greater than zero. If the setting is excluded from the config file it will no longer attempt to print. 

I also edited the comments and removed the CESM ifdefs from the section of code in which the yaml file write is called. WRF and CESM should not write the yaml file and the comments indicate that. Rather than prevent it via pre-processor switch the file path can be excluded from the `geoschem_config.yml` file as it is now.
