### PR TITLE
Fix typo in GCClassic/createRunDir.sh preventing benchmark run script from being copied to run directory

### DIFF
--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -848,7 +848,7 @@ fi
 
 # If benchmark simulation, put run script in directory
 if [[ "x${sim_extra_option}" == "xbenchmark" ]]; then
-    scriptDir = ./runScriptSamples/operational_examples/harvard_cannon
+    scriptDir="./runScriptSamples/operational_examples/harvard_cannon"
     cp ${scriptDir}/geoschem.benchmark.run ${rundir}
     chmod 744 ${rundir}/geoschem.benchmark.run
 fi


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

The line defining `scriptDir` in `run/GCClassic/createRunDir.sh` included spaces around the equals sign. Removing these fixes the error one sees when generating a benchmark run directory.

### Expected changes

This is a zero difference fix.

### Related Github Issue(s)

See #1693 
