### PR TITLE
Remove operator splitting in CH4 simulation that biases diagnostics (closes #1738)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed GCHP ExtData.rc error in tagged ozone simulation
 - Fixed GCHP HISTORY.rc issue preventing diagnostic file overwrite
 - Update GCHP interactive run script to fix error handling silent bugs
+- Removed operator splitting in CH4 simulation that was biasing diagnostics
 
 ## [14.1.1] - 2023-03-03
 ### Added

--- a/GeosCore/global_ch4_mod.F90
+++ b/GeosCore/global_ch4_mod.F90
@@ -896,7 +896,7 @@ CONTAINS
     !$OMP PARALLEL DO       &
     !$OMP DEFAULT( SHARED ) &
     !$OMP PRIVATE( L, J, I, KRATE, Spc2GCH4, GCH4, C_OH ) &
-    !$OMP PRIVATE( C_Cl, KRATE_Cl ) &
+    !$OMP PRIVATE( C_Cl, KRATE_Cl                       ) &
     !$OMP REDUCTION( +:TROPOCH4 )
     DO L = 1, State_Grid%NZ
     DO J = 1, State_Grid%NY
@@ -951,8 +951,8 @@ CONTAINS
           ENDIF
 
           ! Calculate new CH4 value: [CH4]=[CH4](1-k[OH]*delt)
-          GCH4 = GCH4 * ( 1e+0_fp - KRATE    * C_OH * DT )
-          GCH4 = GCH4 * ( 1e+0_fp - KRATE_Cl * C_Cl * DT )
+          GCH4 = GCH4 *                                                      &
+             ( 1.0_fp - ( KRATE * C_OH * DT ) - ( KRATE_Cl * C_Cl * DT )    )
 
           ! Convert back from [molec/cm3] --> [kg/box]
           Spc(1)%Conc(I,J,L) = GCH4 / Spc2GCH4


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to issue #1738 (raised by @toddmooring).  He pointed out that CH4 loss rates needed to be applied to the `GCH4` variable, instead of in two steps, as that was biasing the loss diagnostics.

This is a bug fix and should go into 14.2.0.  I've set the target branch to dev/14.2.0.

### Expected changes

As described in #1738, minor differences (due to roundoff) will be observed.  But most locations will show exactly zero difference w/r/t the prior code.

### Reference(s)

N/A

### Related Github Issue(s)

Closes #1738
