### PR TITLE
Fix GCHP time_mod start and elapsed times 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prevent repeated printing of KPP integrate errors to the stdout stream.
 - Fixed selection of troposphere-stratosphere boundary in `global_ch4_mod.F90`
 - Removed operator splitting in CH4 simulation that was biasing diagnostics
+- Fixed GCHP start and elapsed times in time_mod.F90 to use cap_restart value
 
 ## [14.1.1] - 2023-03-03
 ### Added

--- a/GeosCore/chemistry_mod.F90
+++ b/GeosCore/chemistry_mod.F90
@@ -85,7 +85,6 @@ CONTAINS
     USE State_Met_Mod,    ONLY : MetState
     USE TAGGED_CO_MOD,    ONLY : CHEM_TAGGED_CO
     USE TAGGED_O3_MOD,    ONLY : CHEM_TAGGED_O3
-    USE TIME_MOD,         ONLY : GET_ELAPSED_SEC
     USE TIME_MOD,         ONLY : GET_TS_CHEM
     USE UCX_MOD,          ONLY : CALC_STRAT_AER
     USE UnitConv_Mod,     ONLY : Convert_Spc_Units

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -120,9 +120,6 @@ MODULE SULFATE_MOD
   ! LVOLC      : Number of volcanic levels (20)   [unitless]
   !========================================================================
 
-  ! Time variable
-  INTEGER                :: ELAPSED_SEC
-
   ! Allocatable arrays
   REAL(fp),  ALLOCATABLE :: DMSo(:,:)
   REAL(fp),  ALLOCATABLE :: PMSA_DMS(:,:,:)
@@ -235,7 +232,6 @@ CONTAINS
     USE State_Met_Mod,      ONLY : MetState
     USE TIME_MOD,           ONLY : GET_MONTH
     USE TIME_MOD,           ONLY : GET_TS_CHEM
-    USE TIME_MOD,           ONLY : GET_ELAPSED_SEC
     USE TIME_MOD,           ONLY : ITS_A_NEW_MONTH
     USE UCX_MOD,            ONLY : SETTLE_STRAT_AER
     USE UnitConv_Mod,       ONLY : Convert_Spc_Units
@@ -339,9 +335,6 @@ CONTAINS
        CALL OHNO3TIME( State_Grid )
 
     ENDIF
-
-    ! Store NTIME in a shadow variable
-    ELAPSED_SEC = GET_ELAPSED_SEC()
 
     ! DTCHEM is the chemistry timestep in seconds
     DTCHEM = GET_TS_CHEM()
@@ -1444,7 +1437,6 @@ CONTAINS
     USE State_Grid_Mod,     ONLY : GrdState
     USE State_Met_Mod,      ONLY : MetState
     USE Species_Mod,        ONLY : Species
-    USE TIME_MOD,           ONLY : GET_ELAPSED_SEC
     USE TIME_MOD,           ONLY : GET_TS_CHEM
 #ifdef TOMAS
 #ifdef BPCH_DIAG
@@ -4317,7 +4309,6 @@ CONTAINS
     USE State_Diag_Mod,     ONLY : DgnState
     USE State_Met_Mod,      ONLY : MetState
     USE TIME_MOD,           ONLY : GET_TS_CHEM
-    USE TIME_MOD,           ONLY : GET_ELAPSED_SEC
     USE TIME_MOD,           ONLY : GET_MONTH
     USE TIME_MOD,           ONLY : ITS_A_NEW_MONTH
 !
@@ -4789,8 +4780,8 @@ CONTAINS
     USE Species_Mod,        ONLY : SpcConc
     USE State_Chm_Mod,      ONLY : ChmState
     USE State_Met_Mod,      ONLY : MetState
-    USE TIME_MOD,           ONLY : GET_TS_CHEM,        GET_ELAPSED_SEC
-    USE TIME_MOD,           ONLY : GET_ELAPSED_SEC,    GET_MONTH
+    USE TIME_MOD,           ONLY : GET_TS_CHEM
+    USE TIME_MOD,           ONLY : GET_MONTH
     USE TIME_MOD,           ONLY : ITS_A_NEW_MONTH
 !
 ! !INPUT PARAMETERS:

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -3549,6 +3549,8 @@ CONTAINS
 
     CHARACTER(len=ESMF_MAXSTR)    :: OUTSTR         ! Parallel write nonsense
 
+    ! Saved variables
+    LOGICAL, SAVE                 :: FIRST = .TRUE.
     __Iam__('Extract_')
 
     !=======================================================================
@@ -3842,6 +3844,7 @@ CONTAINS
     !=======================================================================
     ! All done
     !=======================================================================
+    FIRST = .FALSE.
     _RETURN(ESMF_SUCCESS)
 
   END SUBROUTINE Extract_


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR fixes the GCHP simulation start time and elapsed time variables stored in `time_mod.F90` to be consistent with the simulation. Previously these fields used the `BEG_DATE` field in configuration file `CAP.rc` as start time and to compute the elapsed time. This update uses the current time in the first timestep as the start time instead. This update also cleans up some unused instances of `Get_Elapsed_Sec`.

Note that we try not to use begin time and elapsed time that are stored in `time_mod.F90` in GCHP simulations. This update is to allow using them during development of specialty simulations since external developers may not necessarily be aware to avoid these fields.

### Expected changes

This is a zero diff update in GCHP and GC-Classic. The impacted fields in GCHP are not actually used. I confirmed this via before and after diff testing of all integration test run directories.

### Related Github Issue(s)

https://github.com/geoschem/geos-chem/issues/1741
