### PR TITLE
Update GCHP check for python and bc libs to prevent error checking fail

### DIFF
--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -227,8 +227,10 @@ fi
 if [[ ${AutoUpdate_NXNY} == 'ON' ]]; then
    Z=$(( ${NUM_NODES}*${NUM_CORES_PER_NODE}/6 ))
    # Use "bash calculator" if available; Python if not; fail otherwise
-   which bc &> /dev/null; bc_ok=$?
-   which python &> /dev/null; py_ok=$?
+   bc_ok=0
+   py_ok=0
+   which bc &> /dev/null || bc_ok=$?
+   which python &> /dev/null || py_ok=$?
    if [[ $bc_ok -eq 0 ]]; then
       # Use bash calculator
       SQRT=$(echo "sqrt (${Z})" | bc -l)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

The PR prevents `setCommonRunSettings.sh` from failing if either the `bc` or `python` libraries are not found. This is necessary because of a recent update that added `set -e` to the script, causing the script to stop if any command has return status other than 0.

### Expected changes

No failure running `setCommonRunSettings.sh` if `which bc` or `which python` fail.

### Related Github Issue(s)

https://github.com/geoschem/geos-chem/issues/1762
