### PR TITLE
Update global_ch4_mod.F90 to correct bug that incorrectly selects troposphere-stratosphere boundary

### DIFF
--- a/GeosCore/global_ch4_mod.F90
+++ b/GeosCore/global_ch4_mod.F90
@@ -909,7 +909,7 @@ CONTAINS
     DO I = 1, State_Grid%NX
 
        ! Only consider tropospheric boxes
-       IF ( State_Met%InChemGrid(I,J,L) ) THEN
+       IF ( State_Met%InTroposphere(I,J,L) ) THEN
 
           ! Calculate rate coefficients
           KRATE    = 2.45e-12_fp * EXP( -1775e+0_fp / State_Met%T(I,J,L))
@@ -1385,7 +1385,7 @@ CONTAINS
     DO I = 1, State_Grid%NX
 
        ! Only proceed if we are outside of the chemistry grid
-       IF ( .not. State_Met%InChemGrid(I,J,L) ) THEN
+       IF ( .not. State_Met%InTroposphere(I,J,L) ) THEN
 
           ! Conversion factor [kg/box] --> [molec/cm3]
           ! [kg/box] / [AIRVOL * 1e6 cm3] * [XNUMOL_CH4 molec/mole]


### PR DESCRIPTION
### Name and Institution (Required)

Name: Todd Mooring
Institution: Harvard ACMG

### Confirm you have reviewed the following documentation

Yes, I reviewed the guidelines for contributors.

### Describe the update

Methane destruction in the methane specialty simulation is supposed to be computed based on specified OH and Cl fields in the troposphere and GMI loss frequencies in the stratosphere and mesosphere. To calculate methane destruction in this way, each gridbox must be identified as located in the troposphere or in the stratosphere-mesosphere.

Unfortunately, this identification is done incorrectly in a number of recent GCC versions including 14.1.1. In the existing code, whether or not gridbox I,J,L is in the troposphere is determined by the value of State_Met%InChemGrid(I,J,L). If this is true (false), the box is assumed to be in the troposphere (stratosphere-mesosphere).

However, for the 72-level configuration of the methane specialty simulation State_Met%InChemGrid(I,J,L) is true in the bottom 59 levels and false above. Therefore the "troposphere" is assumed to be the bottom 59 levels of the model--and level 59 has a pressure of ~0.9 hPa. The OH/Cl loss calculation is therefore incorrectly used throughout the troposphere and stratosphere, with the GMI loss calculation done only the top 13 layers--roughly the mesosphere.

This bug can be rectified by replacing State_Met%InChemGrid(I,J,L) with State_Met%InTroposphere(I,J,L) at two places in global_ch4_mod.F90. This value correctly indicates whether a grid box is in the troposphere.

### Expected changes

The standard output for the methane specialty simulation includes several variables (LossCH4byOHinTrop, LossCH4byClinTrop, LossCH4inStrat) that contain information about loss rates partitioned by loss mechanism. The attached figure illustrates that for the out-of-the-box simulation with the above-described bug, the OH- and Cl-caused losses are nonzero well into the stratosphere (contrary to their ostensibly tropospheric nature). Furthermore, nonzero GMI losses are applied only above ~1 hPa even though they are supposed to be used in the stratosphere as well. When the bug is fixed, the loss rates adopt more appropriate vertical structures (OH and Cl confined to the troposphere, GMI losses in the stratosphere and mesosphere).

Although this figure confirms that the above-described code changes had the expected effect, a more extensive scientific evaluation has not been conducted in anticipation of the replacement of the (stratospheric) GMI loss frequencies by loss frequencies computed from the GCC 14.0.0 10-year benchmark simulation.

[GCC1411_tropopause_bugfix_validation_032023.pdf](https://github.com/geoschem/geos-chem/files/11023731/GCC1411_tropopause_bugfix_validation_032023.pdf)

### Reference(s)

(Not a science update.)

### Related Github Issue(s)

(No associated Github issue.)
