### PR TITLE
Remove array temporaries in carbon_mod.F90 and seasalt_mod.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Tests now run for 20 model minutes instead of an hour
 - Fixed divide by zero bug in sulfur chemistry introduced in 14.1.0
 - Restore seasalt alkalinity to heterogeneous acid-catalyzed reactions of halogens on seasalt aerosols.
+- Rewrote subroutine calls in `carbon_mod.F90` and `seasalt_mod.F90` to prevent array temporaries.
 
 ## [14.1.1] - 2023-03-03
 ### Added

--- a/GeosCore/seasalt_mod.F90
+++ b/GeosCore/seasalt_mod.F90
@@ -224,7 +224,7 @@ CONTAINS
             State_Diag = State_Diag,                                         &
             State_Grid = State_Grid,                                         &
             State_Met  = State_Met,                                          &
-            TC         = State_Chm%Species(id_SALA)%Conc,                    &
+            spcId      = id_SALA,                                            &
             N          = 1,                                                  &
             RC         = RC                                                 )
 
@@ -249,7 +249,7 @@ CONTAINS
             State_Diag = State_Diag,                                         &
             State_Grid = State_Grid,                                         &
             State_Met  = State_Met,                                          &
-            TC         = State_Chm%Species(id_SALC)%Conc,                    &
+            spcId      = id_SALC,                                            &
             N          = 2,                                                  &
             RC         = RC                                                 )
 
@@ -274,7 +274,7 @@ CONTAINS
             State_Diag = State_Diag,                                         &
             State_Grid = State_Grid,                                         &
             State_Met  = State_Met,                                          &
-            TC         = State_Chm%Species(id_SALACL)%Conc,                  &
+            spcId      = id_SALACL,                                          &
             N          = 3,                                                  &
             RC         = RC                                                 )
 
@@ -299,7 +299,7 @@ CONTAINS
             State_Diag = State_Diag,                                         &
             State_Grid = State_Grid,                                         &
             State_Met  = State_Met,                                          &
-            TC         = State_Chm%Species(id_SALCCL)%Conc,                  &
+            spcId      = id_SALCCL,                                          &
             N          = 4,                                                  &
             RC         = RC                                                 )
 
@@ -324,7 +324,7 @@ CONTAINS
             State_Diag = State_Diag,                                         &
             State_Grid = State_Grid,                                         &
             State_Met  = State_Met,                                          &
-            TC         = State_Chm%Species(id_SALAAL)%Conc,                  &
+            spcId      = id_SALAAL,                                          &
             N          = 5,                                                  &
             RC         = RC                                                 )
 
@@ -349,7 +349,7 @@ CONTAINS
             State_Diag = State_Diag,                                         &
             State_Grid = State_Grid,                                         &
             State_Met  = State_Met,                                          &
-            TC         = State_Chm%Species(id_SALCAL)%Conc,                  &
+            spcId      = id_SALCAL,                                          &
             N          = 6,                                                  &
             RC         = RC                                                 )
 
@@ -452,7 +452,7 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE Wet_Settling( Input_Opt, State_Chm, State_Diag, State_Grid,     &
-                           State_Met, TC,        N,          RC             )
+                           State_Met, spcId,     N,          RC             )
 !
 ! !USES:
 !
@@ -460,6 +460,7 @@ CONTAINS
     USE Error_Mod,      ONLY : Debug_Msg
     USE Input_Opt_Mod,  ONLY : OptInput
     USE PhysConstants
+    USE Species_Mod,    ONLY : SpcConc
     USE State_Chm_Mod,  ONLY : ChmState
     USE State_Diag_Mod, ONLY : DgnState
     USE State_Grid_Mod, ONLY : GrdState
@@ -472,14 +473,12 @@ CONTAINS
     TYPE(ChmState), INTENT(IN)    :: State_Chm   ! Chemistry State object
     TYPE(GrdState), INTENT(IN)    :: State_Grid  ! Grid State object
     TYPE(MetState), INTENT(IN)    :: State_Met   ! Meteorology State object
+    INTEGER,        INTENT(IN)    :: spcId       ! Sea salt species Id
     INTEGER,        INTENT(IN)    :: N           ! odd=accum; even=coarse
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
     TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
-    REAL(fp),       INTENT(INOUT) :: TC(State_Grid%NX, &! Sea salt [kg]
-                                        State_Grid%NY, &
-                                        State_Grid%NZ)
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -515,6 +514,9 @@ CONTAINS
     ! Arrays
     REAL(fp)           :: VTS(State_Grid%NZ)
     REAL(fp)           :: TC0(State_Grid%NZ)
+
+    ! Pointers
+    REAL(fp), POINTER  :: TC(:,:,:)
 
     ! Strings
     CHARACTER(LEN=255) :: ErrMsg
@@ -558,6 +560,9 @@ CONTAINS
        CALL DEBUG_MSG('SEASALT: STARTING WET_SETTLING')
     ENDIF
 
+    ! Point to the species concentration array in State_Chm%Species
+    TC => State_Chm%Species(spcId)%Conc
+    
 !%%% Comment out unused code (not sure who disabled this)
 !%%%    ! Sea salt radius [cm]
 !%%%    !RCM  = REFF * 100e+0_fp
@@ -820,6 +825,9 @@ CONTAINS
     ENDDO ! I
     ENDDO ! J
     !$OMP END PARALLEL DO
+
+    ! Free pointer
+    TC => NULL()
 
     IF ( Input_Opt%Verbose ) THEN
        CALL DEBUG_MSG('SEASALT: ENDING WET_SETTLING')


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to #1726.  The fixes in this PR will prevent array temporaries (i.e. when the an under-the-hood temporary array has to be created in memory in order to pass an array to a subroutine) from being created in `GeosCore/seasalt_mod.F90` and `GeosCore/carbon_mod.F90`. 

### Expected changes

Warning messages such as 
```console
At line 227 of file /n/holyscratch01/jacob_lab/elundgren/testruns/gchp_14.2_updates/integration/CodeDir/src/GCHP_GridComp/GEOSChem_GridComp/geos-chem/GeosCore/seasalt_mod.F90
Fortran runtime warning: An array temporary was created for argument 'tc' of procedure 'wet_settling'
etc.
```
should no longer be generated.  This will also avoid the overhead in memory and CPU cycles caused by having to create a temporary array "under-the-hood".

Also this PR is zero-diff w/r/t 14.2.0-alpha.6.

Integration tests to follow.

### Reference(s)

N/A

### Related Github Issue(s)

Closes #1726 
