### PR TITLE
GCHP bug fixes and run directory updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added 'NcdfUtil/README.md` file directing users to look for netCDF utility scripts at https://github.com/geoschem/netcdf-scripts
 - Restored sink reactions for HOI, IONO, IONO2 (fullchem, custom mechanisms)
 - S(IV) + HOBr and S(IV) + HOCl reactions to `KPP/fullchem/fullchem.eqn`
+- Added setting in GCHP setCommonRunSettings.sh to require species in restarts
+- Added setting in GCHP HISTORY.rc to control whether output can be overwritten
 - Activated nitrate photolysis
 
 ### Changed
@@ -19,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - If KPP integration fails, reset to prior concentrations and set RSTATE(3) = 0 before retrying
 - Suppress integration errors after 20 errors have been printed to stdout
 - Simplified and added comments for bimolecular reactions in clouds in function CloudHet2R
+- Updated GCHP carbon simulation Global Cl and P(CO) inputs to use 14.0.0 files
+- Write GCHP restart files directory to Restarts subdirectory
+- Rename GCHP mid-run checkpoint files to standard GEOS-Chem restart format
+- Rules for species in restarts files are now the same in GCHP as in GC-Classic
 
 ### Removed
 - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files
@@ -34,6 +40,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Tests now run for 20 model minutes instead of an hour
 - Fixed divide by zero bug in sulfur chemistry introduced in 14.1.0
 - Restore seasalt alkalinity to heterogeneous acid-catalyzed reactions of halogens on seasalt aerosols.
+- Fixed GCHP HISTORY.rc issue preventing running with over 3000 cores
+- Fixed GCHP ExtData.rc error in tagged ozone simulation
+- Fixed GCHP HISTORY.rc issue preventing diagnostic file overwrite
+- Update GCHP interactive run script to fix error handling silent bugs
 
 ## [14.1.1] - 2023-03-03
 ### Added

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -282,7 +282,7 @@ CONTAINS
     LOGICAL                       :: EOF
     CHARACTER(LEN=60)             :: landTypeStr, importName, simType
     CHARACTER(LEN=ESMF_MAXPATHLEN):: rstFile
-    INTEGER                       :: restartAttr
+    INTEGER                       :: SpcRestartAttr
     CHARACTER(LEN=ESMF_MAXSTR)    :: HistoryConfigFile ! HISTORY config file
     INTEGER                       :: T
 
@@ -290,19 +290,19 @@ CONTAINS
     TYPE(MAPL_MetaComp),  POINTER :: STATE => NULL()
 #endif
 
+    INTEGER                       :: DoIt
+
 #if defined( MODEL_GEOS )
     CHARACTER(LEN=ESMF_MAXSTR)    :: LongName      ! Long name for diagnostics
     CHARACTER(LEN=ESMF_MAXSTR)    :: ShortName
     CHARACTER(LEN=255)            :: MYFRIENDLIES
     CHARACTER(LEN=127)            :: FullName
-    INTEGER                       :: DoIt
     LOGICAL                       :: FriendMoist, SpcInRestart, ReduceSpc
     CHARACTER(LEN=40)             :: SpcsBlacklist(255)
     INTEGER                       :: nBlacklist
     CHARACTER(LEN=ESMF_MAXSTR)    :: Blacklist
 #endif
 #ifdef ADJOINT
-    INTEGER                       :: restartAttrAdjoint
     LOGICAL                       :: useCFMaskFile
 #endif
 
@@ -451,29 +451,33 @@ CONTAINS
 #   include "GCHPchem_InternalSpec___.h"
 #endif
 
-#if !defined( MODEL_GEOS )
-    ! Determine if using a restart file for the internal state. Setting
-    ! the GCHPchem_INTERNAL_RESTART_FILE to +none in GCHP.rc indicates
-    ! skipping the restart file. Species concentrations will be retrieved
-    ! from the species database, overwriting MAPL-assigned default values.
-    CALL ESMF_ConfigGetAttribute( myState%myCF, rstFile, &
-                                  Label = "GCHPchem_INTERNAL_RESTART_FILE:",&
-                                  __RC__ )
-    IF ( TRIM(rstFile) == '+none' ) THEN
-       restartAttr = MAPL_RestartSkipInitial ! file does not exist;
-                                             ! use background values
+!------ Species in restart file ------
+
+#if defined( MODEL_GEOS )
+    ! Determine if non-advected species shall be included in restart file
+    CALL ESMF_ConfigGetAttribute( myState%myCF, DoIt, &
+                                  Label = "Shortlived_species_in_restart:", &
+                                  Default = 1, __RC__ )
+    IF ( DoIt==1 ) THEN
+       SpcRestartAttr  = MAPL_RestartOptional
+       SpcInRestart = .TRUE.
     ELSE
-       restartAttr = MAPL_RestartOptional    ! try to read species from file;
-                                             ! use background vals if not found
+       SpcRestartAttr  = MAPL_RestartSkip
+       SpcInRestart = .FALSE.
     ENDIF
-#ifdef ADJOINT
-    restartAttrAdjoint = MAPL_RestartSkip
-#endif
+#else
+    ! Determine if all species (SPC_*) are required in initial restart file
+    CALL ESMF_ConfigGetAttribute( myState%myCF, DoIt, &
+                                  Label = "INITIAL_RESTART_SPECIES_REQUIRED:", &
+                                  Default = 1, __RC__ )
+    IF ( DoIt == 1 ) THEN
+       SpcRestartAttr  = MAPL_RestartRequired
+    ELSE
+       SpcRestartAttr  = MAPL_RestartOptional
+    ENDIF
 #endif
 
 !-- Read in species from geoschem_config.yml and set FRIENDLYTO
-    ! ewl TODO: This works but is not ideal. Look into how to remove it.
-
 #if defined( MODEL_GEOS )
     ! Check if species are friendly to moist
     CALL ESMF_ConfigGetAttribute( myState%myCF, DoIt, &
@@ -483,17 +487,6 @@ CONTAINS
     FriendMoist = (DoIt==1)
     IF ( MAPL_am_I_Root() ) THEN
        WRITE(*,*) 'GCC species friendly to MOIST: ',FriendMoist
-    ENDIF
-    ! Determine if non-advected species shall be included in restart file
-    CALL ESMF_ConfigGetAttribute( myState%myCF, DoIt, &
-                                  Label = "Shortlived_species_in_restart:", &
-                                  Default = 1, __RC__ )
-    IF ( DoIt==1 ) THEN
-       restartAttr  = MAPL_RestartOptional
-       SpcInRestart = .TRUE.
-    ELSE
-       restartAttr  = MAPL_RestartSkip
-       SpcInRestart = .FALSE.
     ENDIF
     ! Check if we want to use a reduced set of species for transport
     SpcsBlacklist(:) = ''
@@ -606,7 +599,7 @@ CONTAINS
                VLOCATION       = MAPL_VLocationCenter,                      &
                PRECISION       = ESMF_KIND_R8,                              &
                FRIENDLYTO      = 'DYNAMICS:TURBULENCE:MOIST',               &
-               RESTART         = restartAttr,                               &
+               RESTART         = SpcRestartAttr,                               &
                RC              = RC                                       )
 
           ! Add to list of transported speces
@@ -626,7 +619,7 @@ CONTAINS
                VLOCATION       = MAPL_VLocationCenter,                      &
                PRECISION       = ESMF_KIND_R8,                              &
                FRIENDLYTO      = 'DYNAMICS:TURBULENCE:MOIST',               &
-               RESTART         = restartAttrAdjoint,                        &
+               RESTART         = MAPL_RestartSkip,                          &
                RC              = RC                                        )
 #endif
        ENDIF
@@ -689,7 +682,7 @@ CONTAINS
                !!!PRECISION       = ESMF_KIND_R8,                            &
                   DIMS            = MAPL_DimsHorzVert,                       &
                   FRIENDLYTO      = COMP_NAME,                               &
-                  RESTART         = restartAttr,                             &
+                  RESTART         = SpcRestartAttr,                          &
                   VLOCATION       = MAPL_VLocationCenter,                    &
                                    __RC__                                   )
              ! verbose
@@ -704,7 +697,7 @@ CONTAINS
                   PRECISION       = ESMF_KIND_R8,                            &
                   DIMS            = MAPL_DimsHorzVert,                       &
                   VLOCATION       = MAPL_VLocationCenter,                    &
-                  RESTART         = restartAttr,                             &
+                  RESTART         = SpcRestartAttr,                          &
                   RC              = STATUS                                  )
 #ifdef ADJOINT
              !%%%% GEOS-Chem in GCHP ADJOINT %%%%
@@ -718,7 +711,7 @@ CONTAINS
                   PRECISION       = ESMF_KIND_R8,                            &
                   DIMS            = MAPL_DimsHorzVert,                       &
                   VLOCATION       = MAPL_VLocationCenter,                    &
-                  RESTART         = restartAttrAdjoint,                      &
+                  RESTART         = MAPL_RestartSkip,                        &
                   RC              = STATUS                                  )
 #endif
 #endif

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.Hg
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.Hg
@@ -507,7 +507,7 @@ VerboseOnCores:              root       # Accepted values: root all
 (((CHEMISTRY_INPUT
 
 #==============================================================================
-# --- Oxidant fields (from GEOS-Chem 13.0.0 10-yr benchmark output) ---
+# --- Oxidant fields (from GEOS-Chem 10-yr benchmark output) ---
 #==============================================================================
 (((OXIDANT_FIELDS
 

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -455,22 +455,21 @@ GFED_FRAC_DAY 1 N Y %y4-%m2-%d2T00:00:00 none none GFED_FRACDAY ./HcoDir/GFED4/v
 TIMEZONES count N V - none none UTC_OFFSET ./HcoDir/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc
 
 # --- OH from the latest 10-year benchmark ---
-# ** TODO: Update to 14.0.0 **
-#GLOBAL_OH kg/m3 N N %y4-%m2-01T00:00:00       none none SpeciesConc_OH ./HcoDir/GCClassic_Output/13.0.0/%y4/GEOSChem.SpeciesConc.%y4%m2%d2_0000z.nc4
+#GLOBAL_OH kg/m3 N N %y4-%m2-01T00:00:00       none none SpeciesConc_OH ./HcoDir/GCClassic_Output/14.0.0/%y4/GEOSChem.SpeciesConc.%y4%m2%d2_0000z.nc4
 
 # --- OH from GEOS-Chem v5-07-08 ---
 # --- NOTE: Use this for CH4/IMI ---
 #GLOBAL_OH kg/m3 1985 Y F%y4-%m2-01T00:00:00 none none OH ./HcoDir/OH/v2022-11/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc
 
 # --- Global Cl concentrations
-GLOBAL_Cl mol/mol N Y F%y4-%m2-%d2T00:00:00  none none SpeciesConc_Cl ./HcoDir/GCClassic_Output/13.0.0/%y4/GEOSChem.SpeciesConc.%y4%m201_0000z.nc4
+GLOBAL_Cl mol/mol N Y F%y4-%m2-%d2T00:00:00  none none SpeciesConc_Cl ./HcoDir/GCClassic_Output/14.0.0/%y4/GEOSChem.SpeciesConc.%y4%m201_0000z.nc4
 
 # --- Stratospheric L(CO) from GMI ---
 CH4_LOSS s-1 1985 Y F%y4-%m2-01T00:00:00 none none CH4loss ./HcoDir/CH4/v2022-11/4x5/gmi.ch4loss.geos5_47L.4x5.nc
 
 # --- P(CO) from CH4 and NMVOC from the last 10-yr benchmark ---
-PCO_CH4    molec/cm3/s N Y F%y4-%m2-01T00:00:00 none none ProdCOfromCH4   ./HcoDir/GCClassic_Output/13.0.0/%y4/GEOSChem.ProdLoss.%y4%m201_0000z.nc4
-PCO_NMVOC  molec/cm3/s N Y F%y4-%m2-01T00:00:00 none none ProdCOfromNMVOC ./HcoDir/GCClassic_Output/13.0.0/%y4/GEOSChem.ProdLoss.%y4%m201_0000z.nc4
+PCO_CH4    molec/cm3/s N Y F%y4-%m2-01T00:00:00 none none ProdCOfromCH4   ./HcoDir/GCClassic_Output/14.0.0/%y4/GEOSChem.ProdLoss.%y4%m201_0000z.nc4
+PCO_NMVOC  molec/cm3/s N Y F%y4-%m2-01T00:00:00 none none ProdCOfromNMVOC ./HcoDir/GCClassic_Output/14.0.0/%y4/GEOSChem.ProdLoss.%y4%m201_0000z.nc4
 
 #--- GMI chemistry: prod/loss rates (GMI_PROD_LOSS) ---
 GMI_LOSS_CH4 s-1   2000 Y F%y4-%m2-01T00:00:00 none none loss ./HcoDir/GMI/v2022-11/gmi.clim.CH4.geos5.2x25.nc

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.tagO3
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.tagO3
@@ -217,8 +217,8 @@ TIMEZONES count N V - none none UTC_OFFSET ./HcoDir/TIMEZONES/v2015-02/timezones
 #==============================================================================
 #--- Prod/Loss rates from the fullchem simulation ---
 #==============================================================================
-O3_PROD  1  N Y F%y4-%m2-01T00:00:00 none none Prod_Ox ./HcoDir/GCClassic_Output/14.0.0/%y4/GEOSChem.ProdLoss.%y4%m2%d2_0000z.nc4
-O3_LOSS  1  N Y F%y4-%m2-01T00:00:00 none none Loss_Ox ./HcoDir/GCClassic_Output/14.0.0/%y4/GEOSChem.ProdLoss.%y4%m2%d2_0000z.nc4
+O3_PROD  1  N Y F%y4-%m2-01T00:00:00 none none Prod_Ox ./HcoDir/GCClassic_Output/14.0.0/%y4/GEOSChem.ProdLoss.%y4%m201_0000z.nc4
+O3_LOSS  1  N Y F%y4-%m2-01T00:00:00 none none Loss_Ox ./HcoDir/GCClassic_Output/14.0.0/%y4/GEOSChem.ProdLoss.%y4%m201_0000z.nc4
 #
 #==============================================================================
 # --- Oceanic ozone deposition ---

--- a/run/GCHP/GCHP.rc.template
+++ b/run/GCHP/GCHP.rc.template
@@ -61,6 +61,10 @@ BKG_FREQUENCY: 0
 #-----------------------------------------------------------------
 MAPL_ENABLE_BOOTSTRAP: YES
 
+# Require all species in initial restart file (1 = yes; else no)
+#-----------------------------------------------------------------
+INITIAL_RESTART_SPECIES_REQUIRED: 0
+
 # Settings for production of restart files
 #---------------------------------------------------------------
 # Record frequency (HHMMSS, or monthly) : Frequency of restart file write

--- a/run/GCHP/GCHP.rc.template
+++ b/run/GCHP/GCHP.rc.template
@@ -79,13 +79,13 @@ RECORD_REF_TIME: 000000
 # -------------------------------------
 GCHPchem_INTERNAL_RESTART_FILE:     gchp_restart.nc4
 GCHPchem_INTERNAL_RESTART_TYPE:     pnc4
-GCHPchem_INTERNAL_CHECKPOINT_FILE:  gcchem_internal_checkpoint
+GCHPchem_INTERNAL_CHECKPOINT_FILE:  Restarts/gcchem_internal_checkpoint
 GCHPchem_INTERNAL_CHECKPOINT_TYPE:  pnc4
 
 # GCHP dynamics (FV3) does not use a restart file because its internal state is empty
 #DYN_INTERNAL_RESTART_FILE:    fvcore_internal_rst
 #DYN_INTERNAL_RESTART_TYPE:    pbinary
-#DYN_INTERNAL_CHECKPOINT_FILE: fvcore_internal_checkpoint
+#DYN_INTERNAL_CHECKPOINT_FILE: Restarts/fvcore_internal_checkpoint
 #DYN_INTERNAL_CHECKPOINT_TYPE: pbinary
 #DYN_INTERNAL_HEADER:          1
 

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -17,9 +17,9 @@ VERSION: 1
 # See the collections section later on in this file for instructions on
 # using an alternative grid for output.
 #==============================================================================
-GRID_LABELS: PE24x144-CF
-             PC360x181-DC
-             REGIONAL1x1
+GRID_LABELS: #PE24x144-CF
+             #PC360x181-DC
+             #REGIONAL1x1
     ::
 
     # Example of cubed-sphere grid at c24 resolution

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -1,6 +1,7 @@
 EXPID:  OutputDir/GEOSChem
 EXPDSC: GEOS-Chem_devel
 CoresPerNode: 6
+Allow_Overwrite: .true.
 VERSION: 1
 
 #==============================================================================

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -17,9 +17,9 @@ VERSION: 1
 # See the collections section later on in this file for instructions on
 # using an alternative grid for output.
 #==============================================================================
-GRID_LABELS: PE24x144-CF
-             PC360x181-DC
-             REGIONAL1x1
+GRID_LABELS: #PE24x144-CF
+             #PC360x181-DC
+             #REGIONAL1x1
     ::
 
     # Example of cubed-sphere grid at c24 resolution

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -1,6 +1,7 @@
 EXPID:  OutputDir/GEOSChem
 EXPDSC: GEOS-Chem_devel
 CoresPerNode: 6
+Allow_Overwrite: .true.
 VERSION: 1
 
 #==============================================================================

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -20,9 +20,9 @@ VERSION: 1
 #   SpeciesConc.conservative: 1
 #
 #==============================================================================
-GRID_LABELS: PE24x144-CF
-             PC360x181-DC
-             REGIONAL1x1
+GRID_LABELS: #PE24x144-CF
+             #PC360x181-DC
+             #REGIONAL1x1
     ::
 
     # Example of cubed-sphere grid at c24 resolution

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -1,6 +1,7 @@
 EXPID:  OutputDir/GEOSChem
 EXPDSC: GEOS-Chem_devel
 CoresPerNode: 6
+Allow_Overwrite: .true.
 VERSION: 1
 
 #==============================================================================

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -1,7 +1,7 @@
-
 EXPID:  OutputDir/GEOSChem
 EXPDSC: GEOS-Chem_devel
 CoresPerNode: 6
+Allow_Overwrite: .true.
 VERSION: 1
 
 #==============================================================================

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -18,9 +18,9 @@ VERSION: 1
 # See the collections section later on in this file for instructions on
 # using an alternative grid for output.
 #==============================================================================
-GRID_LABELS: PE24x144-CF
-             PC360x181-DC
-             REGIONAL1x1
+GRID_LABELS: #PE24x144-CF
+             #PC360x181-DC
+             #REGIONAL1x1
     ::
 
     # Example of cubed-sphere grid at c24 resolution

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.tagO3
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.tagO3
@@ -1,7 +1,7 @@
-
 EXPID:  OutputDir/GEOSChem
 EXPDSC: GEOS-Chem_devel
 CoresPerNode: 6
+Allow_Overwrite: .true.
 VERSION: 1
 
 #==============================================================================

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.tagO3
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.tagO3
@@ -18,9 +18,9 @@ VERSION: 1
 # See the collections section later on in this file for instructions on
 # using an alternative grid for output.
 #==============================================================================
-GRID_LABELS: PE24x144-CF
-             PC360x181-DC
-             REGIONAL1x1
+GRID_LABELS: #PE24x144-CF
+             #PC360x181-DC
+             #REGIONAL1x1
     ::
 
     # Example of cubed-sphere grid at c24 resolution

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -530,6 +530,18 @@ else
     RUNDIR_VARS+="RUNDIR_OFFLINE_SOILNOX='true '\n"
 fi
 RUNDIR_VARS+="$(cat ${gcdir}/run/shared/settings/gmao_hemco.txt)\n"
+if [[ "x${sim_extra_option}" == "xbenchmark"        ||
+      "x${sim_extra_option}" == "xaciduptake"       ||
+      "x${sim_extra_option}" == "xmarinePOA"        ||
+      "x${sim_extra_option}" == "xcomplexSOA_SVPOA" ||
+      "x${sim_extra_option}" == "xAPM"              ||
+      "x${sim_name}"         == "xPOPs"             ||
+      "x${sim_name}"         == "xtagCH4"           ||
+      "x${sim_name}"         == "xtagO3"        ]]; then
+    RUNDIR_VARS+="RUNDIR_INITIAL_RESTART_SPECIES_REQUIRED='0'\n"
+else
+    RUNDIR_VARS+="RUNDIR_INITIAL_RESTART_SPECIES_REQUIRED='1'\n"
+fi
 
 #--------------------------------------------------------------------
 # Replace settings in config files with RUNDIR variables

--- a/run/GCHP/runScriptSamples/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/gchp.batch_job.sh
@@ -144,7 +144,7 @@ source checkRunSettings.sh
 #
 # POST-RUN COMMANDS
 #
-# If new start time in cap_restart is okay, rename and move restart file
+# If new start time in cap_restart is okay, rename restart file
 # and update restart symlink
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
@@ -152,6 +152,6 @@ if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh
 fi

--- a/run/GCHP/runScriptSamples/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/gchp.batch_job.sh
@@ -155,3 +155,17 @@ else
     mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh
 fi
+
+# Rename other checkpoint files generated during the run, if any,
+# but discard the first checkpoint since duplicate with original restart
+chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+for chkpnt in ${chkpnts}
+do
+   chkpnt_time=${chkpnt:36:13}
+   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+      rm ${chkpnt}
+   else
+      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+      mv ${chkpnt} ${new_chkpnt}
+   fi
+done

--- a/run/GCHP/runScriptSamples/gchp.local.run
+++ b/run/GCHP/runScriptSamples/gchp.local.run
@@ -6,6 +6,9 @@
 # run directory to specify start date. Set grid resolution, number of cores,
 # and other common settings in setCommonRunSettings.sh prior to running.
 
+# Stop run if errors encountered
+set -eo pipefail
+
 # Define log name to include simulation start date
 start_str=$(sed 's/ /_/g' cap_restart)
 log=gchp.${start_str:0:13}z.log

--- a/run/GCHP/runScriptSamples/gchp.local.run
+++ b/run/GCHP/runScriptSamples/gchp.local.run
@@ -19,9 +19,9 @@ else
 fi
 
 # Update config files, set restart symlink, and do sanity checks
-source setCommonRunSettings.sh --verbose >> ${log}
-source setRestartLink.sh >> ${log}
-source checkRunSettings.sh >> ${log}
+source setCommonRunSettings.sh --verbose 2>&1 | tee ${log}
+source setRestartLink.sh 2>&1 | tee ${log}
+source checkRunSettings.sh 2>&1 | tee ${log}
 
 # Run GCHP with # processors specified in config file setCommonRunSettings.sh
 nCores=$( grep -oP 'TOTAL_CORES=\s*\K\d+' setCommonRunSettings.sh )

--- a/run/GCHP/runScriptSamples/gchp.local.run
+++ b/run/GCHP/runScriptSamples/gchp.local.run
@@ -42,3 +42,16 @@ else
     source setRestartLink.sh 2>&1 | tee -a ${log}
 fi
 
+# Rename other checkpoint files generated during the run, if any,
+# but discard the first checkpoint since duplicate with original restart
+chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+for chkpnt in ${chkpnts}
+do
+   chkpnt_time=${chkpnt:36:13}
+   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+      rm ${chkpnt}
+   else
+      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+      mv ${chkpnt} ${new_chkpnt}
+   fi
+done

--- a/run/GCHP/runScriptSamples/gchp.local.run
+++ b/run/GCHP/runScriptSamples/gchp.local.run
@@ -31,14 +31,14 @@ nCores=$( grep -oP 'TOTAL_CORES=\s*\K\d+' setCommonRunSettings.sh )
 #--------------------------------------------------
 time mpirun -np ${nCores} ./gchp 2>&1 | tee -a ${log}
 
-# Rename and move restart file and update restart symlink if new start time ok
+# Rename restart file and update restart symlink if new start time ok
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
    echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh 2>&1 | tee -a ${log}
 fi
 

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -35,14 +35,14 @@ if [[ $(( ${coreCount} % ${SLURM_NNODES} )) > 0 ]]; then
 fi
 time srun -n ${coreCount} -N ${SLURM_NNODES} -m plane=${planeCount} --mpi=pmix ./gchp >> ${log}
 
-# Rename and move restart file and update restart symlink if new start time ok
+# Rename restart file and update restart symlink if new start time ok
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
    echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh
 fi
 

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -46,4 +46,18 @@ else
     source setRestartLink.sh
 fi
 
+# Rename other checkpoint files generated during the run, if any,
+# but discard the first checkpoint since duplicate with original restart
+chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+for chkpnt in ${chkpnts}
+do
+   chkpnt_time=${chkpnt:36:13}
+   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+      rm ${chkpnt}
+   else
+      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+      mv ${chkpnt} ${new_chkpnt}
+   fi
+done
+
 exit 0

--- a/run/GCHP/runScriptSamples/operational_examples/mit_hex/gchp.run_HEX
+++ b/run/GCHP/runScriptSamples/operational_examples/mit_hex/gchp.run_HEX
@@ -44,4 +44,18 @@ else
     source setRestartLink.sh
 fi
 
+# Rename other checkpoint files generated during the run, if any,
+# but discard the first checkpoint since duplicate with original restart
+chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+for chkpnt in ${chkpnts}
+do
+   chkpnt_time=${chkpnt:36:13}
+   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+      rm ${chkpnt}
+   else
+      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+      mv ${chkpnt} ${new_chkpnt}
+   fi
+done
+
 exit 0

--- a/run/GCHP/runScriptSamples/operational_examples/mit_hex/gchp.run_HEX
+++ b/run/GCHP/runScriptSamples/operational_examples/mit_hex/gchp.run_HEX
@@ -33,14 +33,14 @@ coreCount=$(( ${NX} * ${NY} ))
 
 mpirun ./gchp >> $log
 
-# Rename and move restart file and update restart symlink if new start time ok
+# Rename restart file and update restart symlink if new start time ok
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
    echo "ERROR: cap_restart either did not change or is empty."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh
 fi
 

--- a/run/GCHP/runScriptSamples/operational_examples/mit_svante/gchp.run_SVANTE.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/mit_svante/gchp.run_SVANTE.sh
@@ -37,4 +37,18 @@ else
     source setRestartLink.sh
 fi
 
+# Rename other checkpoint files generated during the run, if any,
+# but discard the first checkpoint since duplicate with original restart
+chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+for chkpnt in ${chkpnts}
+do
+   chkpnt_time=${chkpnt:36:13}
+   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+      rm ${chkpnt}
+   else
+      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+      mv ${chkpnt} ${new_chkpnt}
+   fi
+done
+
 exit 0

--- a/run/GCHP/runScriptSamples/operational_examples/mit_svante/gchp.run_SVANTE.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/mit_svante/gchp.run_SVANTE.sh
@@ -26,14 +26,14 @@ NY=$( grep NY GCHP.rc | awk '{print $2}' )
 coreCount=$(( ${NX} * ${NY} ))
 time mpirun -n ${coreCount} ./gchp >> ${log}
 
-# Rename and move restart file and update restart symlink if new start time ok
+# Rename restart file and update restart symlink if new start time ok
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
    echo "ERROR: cap_restart either did not change or is empty."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh
 fi
 

--- a/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
@@ -64,6 +64,20 @@ else
     source setRestartLink.sh
 fi
 
+# Rename other checkpoint files generated during the run, if any,
+# but discard the first checkpoint since duplicate with original restart
+chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+for chkpnt in ${chkpnts}
+do
+   chkpnt_time=${chkpnt:36:13}
+   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+      rm ${chkpnt}
+   else
+      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+      mv ${chkpnt} ${new_chkpnt}
+   fi
+done
+
 # Echo end date
 echo '===> Run ended at' `date` >> ${log}
 echo "Exit code: $rc"

--- a/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
@@ -53,14 +53,14 @@ tail --pid=$! -f $log
 #mpiexec dplace -s1 -c 4-11 ./grinder < run_input > output
 rc=$?
 
-# Rename and move restart file and update restart symlink if new start time ok
+# Rename restart file and update restart symlink if new start time ok
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
    echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh
 fi
 

--- a/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
@@ -44,6 +44,20 @@ else
     source setRestartLink.sh
 fi
 
+# Rename other checkpoint files generated during the run, if any,
+# but discard the first checkpoint since duplicate with original restart
+chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+for chkpnt in ${chkpnts}
+do
+   chkpnt_time=${chkpnt:36:13}
+   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+      rm ${chkpnt}
+   else
+      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+      mv ${chkpnt} ${new_chkpnt}
+   fi
+done
+
 trap times EXIT
 
 

--- a/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
@@ -33,14 +33,14 @@ source checkRunSettings.sh >> ${log}
 # Run the code
 mpirun ./gchp >> $log
 
-# Rename and move restart file and update restart symlink if new start time ok
+# Rename restart file and update restart symlink if new start time ok
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
    echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh
 fi
 

--- a/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
@@ -58,7 +58,7 @@ source checkRunSettings.sh
 #
 # POST-RUN COMMANDS
 #
-# If new start time in cap_restart is okay, rename and move restart file
+# If new start time in cap_restart is okay, rename restart file
 # and update restart symlink
 new_start_str=$(sed 's/ /_/g' cap_restart)
 if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
@@ -66,6 +66,6 @@ if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
    exit 1
 else
     N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh
 fi

--- a/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
@@ -69,3 +69,17 @@ else
     mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
     source setRestartLink.sh
 fi
+
+# Rename other checkpoint files generated during the run, if any,
+# but discard the first checkpoint since duplicate with original restart
+chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+for chkpnt in ${chkpnts}
+do
+   chkpnt_time=${chkpnt:36:13}
+   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+      rm ${chkpnt}
+   else
+      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+      mv ${chkpnt} ${new_chkpnt}
+   fi
+done

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -118,6 +118,11 @@ Checkpoint_Freq=monthly
 Model_Phase=FORWARD
 
 #------------------------------------------------
+#   REQUIRE ALL SPECIES IN INITIAL RESTART FILE
+#------------------------------------------------
+Require_Species_in_Restart=${RUNDIR_INITIAL_RESTART_SPECIES_REQUIRED}
+
+#------------------------------------------------
 #    TIMESTEPS
 #------------------------------------------------
 # Timesteps in GCHP are resolution-dependent
@@ -558,6 +563,12 @@ print_msg "---------------"
 if [[ ${dustSetting[3]} = "on" ]]; then
     replace_val "--> Mass tuning factor" ${Dust_SF} HEMCO_Config.rc
 fi
+
+###  Set initial restart file options
+print_msg ""
+print_msg "Initial restart settings:"
+print_msg "-------------------------"
+replace_val INITIAL_RESTART_SPECIES_REQUIRED ${Require_Species_in_Restart} GCHP.rc
 
 #### Set frequency of writing restart files
 # Set to a very large number if turned off

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -181,6 +181,7 @@ function update_gchp_config_files() {
     sed_ie "s/TOTAL_CORES=.*/TOTAL_CORES=24/"                       "${file}"
     sed_ie "s/NUM_NODES=.*/NUM_NODES=1/"                            "${file}"
     sed_ie "s/NUM_CORES_PER_NODE=.*/NUM_CORES_PER_NODE=24/"         "${file}"
+    sed_ie "s/Require_Species_in_Restart=.*/Require_Species_in_Restart=0/" "${file}"
 }
 
 function update_config_files() {

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -38,14 +38,7 @@ SED_HEMCO_CONF_1='s/GEOS_0.25x0.3125/GEOS_0.25x0.3125_NA/'
 SED_HEMCO_CONF_2='s/GEOS_0.5x0.625/GEOS_0.5x0.625_NA/'
 SED_HEMCO_CONF_N='s/\$RES.\$NC/\$RES.NA.\$NC/'
 SED_HISTORY_RC_1='s/00000100 000000/00000000 010000/'
-SED_HISTORY_RC_2='s/7440000/010000/'
 SED_HISTORY_RC_N='s/00000100 000000/00000000 002000/'
-SED_RUN_CONFIG_1='s/20160101 000000/20190101 000000/'
-SED_RUN_CONFIG_2='s/20160201 000000/20190101 010000/'
-SED_RUN_CONFIG_3='s/20190201 000000/20190101 010000/'
-SED_RUN_CONFIG_4='s/00000100 000000/00000000 010000/'
-SED_RUN_CONFIG_5='s/7440000/010000/'
-SED_RUN_CONFIG_6='s/1680000/010000/'
 CMP_PASS_STR='Configure & Build.....PASS'
 CMP_FAIL_STR='Configure & Build.....FAIL'
 EXE_PASS_STR='Execute Simulation....PASS'
@@ -164,23 +157,28 @@ function update_gchp_config_files() {
     # 2nd argument: Integration test root directory
     #========================================================================
     runPath=$(absolute_path "${1}")           # GCHP run dir (abs path)
-    file="${runPath}/setCommonRunSettings.sh" # config file to edit
 
-    # Replace text in config file
-    sed_ie "${SED_RUN_CONFIG_1}"                                    "${file}"
-    sed_ie "${SED_RUN_CONFIG_2}"                                    "${file}"
-    sed_ie "${SED_RUN_CONFIG_3}"                                    "${file}"
-    sed_ie "${SED_RUN_CONFIG_4}"                                    "${file}"
-    sed_ie "${SED_RUN_CONFIG_5}"                                    "${file}"
-    sed_ie "${SED_RUN_CONFIG_6}"                                    "${file}"
+    # Edit config file setCommonRunSettings.sh
+    file="${runPath}/setCommonRunSettings.sh"
+
+    # 24 cores on 1 node
+    sed_ie "s/TOTAL_CORES=.*/TOTAL_CORES=24/"                       "${file}"
+    sed_ie "s/NUM_NODES=.*/NUM_NODES=1/"                            "${file}"
+    sed_ie "s/NUM_CORES_PER_NODE=.*/NUM_CORES_PER_NODE=24/"         "${file}"
+
+    # C24 grid resolution
     sed_ie "s/CS_RES=.*/CS_RES=24/"                                 "${file}"
+
+    # 1-hr duration
+    sed_ie "s/Run_Duration=\".*/Run_Duration=\"00000000 010000\"/"  "${file}"
+
+    # 1-hr diagnostics
     sed_ie "s/AutoUpdate_Diagnostics=.*/AutoUpdate_Diagnostics=ON/" "${file}"
     sed_ie "s/Diag_Monthly=\"1\".*/Diag_Monthly=\"0\"/"             "${file}"
     sed_ie "s/Diag_Frequency=\".*/Diag_Frequency=\"010000\"/"       "${file}"
     sed_ie "s/Diag_Duration=\".*/Diag_Duration=\"010000\"/"         "${file}"
-    sed_ie "s/TOTAL_CORES=.*/TOTAL_CORES=24/"                       "${file}"
-    sed_ie "s/NUM_NODES=.*/NUM_NODES=1/"                            "${file}"
-    sed_ie "s/NUM_CORES_PER_NODE=.*/NUM_CORES_PER_NODE=24/"         "${file}"
+
+    # Do not require species in restart file
     sed_ie "s/Require_Species_in_Restart=.*/Require_Species_in_Restart=0/" "${file}"
 }
 
@@ -252,7 +250,6 @@ function update_config_files() {
 
     # Other text replacements
     sed_ie "${SED_HISTORY_RC_1}" "${runPath}/HISTORY.rc"
-    sed_ie "${SED_HISTORY_RC_2}" "${runPath}/HISTORY.rc"
 }
 
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR includes the following GCHP updates:

1. Example grid labels are now commented out in all HISTORY.rc files by default. This avoids a decomposition problem if running with over 3000 cores since grids are created for all uncommented grid labels regardless of whether they are used in a collection.

2. The interactive run script now prints error messages to screen in addition to the log, and also stops if an error is encountered. Previously some error messages were only written to log and the script kept going if an error was encountered, such as a non-existent restart file.

3. Simulations that require all species in the GC-Classic restart file, e.g. standard fullchem, now also require all species in the GCHP restart file. A new toggle in `setCommonRunSettings.sh` allows changing this behavior. Like GC-Classic, all simulations allow missing species during integration testing.

4. Overwriting existing GCHP diagnostic files is allowed again after not working since 14.0 when MAPL was updated. The behavior is now controlled from a switch at the top of `HISTORY.rc`.

5. All GCHP checkpoint files are now written directly to the `Restarts` folder in the run directory. This avoids writing large files locally if necessary since the `Restarts` folder can be symbolically linked to a different drive.

6. All GCHP checkpoint files are now renamed to the standard GEOS-Chem restart filename format, with the exception of the checkpoint file for the start time. That file is deleted so as not to overwrite the original restart file of the run.

7. GCHP tagged ozone simulation is functional again after fixing a bug in the prod/loss input filename in `ExtData.rc`.

8. Change GCHP carbon simulation inputs for global Cl and P(CO) to data generated from the 14.0.0 10-year benchmark.

### Expected changes

This update is zero diff for for all simulation diagnostics and restart files with the exception of the carbon simulation which now uses updated global Cl and P(CO data.

All other changes are related to run directory behavior. It is now possible to:
1. Allow overwriting diagnostics files
2. Restart GCHP directly from an output checkpoint file generated in the middle of a run
3. Run GCHP with >3000 cores
4. Better detect run directory problems such as missing restart file
5. Force the model to crash if a species is missing from the restart file
6. Write all restart files directly to the Restarts subdirectory

### Reference(s)

None

### Related Github Issue(s)

Closes https://github.com/geoschem/GCHP/issues/303
Closes https://github.com/geoschem/GCHP/issues/300
Closes https://github.com/geoschem/GCHP/issues/296
Closes https://github.com/geoschem/GCHP/issues/295
Closes https://github.com/geoschem/geos-chem/issues/1412
https://github.com/geoschem/geos-chem/pull/1717
