### PR TITLE
Remove X-HRS printout from GEOS-Chem log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
   - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files
   - Removed the `NcdfUtil/perl` folder
+  - Removed `X-HRS` output from log file
 
 ## [14.1.0] - 2023-02-01
 ### Added

--- a/GeosUtil/time_mod.F90
+++ b/GeosUtil/time_mod.F90
@@ -3816,8 +3816,8 @@ CONTAINS
 !
 ! !IROUTINE: Print_Current_Time
 !
-! !DESCRIPTION: Subroutine PRINT\_CURRENT\_TIME prints the date, GMT time, and
-!  elapsed hours of a GEOS-Chem simulation.
+! !DESCRIPTION: Subroutine PRINT\_CURRENT\_TIME prints the date, and UTC time
+!  of a GEOS-Chem simulation.
 !\\
 !\\
 ! !INTERFACE:
@@ -3831,19 +3831,12 @@ CONTAINS
 !------------------------------------------------------------------------------
 !BOC
 !
-! !LOCAL VARIABLES:
-!
-    REAL(f4) :: E_HOURS
-
-    ! Hours since start of run
-    E_HOURS = REAL( ELAPSED_SEC ) / 3600e+0_f4
-
     ! Write quantities
-    WRITE( 6, 100 ) YEAR, MONTH, DAY, HOUR, MINUTE, E_HOURS
+    WRITE( 6, 100 ) YEAR, MONTH, DAY, HOUR, MINUTE
 
     ! Format string
 100 FORMAT( '---> DATE: ', i4.4, '/', i2.2, '/', i2.2, &
-                '  UTC: ', i2.2, ':', i2.2, '  X-HRS: ', f13.6 )
+                '  UTC: ', i2.2, ':', i2.2 )
 
   END SUBROUTINE PRINT_CURRENT_TIME
 !EOC


### PR DESCRIPTION
This is a simple PR removing X-HRS (elapsed hours from the beginning of the simulation) from the line in the GEOS-Chem log file that lists the date and time of each timestep. 

Closes #1676 