### PR TITLE
Fix computation of planeCount for Harvard Cannon GCHP run scripts and integration test scripts

### DIFF
--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -28,9 +28,11 @@ export OMPI_MCL_btl=openib
 # Run GCHP and evenly distribute tasks across nodes
 NX=$( grep NX GCHP.rc | awk '{print $2}' )
 NY=$( grep NY GCHP.rc | awk '{print $2}' )
-let coreCount=$(( ${NX} * ${NY} ))
-let planeCount=$(( ${coreCount} / ${SLURM_NNODES} ))
-[[ $(( ${coreCount} % ${SLURM_NNODES} )) > 0 ]] && let planeCount+=1
+coreCount=$(( ${NX} * ${NY} ))
+planeCount=$(( ${coreCount} / ${SLURM_NNODES} ))
+if [[ $(( ${coreCount} % ${SLURM_NNODES} )) > 0 ]]; then
+    planeCount=$(( ${planeCount} + 1 ))
+fi
 time srun -n ${coreCount} -N ${SLURM_NNODES} -m plane=${planeCount} --mpi=pmix ./gchp >> ${log}
 
 # Rename and move restart file and update restart symlink if new start time ok

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -28,11 +28,9 @@ export OMPI_MCL_btl=openib
 # Run GCHP and evenly distribute tasks across nodes
 NX=$( grep NX GCHP.rc | awk '{print $2}' )
 NY=$( grep NY GCHP.rc | awk '{print $2}' )
-coreCount=$(( ${NX} * ${NY} ))
-planeCount=$(( ${coreCount} / ${SLURM_NNODES} ))
-if [[ $(( ${coreCount} % ${SLURM_NNODES} )) > 0 ]]; then
-	${planeCount}=$(( ${planeCount} + 1 ))
-fi
+let coreCount=$(( ${NX} * ${NY} ))
+let planeCount=$(( ${coreCount} / ${SLURM_NNODES} ))
+[[ $(( ${coreCount} % ${SLURM_NNODES} )) > 0 ]] && let planeCount+=1
 time srun -n ${coreCount} -N ${SLURM_NNODES} -m plane=${planeCount} --mpi=pmix ./gchp >> ${log}
 
 # Rename and move restart file and update restart symlink if new start time ok

--- a/test/GCHP/integration/integrationTestExecute.sh
+++ b/test/GCHP/integration/integrationTestExecute.sh
@@ -213,10 +213,10 @@ for runDir in *; do
 		#  runScriptSamples/operational_examples/harvard_cannon
 		NX=$(grep NX GCHP.rc | awk '{print $2}')
 		NY=$(grep NY GCHP.rc | awk '{print $2}')
-		let coreCt=$(( ${NX} * ${NY} ))
-		let planeCt=$(( ${coreCt} / ${SLURM_NNODES} ))
+		coreCt=$(( ${NX} * ${NY} ))
+		planeCt=$(( ${coreCt} / ${SLURM_NNODES} ))
 		if [[ $(( ${coreCt} % ${SLURM_NNODES} )) > 0 ]]; then
-		    let planeCt+=1
+		    planeCt=$(( ${planeCt} + 1 ))
 		fi
 
 		# Execute GCHP with srun

--- a/test/GCHP/integration/integrationTestExecute.sh
+++ b/test/GCHP/integration/integrationTestExecute.sh
@@ -213,10 +213,10 @@ for runDir in *; do
 		#  runScriptSamples/operational_examples/harvard_cannon
 		NX=$(grep NX GCHP.rc | awk '{print $2}')
 		NY=$(grep NY GCHP.rc | awk '{print $2}')
-		coreCt=$(( ${NX} * ${NY} ))
-		planeCt=$(( ${coreCt} / ${SLURM_NNODES} ))
+		let coreCt=$(( ${NX} * ${NY} ))
+		let planeCt=$(( ${coreCt} / ${SLURM_NNODES} ))
 		if [[ $(( ${coreCt} % ${SLURM_NNODES} )) > 0 ]]; then
-		    ${planeCt}=$(( ${planeCt} + 1 ))
+		    let planeCt+=1
 		fi
 
 		# Execute GCHP with srun


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard / GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This fixes an error in the computation of the plane count.  This is passed as an argument to the `srun` command in order to run GCHP on the Harvard Cannon cluster with OpenMPI.

### Expected changes

This will increment the plane count by 1 in the rare event that the core count is not evenly divisible by the number of nodes. 

### Reference(s)

N/A

### Related Github Issue(s)

This issue was raised by @sdeastham in #1685.  This PR closes #1685.