### PR TITLE
Prevent divide by zero in sulfur chemistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
   - Fixed typo in `GCClassic/createRunDir.sh` preventing benchmark run script from being copied to the run directory
+  - Fixed divide by zero bug in sulfur chemistry introduced in 14.1.0
 
 ## [14.1.1] - 2023-03-03
 ### Added

--- a/KPP/fullchem/fullchem_SulfurChemFuncs.F90
+++ b/KPP/fullchem/fullchem_SulfurChemFuncs.F90
@@ -165,6 +165,7 @@ CONTAINS
     ! Scalars
     LOGICAL            :: SALAAL_gt_0_1
     LOGICAL            :: SALCAL_gt_0_1
+    LOGICAL            :: O3_gt_0
     REAL(fp)           :: k_ex
 
     ! Strings
@@ -181,6 +182,7 @@ CONTAINS
     K_MT          = 0.0_dp
     SALAAL_gt_0_1 = ( C(ind_SALAAL) > 0.1_dp )
     SALCAL_gt_0_1 = ( C(ind_SALCAL) > 0.1_dp )
+    O3_gt_0       = ( C(ind_O3) > 0.0_dp )
 
     !======================================================================
     ! Reaction rates [1/s] for fine sea salt alkalinity (aka SALAAL)
@@ -195,7 +197,7 @@ CONTAINS
     !------------------------------------------------------------------------
     ! SALAAL + SO2 + O3 = SO4 - SALAAL
     !------------------------------------------------------------------------
-    IF ( SALAAL_gt_0_1 ) THEN
+    IF ( SALAAL_gt_0_1 .AND. O3_gt_0 ) THEN
 
        ! 1st order uptake
        k_ex = Ars_L1K( area   = State_Chm%WetAeroArea(I,J,L,11),             &
@@ -250,7 +252,7 @@ CONTAINS
     !------------------------------------------------------------------------
     ! SALCAL + SO2 + O3 = SO4s - SALCAL
     !------------------------------------------------------------------------
-    IF ( SALCAL_gt_0_1 ) THEN
+    IF ( SALCAL_gt_0_1 .AND. O3_gt_0 ) THEN
 
        ! 1st order uptake
        k_ex = Ars_L1K( area   = State_Chm%WetAeroArea(I,J,L,12),             &


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR fixes a bug introduced in version 14.1 in KPP sulfur chemistry where ozone concentration was in the denominator of a quotient without divide by zero handling. This resulted in the model crashing at various points during full chemistry runs using GEOS-Chem 14.1.

### Expected changes

This update will avoid NaN values for species concentrations.

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue(s)

* [geoschem/geos-chem Issue #1662](https://github.com/geoschem/geos-chem/issues/1662)
* [geoschem/gchp Issue #302](https://github.com/geoschem/GCHP/issues/302)

