### PR TITLE
Avoid compiler warning and compilation restart for KPP/fullchem/gckpp_Jacobian.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed bug in where writing species metadata yaml file write was always attempted
+- Prevent a warning from being generated when compiling `gckpp_Jacobian.F90`
 
 ### Removed
 - Removed `intTest*_slurm.sh`, `intTest_*lsf.sh`, and `intTest*_interactive.sh` integration test scripts

--- a/KPP/fullchem/CMakeLists.txt
+++ b/KPP/fullchem/CMakeLists.txt
@@ -63,7 +63,7 @@ target_compile_options(KPP
 )
 
 # FOR GFORTRAN ONLY: Disable variable tracking for gckpp_Jacobian.F90 in the
-# KPP/fullchem mechanism generated with KPP 3.0.0.  This will avoid a compiler
+# KPP/fullchem mechanism generated with KPP.  This will avoid a compiler
 # warning and a restart of the KPP library build.  This only has to be done
 # for release types "Release" and "RelWithDebugInfo".
 #   -- Bob Yantosca (16 Feb 2023)

--- a/KPP/fullchem/CMakeLists.txt
+++ b/KPP/fullchem/CMakeLists.txt
@@ -61,3 +61,17 @@ target_compile_options(KPP
   $<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","Intel">:-r8>
   $<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","GNU">:-fdefault-real-8 -fdefault-double-8>
 )
+
+# FOR GFORTRAN ONLY: Disable variable tracking for gckpp_Jacobian.F90 in the
+# KPP/fullchem mechanism generated with KPP 3.0.0.  This will avoid a compiler
+# warning and a restart of the KPP library build.  This only has to be done
+# for release types "Release" and "RelWithDebugInfo".
+#   -- Bob Yantosca (16 Feb 2023)
+if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+  if(NOT ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Debug"))
+    set_source_files_properties(gckpp_Jacobian.F90
+      PROPERTIES
+      COMPILE_OPTIONS -fno-var-tracking-assignments
+    )
+  endif()
+endif()

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -681,9 +681,4 @@ msg+="$ make install\n"
 printf "${msg}" > ${rundir}/build/README
 unset msg
 
-#-----------------------------------------------------------------
-# Done!
-#-----------------------------------------------------------------
-printf "\nCreated ${rundir}\n"
-
 exit 0


### PR DESCRIPTION
When compiling the `KPP/fullchem` mechanism generated with KPP 3.0.0, we often get this compiler warning:
```console
   48 | SUBROUTINE Jac_SP ( V, F, RCT, JVS )
      | 
note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’, retrying without
```
This indicates that the compilation is being restarted because the optimizer cannot keep track of the number of variable definitions in `gckpp_Jacobian.F90`.  This causes compilation to take longer. 

To avoid this, we have added code to the `KPP/fullchem/CMakeLists.txt` to prevent this compiler warning when `KPP/fullchem/gckpp_Jacobian.F90` is being compiled.  The code is only activated when building the `Release` or `RelWithDebugInfo` build types, as these options invoke the GNU Fortran optimizer, whereas `Debug` does not.