### PR TITLE
Set CO2 concentration to 421 ppm in fullchem simulations -- fixes CO2 error norm for KPP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added a printout of GEOS-Chem species and indices
 - Added 'NcdfUtil/README.md` file directing users to look for netCDF utility scripts at https://github.com/geoschem/netcdf-scripts
-- Restored sink reactions for HOI, IONO, IONO2 (fullchem, custom mechanisms)
+- Restored sink reactions for HOI, IONO, IONO2 (fullchem, custom mechanisms)Geos
 - S(IV) + HOBr and S(IV) + HOCl reactions to `KPP/fullchem/fullchem.eqn`
 - Activated nitrate photolysis
 
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - If KPP integration fails, reset to prior concentrations and set RSTATE(3) = 0 before retrying
 - Suppress integration errors after 20 errors have been printed to stdout
 - Simplified and added comments for bimolecular reactions in clouds in function CloudHet2R
+- In fullchem simulations, set CO2 to 421 ppm (avg global conc in 2022) everywhere
 
 ### Removed
 - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files

--- a/GeosCore/chemistry_mod.F90
+++ b/GeosCore/chemistry_mod.F90
@@ -39,9 +39,6 @@ MODULE Chemistry_Mod
 !
 ! !PRIVATE TYPES:
 !
-
-  INTEGER :: id_DST1, id_NK1   ! Species ID flags
-
 CONTAINS
 !EOC
 !------------------------------------------------------------------------------
@@ -129,6 +126,9 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
+    ! SAVEd scalars
+    INTEGER, SAVE      :: id_DST1, id_NK1, id_CO2   ! Species ID flags
+
     ! Scalars
     INTEGER            :: N_TROP, N
     INTEGER            :: MONTH
@@ -161,6 +161,7 @@ CONTAINS
     IF ( FIRST ) THEN
        id_DST1 = Ind_('DST1')
        id_NK1  = Ind_('NK1' )
+       id_CO2  = Ind_('CO2' )
     ENDIF
 
     !========================================================================
@@ -198,6 +199,16 @@ CONTAINS
     !========================================================================
     ! Convert species units to [kg] for chemistry (ewl, 8/12/15)
     !========================================================================
+
+    ! Here, units are still in mol/mol dry.   For fullchem-simulation only,
+    ! set CO2 to 421 ppm (or 421e-6 mol/mol dry) since this is the global
+    ! average value. This is necessary to reduce the error norm in KPP.
+    ! See https://github.com/geoschem/geos-chem/issues/1529.
+    IF ( Input_Opt%ITS_A_FULLCHEM_SIM ) THEN
+       State_Chm%Species(id_CO2)%Conc = 421.0e-6_fp
+    ENDIF
+
+    ! Convert units from mol/mol dry to kg
     CALL Convert_Spc_Units( Input_Opt  = Input_Opt,                          &
                             State_Chm  = State_Chm,                          &
                             State_Grid = State_Grid,                         &

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -345,13 +345,6 @@ CONTAINS
           END SELECT
        ENDIF
 
-       ! Temporary fix for CO2
-       ! CO2 is a dead species and needs to be set to zero to
-       ! match the old SMVGEAR code (mps, 6/14/16)
-       IF ( TRIM( SpcInfo%Name ) == 'CO2' ) THEN
-          State_Chm%Species(N)%Conc(:,:,:) = 0.0_fp
-       ENDIF
-
        ! Free pointer
        SpcInfo => NULL()
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to #1529.  In that issue, @msl3v pointed out that we were resetting CO2 (which is fixed for KPP) to zero due to legacy code. 

In this PR we now set CO2 everywhere to 421 ppm in `GeosCore/chemistry_mod.F90`, right before the unit conversion to from `mol/mol dry` to kg.  A further unit conversion to `molec/cm` is done in `GeosCore/fullchem_mod.F90`, before the call to the KPP integration routine

NOTE: I have targeted this update for 14.2.0.  If this PR is not merged in time for 14.2.0, please update the target branch before deleting `dev/14.2.0`.

### Expected changes

In general we see very small differences in the output.

#### Surface plots 
![co](https://user-images.githubusercontent.com/5880296/229157426-6a142349-bfd6-4780-8baa-5fd09efb6c2d.png)
![o3](https://user-images.githubusercontent.com/5880296/229157292-b879bb15-05ed-466a-8094-25a79383711d.png)

#### Zonal mean plots
![co_zonal](https://user-images.githubusercontent.com/5880296/229157371-470e9da4-d501-4058-9df5-1ab45059a8de.png)
![o3_zonal](https://user-images.githubusercontent.com/5880296/229157320-1cce04e5-d6f8-4fea-9fd3-7e774d5f9dcb.png)

Other species show similar small diffs. 

### Reference(s)

@msl3v wrote in #1529:

> Hello all.
> 
> We've been looking at the process of error estimation in KPP's Rosenbrock solver, and noticed that in calculating the error norm of a FullChem run, the relative error of CO2 is large. There are several points this raises:
> 
> 1. The error norm determines the internal substep size.
> 2. CO2 is not a stiff or active species. It is essentially for mass balance of carbon oxidation. It is nowhere a reactant.
> 3. The reason the relative error for CO2 is high is because it is initialized to zero for every timestep.
> 4. the error norm should be minimized: non-relevant terms should be excluded or their impacts kept small.
> 
> This issue can be resolved by simply setting CO2 to a relevant (or even arbitrarily) large value. Pardon me if I don't propose a number here, because C(ind_CO2) is in molec/cm3, and would be pressure dependent if it were calculated appropriately.

### Related Github Issue(s)

Closes #1529
