### PR TITLE
Fix several issues with GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GEOS-Chem user manual
+    url: https://geos-chem.readthedocs.io/en/stable
+    about: Click this link to read the GEOS-Chem user manual.

--- a/.github/ISSUE_TEMPLATE/new-feature-or-discussion.md
+++ b/.github/ISSUE_TEMPLATE/new-feature-or-discussion.md
@@ -1,5 +1,6 @@
 ---
 name: Request a new GEOS-Chem feature or start a discussion
+about: Use this form to request a new GEOS-Chem feature or start a discussion
 ---
 
 ### Name and Institution (Required)

--- a/.github/ISSUE_TEMPLATE/question-issue.md
+++ b/.github/ISSUE_TEMPLATE/question-issue.md
@@ -1,5 +1,6 @@
 ---
-name: Ask a question about or report an issue with GEOS-Chem
+name: Ask a question about GEOS-Chem or report an issue with GEOS-Chem
+about: Use this form to ask a question about GEOS-Chem or to report an issue
 ---
 
 ### Name and Institution (Required)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
----
-name: Submit updates to GEOS-Chem with a pull request
-labels: 'never stale'
-
----
-
 ### Name and Institution (Required)
 
 Name:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added GCHP and GCClassic integration tests for the carbon simulation
 - Integration and parallelization test folders have been separated into subdirectories to minimize clutter.
 - GEOS-only updates
+- Add `about` to GitHub issue templates (ensures they will be displayed)
+- Added `.github/ISSUE_TEMPLATE/config.yml` file w/ Github issue options
 
 ### Changed
 - GCClassic integration tests now use a single set of scripts
@@ -26,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Ask users for the name of their PI at registration
 - Do not compile GCHP for tagO3 integration tests; use the default build instead
 - Moved GC-Classic sample run scripts to operational_examples/harvard_cannon
+- The GitHub PR template is now named `./github/PULL_REQUEST_TEMPLATE.md`
 
 ### Fixed
 - Fixed bug in where writing species metadata yaml file write was always attempted


### PR DESCRIPTION
This PR fixes some problems with the GitHub issue and PR templates.  Namely:

1. Issue templates must have the `about:` yaml tag at top of file.
2. The PR template is now `.github/PULL_REQUEST_TEMPLATE.md`
3. Added `.github/ISSUE_TEMPLATE/config.yml` to prevent blank issues and add a link to the GC manual at RTD.

This is a zero-diff update, as only code in the `.github` folder was touched.