### PR TITLE
Explicitly define tagCH4 simulations instead of making assumption based on number of species

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased TBD]
+### Changed
+- Explicitly define tagCH4 simulations in Input_Opt rather than basing off of number of advected species
+
+### Removed
+- Remove references to the obsolete tagged Hg simulation
+
 ## [Unreleased 14.2.0]
 ### Added
 - Added a printout of GEOS-Chem species and indices

--- a/GeosCore/chemistry_mod.F90
+++ b/GeosCore/chemistry_mod.F90
@@ -956,7 +956,7 @@ CONTAINS
        !=====================================================================
        ! CH4
        !=====================================================================
-       ELSE IF ( Input_Opt%ITS_A_CH4_SIM ) THEN
+       ELSE IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_TAGCH4_SIM ) THEN
 
           ! Do CH4 chemistry
           CALL ChemCh4( Input_Opt  = Input_Opt,                              &

--- a/GeosCore/emissions_mod.F90
+++ b/GeosCore/emissions_mod.F90
@@ -277,7 +277,7 @@ CONTAINS
     ! To enable CH4 emissions in a full-chemistry simulation, add entries
     ! in HEMCO_Config.rc as is done for other species. 
     ! (mps, 2/12/21)
-    IF ( Input_Opt%ITS_A_CH4_SIM ) THEN
+    IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_TAGCH4_SIM ) THEN
        CALL EmissCh4( Input_Opt, State_Chm, State_Grid, State_Met, RC )
 
        ! Trap potential errors

--- a/GeosCore/gamap_mod.F90
+++ b/GeosCore/gamap_mod.F90
@@ -1078,7 +1078,6 @@ CONTAINS
     CHARACTER(LEN=40)       :: NAME5, NAME6
     REAL(fp),      SAVE     :: POP_XMW
     REAL(fp)                :: DUM
-    INTEGER                 :: N_Hg_CATS
     INTEGER                 :: SPC_INDEX
 
     ! Objects
@@ -2027,7 +2026,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     INTEGER                :: AS, NYMDb, NHMSb
-    INTEGER                :: MAXTRACER_HG, N
+    INTEGER                :: N
 
     !=================================================================
     ! INIT_GAMAP begins here!
@@ -2073,61 +2072,29 @@ CONTAINS
     IF ( AS /= 0 ) CALL ALLOC_ERR( 'NTRAC' )
     NTRAC = 0
 
-    IF ( Input_Opt%ITS_A_MERCURY_SIM .and. Input_Opt%LSPLIT) THEN
+    ALLOCATE( INDEX( MAXTRACER, MAXDIAG ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'INDEX' )
+    INDEX = 0
 
-       MAXTRACER_HG = 480
+    ALLOCATE( MWT( MAXTRACER, MAXDIAG ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'MWT' )
+    MWT = 0.0
 
-       ALLOCATE( INDEX( MAXTRACER_HG, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'INDEX' )
-       INDEX = 0
+    ALLOCATE( SCALE( MAXTRACER, MAXDIAG ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'SCALE' )
+    SCALE = 0.0
 
-       ALLOCATE( MWT( MAXTRACER_HG, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'MWT' )
-       MWT = 0.0
+    ALLOCATE( NAME( MAXTRACER, MAXDIAG ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'NAME' )
+    NAME = ''
 
-       ALLOCATE( SCALE( MAXTRACER_HG, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'SCALE' )
-       SCALE = 0.0
+    ALLOCATE( FNAME( MAXTRACER, MAXDIAG ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'FNAME' )
+    FNAME = ''
 
-       ALLOCATE( NAME( MAXTRACER_HG, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'NAME' )
-       NAME = ''
-
-       ALLOCATE( FNAME( MAXTRACER_HG, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'FNAME' )
-       FNAME = ''
-
-       ALLOCATE( UNIT( MAXTRACER_HG, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'UNIT' )
-       UNIT = ''
-
-    ELSE
-
-       ALLOCATE( INDEX( MAXTRACER, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'INDEX' )
-       INDEX = 0
-
-       ALLOCATE( MWT( MAXTRACER, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'MWT' )
-       MWT = 0.0
-
-       ALLOCATE( SCALE( MAXTRACER, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'SCALE' )
-       SCALE = 0.0
-
-       ALLOCATE( NAME( MAXTRACER, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'NAME' )
-       NAME = ''
-
-       ALLOCATE( FNAME( MAXTRACER, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'FNAME' )
-       FNAME = ''
-
-       ALLOCATE( UNIT( MAXTRACER, MAXDIAG ), STAT=AS )
-       IF ( AS /= 0 ) CALL ALLOC_ERR( 'UNIT' )
-       UNIT = ''
-
-    ENDIF
+    ALLOCATE( UNIT( MAXTRACER, MAXDIAG ), STAT=AS )
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'UNIT' )
+    UNIT = ''
 
     !=================================================================
     ! Initialize arrays for "diaginfo.dat" & "tracerinfo.dat" files

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -726,7 +726,7 @@ CONTAINS
     !-----------------------------------------------------------------
     ! CH4
     !-----------------------------------------------------------------
-    IF ( Input_Opt%ITS_A_CH4_SIM ) THEN
+    IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_TAGCH4_SIM ) THEN
        CALL Init_Global_Ch4( Input_Opt, State_Chm, State_Diag, State_Grid, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_Global_CH4"!'

--- a/GeosCore/global_ch4_mod.F90
+++ b/GeosCore/global_ch4_mod.F90
@@ -118,8 +118,7 @@ CONTAINS
     CHARACTER(LEN=255) :: ErrMsg
     CHARACTER(LEN=255) :: ThisLoc
 
-    ! For fields from Input_Opt
-    LOGICAL            :: ITS_A_CH4_SIM
+    ! Logicals
     LOGICAL, SAVE      :: FIRST = .TRUE.
 
     ! Arrays of state vector elements for applying emissions perturbations
@@ -143,10 +142,7 @@ CONTAINS
     ErrMsg  = ''
     ThisLoc = ' -> at EMISSCH4 (in GeosCore/global_ch4_mod.F90)'
 
-    ! Copy values from Input_Opt
-    ITS_A_CH4_SIM  = Input_Opt%ITS_A_CH4_SIM
-
-    IF ( ITS_A_CH4_SIM .and. Input_Opt%Verbose ) THEN
+    IF ( Input_Opt%Verbose ) THEN
        print*,'BEGIN SUBROUTINE: EMISSCH4'
     ENDIF
 
@@ -560,7 +556,7 @@ CONTAINS
 
     ENDIF
 
-    IF ( ITS_A_CH4_SIM .and. Input_Opt%Verbose ) THEN
+    IF ( Input_Opt%Verbose ) THEN
        print*,'END SUBROUTINE: EMISSCH4'
     ENDIF
 
@@ -646,9 +642,6 @@ CONTAINS
     INTEGER            :: NODAYS(12) = (/ 31, 28, 31, 30, 31, 30, &
                                           31, 31, 30, 31, 30, 31 /)
 
-    ! For fields from Input_Opt
-    LOGICAL            :: LSPLIT
-
     ! Pointers
     TYPE(SpcConc), POINTER :: Spc(:)
 
@@ -664,9 +657,6 @@ CONTAINS
     RC      = GC_SUCCESS
     ErrMsg  = ''
     ThisLoc = ' -> at CHEMCH4 (in module GeosCore/global_ch4_mod.F90)'
-
-    ! Copy values from Input_Opt
-    LSPLIT  = Input_Opt%LSPLIT
 
     ! Point to the chemical species
     Spc     => State_Chm%Species
@@ -736,7 +726,7 @@ CONTAINS
     ! If multi-CH4 species, we store the CH4 total conc. to
     ! distribute the sink after the chemistry. (ccc, 2/10/09)
     !=================================================================
-    IF ( LSPLIT ) THEN
+    IF ( Input_Opt%ITS_A_TAGCH4_SIM ) THEN
 
        !$OMP PARALLEL DO       &
        !$OMP DEFAULT( SHARED ) &
@@ -768,7 +758,7 @@ CONTAINS
     ! Distribute the chemistry sink from total CH4 to other CH4
     !     species. (ccc, 2/10/09)
     !=================================================================
-    IF ( LSPLIT ) THEN
+    IF ( Input_Opt%ITS_A_TAGCH4_SIM ) THEN
        CALL CH4_DISTRIB( Input_Opt, State_Chm, State_Grid, PREVCH4 )
     ENDIF
 

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -4772,17 +4772,16 @@ CONTAINS
         ! Add total emissions in the PBL to the EFLX array
         ! which tracks emission fluxes.  Units are [kg/m2/s].
         !------------------------------------------------------------------
-        IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_TAGCH4_SIM ) THEN
+        IF ( Input_Opt%ITS_A_CH4_SIM ) THEN
+
+           eflx(I,J,NA) = State_Chm%CH4_EMIS(I,J,1)
+
+        ELSE IF ( Input_Opt%ITS_A_TAGCH4_SIM ) THEN
 
            ! CH4 emissions become stored in state_chm_mod.F90.
            ! We use CH4_EMIS here instead of the HEMCO internal emissions
            ! only to make sure that total CH4 emissions are properly defined
-           ! in a multi-tracer CH4 simulation. For a single-tracer simulation
-           ! and/or all other source types, we could use the HEMCO internal
-           ! values set above and would not need the code below.
-           ! Units are already in kg/m2/s. (ckeller, 10/21/2014)
-           !
-           !%%% NOTE: MAYBE THIS CAN BE REMOVED SOON (bmy, 5/18/19)%%%
+           ! in a multi-tracer CH4 simulation.
            eflx(I,J,NA) = State_Chm%CH4_EMIS(I,J,NA)
 
         ELSE IF ( EmisSpec ) THEN  ! Are there emissions for these species?

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -3600,14 +3600,15 @@ CONTAINS
     !-----------------------------------------------------------------
     IF ( Input_Opt%ITS_A_FULLCHEM_SIM     .or.                               &
          Input_Opt%ITS_AN_AEROSOL_SIM     .or.                               &
+         Input_Opt%ITS_A_CARBON_SIM       .or.                               &
          Input_Opt%ITS_A_CO2_SIM          .or.                               &
          Input_Opt%ITS_A_CH4_SIM          .or.                               &
          Input_Opt%ITS_A_MERCURY_SIM      .or.                               &
          Input_Opt%ITS_A_POPS_SIM         .or.                               &
          Input_Opt%ITS_A_RnPbBe_SIM       .or.                               &
-         Input_Opt%ITS_A_TAGO3_SIM        .or.                               &
+         Input_Opt%ITS_A_TAGCH4_SIM       .or.                               &
          Input_Opt%ITS_A_TAGCO_SIM        .or.                               &
-         Input_Opt%ITS_A_CARBON_SIM       .or.                               &
+         Input_Opt%ITS_A_TAGO3_SIM        .or.                               &
          Input_Opt%ITS_A_TRACEMETAL_SIM ) THEN
 
 
@@ -4164,7 +4165,7 @@ CONTAINS
     ! If we have turned on CH4 options in geoschem_config.yml, then we
     ! also need to toggle switches so that HEMCO reads the appropriate data.
     !-----------------------------------------------------------------------
-    IF ( Input_Opt%ITS_A_CH4_SIM ) THEN
+    IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_TAGCH4_SIM) THEN
 
        IF ( Input_Opt%AnalyticalInv ) THEN
           CALL GetExtOpt( HcoConfig, -999, 'AnalyticalInv', &
@@ -4771,7 +4772,7 @@ CONTAINS
         ! Add total emissions in the PBL to the EFLX array
         ! which tracks emission fluxes.  Units are [kg/m2/s].
         !------------------------------------------------------------------
-        IF ( Input_Opt%ITS_A_CH4_SIM ) THEN
+        IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_TAGCH4_SIM ) THEN
 
            ! CH4 emissions become stored in state_chm_mod.F90.
            ! We use CH4_EMIS here instead of the HEMCO internal emissions

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -1630,10 +1630,7 @@ CONTAINS
    REAL*4,  POINTER          :: Ptr3D(:,:,:)
 
    ! For Hg simulation
-   INTEGER                   :: Num_Hg_Categories
-   INTEGER                   :: Total_Hg_Id
    CHARACTER(LEN=60)         :: HgSpc
-   CHARACTER(LEN=4), POINTER :: Hg_Cat_Name(:)
 
    ! Default background concentration
    REAL(fp)                  :: Background_VV
@@ -1653,7 +1650,6 @@ CONTAINS
    Ptr2D       => NULL()
    Ptr3D       => NULL()
    SpcInfo     => NULL()
-   Hg_Cat_Name => NULL()
 
    ! Name of this routine
    LOC = ' -> at Get_GC_Restart (in GeosCore/hco_utilities_gc_mod.F90)'
@@ -2382,17 +2378,6 @@ CONTAINS
       ! Format strings
 230   FORMAT( a24, ' not found in restart file, set to zero')
 240   FORMAT( a24, ':   ', es15.9, 1x, a4)
-
-      ! Print note that variables are initialized to zero if not
-      ! found (currently only happens in tagged Hg simulation)
-      IF ( Input_Opt%LSPLIT ) THEN
-         WRITE( 6, 250 )
-250      FORMAT( /, 'NOTE: all variables not found in restart ', &
-                    'are initialized to zero')
-      ENDIF
-
-      ! Free pointers for Hg indexing
-      Hg_Cat_Name => NULL()
 
    ENDIF
 

--- a/GeosCore/hcoi_gc_diagn_mod.F90
+++ b/GeosCore/hcoi_gc_diagn_mod.F90
@@ -234,6 +234,7 @@ CONTAINS
 
     ! Exit if the CH4 simulation is not selected
     IF ( ( .not. Input_Opt%ITS_A_CH4_SIM      ) .and. &
+         ( .not. Input_Opt%ITS_A_TAGCH4_SIM   ) .and. &
          ( .not. Input_Opt%ITS_A_CARBON_SIM ) ) RETURN
 
     ! Get default HEMCO species ID for CH4

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -243,7 +243,8 @@ CONTAINS
     !========================================================================
 
     ! CH4/carbon simulation settings
-    IF ( Input_Opt%Its_A_CH4_Sim .or. Input_Opt%Its_A_Carbon_Sim ) THEN
+    IF ( Input_Opt%Its_A_CH4_Sim .or. Input_Opt%Its_A_TagCH4_Sim .or. &
+         Input_Opt%Its_A_Carbon_Sim ) THEN
        CALL Config_CH4( Config, Input_Opt, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           errMsg = 'Error in "Config_CH4"!'
@@ -493,35 +494,40 @@ CONTAINS
 
     ! Error check simulation name
     Sim = To_UpperCase( TRIM( Input_Opt%SimulationName ) )
-    IF ( TRIM(Sim) /= 'AEROSOL' .and. TRIM(Sim) /= 'CH4'               .and. &
-         TRIM(Sim) /= 'CO2'     .and. TRIM(Sim) /= 'FULLCHEM'          .and. &
-         TRIM(Sim) /= 'HG'      .and. TRIM(Sim) /= 'METALS'            .and. &
-         TRIM(Sim) /= 'POPS'    .and. TRIM(Sim) /= 'TRANSPORTTRACERS'  .and. &
-         TRIM(Sim) /= 'TAGCO'   .and. TRIM(Sim) /= 'TAGCH4'            .and. &
-         TRIM(Sim) /= 'TAGHG'   .and. TRIM(Sim) /= 'TAGO3'             .and. &
-         TRIM(Sim) /= 'CARBON'                                       ) THEN
+    IF ( TRIM(Sim) /= 'AEROSOL'          .and. &
+         TRIM(Sim) /= 'CARBON'           .and. &
+         TRIM(Sim) /= 'CH4'              .and. &
+         TRIM(Sim) /= 'CO2'              .and. &
+         TRIM(Sim) /= 'FULLCHEM'         .and. &
+         TRIM(Sim) /= 'HG'               .and. &
+         TRIM(Sim) /= 'METALS'           .and. &
+         TRIM(Sim) /= 'POPS'             .and. &
+         TRIM(Sim) /= 'TRANSPORTTRACERS' .and. &
+         TRIM(Sim) /= 'TAGCH4'           .and. &
+         TRIM(Sim) /= 'TAGCO'            .and. &
+         TRIM(Sim) /= 'TAGO3'            ) THEN
          
        errMsg = Trim( Input_Opt%SimulationName) // ' is not a'            // &
                 ' valid simulation. Supported simulations are:'           // &
-                ' aerosol, carbon, CH4, CO2, fullchem, Hg, POPs,'    // &
-                ' TransportTracers, TagCO, TagCH4, or TagO3.'
+                ' aerosol, carbon, CH4, CO2, fullchem, Hg, Metals, POPs,' // &
+                ' TransportTracers, TagCH4, TagCO, or TagO3.'
        CALL GC_Error( errMsg, RC, thisLoc )
        RETURN
     ENDIF
 
     ! Set simulation type flags in Input_Opt
-    Input_Opt%ITS_A_CH4_SIM        = ( TRIM(Sim) == 'CH4'              .or.  &
-                                       TRIM(Sim) == 'TAGCH4'                )
+    Input_Opt%ITS_AN_AEROSOL_SIM   = ( TRIM(Sim) == 'AEROSOL'               )
+    Input_Opt%ITS_A_CARBON_SIM     = ( TRIM(Sim) == 'CARBON'                )
+    Input_Opt%ITS_A_CH4_SIM        = ( TRIM(Sim) == 'CH4'                   )
     Input_Opt%ITS_A_CO2_SIM        = ( TRIM(Sim) == 'CO2'                   )
     Input_Opt%ITS_A_FULLCHEM_SIM   = ( TRIM(Sim) == 'FULLCHEM'              )
     Input_Opt%ITS_A_MERCURY_SIM    = ( TRIM(Sim) == 'HG'                    )
+    Input_Opt%ITS_A_TRACEMETAL_SIM = ( TRIM(SIM) == 'METALS'                )
     Input_Opt%ITS_A_POPS_SIM       = ( TRIM(Sim) == 'POPS'                  )
     Input_Opt%ITS_A_RnPbBe_SIM     = ( TRIM(Sim) == 'TRANSPORTTRACERS'      )
-    Input_Opt%ITS_A_TAGO3_SIM      = ( TRIM(Sim) == 'TAGO3'                 )
+    Input_Opt%ITS_A_TAGCH4_SIM     = ( TRIM(Sim) == 'TAGCH4'                )
     Input_Opt%ITS_A_TAGCO_SIM      = ( TRIM(Sim) == 'TAGCO'                 )
-    Input_Opt%ITS_AN_AEROSOL_SIM   = ( TRIM(Sim) == 'AEROSOL'               )
-    Input_Opt%ITS_A_TRACEMETAL_SIM = ( TRIM(SIM) == 'METALS'                )
-    Input_Opt%ITS_A_CARBON_SIM     = ( TRIM(Sim) == 'CARBON'                )
+    Input_Opt%ITS_A_TAGO3_SIM      = ( TRIM(Sim) == 'TAGO3'                 )
 
     !------------------------------------------------------------------------
     ! Species database file
@@ -828,38 +834,6 @@ CONTAINS
        RETURN
     ENDIF
     Input_Opt%UseTimers = v_bool
-
-    ! Error check simulation name
-    Sim = To_UpperCase( TRIM( Input_Opt%SimulationName ) )
-    IF ( TRIM(Sim) /= 'AEROSOL' .and. TRIM(Sim) /= 'CH4'               .and. &
-         TRIM(Sim) /= 'CO2'     .and. TRIM(Sim) /= 'FULLCHEM'          .and. &
-         TRIM(Sim) /= 'HG'      .and. TRIM(Sim) /= 'METALS'            .and. &
-         TRIM(Sim) /= 'POPS'    .and. TRIM(Sim) /= 'TRANSPORTTRACERS'  .and. &
-         TRIM(Sim) /= 'TAGCO'   .and. TRIM(Sim) /= 'TAGCH4'            .and. &
-         TRIM(Sim) /= 'CARBON'                                         .and. &
-         TRIM(Sim) /= 'TAGHG'   .and. TRIM(Sim) /= 'TAGO3'           ) THEN
-       ErrMsg = Trim( Input_Opt%SimulationName) // ' is not a'            // &
-                ' valid simulation. Supported simulations are:'           // &
-                ' aerosol, CH4, CO2, fullchem, Hg, POPs,'                 // &
-                ' TransportTracers, TagCO, TagCH4, TagHg, or TagO3.'
-       CALL GC_Error( ErrMsg, RC, ThisLoc )
-       RETURN
-    ENDIF
-
-    ! Set simulation type flags in Input_Opt
-    Input_Opt%ITS_A_CH4_SIM        = ( TRIM(Sim) == 'CH4'              .or.  &
-                                       TRIM(Sim) == 'TAGCH4'                )
-    Input_Opt%ITS_A_CO2_SIM        = ( TRIM(Sim) == 'CO2'                   )
-    Input_Opt%ITS_A_FULLCHEM_SIM   = ( TRIM(Sim) == 'FULLCHEM'              )
-    Input_Opt%ITS_A_MERCURY_SIM    = ( TRIM(Sim) == 'HG'               .or.  &
-                                       TRIM(Sim) == 'TAGHG'                 )
-    Input_Opt%ITS_A_POPS_SIM       = ( TRIM(Sim) == 'POPS'                  )
-    Input_Opt%ITS_A_RnPbBe_SIM     = ( TRIM(Sim) == 'TRANSPORTTRACERS'      )
-    Input_Opt%ITS_A_TAGO3_SIM      = ( TRIM(Sim) == 'TAGO3'                 )
-    Input_Opt%ITS_A_TAGCO_SIM      = ( TRIM(Sim) == 'TAGCO'                 )
-    Input_Opt%ITS_AN_AEROSOL_SIM   = ( TRIM(Sim) == 'AEROSOL'               )
-    Input_Opt%ITS_A_TRACEMETAL_SIM = ( TRIM(SIM) == 'METALS'                )
-    Input_Opt%ITS_A_CARBON_SIM     = ( TRIM(SIM) == 'CARBON'                )
 
     !------------------------------------------------------------------------
     ! Set start time of run in "time_mod.F90"
@@ -1376,7 +1350,9 @@ CONTAINS
 
     IF ( TRIM( Input_Opt%MetField ) == 'MERRA2'                        .and. &
          TRIM( State_Grid%GridRes ) == '0.5x0.625' )                   THEN
-       IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_CO2_SIM )     THEN
+       IF ( Input_Opt%ITS_A_CH4_SIM     .or. &
+            Input_Opt%ITS_A_TAGCH4_SIM  .or. &
+            Input_Opt%ITS_A_CO2_SIM )   THEN
           IF ( Input_Opt%TS_DYN > 300 .or. Input_Opt%TS_CHEM > 600 )   THEN
              IF ( Input_Opt%amIRoot ) THEN
                 WRITE( 6,'(a)' ) ''
@@ -1618,13 +1594,15 @@ CONTAINS
     ! Call setup routines from other F90 modules
     !=================================================================
 
-    ! Split into tagged species (turn off for full-chemistry)
-    IF ( Input_Opt%ITS_A_FULLCHEM_SIM ) THEN
-       Input_Opt%LSPLIT = .FALSE.                     ! No tagged species
+    ! Split into tagged species
+    IF ( Input_Opt%ITS_A_TAGCO_SIM .or. Input_Opt%ITS_A_TAGO3_SIM ) THEN
+       Input_Opt%LSPLIT = ( Input_Opt%N_ADVECT > 1 )  ! Tags if > 1 species
     ELSE IF ( Input_Opt%ITS_A_CARBON_SIM ) THEN
        Input_Opt%LSPLIT = ( Input_Opt%N_ADVECT > 4 )  ! Tags if > 4 species
+    ELSE IF ( Input_Opt%ITS_A_TAGCH4_SIM ) THEN
+       Input_Opt%LSPLIT = .TRUE.                      ! Always tag for this sim
     ELSE
-       Input_Opt%LSPLIT = ( Input_Opt%N_ADVECT > 1 )  ! Tags if > 1 species
+       Input_Opt%LSPLIT = .FALSE.  
     ENDIF
 
     ! Initialize arrays in Input_Opt that depend on N_ADVECT
@@ -3435,9 +3413,10 @@ CONTAINS
     IF ( Input_Opt%ITS_A_TAGCO_SIM   ) Input_Opt%LDRYD = .FALSE.
 
     ! Turn off wetdep for simulations that don't need it
-    IF ( Input_Opt%ITS_A_TAGO3_SIM   ) Input_Opt%LWETD = .FALSE.
-    IF ( Input_Opt%ITS_A_TAGCO_SIM   ) Input_Opt%LWETD = .FALSE.
     IF ( Input_Opt%ITS_A_CH4_SIM     ) Input_Opt%LWETD = .FALSE.
+    IF ( Input_Opt%ITS_A_TAGCH4_SIM  ) Input_Opt%LWETD = .FALSE.
+    IF ( Input_Opt%ITS_A_TAGCO_SIM   ) Input_Opt%LWETD = .FALSE.
+    IF ( Input_Opt%ITS_A_TAGO3_SIM   ) Input_Opt%LWETD = .FALSE.
 
     ! If CO2 effect on RS in turned on, calculate the scaling factor
     ! on Rs based on Franks et al. (2013) (ayhwong, 6/25/2019)

--- a/GeosCore/mercury_mod.F90
+++ b/GeosCore/mercury_mod.F90
@@ -3279,7 +3279,7 @@ CONTAINS
 
     ENDIF
 
-    ! Only doing Hg0 overall, should add trap for LSPLIT (cpt - 2017)
+    ! Only doing Hg0 overall
     Hg0aq = OCEAN_CONC(:,:,1)
 
     ! Emission timestep [s]

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -280,13 +280,12 @@ CONTAINS
     REAL(fp),      POINTER  :: DepFreq(:,:,:  )  ! IM, JM, nDryDep
 
     ! Temporary save for total ch4 (Xueying Yu, 12/08/2017)
-    LOGICAL                 :: ITS_A_CH4_SIM
     REAL(fp)                :: total_ch4_pre_soil_absorp(State_Grid%NX, &
                                                          State_Grid%NY, &
                                                          State_Grid%NZ)
 
     ! Strings
-    CHARACTER(LEN=255) :: ErrMsg, ErrorMsg, ThisLoc
+    CHARACTER(LEN=255)      :: ErrMsg, ErrorMsg, ThisLoc
 
 #ifdef ADJOINT
     LOGICAL                 :: IS_ADJ
@@ -310,7 +309,6 @@ CONTAINS
     LEMIS             = Input_Opt%DoEmissions
     LDRYD             = Input_Opt%LDRYD
     PBL_DRYDEP        = Input_Opt%PBL_DRYDEP
-    ITS_A_CH4_SIM     = Input_Opt%ITS_A_CH4_SIM
     nAdvect           = State_Chm%nAdvect
 
     ! Initialize pointer
@@ -457,7 +455,7 @@ CONTAINS
     ! For tagged CH4 simulations
     ! Save the total CH4 concentration before apply soil absorption
     !-----------------------------------------------------------------------
-    IF ( ITS_A_CH4_SIM .and. Input_Opt%LSPLIT ) THEN
+    IF ( Input_Opt%ITS_A_TAGCH4_SIM ) THEN
        total_ch4_pre_soil_absorp = State_Chm%Species(1)%Conc(:,:,:)
     ENDIF
 
@@ -791,7 +789,7 @@ CONTAINS
              ! Tagged CH4 species are split off into a separate loop to
              ! ensure we remove soil absorption from NA=1 (total CH4) first
              !--------------------------------------------------------------
-             IF ( ITS_A_CH4_SIM .and. Input_Opt%LSPLIT ) THEN
+             IF ( Input_Opt%ITS_A_TAGCH4_SIM ) THEN
 
                 ! If we are in the chemistry grid
                 IF ( L <= EMIS_TOP ) THEN
@@ -866,7 +864,7 @@ CONTAINS
     !--------------------------------------------------------------
     ! Special handling for tagged CH4 simulations
     !--------------------------------------------------------------
-    IF ( ITS_A_CH4_SIM .and. Input_Opt%LSPLIT ) THEN
+    IF ( Input_Opt%ITS_A_TAGCH4_SIM ) THEN
 
        !$OMP PARALLEL DO                         &
        !$OMP DEFAULT( SHARED                   ) &

--- a/GeosCore/ocean_mercury_mod.F90
+++ b/GeosCore/ocean_mercury_mod.F90
@@ -912,7 +912,6 @@ CONTAINS
     REAL(fpp), PARAMETER :: CHLMINNUM   = 1e-1_fpp
 
     ! For values from Input_Opt
-    LOGICAL              :: LSPLIT
     LOGICAL              :: LArcticRiv,  LKRedUV
 
     ! Pointers
@@ -945,7 +944,6 @@ CONTAINS
     TOMS_LT => NULL()
 
     ! Copy values from Input_Opt
-    LSPLIT       = Input_Opt%LSPLIT
     LArcticRiv   = Input_Opt%LArcticRiv
     LKRedUV      = Input_Opt%LKRedUV
 
@@ -2262,9 +2260,6 @@ CONTAINS
     REAL(fpp)             :: A_M2, DELTAH, FRAC_O,  MHg
     REAL(fpp)             :: X, Y                   !(added anls 01/05/09)
 
-    ! For fields from Input_Opt
-    LOGICAL               :: LSPLIT
-
     ! Pointers
     REAL(fpp), POINTER   :: Hg0aq(:,:)
     REAL(fpp), POINTER   :: Hg2aq(:,:)
@@ -2273,9 +2268,6 @@ CONTAINS
     !=================================================================
     ! MLD_ADJUSTMENT begins here!
     !=================================================================
-
-    ! Copy values from Input_Opt
-    LSPLIT       = Input_Opt%LSPLIT
 
     ! Point to fields in State_Chm
     Hg0aq       => State_Chm%OceanHg0

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -70,20 +70,21 @@ MODULE Input_Opt_Mod
      CHARACTER(LEN=255)          :: SimulationName
      CHARACTER(LEN=255)          :: SpcDatabaseFile
      CHARACTER(LEN=255)          :: SpcMetaDataOutFile
+     LOGICAL                     :: ITS_AN_AEROSOL_SIM
+     LOGICAL                     :: ITS_A_CARBON_SIM
      LOGICAL                     :: ITS_A_CH4_SIM
      LOGICAL                     :: ITS_A_CO2_SIM
      LOGICAL                     :: ITS_A_FULLCHEM_SIM
      LOGICAL                     :: ITS_A_MERCURY_SIM
      LOGICAL                     :: ITS_A_POPS_SIM
      LOGICAL                     :: ITS_A_RnPbBe_SIM
-     LOGICAL                     :: ITS_A_TAGO3_SIM
+     LOGICAL                     :: ITS_A_TAGCH4_SIM
      LOGICAL                     :: ITS_A_TAGCO_SIM
-     LOGICAL                     :: ITS_AN_AEROSOL_SIM
+     LOGICAL                     :: ITS_A_TAGO3_SIM
      LOGICAL                     :: ITS_A_TRACEMETAL_SIM
      LOGICAL                     :: VerboseRequested
      CHARACTER(LEN=10)           :: VerboseOnCores
      LOGICAL                     :: Verbose
-     LOGICAL                     :: ITS_A_CARBON_SIM
      LOGICAL                     :: useTimers
 
      !----------------------------------------
@@ -584,6 +585,7 @@ CONTAINS
     Input_Opt%SimulationName         = ''
     Input_Opt%SpcDatabaseFile        = ''
     Input_Opt%SpcMetaDataOutFile     = ''
+    Input_Opt%ITS_AN_AEROSOL_SIM     = .FALSE.
     Input_Opt%ITS_A_CARBON_SIM       = .FALSE.
     Input_Opt%ITS_A_CH4_SIM          = .FALSE.
     Input_Opt%ITS_A_CO2_SIM          = .FALSE.
@@ -591,9 +593,9 @@ CONTAINS
     Input_Opt%ITS_A_MERCURY_SIM      = .FALSE.
     Input_Opt%ITS_A_POPS_SIM         = .FALSE.
     Input_Opt%ITS_A_RnPbBe_SIM       = .FALSE.
-    Input_Opt%ITS_A_TAGO3_SIM        = .FALSE.
+    Input_Opt%ITS_A_TAGCH4_SIM       = .FALSE.
     Input_Opt%ITS_A_TAGCO_SIM        = .FALSE.
-    Input_Opt%ITS_AN_AEROSOL_SIM     = .FALSE.
+    Input_Opt%ITS_A_TAGO3_SIM        = .FALSE.
     Input_Opt%ITS_A_TRACEMETAL_SIM   = .FALSE.
     Input_Opt%VerboseRequested       = .FALSE.
     Input_Opt%VerboseOnCores         = ''

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -2218,7 +2218,7 @@ CONTAINS
     !=======================================================================
     ! Initialize State_Chm quantities pertinent to CH4 simulations
     !=======================================================================
-    IF ( Input_Opt%ITS_A_CH4_SIM ) THEN
+    IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_TAGCH4_SIM ) THEN
         ! CH4_EMIS
         chmId = 'CH4_EMIS'
         CALL Init_and_Register(                                              &

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -6306,8 +6306,9 @@ CONTAINS
     ! and THE CH4 SPECIALTY SIMULATION
     !=======================================================================
     IF ( Input_Opt%ITS_A_FULLCHEM_SIM                                   .or. &
+         Input_Opt%ITS_A_CARBON_SIM                                     .or. &
          Input_Opt%ITS_A_CH4_SIM                                        .or. &
-         Input_Opt%ITS_A_CARBON_SIM                                   ) THEN
+         Input_Opt%ITS_A_TAGCH4_SIM                                     ) THEN
 
        !--------------------------------------------------------------------
        ! OH concentration upon exiting the FlexChem solver (fullchem
@@ -8827,7 +8828,9 @@ CONTAINS
     !
     ! THE CH4 SPECIALTY SIMULATION
     !=======================================================================
-    IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_CARBON_SIM ) THEN
+    IF ( Input_Opt%ITS_A_CH4_SIM      .or. &
+         Input_Opt%ITS_A_TAGCH4_SIM   .or. &
+         Input_Opt%ITS_A_CARBON_SIM ) THEN
 
        !--------------------------------------------------------------------
        ! Loss of CH4 by Cl in troposphere


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard/GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR removes use of `Input_Opt%LSPLIT` for CH4 simulations. Instead, we now explicitly set `Input_Opt%ITS_A_TAG_CH4_SIM` when using the tagCH4 simulation. This allows for greater flexibility to add more species to the CH4 simulation for the IMI (and other research purposes). 

Also in this PR references to LSPLIT and Hg categories have been removed from Hg code to avoid confusion. The tagHg option is not supported at this time.

### Expected changes

This is a zero difference update.

### Related Github Issue(s)

Closes #1798
