### PR TITLE
Fix bug in RRTMG optic diagnostics (AOD, SSA, Asym)

### DIFF
--- a/GeosCore/rrtmg_rad_transfer_mod.F90
+++ b/GeosCore/rrtmg_rad_transfer_mod.F90
@@ -1649,33 +1649,33 @@ CONTAINS
              IF ( State_Diag%Archive_RadOptics ) THEN
                 IF ( W == 1 ) THEN
                    IF ( State_Diag%Archive_RADAODWL1 ) THEN
-                      State_Diag%RADAODWL1(I,J,OUTIDX) = AODOUT
+                      State_Diag%RADAODWL1(I,J,iNcDiag) = AODOUT
                    ENDIF
                    IF ( State_Diag%Archive_RADSSAWL1 ) THEN
-                   State_Diag%RADSSAWL1(I,J,OUTIDX) = SSAOUT
+                   State_Diag%RADSSAWL1(I,J,iNcDiag) = SSAOUT
                       ENDIF
                    IF ( State_Diag%Archive_RADAsymWL1 ) THEN
-                      State_Diag%RADAsymWL1(I,J,OUTIDX) = ASYMOUT
+                      State_Diag%RADAsymWL1(I,J,iNcDiag) = ASYMOUT
                    ENDIF
                 ELSEIF ( W == 2 ) THEN
                    IF ( State_Diag%Archive_RADAODWL2 ) THEN
-                      State_Diag%RADAODWL2(I,J,OUTIDX) = AODOUT
+                      State_Diag%RADAODWL2(I,J,iNcDiag) = AODOUT
                    ENDIF
                    IF ( State_Diag%Archive_RADSSAWL2 ) THEN
-                      State_Diag%RADSSAWL2(I,J,OUTIDX) = SSAOUT
+                      State_Diag%RADSSAWL2(I,J,iNcDiag) = SSAOUT
                    ENDIF
                    IF ( State_Diag%Archive_RADAsymWL2 ) THEN
-                      State_Diag%RADAsymWL2(I,J,OUTIDX) = ASYMOUT
+                      State_Diag%RADAsymWL2(I,J,iNcDiag) = ASYMOUT
                    ENDIF
                 ELSEIF ( W == 3 ) THEN
                    IF ( State_Diag%Archive_RADAODWL3 ) THEN
-                      State_Diag%RADAODWL3(I,J,OUTIDX) = AODOUT
+                      State_Diag%RADAODWL3(I,J,iNcDiag) = AODOUT
                    ENDIF
                    IF ( State_Diag%Archive_RADSSAWL3 ) THEN
-                      State_Diag%RADSSAWL3(I,J,OUTIDX) = SSAOUT
+                      State_Diag%RADSSAWL3(I,J,iNcDiag) = SSAOUT
                    ENDIF
                    IF ( State_Diag%Archive_RADASYMWL3 ) THEN
-                      State_Diag%RADAsymWL3(I,J,OUTIDX) = ASYMOUT
+                      State_Diag%RADAsymWL3(I,J,iNcDiag) = ASYMOUT
                    ENDIF
                 ENDIF
              ENDIF


### PR DESCRIPTION
This PR fixes a bug that impacts radiation AOD, SSA, and Asym diagnostics. Indexing for these diagnostics was incorrect, potentially causing a silent bug when assigning data to the arrays. If a reduced set of diagnostics was included in `HISTORY.r` then an out-of-bounds error might be encountered, but only triggered if building with `Debug`, and the ordering of the data in the arrays might be wrong. If `?RRTMG?` wildcard was included in `HISTORY.rc` then there was no issue.

Background: RRTMG `State_Diag` array indexing may be different than RRTMG regular array indexing since the `State_Diag` arrays are only allocated for the diagnostics that are enabled in `HISTORY.rc`. For example, if no `PM` diagnostics are enabled in `HISTORY.rc` then the diagnostic arrays will be reduced in size to not include `PM`. The ordering of the diagnostic arrays are in the order of the output categories encountered, but with `BASE` always first, while the RRTMG array categories are always in the same order. If the `?RRTMG?` wildcard is used in `HISTORY.rc` then the diagnostic arrays include all output categories and the diagnostic and RRTMG array indexing is the same .

A problem in these diagnostics was first reported in https://github.com/geoschem/geos-chem/issues/1662.