### PR TITLE
Fix bug in HOBr uptake rate calculation (closes #1746)

### DIFF
--- a/KPP/fullchem/fullchem_RateLawFuncs.F90
+++ b/KPP/fullchem/fullchem_RateLawFuncs.F90
@@ -2042,8 +2042,7 @@ CONTAINS
     ENDIF
 
     ! Assume HOBr is limiting, so update the removal rate accordingly
-    ! Convert SO2 to HSO3- with the HSO3-/SO2 ratio
-    k = kIIR1Ltd( C(ind_HOBr), C(ind_SO2), k ) * H%HSO3m
+    k = kIIR1Ltd( C(ind_HOBr), C(ind_SO2), k )
   END FUNCTION HOBrUptkByHSO3m
 
   FUNCTION HOBrUptkBySO3mm( H ) RESULT( k )
@@ -2076,8 +2075,7 @@ CONTAINS
     ENDIF
 
     ! Assume HOBr is limiting, so update the removal rate accordingly
-    ! Convert SO2 to SO3-- with the SO3--/SO2 ratio
-    k = kIIR1Ltd( C(ind_HOBr), C(ind_SO2), k ) * H%SO3mm
+    k = kIIR1Ltd( C(ind_HOBr), C(ind_SO2), k )
 
   END FUNCTION HOBrUptkBySO3mm
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to #1746.  In that issue, @viral211 and @beckyalexander have confirmed that the rate law computations for HOBr uptake were being unnecessarily multiplied by scale factors that have already been accounted for in the reaction rate computation. 

Line 2046 of `KPP/fullchem/fullchem_RateLawFuncs` was modified accordingly:
```F90 
old: k = kIIR1Ltd( C(ind_HOBr), C(ind_SO2), k ) * H%HSO3m
new: k = kIIR1Ltd( C(ind_HOBr), C(ind_SO2), k )  
```
as was line 2048:
```F90
old: k = kIIR1Ltd( C(ind_HOBr), C(ind_SO2), k ) * H%SO3mm
new: k = kIIR1Ltd( C(ind_HOBr), C(ind_SO2), k )
```

### Expected changes

@viral211 wrote:
>Fixing this will increase the loss of HOBr (to HBr) and could lower BrOx levels, with a larger effect for simulations that include sea salt aerosol debromination.

### Reference(s)

N/A

### Related Github Issue(s)

Closes #1746

If possible, this should go into 14.2.0, along with the other chemistry updates.  This might help to lower the mean OH concentration, which is currently high.