### PR TITLE
Reset "EFY" to "CYS" for nested boundary conditions in GCClassic integration & parallel tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 14.2.0]
 ### Added
-  - Added a printout of GEOS-Chem species and indices
-  - Added 'NcdfUtil/README.md` file directing users to look for netCDF utility scripts at https://github.com/geoschem/netcdf-scripts
+- Added a printout of GEOS-Chem species and indices
+- Added 'NcdfUtil/README.md` file directing users to look for netCDF utility scripts at https://github.com/geoschem/netcdf-scripts
 
 ### Changed
-  - Most printout has been converted to debug printout (toggled by `debug_printout: true` in `geoschem_config.yml`
-  - `HEMCO_Config.rc` template files now use `Verbose: true` to toggle debug printout
-  - Turn on sea salt debromination via switches in `HEMCO_config.rc`
+- Most printout has been converted to debug printout (toggled by `debug_printout: true` in `geoschem_config.yml`
+- `HEMCO_Config.rc` template files now use `Verbose: true` to toggle debug printout
+- Turn on sea salt debromination via switches in `HEMCO_config.rc`
 
 ### Removed
-  - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files
-  - Removed the `NcdfUtil/perl` folder
-  - Removed `X-HRS` output from log file
+- `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files
+- Removed the `NcdfUtil/perl` folder
+- Removed `X-HRS` output from log file
 
 ### Fixed
-  - Fixed typo in `GCClassic/createRunDir.sh` preventing benchmark run script from being copied to the run directory
-  - Fixed divide by zero bug in sulfur chemistry introduced in 14.1.0
+- Fixed typo in `GCClassic/createRunDir.sh` preventing benchmark run script from being copied to the run directory
+- Fixed divide by zero bug in sulfur chemistry introduced in 14.1.0
+- Updates for 0.5 x 0.625 degree GCClassic integration & parallel tests
+  - Use `CYS` in `HEMCO_Config.rc` so that missing species in `GC_BCs` will not stop simulations
+  - Tests now run for 20 model minutes instead of an hour
 
 ## [14.1.1] - 2023-03-03
 ### Added

--- a/test/GCClassic/integration/integrationTestExecute.sh
+++ b/test/GCClassic/integration/integrationTestExecute.sh
@@ -188,9 +188,10 @@ for runDir in *; do
             # Remove any leftover files in the run dir
             ./cleanRunDir.sh --no-interactive >> "${log}" 2>&1
 
-	    # Change time cycle flag in HEMCO_Config.rc from EFYO to CYS,
+	    # Change time cycle flags in HEMCO_Config.rc from EFYO to CYS,
 	    # to allow missing species to be set a default value.
-	    sed_ie "s/EFYO/CYS/" HEMCO_Config.rc
+	    sed_ie "s/EFYO/CYS/"            HEMCO_Config.rc  # GC_RESTART
+	    sed_ie "s/EFY xyz 1/CYS xyz 1/" HEMCO_Config.rc  # GC_BCs
 
             # Run the code if the executable is present.  Then update the
             # pass/fail counters and write a message to the results log file.

--- a/test/GCClassic/parallel/parallelTestExecute.sh
+++ b/test/GCClassic/parallel/parallelTestExecute.sh
@@ -186,7 +186,8 @@ for runDir in *; do
 
 	    # Change time cycle flag in HEMCO_Config.rc from EFYO to CYS,
 	    # to allow missing species to be set a default value.
-	    sed_ie "s/EFYO/CYS/" HEMCO_Config.rc
+	    sed_ie "s/EFYO/CYS/"            HEMCO_Config.rc  # GC_RESTART
+	    sed_ie "s/EFY xyz 1/CYS xyz 1/" HEMCO_Config.rc  # GC_BCs
 
             #----------------------------------------------------------------
             # First test: Use all available threads

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -32,7 +32,8 @@ SED_CONFIG_3='s/end_date: \[20160201, 000000\]/end_date: \[20190101, 010000\]/'
 SED_CONFIG_4='s/end_date: \[20160101, 000000\]/end_date: \[20190101, 010000\]/'
 SED_CONFIG_5='s/end_date: \[20190201, 000000\]/end_date: \[20190101, 010000\]/'
 SED_CONFIG_6='s/end_date: \[20190801, 000000\]/end_date: \[20190701, 010000\]/'
-SED_CONFIG_N='s/end_date: \[20190801, 000000\]/end_date: \[20190701, 002000\]/'
+SED_CONFIG_N1='s/end_date: \[20190201, 000000\]/end_date: \[20190101, 002000\]/'
+SED_CONFIG_N2='s/end_date: \[20190801, 000000\]/end_date: \[20190701, 002000\]/'
 SED_HEMCO_CONF_1='s/GEOS_0.25x0.3125/GEOS_0.25x0.3125_NA/'
 SED_HEMCO_CONF_2='s/GEOS_0.5x0.625/GEOS_0.5x0.625_NA/'
 SED_HEMCO_CONF_N='s/\$RES.\$NC/\$RES.NA.\$NC/'
@@ -198,7 +199,8 @@ function update_config_files() {
     # For nested-grid fullchem runs, change simulation time to 20 minutes
     # in order to reduce the run time of the whole set of integration tests.
     if grep -q "05x0625" <<< "${runPath}"; then
-	sed_ie "${SED_CONFIG_N}" "${runPath}/geoschem_config.yml"
+	sed_ie "${SED_CONFIG_N1}" "${runPath}/geoschem_config.yml"
+	sed_ie "${SED_CONFIG_N2}" "${runPath}/geoschem_config.yml"
     fi
 
     # Other text replacements

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -197,10 +197,7 @@ function update_config_files() {
 
     # For nested-grid fullchem runs, change simulation time to 20 minutes
     # in order to reduce the run time of the whole set of integration tests.
-    if grep -q "025x03125_fullchem" <<< "${runPath}"; then
-	sed_ie "${SED_CONFIG_N}" "${runPath}/geoschem_config.yml"
-    fi
-    if grep -q "05x0625_fullchem" <<< "${runPath}"; then
+    if [[ "x${runPath}" == "xgc_05x0625_NA_47L_merra2_fullchem" ]]; then
 	sed_ie "${SED_CONFIG_N}" "${runPath}/geoschem_config.yml"
     fi
 
@@ -217,9 +214,6 @@ function update_config_files() {
     #------------------------------------------------------------------------
 
     # For all nested-grid rundirs, add a NA into the entries for met fields
-    if grep -q "025x03125" <<< "${runPath}"; then
-	sed_ie "${SED_HEMCO_CONF_N}" "${runPath}/HEMCO_Config.rc"
-    fi
     if grep -q "05x0625" <<< "${runPath}"; then
 	sed_ie "${SED_HEMCO_CONF_N}" "${runPath}/HEMCO_Config.rc"
     fi
@@ -234,9 +228,6 @@ function update_config_files() {
 
     if [[ -f "${runPath}/HEMCO_Config.rc.gmao_metfields" ]]; then
 	# For all nested-grid rundirs, add a NA into the entries for met fields
-	if grep -q "025x03125" <<< "${runPath}"; then
-	    sed_ie "${SED_HEMCO_CONF_N}" "${runPath}/HEMCO_Config.rc.gmao_metfields"
-	fi
 	if grep -q "05x0625" <<< "${runPath}"; then
 	    sed_ie "${SED_HEMCO_CONF_N}" "${runPath}/HEMCO_Config.rc.gmao_metfields"
 	fi
@@ -252,10 +243,7 @@ function update_config_files() {
 
     # For nested-grid fullchem runs, change frequency and duration to 20 mins
     # in order to reduce the run time of the whole set of integration tests.
-    if grep -q "025x03125_fullchem" <<< "${runPath}"; then
-	sed_ie "${SED_HISTORY_RC_N}" "${runPath}/HISTORY.rc"
-    fi
-    if grep -q "05x0625_fullchem" <<< "${runPath}"; then
+    if [[ "x${runPath}" == "xgc_05x0625_NA_47L_merra2_fullchem" ]]; then
 	sed_ie "${SED_HISTORY_RC_N}" "${runPath}/HISTORY.rc"
     fi
 

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -197,7 +197,7 @@ function update_config_files() {
 
     # For nested-grid fullchem runs, change simulation time to 20 minutes
     # in order to reduce the run time of the whole set of integration tests.
-    if [[ "x${runPath}" == "xgc_05x0625_NA_47L_merra2_fullchem" ]]; then
+    if grep -q "05x0625" <<< "${runPath}"; then
 	sed_ie "${SED_CONFIG_N}" "${runPath}/geoschem_config.yml"
     fi
 
@@ -243,7 +243,7 @@ function update_config_files() {
 
     # For nested-grid fullchem runs, change frequency and duration to 20 mins
     # in order to reduce the run time of the whole set of integration tests.
-    if [[ "x${runPath}" == "xgc_05x0625_NA_47L_merra2_fullchem" ]]; then
+    if grep -q "05x0625" <<< "${runPath}"; then
 	sed_ie "${SED_HISTORY_RC_N}" "${runPath}/HISTORY.rc"
     fi
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to issue #1705.  A fix has been added to GEOS-Chem Classic integration and parallel test scripts to reset the HEMCO time cycle flag from `EFY` to `CYS` for the boundary conditions collection `GC_BCs`.

Also included in this PR is a fix to integration test script `commonFunctionsForTests.sh` to restore shorter run times to the nested-grid fullchem integration & parallel tests.  The directory names for integration tests changed in 14.1.1 but this script was never updated.  This should result in faster integration & parallel tests, which should hopefuly avoid cluster timeouts.

This will be a zero-diff update,  as it only affects the GCClassic integration & parallel tests.

### Expected changes

The `gc_05x0625_NA_47L_merra2_fullchem` integration test, which was failing due to missing species (introduced in 14.2.0-alpha.1) should now pass.

### Reference(s)

N/A

### Related Github Issue(s)

Closes #1705 

NOTE: This should go into 14.2.0 ASAP.  It can be bundled with another science update.