### PR TITLE
Fix bug renaming midrun checkpoint files

### DIFF
--- a/run/GCHP/runScriptSamples/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/gchp.batch_job.sh
@@ -156,16 +156,18 @@ else
     source setRestartLink.sh
 fi
 
-# Rename other checkpoint files generated during the run, if any,
-# but discard the first checkpoint since duplicate with original restart
-chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+# Rename mid-run checkpoint files, if any. Discard file if time corresponds
+# to run start time since duplicate with initial restart file.
+chkpnts=$(ls Restarts)
 for chkpnt in ${chkpnts}
 do
-   chkpnt_time=${chkpnt:36:13}
-   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
-      rm ${chkpnt}
-   else
-      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
-      mv ${chkpnt} ${new_chkpnt}
-   fi
+    if [[ "$chkpnt" == *"gcchem_internal_checkpoint."* ]]; then
+       chkpnt_time=${chkpnt:27:13}
+       if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+          rm ./Restarts/${chkpnt}
+       else
+          new_chkpnt=./Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+          mv ./Restarts/${chkpnt} ${new_chkpnt}
+       fi
+    fi
 done

--- a/run/GCHP/runScriptSamples/gchp.local.run
+++ b/run/GCHP/runScriptSamples/gchp.local.run
@@ -45,16 +45,18 @@ else
     source setRestartLink.sh 2>&1 | tee -a ${log}
 fi
 
-# Rename other checkpoint files generated during the run, if any,
-# but discard the first checkpoint since duplicate with original restart
-chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+# Rename mid-run checkpoint files, if any. Discard file if time corresponds
+# to run start time since duplicate with initial restart file.
+chkpnts=$(ls Restarts)
 for chkpnt in ${chkpnts}
 do
-   chkpnt_time=${chkpnt:36:13}
-   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
-      rm ${chkpnt}
-   else
-      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
-      mv ${chkpnt} ${new_chkpnt}
-   fi
+    if [[ "$chkpnt" == *"gcchem_internal_checkpoint."* ]]; then
+       chkpnt_time=${chkpnt:27:13}
+       if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+          rm ./Restarts/${chkpnt}
+       else
+          new_chkpnt=./Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+          mv ./Restarts/${chkpnt} ${new_chkpnt}
+       fi
+    fi
 done

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -46,18 +46,20 @@ else
     source setRestartLink.sh
 fi
 
-# Rename other checkpoint files generated during the run, if any,
-# but discard the first checkpoint since duplicate with original restart
-chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+# Rename mid-run checkpoint files, if any. Discard file if time corresponds
+# to run start time since duplicate with initial restart file.
+chkpnts=$(ls Restarts)
 for chkpnt in ${chkpnts}
 do
-   chkpnt_time=${chkpnt:36:13}
-   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
-      rm ${chkpnt}
-   else
-      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
-      mv ${chkpnt} ${new_chkpnt}
-   fi
+    if [[ "$chkpnt" == *"gcchem_internal_checkpoint."* ]]; then
+       chkpnt_time=${chkpnt:27:13}
+       if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+          rm ./Restarts/${chkpnt}
+       else
+          new_chkpnt=./Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+          mv ./Restarts/${chkpnt} ${new_chkpnt}
+       fi
+    fi
 done
 
 exit 0

--- a/run/GCHP/runScriptSamples/operational_examples/mit_hex/gchp.run_HEX
+++ b/run/GCHP/runScriptSamples/operational_examples/mit_hex/gchp.run_HEX
@@ -44,18 +44,20 @@ else
     source setRestartLink.sh
 fi
 
-# Rename other checkpoint files generated during the run, if any,
-# but discard the first checkpoint since duplicate with original restart
-chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+# Rename mid-run checkpoint files, if any. Discard file if time corresponds
+# to run start time since duplicate with initial restart file.
+chkpnts=$(ls Restarts)
 for chkpnt in ${chkpnts}
 do
-   chkpnt_time=${chkpnt:36:13}
-   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
-      rm ${chkpnt}
-   else
-      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
-      mv ${chkpnt} ${new_chkpnt}
-   fi
+    if [[ "$chkpnt" == *"gcchem_internal_checkpoint."* ]]; then
+       chkpnt_time=${chkpnt:27:13}
+       if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+          rm ./Restarts/${chkpnt}
+       else
+          new_chkpnt=./Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+          mv ./Restarts/${chkpnt} ${new_chkpnt}
+       fi
+    fi
 done
 
 exit 0

--- a/run/GCHP/runScriptSamples/operational_examples/mit_svante/gchp.run_SVANTE.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/mit_svante/gchp.run_SVANTE.sh
@@ -37,18 +37,20 @@ else
     source setRestartLink.sh
 fi
 
-# Rename other checkpoint files generated during the run, if any,
-# but discard the first checkpoint since duplicate with original restart
-chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+# Rename mid-run checkpoint files, if any. Discard file if time corresponds
+# to run start time since duplicate with initial restart file.
+chkpnts=$(ls Restarts)
 for chkpnt in ${chkpnts}
 do
-   chkpnt_time=${chkpnt:36:13}
-   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
-      rm ${chkpnt}
-   else
-      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
-      mv ${chkpnt} ${new_chkpnt}
-   fi
+    if [[ "$chkpnt" == *"gcchem_internal_checkpoint."* ]]; then
+       chkpnt_time=${chkpnt:27:13}
+       if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+          rm ./Restarts/${chkpnt}
+       else
+          new_chkpnt=./Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+          mv ./Restarts/${chkpnt} ${new_chkpnt}
+       fi
+    fi
 done
 
 exit 0

--- a/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
@@ -64,18 +64,20 @@ else
     source setRestartLink.sh
 fi
 
-# Rename other checkpoint files generated during the run, if any,
-# but discard the first checkpoint since duplicate with original restart
-chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+# Rename mid-run checkpoint files, if any. Discard file if time corresponds
+# to run start time since duplicate with initial restart file.
+chkpnts=$(ls Restarts)
 for chkpnt in ${chkpnts}
 do
-   chkpnt_time=${chkpnt:36:13}
-   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
-      rm ${chkpnt}
-   else
-      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
-      mv ${chkpnt} ${new_chkpnt}
-   fi
+    if [[ "$chkpnt" == *"gcchem_internal_checkpoint."* ]]; then
+       chkpnt_time=${chkpnt:27:13}
+       if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+          rm ./Restarts/${chkpnt}
+       else
+          new_chkpnt=./Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+          mv ./Restarts/${chkpnt} ${new_chkpnt}
+       fi
+    fi
 done
 
 # Echo end date

--- a/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
@@ -44,18 +44,20 @@ else
     source setRestartLink.sh
 fi
 
-# Rename other checkpoint files generated during the run, if any,
-# but discard the first checkpoint since duplicate with original restart
-chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+# Rename mid-run checkpoint files, if any. Discard file if time corresponds
+# to run start time since duplicate with initial restart file.
+chkpnts=$(ls Restarts)
 for chkpnt in ${chkpnts}
 do
-   chkpnt_time=${chkpnt:36:13}
-   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
-      rm ${chkpnt}
-   else
-      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
-      mv ${chkpnt} ${new_chkpnt}
-   fi
+    if [[ "$chkpnt" == *"gcchem_internal_checkpoint."* ]]; then
+       chkpnt_time=${chkpnt:27:13}
+       if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+          rm ./Restarts/${chkpnt}
+       else
+          new_chkpnt=./Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+          mv ./Restarts/${chkpnt} ${new_chkpnt}
+       fi
+    fi
 done
 
 trap times EXIT

--- a/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
@@ -70,16 +70,18 @@ else
     source setRestartLink.sh
 fi
 
-# Rename other checkpoint files generated during the run, if any,
-# but discard the first checkpoint since duplicate with original restart
-chkpnts=$(ls Restarts/gcchem_internal_checkpoint.*)
+# Rename mid-run checkpoint files, if any. Discard file if time corresponds
+# to run start time since duplicate with initial restart file.
+chkpnts=$(ls Restarts)
 for chkpnt in ${chkpnts}
 do
-   chkpnt_time=${chkpnt:36:13}
-   if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
-      rm ${chkpnt}
-   else
-      new_chkpnt=Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
-      mv ${chkpnt} ${new_chkpnt}
-   fi
+    if [[ "$chkpnt" == *"gcchem_internal_checkpoint."* ]]; then
+       chkpnt_time=${chkpnt:27:13}
+       if [[ "${chkpnt_time}" = "${start_str:0:13}" ]]; then
+          rm ./Restarts/${chkpnt}
+       else
+          new_chkpnt=./Restarts/GEOSChem.Restart.${chkpnt_time}z.c${N}.nc4
+          mv ./Restarts/${chkpnt} ${new_chkpnt}
+       fi
+    fi
 done

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -97,11 +97,11 @@ Diag_Collections=(SpeciesConc    \
 #------------------------------------------------------------
 #    MID-RUN CHECKPOINT FILES
 #------------------------------------------------------------
-Periodic_Checkpoint=OFF
+Midrun_Checkpoint=OFF
 Checkpoint_Freq=monthly
 
 # Instructions for configuring restart output before end of run:
-#  1. Set Periodic_Checkpoint=ON
+#  1. Set Midrun_Checkpoint=ON
 #  2. Set Checkpoint_Freq to either monthly or a string of format HHmmss
 #     where HHmmss is frequency hours, minutes, and seconds.
 #     More than 2 digits for hours is permitted, e.g. "1680000" for 7 days.
@@ -573,9 +573,9 @@ replace_val INITIAL_RESTART_SPECIES_REQUIRED ${Require_Species_in_Restart} GCHP.
 #### Set frequency of writing restart files
 # Set to a very large number if turned off
 print_msg " "
-print_msg "Periodic checkpoints:"
+print_msg "Mid-run checkpoints:"
 print_msg "---------------------"
-if [[ ${Periodic_Checkpoint} == "ON" ]]; then
+if [[ ${Midrun_Checkpoint} == "ON" ]]; then
     uncomment_line RECORD_FREQUENCY GCHP.rc
     uncomment_line RECORD_REF_DATE  GCHP.rc
     uncomment_line RECORD_REF_TIME  GCHP.rc
@@ -585,13 +585,13 @@ if [[ ${Periodic_Checkpoint} == "ON" ]]; then
     Checkpoint_Ref_Time="${start_str:9:6}"
     replace_val RECORD_REF_DATE "${Checkpoint_Ref_Date}" GCHP.rc
     replace_val RECORD_REF_TIME "${Checkpoint_Ref_Time}" GCHP.rc
-elif [[ ${Periodic_Checkpoint} == "OFF" ]]; then
-    print_msg "WARNING: Periodic checkpoints are turned off"
+elif [[ ${Midrun_Checkpoint} == "OFF" ]]; then
+    print_msg "WARNING: Midrun checkpoints are turned off"
     comment_line RECORD_FREQUENCY GCHP.rc
     comment_line RECORD_REF_DATE  GCHP.rc
     comment_line RECORD_REF_TIME  GCHP.rc
 else
-    print_msg "ERROR: unknown setting for Periodic_Checkpoint. Must be ON or OFF."
+    print_msg "ERROR: unknown setting for Midrun_Checkpoint. Must be ON or OFF."
     exit 1
 fi
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR fixes a bug in https://github.com/geoschem/geos-chem/pull/1724, in which the GCHP run script would exit with status code 1 if mid-run checkpoint files were not present in the Restarts folder. This bug did not impact GCHP runs and is not present in any version releases.

### Expected changes

GCHP run scripts exit with status code 0.
