### PR TITLE
Add RxnConst diagnostic for archiving reaction rate constants

### DIFF
--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -267,6 +267,7 @@ CONTAINS
     IF (State_Diag%Archive_ProdCOfromNMVOC) State_Diag%ProdCOfromNMVOC= 0.0_f4
     IF (State_Diag%Archive_OHreactivity   ) State_Diag%OHreactivity   = 0.0_f4
     IF (State_Diag%Archive_RxnRate        ) State_Diag%RxnRate        = 0.0_f4
+    IF (State_Diag%Archive_RxnConst       ) State_Diag%RxnConst       = 0.0_f4
     IF (State_Diag%Archive_SatDiagnRxnRate) State_Diag%SatDiagnRxnRate= 0.0_f4
     IF (State_Diag%Archive_KppDiags) THEN
        IF (State_Diag%Archive_KppIntCounts) State_Diag%KppIntCounts   = 0.0_f4
@@ -977,7 +978,7 @@ CONTAINS
        !=====================================================================
        ! HISTORY (aka netCDF diagnostics)
        !
-       ! Archive KPP reaction rates [s-1]
+       ! Archive KPP reaction rates [molec cm-3 s-1]
        ! See gckpp_Monitor.F90 for a list of chemical reactions
        !
        ! NOTE: In KPP 2.5.0+, VAR and FIX are now private to the integrator
@@ -1009,6 +1010,18 @@ CONTAINS
                 State_Diag%SatDiagnRxnRate(I,J,L,S) = Aout(N)
              ENDDO
           ENDIF
+       ENDIF
+
+       ! Archive KPP reaction rate constants (RCONST). The units vary.
+       ! They are already updated in Update_RCONST, and do not require
+       ! a call of Fun(). (hplin, 3/28/23)
+       IF ( State_Diag%Archive_RxnConst ) THEN
+
+          DO S = 1, State_Diag%Map_RxnConst%nSlots
+             N = State_Diag%Map_RxnConst%slot2Id(S)
+             State_Diag%RxnConst(I,J,L,S) = RCONST(N)
+          ENDDO
+
        ENDIF
 
        !=====================================================================

--- a/GeosCore/mercury_mod.F90
+++ b/GeosCore/mercury_mod.F90
@@ -822,6 +822,7 @@ CONTAINS
     IF (State_Diag%Archive_JNoon          ) State_Diag%JNoon          = 0.0_f4
     IF (State_Diag%Archive_OHreactivity   ) State_Diag%OHreactivity   = 0.0_f4
     IF (State_Diag%Archive_RxnRate        ) State_Diag%RxnRate        = 0.0_f4
+    IF (State_Diag%Archive_RxnConst       ) State_Diag%RxnConst       = 0.0_f4
     IF (State_Diag%Archive_HgBrAfterChem  ) State_Diag%HgBrAfterChem  = 0.0_f4
     IF (State_Diag%Archive_HgClAfterChem  ) State_Diag%HgClAfterChem  = 0.0_f4
     IF (State_Diag%Archive_HgOHAfterChem  ) State_Diag%HgOHAfterChem  = 0.0_f4
@@ -1107,6 +1108,18 @@ CONTAINS
           DO S = 1, State_Diag%Map_RxnRate%nSlots
              N = State_Diag%Map_RxnRate%slot2Id(S)
              State_Diag%RxnRate(I,J,L,S) = Aout(N)
+          ENDDO
+
+       ENDIF
+
+       ! Archive KPP reaction rate constants (RCONST). The units vary.
+       ! They are already updated in Update_RCONST, and do not require
+       ! a call of Fun(). (hplin, 3/28/23)
+       IF ( State_Diag%Archive_RxnConst ) THEN
+
+          DO S = 1, State_Diag%Map_RxnConst%nSlots
+             N = State_Diag%Map_RxnConst%slot2Id(S)
+             State_Diag%RxnConst(I,J,L,S) = RCONST(N)
           ENDDO
 
        ENDIF

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -12550,7 +12550,7 @@ CONTAINS
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'RXNCONST' ) THEN
        IF ( isDesc    ) Desc  = 'KPP equation reaction rate constants'
-       IF ( isUnits   ) Units = 'various'
+       IF ( isUnits   ) Units = '(cm3 molec-1)**nreactants s-1'
        IF ( isRank    ) Rank  = 3
        IF ( isTagged  ) TagId = 'RXN'
 

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -12550,7 +12550,7 @@ CONTAINS
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'RXNCONST' ) THEN
        IF ( isDesc    ) Desc  = 'KPP equation reaction rate constants'
-       IF ( isUnits   ) Units = '(cm3 molec-1)**nreactants s-1'
+       IF ( isUnits   ) Units = '(cm3 molec-1)**(nreactants - 1) s-1'
        IF ( isRank    ) Rank  = 3
        IF ( isTagged  ) TagId = 'RXN'
 

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -45,6 +45,7 @@ COLLECTIONS: 'Restart',
              ##'ProdLoss',
              ##'RRTMG',
              ##'RxnRates',
+             ##'RxnConst',
              ##'SatDiagn',
              ##'StateChm',
              #'StateMet',
@@ -551,6 +552,26 @@ COLLECTIONS: 'Restart',
   RxnRates.mode:       'time-averaged'
   RxnRates.fields:     'RxnRate_EQ001                           ',
                        'RxnRate_EQ002                           ',
+::
+#==============================================================================
+# %%%%% THE RxnConst COLLECTION %%%%%
+#
+# Archives chemical reaction rates constants from the KPP solver.
+# It is best to list individual reactions to avoid using too much memory.
+# Reactions should be listed as "RxnConst_EQnnn", where nnn is the reaction
+# index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
+#
+# The units of reaction rate constants vary according to the number of reactants
+# in the reaction.
+#
+# Available for the fullchem simulations.
+#==============================================================================
+  RxnConst.template:   '%y4%m2%d2_%h2%n2z.nc4',
+  RxnConst.frequency:  ${RUNDIR_HIST_TIME_AVG_FREQ}
+  RxnConst.duration:   ${RUNDIR_HIST_TIME_AVG_DUR}
+  RxnConst.mode:       'time-averaged'
+  RxnConst.fields:     'RxnConst_EQ001                          ',
+                       'RxnConst_EQ002                          ',
 ::
 #==============================================================================
 # %%%%% THE SatDiagn COLLECTION %%%%%

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -73,6 +73,7 @@ COLLECTIONS: @#'DefaultCollection',
              @#'ProdLoss',
              @##'RRTMG',
              @##'RxnRates',
+             @##'RxnConst',
              #'SpeciesConc',
              @#'StateChm',
              #'StateMet',
@@ -4929,6 +4930,29 @@ COLLECTIONS: @#'DefaultCollection',
   RxnRates.mode:           'time-averaged'
   RxnRates.fields:         'RxnRate_EQ001     ', 'GCHPchem',
                            'RxnRate_EQ002     ', 'GCHPchem',
+::
+#==============================================================================
+# %%%%% THE RxnConst COLLECTION %%%%%
+#
+# Archives chemical reaction rates constants from the KPP solver.
+# It is best to list individual reactions to avoid using too much memory.
+# Reactions should be listed as "RxnConst_EQnnn", where nnn is the reaction
+# index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
+#
+# The units of reaction rate constants vary according to the number of reactants
+# in the reaction.
+#
+# Available for the fullchem simulations.
+#==============================================================================
+  RxnConst.template:       '%y4%m2%d2_%h2%n2z.nc4',
+  RxnConst.format:         'CFIO',
+  RxnConst.timestampStart: .true.
+  RxnConst.monthly:        1
+  RxnConst.frequency:      010000
+  RxnConst.duration:       010000
+  RxnConst.mode:           'time-averaged'
+  RxnConst.fields:         'RxnConst_EQ001    ', 'GCHPchem',
+                           'RxnConst_EQ002    ', 'GCHPchem',
 ::
 #==============================================================================
 # %%%%% THE SpeciesConc COLLECTION %%%%%


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard Univ

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This pull request implements the RxnConst_?RXN? diagnostic, allowing for archival of reaction rate constants (units vary) from KPP.

It is not enabled by default but can be enabled in a similar manner to the existing RxnRate_ diagnostics, which output the reaction rates (in molec cm-3 s-1) which are the rate constants with the species concentrations already applied.

Minor cosmetic fixes to the comments and metadata are added to describe the correct units of the RxnRate diagnostic (molec cm-3 s-1) as well.

### Expected changes

No changes to output are expected. These changes add a new diagnostic that is not enabled by default.

### Reference(s)

N/A