### PR TITLE
Reset SPC_ time entry from EFYO to CYS for integration tests and fullchem_benchmark runs

### DIFF
--- a/run/shared/setupConfigFiles.sh
+++ b/run/shared/setupConfigFiles.sh
@@ -111,6 +111,8 @@ function set_common_settings() {
     #------------------------------------------------------------------------
     if [[ "x${sim_extra_option}" == "xbenchmark" ]]; then
 
+	sed_ie 's|EFYO|CYS |'                         HEMCO_Config.rc  # Don't stop if species not found in restart file
+
         sed_ie 's|NO     0      3 |NO     104    -1|' HEMCO_Diagn.rc   # Use online soil NOx (ExtNr=104)
 	sed_ie 's|SALA  0      3 |SALA  107    -1|'   HEMCO_Diagn.rc   # Use online sea salt (ExtNr=107)
 	sed_ie 's|SALC  0      3 |SALC  107    -1|'   HEMCO_Diagn.rc   #   "   "

--- a/test/GCClassic/intTestExecute_slurm.sh
+++ b/test/GCClassic/intTestExecute_slurm.sh
@@ -106,6 +106,11 @@ for runDir in *; do
 	    # Copy the executable file here
 	    cp -f ${root}/exe_files/${exeFile} .
 
+	    # BMY KLUDGE!  Change EFYO to CYS in HEMCO_Config.rc
+	    # We will make the same chane in 14.1.1
+	    #  -- Bob Yantosca (08 Feb 2023)
+	    sed_ie 's/EFYO/CYS/' ./HEMCO_Config.rc
+
 	    # Run the code if the executable is present.  Then update the
 	    # pass/fail counters and write a message to the results log file.
 	    srun -c ${OMP_NUM_THREADS} ./${exeFile} >> ${log} 2>&1

--- a/test/GCHP/intTestCompile_slurm.sh
+++ b/test/GCHP/intTestCompile_slurm.sh
@@ -124,6 +124,12 @@ if [[ "x${passed}" == "x${numTests}" ]]; then
     for runDir in *; do
 	expr=$(is_gchp_rundir "${root}/${runDir}")
 	if [[ "x${expr}" == "xTRUE" ]]; then
+
+	    # BMY KLUDGE!  Change EFYO to CYS in HEMCO_Config.rc
+	    # We will make the same chane in 14.1.1
+	    #  -- Bob Yantosca (08 Feb 2023)
+	    sed_ie 's/EFYO/CYS/' ${root}/${rundir}/HEMCO_Config.rc
+	    
 	    jobId=$(submit_gchp_slurm_job ${root} ${runDir} ${jobId})
 	    print_to_log "${runDir} submitted as job ${jobId}" ${log}
 	fi


### PR DESCRIPTION
This PR does resets EFYO -> CYS time cycle flags (for restart file entry SPC_) in:

1. GCClassic integration tests
2. GCHP integration tests
3. fullchem_benchmark simulations.

This is necessary in order to allow integration tests and benchmark simulations to run when new species are added to a simulation.  Missing species will be assigned default background values.

NOTE: This is a kludge in order to get 14.2.0 integration tests running again.  We will make the same fix in 14.1.1, which has the updated integration test scrips (which have not yet been merged into 14.2.0).