### PR TITLE
Remove references to Compute Canada from data download scripts

### DIFF
--- a/run/shared/download_data.gcap2.40L.yml
+++ b/run/shared/download_data.gcap2.40L.yml
@@ -11,12 +11,6 @@ mirrors:
     remote: s3://gcgrid
     command: 'aws s3 cp --request-payer=requester '
     quote: ""
-  computecanada:
-    short_name: cc
-    s3_bucket: False
-    remote: http://geoschemdata.computecanada.ca/ExtData
-    command:  'wget -r -np -nH -R "*.html" -N -P @PATH@ '
-    quote: '"'
   rochester:
     short_name: ur
     s3_bucket: False

--- a/run/shared/download_data.py
+++ b/run/shared/download_data.py
@@ -10,9 +10,8 @@ the following:
     (1) Creates a list of unique files that are required for the
         GEOS-Chem or HEMCO-standalone simulation;
 
-    (2) Creates a bash script to download missing files from either
-        the ComputeCanada server (default) or the AWS s3://gcgrid
-        bucket;
+    (2) Creates a bash script to download missing files from the AWS
+        s3://gcgrid bucket or from a specified server;
 
     (3) Executes the bash script to download the necessary data;
 
@@ -319,8 +318,8 @@ def write_unique_paths(paths, unique_log):
 def create_download_script(paths, args):
     """
     Creates a data download script to obtain missing files
-    from the ComputeCanada data archive (default), or the
-    GEOS-Chem s3://gcgrid bucket on the AWS cloud,
+    from the s3://gcgrid bucket on the AWS cloud or from a
+    specified server.
 
     Args:
     -----
@@ -519,8 +518,8 @@ def create_download_script(paths, args):
 
 def download_the_data(args):
     """
-    Downloads GEOS-Chem data files from the ComputeCanada server
-    or the AWS s3://gcgrid bucket.
+    Downloads GEOS-Chem data files from the AWS s3://gcgrid bucket
+    or from a specified server.
 
     Args:
     -----

--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -11,12 +11,6 @@ mirrors:
     remote: s3://gcgrid
     command: 'aws s3 cp --request-payer=requester '
     quote: ""
-  computecanada:
-    short_name: cc
-    s3_bucket: False
-    remote: http://geoschemdata.computecanada.ca/ExtData
-    command:  'wget -r -np -nH -R "*.html" -N -P @PATH@ '
-    quote: '"'
   rochester:
     short_name: ur
     s3_bucket: False


### PR DESCRIPTION
The ComputeCanada site hosting GEOS-Chem data has been retired. References to it have been removed from the download data scripts and yaml files.