### PR TITLE
Restore vertical emission distributions to CEDS energy and industry emissions

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -1088,22 +1088,22 @@ Warnings:                    1
 # EDGAR, HTAPv3 or CMIP6_SFC_LAND_ANTHRO for the global base emissions %%%
 #==============================================================================
 (((CEDSv2
-0 CEDS_SOAP_ENE   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ene            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280    1 5
-0 CEDS_SOAP_IND   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ind            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280    1 5
-0 CEDS_SOAP_TRA   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_tra            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280    1 5
-0 CEDS_SOAP_RCO   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_rco            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280    1 5
-0 CEDS_SOAP_SLV   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_slv            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280    1 5
-0 CEDS_SOAP_WST   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_wst            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280    1 5
+0 CEDS_SOAP_ENE   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ene            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280/315 1 5
+0 CEDS_SOAP_IND   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ind            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280/316 1 5
+0 CEDS_SOAP_TRA   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_tra            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280     1 5
+0 CEDS_SOAP_RCO   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_rco            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280     1 5
+0 CEDS_SOAP_SLV   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_slv            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280     1 5
+0 CEDS_SOAP_WST   $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_wst            1750-2019/1-12/1/0 C xy kg/m2/s SOAP  26/280     1 5
 
 0 CEDS_SO2_AGR    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_agr           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
 0 CEDS_SO4_AGR    -                                                                    -                 -                  - -  -       SO4   63        1 5
 0 CEDS_pFe_AGR    -                                                                    -                 -                  - -  -       pFe   66        1 5
-0 CEDS_SO2_ENE    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
-0 CEDS_SO4_ENE    -                                                                    -                 -                  - -  -       SO4   63        1 5
-0 CEDS_pFe_ENE    -                                                                    -                 -                  - -  -       pFe   66        1 5
-0 CEDS_SO2_IND    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
-0 CEDS_SO4_IND    -                                                                    -                 -                  - -  -       SO4   63        1 5
-0 CEDS_pFe_IND    -                                                                    -                 -                  - -  -       pFe   66        1 5
+0 CEDS_SO2_ENE    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s SO2   315       1 5
+0 CEDS_SO4_ENE    -                                                                    -                 -                  - -  -       SO4   63/315    1 5
+0 CEDS_pFe_ENE    -                                                                    -                 -                  - -  -       pFe   66/315    1 5
+0 CEDS_SO2_IND    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s SO2   316       1 5
+0 CEDS_SO4_IND    -                                                                    -                 -                  - -  -       SO4   63/316    1 5
+0 CEDS_pFe_IND    -                                                                    -                 -                  - -  -       pFe   66/316    1 5
 0 CEDS_SO2_TRA    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_tra           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
 0 CEDS_SO4_TRA    -                                                                    -                 -                  - -  -       SO4   63        1 5
 0 CEDS_pFe_TRA    -                                                                    -                 -                  - -  -       pFe   66        1 5
@@ -1118,8 +1118,8 @@ Warnings:                    1
 0 CEDS_pFe_WST    -                                                                    -                 -                  - -  -       pFe   66        1 5
 
 0 CEDS_NH3_AGR    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_agr           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
-0 CEDS_NH3_ENE    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ene           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
-0 CEDS_NH3_IND    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ind           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
+0 CEDS_NH3_ENE    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ene           1750-2019/1-12/1/0 C xy kg/m2/s NH3   315      1 5
+0 CEDS_NH3_IND    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ind           1750-2019/1-12/1/0 C xy kg/m2/s NH3   316       1 5
 0 CEDS_NH3_TRA    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_tra           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
 0 CEDS_NH3_RCO    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_rco           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
 0 CEDS_NH3_SLV    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_slv           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
@@ -1127,10 +1127,10 @@ Warnings:                    1
 
 0 CEDS_BCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_agr            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
 0 CEDS_BCPO_AGR   -                                                                    -                 -                  - -  -       BCPO  71        1 5
-0 CEDS_BCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
-0 CEDS_BCPO_ENE   -                                                                    -                 -                  - -  -       BCPO  71        1 5
-0 CEDS_BCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
-0 CEDS_BCPO_IND   -                                                                    -                 -                  - -  -       BCPO  71        1 5
+0 CEDS_BCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70/315    1 5
+0 CEDS_BCPO_ENE   -                                                                    -                 -                  - -  -       BCPO  71/315    1 5
+0 CEDS_BCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70/316    1 5
+0 CEDS_BCPO_IND   -                                                                    -                 -                  - -  -       BCPO  71/316    1 5
 0 CEDS_BCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_tra            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
 0 CEDS_BCPO_TRA   -                                                                    -                 -                  - -  -       BCPO  71        1 5
 0 CEDS_BCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_rco            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
@@ -1142,10 +1142,10 @@ Warnings:                    1
 
 0 CEDS_OCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_agr            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_AGR   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
-0 CEDS_OCPO_ENE   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
-0 CEDS_OCPO_IND   -                                                                    -                 -                  - -  -       OCPO  73        1 5
+0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72/315    1 5
+0 CEDS_OCPO_ENE   -                                                                    -                 -                  - -  -       OCPO  73/315    1 5
+0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72/316    1 5
+0 CEDS_OCPO_IND   -                                                                    -                 -                  - -  -       OCPO  73/316    1 5
 0 CEDS_OCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_tra            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_TRA   -                                                                    -                 -                  - -  -       OCPO  73        1 5
 0 CEDS_OCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_rco            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -1358,37 +1358,37 @@ Warnings:                    1
 #==============================================================================
 (((CEDSv2
 0 CEDS_NO_AGR     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_agr            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
-0 CEDS_NO_ENE     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ene            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
-0 CEDS_NO_IND     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ind            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
+0 CEDS_NO_ENE     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ene            1750-2019/1-12/1/0 C xy kg/m2/s NO    25/315    1 5
+0 CEDS_NO_IND     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ind            1750-2019/1-12/1/0 C xy kg/m2/s NO    25/316    1 5
 0 CEDS_NO_TRA     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_tra            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
 0 CEDS_NO_RCO     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_rco            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
 0 CEDS_NO_SLV     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_slv            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
 0 CEDS_NO_WST     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_wst            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
 
-0 CEDS_CO_AGR     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_agr            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_AGR   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_ENE     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ene            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_ENE   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_IND     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ind            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_IND   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_TRA     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_tra            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_TRA   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_RCO     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_rco            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_RCO   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_SLV     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_slv            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_SLV   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_WST     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_wst            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_WST   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
+0 CEDS_CO_AGR     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_agr            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_AGR   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
+0 CEDS_CO_ENE     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ene            1750-2019/1-12/1/0 C xy kg/m2/s CO    26/315     1 5
+0 CEDS_SOAP_ENE   -                                                                    -                 -                  - -  -       SOAP  26/280/315 1 5
+0 CEDS_CO_IND     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ind            1750-2019/1-12/1/0 C xy kg/m2/s CO    26/316     1 5
+0 CEDS_SOAP_IND   -                                                                    -                 -                  - -  -       SOAP  26/280/316 1 5
+0 CEDS_CO_TRA     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_tra            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_TRA   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
+0 CEDS_CO_RCO     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_rco            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_RCO   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
+0 CEDS_CO_SLV     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_slv            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_SLV   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
+0 CEDS_CO_WST     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_wst            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_WST   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
 
 0 CEDS_SO2_AGR    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_agr           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
 0 CEDS_SO4_AGR    -                                                                    -                 -                  - -  -       SO4   63        1 5
 0 CEDS_pFe_AGR    -                                                                    -                 -                  - -  -       pFe   66        1 5
-0 CEDS_SO2_ENE    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
-0 CEDS_SO4_ENE    -                                                                    -                 -                  - -  -       SO4   63        1 5
-0 CEDS_pFe_ENE    -                                                                    -                 -                  - -  -       pFe   66        1 5
-0 CEDS_SO2_IND    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
-0 CEDS_SO4_IND    -                                                                    -                 -                  - -  -       SO4   63        1 5
-0 CEDS_pFe_IND    -                                                                    -                 -                  - -  -       pFe   66        1 5
+0 CEDS_SO2_ENE    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s SO2   315       1 5
+0 CEDS_SO4_ENE    -                                                                    -                 -                  - -  -       SO4   63/315    1 5
+0 CEDS_pFe_ENE    -                                                                    -                 -                  - -  -       pFe   66/315    1 5
+0 CEDS_SO2_IND    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s SO2   316       1 5
+0 CEDS_SO4_IND    -                                                                    -                 -                  - -  -       SO4   63/316    1 5
+0 CEDS_pFe_IND    -                                                                    -                 -                  - -  -       pFe   66/316    1 5
 0 CEDS_SO2_TRA    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_tra           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
 0 CEDS_SO4_TRA    -                                                                    -                 -                  - -  -       SO4   63        1 5
 0 CEDS_pFe_TRA    -                                                                    -                 -                  - -  -       pFe   66        1 5
@@ -1403,8 +1403,8 @@ Warnings:                    1
 0 CEDS_pFe_WST    -                                                                    -                 -                  - -  -       pFe   66        1 5
 
 0 CEDS_NH3_AGR    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_agr           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
-0 CEDS_NH3_ENE    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ene           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
-0 CEDS_NH3_IND    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ind           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
+0 CEDS_NH3_ENE    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ene           1750-2019/1-12/1/0 C xy kg/m2/s NH3   315       1 5
+0 CEDS_NH3_IND    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ind           1750-2019/1-12/1/0 C xy kg/m2/s NH3   316       1 5
 0 CEDS_NH3_TRA    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_tra           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
 0 CEDS_NH3_RCO    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_rco           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
 0 CEDS_NH3_SLV    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_slv           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
@@ -1412,10 +1412,10 @@ Warnings:                    1
 
 0 CEDS_BCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_agr            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
 0 CEDS_BCPO_AGR   -                                                                    -                 -                  - -  -       BCPO  71        1 5
-0 CEDS_BCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
-0 CEDS_BCPO_ENE   -                                                                    -                 -                  - -  -       BCPO  71        1 5
-0 CEDS_BCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
-0 CEDS_BCPO_IND   -                                                                    -                 -                  - -  -       BCPO  71        1 5
+0 CEDS_BCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70/315    1 5
+0 CEDS_BCPO_ENE   -                                                                    -                 -                  - -  -       BCPO  71/315    1 5
+0 CEDS_BCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70/316    1 5
+0 CEDS_BCPO_IND   -                                                                    -                 -                  - -  -       BCPO  71/316    1 5
 0 CEDS_BCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_tra            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
 0 CEDS_BCPO_TRA   -                                                                    -                 -                  - -  -       BCPO  71        1 5
 0 CEDS_BCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_rco            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
@@ -1429,14 +1429,14 @@ Warnings:                    1
 0 CEDS_OCPO_AGR   -                                                                    -                 -                  - -  -       OCPO  73        1 5
 0 CEDS_POG1_AGR   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
 0 CEDS_POG2_AGR   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
-0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
-0 CEDS_OCPO_ENE   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_ENE   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
-0 CEDS_POG2_ENE   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
-0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
-0 CEDS_OCPO_IND   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_IND   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
-0 CEDS_POG2_IND   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
+0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72/315    1 5
+0 CEDS_OCPO_ENE   -                                                                    -                 -                  - -  -       OCPO  73/315    1 5
+0 CEDS_POG1_ENE   -                                                                    -                 -                  - -  -       POG1  74/76/315 1 5
+0 CEDS_POG2_ENE   -                                                                    -                 -                  - -  -       POG2  74/77/315 1 5
+0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72/316    1 5
+0 CEDS_OCPO_IND   -                                                                    -                 -                  - -  -       OCPO  73/316    1 5
+0 CEDS_POG1_IND   -                                                                    -                 -                  - -  -       POG1  74/76/316 1 5
+0 CEDS_POG2_IND   -                                                                    -                 -                  - -  -       POG2  74/77/316 1 5
 0 CEDS_OCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_tra            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_TRA   -                                                                    -                 -                  - -  -       OCPO  73        1 5
 0 CEDS_POG1_TRA   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
@@ -1456,8 +1456,8 @@ Warnings:                    1
 
 # Comment out CO2 for fullchem simulations: CO2 not advected
 #0 CEDS_CO2_AGR   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_agr           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
-#0 CEDS_CO2_ENE   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
-#0 CEDS_CO2_IND   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
+#0 CEDS_CO2_ENE   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s CO2   315       1 5
+#0 CEDS_CO2_IND   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s CO2   316       1 5
 #0 CEDS_CO2_TRA   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_tra           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
 #0 CEDS_CO2_RCO   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_rco           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
 #0 CEDS_CO2_SLV   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_slv           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
@@ -1466,8 +1466,8 @@ Warnings:                    1
 # Comment out CH4 for fullchem simulations: do not use CH4 emissions
 # CEDS CH4 emissions are only available for 1970-2014
 #0 CEDS_CH4_AGR   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_agr           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
-#0 CEDS_CH4_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ene           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
-#0 CEDS_CH4_IND   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ind           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
+#0 CEDS_CH4_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ene           1970-2014/1-12/1/0 C xy kg/m2/s CH4   315       1 5
+#0 CEDS_CH4_IND   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ind           1970-2014/1-12/1/0 C xy kg/m2/s CH4   316       1 5
 #0 CEDS_CH4_TRA   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_tra           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
 #0 CEDS_CH4_RCO   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_rco           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
 #0 CEDS_CH4_SLV   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_slv           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
@@ -1477,12 +1477,12 @@ Warnings:                    1
 0 CEDS_MOH_AGR    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_agr           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90     1 5
 0 CEDS_EOH_AGR    -                                                                    -                 -                  - -  -       EOH   26/91     1 5
 0 CEDS_ROH_AGR    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
-0 CEDS_MOH_ENE    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ene           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90     1 5
-0 CEDS_EOH_ENE    -                                                                    -                 -                  - -  -       EOH   26/91     1 5
-0 CEDS_ROH_ENE    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
-0 CEDS_MOH_IND    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ind           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90     1 5
-0 CEDS_EOH_IND    -                                                                    -                 -                  - -  -       EOH   26/91     1 5
-0 CEDS_ROH_IND    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
+0 CEDS_MOH_ENE    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ene           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90/315 1 5
+0 CEDS_EOH_ENE    -                                                                    -                 -                  - -  -       EOH   26/91/315 1 5
+0 CEDS_ROH_ENE    -                                                                    -                 -                  - -  -       ROH   26/92/315 1 5
+0 CEDS_MOH_IND    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ind           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90/316 1 5
+0 CEDS_EOH_IND    -                                                                    -                 -                  - -  -       EOH   26/91/316 1 5
+0 CEDS_ROH_IND    -                                                                    -                 -                  - -  -       ROH   26/92/316 1 5
 0 CEDS_MOH_TRA    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_tra           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90     1 5
 0 CEDS_EOH_TRA    -                                                                    -                 -                  - -  -       EOH   26/91     1 5
 0 CEDS_ROH_TRA    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
@@ -1497,120 +1497,120 @@ Warnings:                    1
 0 CEDS_ROH_WST    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
 
 0 CEDS_C2H6_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_agr          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
-0 CEDS_C2H6_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
-0 CEDS_C2H6_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
+0 CEDS_C2H6_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26/315    1 5
+0 CEDS_C2H6_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26/316    1 5
 0 CEDS_C2H6_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_tra          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
 0 CEDS_C2H6_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_rco          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
 0 CEDS_C2H6_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_slv          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
 0 CEDS_C2H6_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_wst          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
 
 0 CEDS_C3H8_AGR   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_agr          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
-0 CEDS_C3H8_ENE   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ene          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
-0 CEDS_C3H8_IND   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ind          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
+0 CEDS_C3H8_ENE   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ene          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26/315    1 5
+0 CEDS_C3H8_IND   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ind          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26/316    1 5
 0 CEDS_C3H8_TRA   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_tra          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
 0 CEDS_C3H8_RCO   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_rco          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
 0 CEDS_C3H8_SLV   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_slv          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
 0 CEDS_C3H8_WST   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_wst          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
 
 0 CEDS_C4H10_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_agr  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C4H10_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ene  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C4H10_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ind  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
+0 CEDS_C4H10_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ene  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/315    1 5
+0 CEDS_C4H10_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ind  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/316    1 5
 0 CEDS_C4H10_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_tra  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C4H10_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_rco  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C4H10_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_slv  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C4H10_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_wst  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 
 0 CEDS_C5H12_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_agr 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C5H12_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ene 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C5H12_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ind 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
+0 CEDS_C5H12_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ene 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/315    1 5
+0 CEDS_C5H12_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ind 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/316    1 5
 0 CEDS_C5H12_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_tra 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C5H12_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_rco 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C5H12_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_slv 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C5H12_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_wst 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 
 0 CEDS_C6H14_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_agr  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C6H14_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ene  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C6H14_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ind  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
+0 CEDS_C6H14_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ene  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/315    1 5
+0 CEDS_C6H14_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ind  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/316    1 5
 0 CEDS_C6H14_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_tra  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C6H14_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_rco  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C6H14_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_slv  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C6H14_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_wst  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 
 0 CEDS_C2H4_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_agr          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
-0 CEDS_C2H4_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
-0 CEDS_C2H4_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
+0 CEDS_C2H4_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26/315    1 5
+0 CEDS_C2H4_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26/316    1 5
 0 CEDS_C2H4_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_tra          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
 0 CEDS_C2H4_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_rco          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
 0 CEDS_C2H4_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_slv          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
 0 CEDS_C2H4_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_wst          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
 
 0 CEDS_PRPE_AGR   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_agr          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
-0 CEDS_PRPE_ENE   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ene          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
-0 CEDS_PRPE_IND   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ind          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
+0 CEDS_PRPE_ENE   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ene          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26/315    1 5
+0 CEDS_PRPE_IND   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ind          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26/316    1 5
 0 CEDS_PRPE_TRA   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_tra          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
 0 CEDS_PRPE_RCO   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_rco          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
 0 CEDS_PRPE_SLV   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_slv          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
 0 CEDS_PRPE_WST   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_wst          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
 
 0 CEDS_C2H2_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_agr          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
-0 CEDS_C2H2_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
-0 CEDS_C2H2_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
+0 CEDS_C2H2_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26/315    1 5
+0 CEDS_C2H2_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26/316    1 5
 0 CEDS_C2H2_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_tra          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
 0 CEDS_C2H2_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_rco          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
 0 CEDS_C2H2_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_slv          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
 0 CEDS_C2H2_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_wst          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
 
 0 CEDS_BENZ_AGR   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_agr          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
-0 CEDS_BENZ_ENE   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ene          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
-0 CEDS_BENZ_IND   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ind          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
+0 CEDS_BENZ_ENE   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ene          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26/315    1 5
+0 CEDS_BENZ_IND   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ind          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26/316    1 5
 0 CEDS_BENZ_TRA   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_tra          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
 0 CEDS_BENZ_RCO   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_rco          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
 0 CEDS_BENZ_SLV   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_slv          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
 0 CEDS_BENZ_WST   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_wst          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
 
 0 CEDS_TOLU_AGR   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_agr          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
-0 CEDS_TOLU_ENE   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ene          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
-0 CEDS_TOLU_IND   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ind          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
+0 CEDS_TOLU_ENE   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ene          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26/315    1 5
+0 CEDS_TOLU_IND   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ind          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26/316    1 5
 0 CEDS_TOLU_TRA   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_tra          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
 0 CEDS_TOLU_RCO   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_rco          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
 0 CEDS_TOLU_SLV   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_slv          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
 0 CEDS_TOLU_WST   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_wst          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
 
 0 CEDS_XYLE_AGR   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_agr          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
-0 CEDS_XYLE_ENE   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ene          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
-0 CEDS_XYLE_IND   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ind          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
+0 CEDS_XYLE_ENE   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ene          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26/315    1 5
+0 CEDS_XYLE_IND   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ind          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26/316    1 5
 0 CEDS_XYLE_TRA   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_tra          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
 0 CEDS_XYLE_RCO   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_rco          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
 0 CEDS_XYLE_SLV   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_slv          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
 0 CEDS_XYLE_WST   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_wst          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
 
 0 CEDS_CH2O_AGR   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_agr          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
-0 CEDS_CH2O_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ene          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
-0 CEDS_CH2O_IND   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ind          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
+0 CEDS_CH2O_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ene          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26/315    1 5
+0 CEDS_CH2O_IND   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ind          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26/316    1 5
 0 CEDS_CH2O_TRA   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_tra          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
 0 CEDS_CH2O_RCO   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_rco          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
 0 CEDS_CH2O_SLV   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_slv          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
 0 CEDS_CH2O_WST   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_wst          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
 
 0 CEDS_ALD2_AGR   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_agr          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
-0 CEDS_ALD2_ENE   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ene          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
-0 CEDS_ALD2_IND   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ind          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
+0 CEDS_ALD2_ENE   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ene          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26/315    1 5
+0 CEDS_ALD2_IND   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ind          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26/316    1 5
 0 CEDS_ALD2_TRA   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_tra          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
 0 CEDS_ALD2_RCO   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_rco          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
 0 CEDS_ALD2_SLV   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_slv          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
 0 CEDS_ALD2_WST   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_wst          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
 
 0 CEDS_MEK_AGR    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_agr           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
-0 CEDS_MEK_ENE    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ene           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
-0 CEDS_MEK_IND    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ind           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
+0 CEDS_MEK_ENE    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ene           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26/315    1 5
+0 CEDS_MEK_IND    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ind           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26/316    1 5
 0 CEDS_MEK_TRA    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_tra           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
 0 CEDS_MEK_RCO    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_rco           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
 0 CEDS_MEK_SLV    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_slv           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
 0 CEDS_MEK_WST    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_wst           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
 
 0 CEDS_HCOOH_AGR  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_agr         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
-0 CEDS_HCOOH_ENE  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ene         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
-0 CEDS_HCOOH_IND  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ind         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
+0 CEDS_HCOOH_ENE  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ene         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26/315    1 5
+0 CEDS_HCOOH_IND  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ind         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26/316    1 5
 0 CEDS_HCOOH_TRA  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_tra         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
 0 CEDS_HCOOH_RCO  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_rco         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
 0 CEDS_HCOOH_SLV  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_slv         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -1357,37 +1357,37 @@ Warnings:                    1
 #==============================================================================
 (((CEDSv2
 0 CEDS_NO_AGR     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_agr            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
-0 CEDS_NO_ENE     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ene            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
-0 CEDS_NO_IND     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ind            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
+0 CEDS_NO_ENE     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ene            1750-2019/1-12/1/0 C xy kg/m2/s NO    25/315    1 5
+0 CEDS_NO_IND     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ind            1750-2019/1-12/1/0 C xy kg/m2/s NO    25/316    1 5
 0 CEDS_NO_TRA     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_tra            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
 0 CEDS_NO_RCO     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_rco            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
 0 CEDS_NO_SLV     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_slv            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
 0 CEDS_NO_WST     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_wst            1750-2019/1-12/1/0 C xy kg/m2/s NO    25        1 5
 
-0 CEDS_CO_AGR     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_agr            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_AGR   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_ENE     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ene            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_ENE   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_IND     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ind            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_IND   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_TRA     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_tra            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_TRA   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_RCO     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_rco            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_RCO   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_SLV     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_slv            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_SLV   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
-0 CEDS_CO_WST     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_wst            1750-2019/1-12/1/0 C xy kg/m2/s CO    26        1 5
-0 CEDS_SOAP_WST   -                                                                    -                 -                  - -  -       SOAP  26/280    1 5
+0 CEDS_CO_AGR     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_agr            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_AGR   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
+0 CEDS_CO_ENE     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ene            1750-2019/1-12/1/0 C xy kg/m2/s CO    26/315     1 5
+0 CEDS_SOAP_ENE   -                                                                    -                 -                  - -  -       SOAP  26/280/315 1 5
+0 CEDS_CO_IND     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ind            1750-2019/1-12/1/0 C xy kg/m2/s CO    26/316     1 5
+0 CEDS_SOAP_IND   -                                                                    -                 -                  - -  -       SOAP  26/280/316 1 5
+0 CEDS_CO_TRA     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_tra            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_TRA   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
+0 CEDS_CO_RCO     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_rco            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_RCO   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
+0 CEDS_CO_SLV     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_slv            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_SLV   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
+0 CEDS_CO_WST     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_wst            1750-2019/1-12/1/0 C xy kg/m2/s CO    26         1 5
+0 CEDS_SOAP_WST   -                                                                    -                 -                  - -  -       SOAP  26/280     1 5
 
 0 CEDS_SO2_AGR    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_agr           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
 0 CEDS_SO4_AGR    -                                                                    -                 -                  - -  -       SO4   63        1 5
 0 CEDS_pFe_AGR    -                                                                    -                 -                  - -  -       pFe   66        1 5
-0 CEDS_SO2_ENE    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
-0 CEDS_SO4_ENE    -                                                                    -                 -                  - -  -       SO4   63        1 5
-0 CEDS_pFe_ENE    -                                                                    -                 -                  - -  -       pFe   66        1 5
-0 CEDS_SO2_IND    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
-0 CEDS_SO4_IND    -                                                                    -                 -                  - -  -       SO4   63        1 5
-0 CEDS_pFe_IND    -                                                                    -                 -                  - -  -       pFe   66        1 5
+0 CEDS_SO2_ENE    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s SO2   315       1 5
+0 CEDS_SO4_ENE    -                                                                    -                 -                  - -  -       SO4   63/315    1 5
+0 CEDS_pFe_ENE    -                                                                    -                 -                  - -  -       pFe   66/315    1 5
+0 CEDS_SO2_IND    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s SO2   316       1 5
+0 CEDS_SO4_IND    -                                                                    -                 -                  - -  -       SO4   63/316    1 5
+0 CEDS_pFe_IND    -                                                                    -                 -                  - -  -       pFe   66/316    1 5
 0 CEDS_SO2_TRA    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_tra           1750-2019/1-12/1/0 C xy kg/m2/s SO2   -         1 5
 0 CEDS_SO4_TRA    -                                                                    -                 -                  - -  -       SO4   63        1 5
 0 CEDS_pFe_TRA    -                                                                    -                 -                  - -  -       pFe   66        1 5
@@ -1402,8 +1402,8 @@ Warnings:                    1
 0 CEDS_pFe_WST    -                                                                    -                 -                  - -  -       pFe   66        1 5
 
 0 CEDS_NH3_AGR    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_agr           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
-0 CEDS_NH3_ENE    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ene           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
-0 CEDS_NH3_IND    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ind           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
+0 CEDS_NH3_ENE    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ene           1750-2019/1-12/1/0 C xy kg/m2/s NH3   315       1 5
+0 CEDS_NH3_IND    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ind           1750-2019/1-12/1/0 C xy kg/m2/s NH3   316       1 5
 0 CEDS_NH3_TRA    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_tra           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
 0 CEDS_NH3_RCO    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_rco           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
 0 CEDS_NH3_SLV    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_slv           1750-2019/1-12/1/0 C xy kg/m2/s NH3   -         1 5
@@ -1411,10 +1411,10 @@ Warnings:                    1
 
 0 CEDS_BCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_agr            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
 0 CEDS_BCPO_AGR   -                                                                    -                 -                  - -  -       BCPO  71        1 5
-0 CEDS_BCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
-0 CEDS_BCPO_ENE   -                                                                    -                 -                  - -  -       BCPO  71        1 5
-0 CEDS_BCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
-0 CEDS_BCPO_IND   -                                                                    -                 -                  - -  -       BCPO  71        1 5
+0 CEDS_BCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70/315    1 5
+0 CEDS_BCPO_ENE   -                                                                    -                 -                  - -  -       BCPO  71/315    1 5
+0 CEDS_BCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70/316    1 5
+0 CEDS_BCPO_IND   -                                                                    -                 -                  - -  -       BCPO  71/316    1 5
 0 CEDS_BCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_tra            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
 0 CEDS_BCPO_TRA   -                                                                    -                 -                  - -  -       BCPO  71        1 5
 0 CEDS_BCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_rco            1750-2019/1-12/1/0 C xy kg/m2/s BCPI  70        1 5
@@ -1428,14 +1428,14 @@ Warnings:                    1
 0 CEDS_OCPO_AGR   -                                                                    -                 -                  - -  -       OCPO  73        1 5
 0 CEDS_POG1_AGR   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
 0 CEDS_POG2_AGR   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
-0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
-0 CEDS_OCPO_ENE   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_ENE   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
-0 CEDS_POG2_ENE   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
-0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
-0 CEDS_OCPO_IND   -                                                                    -                 -                  - -  -       OCPO  73        1 5
-0 CEDS_POG1_IND   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
-0 CEDS_POG2_IND   -                                                                    -                 -                  - -  -       POG2  74/77     1 5
+0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72/315    1 5
+0 CEDS_OCPO_ENE   -                                                                    -                 -                  - -  -       OCPO  73/315    1 5
+0 CEDS_POG1_ENE   -                                                                    -                 -                  - -  -       POG1  74/76/315 1 5
+0 CEDS_POG2_ENE   -                                                                    -                 -                  - -  -       POG2  74/77/315 1 5
+0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72/316    1 5
+0 CEDS_OCPO_IND   -                                                                    -                 -                  - -  -       OCPO  73/316    1 5
+0 CEDS_POG1_IND   -                                                                    -                 -                  - -  -       POG1  74/76/316 1 5
+0 CEDS_POG2_IND   -                                                                    -                 -                  - -  -       POG2  74/77/316 1 5
 0 CEDS_OCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_tra            1750-2019/1-12/1/0 C xy kg/m2/s OCPI  72        1 5
 0 CEDS_OCPO_TRA   -                                                                    -                 -                  - -  -       OCPO  73        1 5
 0 CEDS_POG1_TRA   -                                                                    -                 -                  - -  -       POG1  74/76     1 5
@@ -1455,8 +1455,8 @@ Warnings:                    1
 
 # Comment out CO2 for fullchem simulations: CO2 not advected
 #0 CEDS_CO2_AGR   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_agr           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
-#0 CEDS_CO2_ENE   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
-#0 CEDS_CO2_IND   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
+#0 CEDS_CO2_ENE   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ene           1750-2019/1-12/1/0 C xy kg/m2/s CO2   315       1 5
+#0 CEDS_CO2_IND   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ind           1750-2019/1-12/1/0 C xy kg/m2/s CO2   316       1 5
 #0 CEDS_CO2_TRA   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_tra           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
 #0 CEDS_CO2_RCO   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_rco           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
 #0 CEDS_CO2_SLV   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_slv           1750-2019/1-12/1/0 C xy kg/m2/s CO2   -         1 5
@@ -1465,8 +1465,8 @@ Warnings:                    1
 # Comment out CH4 for fullchem simulations: do not use CH4 emissions
 # CEDS CH4 emissions are only available for 1970-2014
 #0 CEDS_CH4_AGR   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_agr           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
-#0 CEDS_CH4_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ene           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
-#0 CEDS_CH4_IND   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ind           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
+#0 CEDS_CH4_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ene           1970-2014/1-12/1/0 C xy kg/m2/s CH4   315       1 5
+#0 CEDS_CH4_IND   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ind           1970-2014/1-12/1/0 C xy kg/m2/s CH4   316       1 5
 #0 CEDS_CH4_TRA   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_tra           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
 #0 CEDS_CH4_RCO   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_rco           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
 #0 CEDS_CH4_SLV   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_slv           1970-2014/1-12/1/0 C xy kg/m2/s CH4   -         1 5
@@ -1476,12 +1476,12 @@ Warnings:                    1
 0 CEDS_MOH_AGR    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_agr           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90     1 5
 0 CEDS_EOH_AGR    -                                                                    -                 -                  - -  -       EOH   26/91     1 5
 0 CEDS_ROH_AGR    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
-0 CEDS_MOH_ENE    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ene           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90     1 5
-0 CEDS_EOH_ENE    -                                                                    -                 -                  - -  -       EOH   26/91     1 5
-0 CEDS_ROH_ENE    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
-0 CEDS_MOH_IND    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ind           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90     1 5
-0 CEDS_EOH_IND    -                                                                    -                 -                  - -  -       EOH   26/91     1 5
-0 CEDS_ROH_IND    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
+0 CEDS_MOH_ENE    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ene           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90/315 1 5
+0 CEDS_EOH_ENE    -                                                                    -                 -                  - -  -       EOH   26/91/315 1 5
+0 CEDS_ROH_ENE    -                                                                    -                 -                  - -  -       ROH   26/92/315 1 5
+0 CEDS_MOH_IND    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ind           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90/316 1 5
+0 CEDS_EOH_IND    -                                                                    -                 -                  - -  -       EOH   26/91/316 1 5
+0 CEDS_ROH_IND    -                                                                    -                 -                  - -  -       ROH   26/92/316 1 5
 0 CEDS_MOH_TRA    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_tra           1750-2019/1-12/1/0 C xy kg/m2/s MOH   26/90     1 5
 0 CEDS_EOH_TRA    -                                                                    -                 -                  - -  -       EOH   26/91     1 5
 0 CEDS_ROH_TRA    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
@@ -1496,120 +1496,120 @@ Warnings:                    1
 0 CEDS_ROH_WST    -                                                                    -                 -                  - -  -       ROH   26/92     1 5
 
 0 CEDS_C2H6_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_agr          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
-0 CEDS_C2H6_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
-0 CEDS_C2H6_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
+0 CEDS_C2H6_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26/315    1 5
+0 CEDS_C2H6_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26/316    1 5
 0 CEDS_C2H6_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_tra          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
 0 CEDS_C2H6_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_rco          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
 0 CEDS_C2H6_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_slv          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
 0 CEDS_C2H6_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_wst          1750-2019/1-12/1/0 C xy kg/m2/s C2H6  26        1 5
 
 0 CEDS_C3H8_AGR   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_agr          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
-0 CEDS_C3H8_ENE   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ene          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
-0 CEDS_C3H8_IND   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ind          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
+0 CEDS_C3H8_ENE   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ene          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26/315    1 5
+0 CEDS_C3H8_IND   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ind          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26/316    1 5
 0 CEDS_C3H8_TRA   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_tra          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
 0 CEDS_C3H8_RCO   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_rco          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
 0 CEDS_C3H8_SLV   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_slv          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
 0 CEDS_C3H8_WST   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_wst          1750-2019/1-12/1/0 C xy kg/m2/s C3H8  26        1 5
 
 0 CEDS_C4H10_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_agr  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C4H10_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ene  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C4H10_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ind  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
+0 CEDS_C4H10_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ene  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/315    1 5
+0 CEDS_C4H10_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ind  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/316    1 5
 0 CEDS_C4H10_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_tra  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C4H10_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_rco  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C4H10_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_slv  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C4H10_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_wst  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 
 0 CEDS_C5H12_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_agr 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C5H12_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ene 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C5H12_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ind 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
+0 CEDS_C5H12_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ene 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/315    1 5
+0 CEDS_C5H12_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ind 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/316    1 5
 0 CEDS_C5H12_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_tra 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C5H12_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_rco 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C5H12_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_slv 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C5H12_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_wst 1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 
 0 CEDS_C6H14_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_agr  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C6H14_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ene  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
-0 CEDS_C6H14_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ind  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
+0 CEDS_C6H14_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ene  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/315    1 5
+0 CEDS_C6H14_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ind  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26/316    1 5
 0 CEDS_C6H14_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_tra  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C6H14_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_rco  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C6H14_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_slv  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 0 CEDS_C6H14_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_wst  1750-2019/1-12/1/0 C xy kg/m2/s ALK4  26        1 5
 
 0 CEDS_C2H4_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_agr          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
-0 CEDS_C2H4_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
-0 CEDS_C2H4_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
+0 CEDS_C2H4_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26/315    1 5
+0 CEDS_C2H4_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26/316    1 5
 0 CEDS_C2H4_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_tra          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
 0 CEDS_C2H4_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_rco          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
 0 CEDS_C2H4_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_slv          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
 0 CEDS_C2H4_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_wst          1750-2019/1-12/1/0 C xy kg/m2/s C2H4  26        1 5
 
 0 CEDS_PRPE_AGR   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_agr          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
-0 CEDS_PRPE_ENE   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ene          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
-0 CEDS_PRPE_IND   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ind          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
+0 CEDS_PRPE_ENE   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ene          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26/315    1 5
+0 CEDS_PRPE_IND   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ind          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26/316    1 5
 0 CEDS_PRPE_TRA   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_tra          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
 0 CEDS_PRPE_RCO   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_rco          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
 0 CEDS_PRPE_SLV   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_slv          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
 0 CEDS_PRPE_WST   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_wst          1750-2019/1-12/1/0 C xy kg/m2/s PRPE  26        1 5
 
 0 CEDS_C2H2_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_agr          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
-0 CEDS_C2H2_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
-0 CEDS_C2H2_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
+0 CEDS_C2H2_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ene          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26/315    1 5
+0 CEDS_C2H2_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ind          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26/316    1 5
 0 CEDS_C2H2_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_tra          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
 0 CEDS_C2H2_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_rco          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
 0 CEDS_C2H2_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_slv          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
 0 CEDS_C2H2_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_wst          1750-2019/1-12/1/0 C xy kg/m2/s C2H2  26        1 5
 
 0 CEDS_BENZ_AGR   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_agr          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
-0 CEDS_BENZ_ENE   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ene          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
-0 CEDS_BENZ_IND   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ind          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
+0 CEDS_BENZ_ENE   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ene          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26/315    1 5
+0 CEDS_BENZ_IND   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ind          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26/316    1 5
 0 CEDS_BENZ_TRA   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_tra          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
 0 CEDS_BENZ_RCO   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_rco          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
 0 CEDS_BENZ_SLV   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_slv          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
 0 CEDS_BENZ_WST   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_wst          1750-2019/1-12/1/0 C xy kg/m2/s BENZ  26        1 5
 
 0 CEDS_TOLU_AGR   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_agr          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
-0 CEDS_TOLU_ENE   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ene          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
-0 CEDS_TOLU_IND   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ind          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
+0 CEDS_TOLU_ENE   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ene          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26/315    1 5
+0 CEDS_TOLU_IND   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ind          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26/316    1 5
 0 CEDS_TOLU_TRA   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_tra          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
 0 CEDS_TOLU_RCO   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_rco          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
 0 CEDS_TOLU_SLV   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_slv          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
 0 CEDS_TOLU_WST   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_wst          1750-2019/1-12/1/0 C xy kg/m2/s TOLU  26        1 5
 
 0 CEDS_XYLE_AGR   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_agr          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
-0 CEDS_XYLE_ENE   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ene          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
-0 CEDS_XYLE_IND   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ind          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
+0 CEDS_XYLE_ENE   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ene          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26/315    1 5
+0 CEDS_XYLE_IND   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ind          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26/316    1 5
 0 CEDS_XYLE_TRA   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_tra          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
 0 CEDS_XYLE_RCO   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_rco          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
 0 CEDS_XYLE_SLV   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_slv          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
 0 CEDS_XYLE_WST   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_wst          1750-2019/1-12/1/0 C xy kg/m2/s XYLE  26        1 5
 
 0 CEDS_CH2O_AGR   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_agr          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
-0 CEDS_CH2O_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ene          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
-0 CEDS_CH2O_IND   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ind          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
+0 CEDS_CH2O_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ene          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26/315    1 5
+0 CEDS_CH2O_IND   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ind          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26/316    1 5
 0 CEDS_CH2O_TRA   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_tra          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
 0 CEDS_CH2O_RCO   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_rco          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
 0 CEDS_CH2O_SLV   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_slv          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
 0 CEDS_CH2O_WST   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_wst          1750-2019/1-12/1/0 C xy kg/m2/s CH2O  26        1 5
 
 0 CEDS_ALD2_AGR   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_agr          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
-0 CEDS_ALD2_ENE   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ene          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
-0 CEDS_ALD2_IND   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ind          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
+0 CEDS_ALD2_ENE   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ene          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26/315    1 5
+0 CEDS_ALD2_IND   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ind          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26/316    1 5
 0 CEDS_ALD2_TRA   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_tra          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
 0 CEDS_ALD2_RCO   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_rco          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
 0 CEDS_ALD2_SLV   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_slv          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
 0 CEDS_ALD2_WST   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_wst          1750-2019/1-12/1/0 C xy kg/m2/s ALD2  26        1 5
 
 0 CEDS_MEK_AGR    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_agr           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
-0 CEDS_MEK_ENE    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ene           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
-0 CEDS_MEK_IND    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ind           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
+0 CEDS_MEK_ENE    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ene           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26/315    1 5
+0 CEDS_MEK_IND    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ind           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26/316    1 5
 0 CEDS_MEK_TRA    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_tra           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
 0 CEDS_MEK_RCO    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_rco           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
 0 CEDS_MEK_SLV    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_slv           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
 0 CEDS_MEK_WST    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_wst           1750-2019/1-12/1/0 C xy kg/m2/s MEK   26        1 5
 
 0 CEDS_HCOOH_AGR  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_agr         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
-0 CEDS_HCOOH_ENE  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ene         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
-0 CEDS_HCOOH_IND  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ind         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
+0 CEDS_HCOOH_ENE  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ene         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26/315    1 5
+0 CEDS_HCOOH_IND  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ind         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26/316    1 5
 0 CEDS_HCOOH_TRA  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_tra         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
 0 CEDS_HCOOH_RCO  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_rco         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5
 0 CEDS_HCOOH_SLV  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_slv         1750-2019/1-12/1/0 C xy kg/m2/s HCOOH 26        1 5


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This feature was originally implemented in version 13.1.0 (commit 87eb68ee). However, when emissions were updated to CEDS v2 in version 13.2.0 (commit 4b499fac), the application of vertical distribution scale factors was not carried over. Here, scale factors 315 (ENERGY_LEVS) and 316 (INDUSTRY_LEVS) are once again applied to  CEDS_*_ENE and CEDS_*_IND emissions, respectively, in HEMCO_Config.rc.

### Expected changes

This fix will impact anthropogenic emissions by decreasing CEDS emissions at the surface and distributing them vertically. The emissions totals should remain the same.

### Related Github Issue(s)

Closes #1646
