### PR TITLE
Bugfix/photolysis off option

### DIFF
--- a/GeosCore/photolysis_mod.F90
+++ b/GeosCore/photolysis_mod.F90
@@ -1022,15 +1022,15 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(OptInput), INTENT(IN) :: Input_Opt
+    TYPE(OptInput), INTENT(IN)    :: Input_Opt
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
-    TYPE(ChmState), INTENT(IN) :: State_Chm
+    TYPE(ChmState), INTENT(INOUT) :: State_Chm
 !
 ! !OUTPUT PARAMETERS:
 !
-    INTEGER,        INTENT(IN) :: RC
+    INTEGER,        INTENT(IN)    :: RC
 !
 ! !REMARKS:
 !  Now the user is able to select any 3 wavelengths for optics

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -437,13 +437,19 @@ CONTAINS
           RRATE(1)  = 5.1e-12_fp*exp(210.e+0_fp*TINV)
           ! 4:  NO2 + hv -> NO + O1D
           !RRATE(k_JNO2) = State_Chm%NOX_J(I,J,L,JNO2IDX)*DAYFRAC
-          RRATE(k_JNO2) = ZPJ(LMINPHOT,State_Chm%Phot%RXN_NO2,I,J)
+          IF ( State_Chm%Phot%RXN_NO2 > 0 ) THEN
+             RRATE(k_JNO2) = ZPJ(LMINPHOT,State_Chm%Phot%RXN_NO2,I,J)
+          ENDIF
           ! 5:  NO3 + hv -> NO2 + O
           !RRATE(k_JNO3) = State_Chm%NOX_J(I,J,L,JNO3IDX)*DAYFRAC
-          RRATE(k_JNO3) = ZPJ(LMINPHOT,State_Chm%Phot%RXN_NO3,I,J)
+          IF ( State_Chm%Phot%RXN_NO3 > 0 ) THEN
+             RRATE(k_JNO3) = ZPJ(LMINPHOT,State_Chm%Phot%RXN_NO3,I,J)
+          ENDIF
           ! 6:  NO + hv -> N + O
           !RRATE(k_JNO ) = State_Chm%NOX_J(I,J,L,JNOIDX)*DAYFRAC
-          RRATE(k_JNO) = ZPJ(LMINPHOT,State_Chm%Phot%RXN_NO,I,J)
+          IF ( State_Chm%Phot%RXN_NO > 0 ) THEN
+             RRATE(k_JNO) = ZPJ(LMINPHOT,State_Chm%Phot%RXN_NO,I,J)
+          ENDIF
           ! 7:  N + NO2 -> N2O + O
           RRATE(7)  = 5.8e-12_fp*exp(220.e+0_fp*TINV)
           ! 8:  N + NO -> N2 + O
@@ -456,7 +462,9 @@ CONTAINS
           RRATE(11) = 7.25e-11_fp*exp(20.e+0_fp*TINV)
           ! 12:  N2O + hv -> N2 + O1D
           !RRATE(k_JN2O) = State_Chm%NOX_J(I,J,L,JN2OIDX)*DAYFRAC
-          RRATE(k_JN2O) = ZPJ(LMINPHOT,State_Chm%Phot%RXN_N2O,I,J)
+          IF ( State_Chm%Phot%RXN_N2O > 0 ) THEN
+             RRATE(k_JN2O) = ZPJ(LMINPHOT,State_Chm%Phot%RXN_N2O,I,J)
+          ENDIF
 
           ! Sanity check
           Where(RRate.lt.0.0e+0_fp) RRate = 0.0e+0_fp
@@ -3834,8 +3842,10 @@ CONTAINS
           LMINPHOT  = State_Met%ChemGridLev(I,J)
 
           ! Retrieve photolysis rate as a fraction of gaseous SO4
+          IF ( State_Chm%Phot%RXN_H2SO4 > 0 ) THEN
           PHOTDELTA = State_Chm%Phot%ZPJ(LMINPHOT,State_Chm%Phot%RXN_H2SO4,I,J)&
                       * DTCHEM
+          ENDIF
           PHOTDELTA = MIN(1.e+0_fp,PHOTDELTA)
 
           DO L=LMINPHOT+1,State_Grid%NZ

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -746,8 +746,10 @@ PROGRAM GEOS_Chem
      ENDIF
   ENDIF
 
-  ! Initialize photolysis
-  IF ( Input_Opt%Do_Photolysis ) THEN
+  ! Initialize photolysis, including reading files for optical properties
+  IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or. &
+       Input_Opt%ITS_AN_AEROSOL_SIM .or. &
+       Input_Opt%ITS_A_MERCURY_SIM  ) THEN
      CALL Init_Photolysis( Input_Opt, State_Chm, State_Diag, RC )
      IF ( RC /= GC_SUCCESS ) THEN
         ErrMsg = 'Error encountered in "Init_Photolysis"!'

--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -512,8 +512,10 @@ CONTAINS
     State_Chm%Spc_Units = 'v/v dry'
 #endif
 
-    ! Initialize photolysis
-    IF ( Input_Opt%Do_Photolysis ) THEN
+    ! Initialize photolysis, including reading files for optical properties
+    IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or. &
+         Input_Opt%ITS_AN_AEROSOL_SIM .or. &
+         Input_Opt%ITS_A_MERCURY_SIM  ) THEN
        CALL Init_Photolysis ( Input_Opt, State_Chm, State_Diag, RC )
        _ASSERT(RC==GC_SUCCESS, 'Error calling Init_Photolysis')
     ENDIF


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This update fixes a bug introduced in 14.2.0 in the photolysis `activate: false` option in `geoschem_config.yml`, which was introduced as a run-time option for debugging purposes. Disabling photolysis caused skipping the calls to `Rd_AOD` and `Calc_AOD` within `Init_Photolysis`. However, these subroutines must be called regardless of whether J-values will be computed since they are used for other parts of GEOS-Chem.

### Expected changes

There will no longer be a run-time error if photolysis is disabled in `geoschem_config.yml`. Otherwise this is a zero diff update.

### Related Github Issue(s)

This corrects an issue introduced in https://github.com/geoschem/geos-chem/pull/1733.
