### PR TITLE
Update text displayed at user registration during rundir creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Suppress integration errors after 20 errors have been printed to stdout
 - Simplified and added comments for bimolecular reactions in clouds in function CloudHet2R
 - `HEMCO_Config.rc` and `ExtData.rc` templates now point `HEMCO/GFED4/v2023-03`
+- In the user registration process:
+  - Now ask for both first and last names of the user
+  - Now state that user registration is needed for GEOS-Chem support
 
 ### Removed
 - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files

--- a/run/shared/newUserRegistration.sh
+++ b/run/shared/newUserRegistration.sh
@@ -73,9 +73,10 @@ function registerNewUser() {
     # Ask user several questions
     printf "\nInitiating User Registration:\n"
     printf "You will only need to fill this information out once.\n"
-    printf "Please respond to all questions.\n"
+    printf "Please respond to all questions.  Registration is required \n"
+    printf "in order to receive GEOS-Chem support.\n"
 
-    printf "${thinline}What is your name?${thinline}"
+    printf "${thinline}What is your name (first and last)?${thinline}"
     name=$(userInput)
 
     # Ask for email


### PR DESCRIPTION
### Name and Institution (Required)

Name:  Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This updates adds extra wording to the GC user registration screen.

### Expected changes
User registration now displays the following text:
```console
===========================================================
GEOS-CHEM RUN DIRECTORY CREATION
===========================================================

Initiating User Registration:
You will only need to fill this information out once.
Please respond to all questions.  Registration is required 
in order to receive GEOS-Chem support.

-----------------------------------------------------------
What is your name (first and last)?
-----------------------------------------------------------
>>> 

... etc., all the other questions are the same as before ...
```

### Reference(s)

N/A

### Related Github Issue(s)

N/A
