### PR TITLE
Allow the use of OFFLINE_SEASALT for seasalt alkalinity, Cl, and Br in GEOS-Chem within CESM

### DIFF
--- a/run/CESM/HEMCO_Config.rc
+++ b/run/CESM/HEMCO_Config.rc
@@ -2881,7 +2881,7 @@ VerboseOnCores:              root       # Accepted values: root all
 (((CalcBrSeasalt
 0 SEASALT_BrSALA  -                                                                                     -            -                     - -  -       BrSALA  617 3 2
 )))CalcBrSeasalt
-0 SEASALT_SALCAL  $ROOT/OFFLINE_SEASALT/v2019-01/0.5x0.625/$YYYY/$MM/seasalt_05.$YYYY$MM$DD.nc SALC_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALC     SALCAL  615 3 2
+0 SEASALT_SALCAL  $ROOT/OFFLINE_SEASALT/v2019-01/0.5x0.625/$YYYY/$MM/seasalt_05.$YYYY$MM$DD.nc SALC_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s          SALCAL  615 3 2
 0 SEASALT_SALCCL  -                                                                                     -            -                     - -  -       SALCCL  616 3 2
 (((CalcBrSeasalt
 0 SEASALT_BrSALC  -                                                                                     -            -                     - -  -       BrSALC  617 3 2

--- a/run/CESM/HEMCO_Config.rc
+++ b/run/CESM/HEMCO_Config.rc
@@ -2862,17 +2862,26 @@ VerboseOnCores:              root       # Accepted values: root all
 
 #==============================================================================
 # --- Offline sea salt emissions ---
+# Note: Seasalt emissions in GEOS-Chem within CESM are generally handled by MAM4.
+# However, it does not include emissions of SSA alkalinity, chlorine, and bromine.
+#
+# If OFFLINE_SEASALT is used in GEOS-Chem within CESM, SALA and SALC will not be
+# emitted by HEMCO, but the offline emissions will be used to scale for AL/Cl/Br.
+# Alternatively, do not use OFFLINE_SEASALT and scale emissions within chemistry.F90.
+# The latter approach is preferred but not implemented, so we scale the offline
+# emissions for now.
+#
+# This means that the below entries differ from GEOS-Chem "Classic" and others
+# by not having SALA / SALC entries. (hplin, 5/23/23)
 #==============================================================================
 (((OFFLINE_SEASALT
 (((.not.SeaSalt
-0 SEASALT_SALA    $ROOT/OFFLINE_SEASALT/v2019-01/0.5x0.625/$YYYY/$MM/seasalt_05.$YYYY$MM$DD.nc SALA_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALA    -   3 2
-0 SEASALT_SALAAL  -                                                                                     -            -                     - -  -       SALAAL  615 3 2
+0 SEASALT_SALAAL  $ROOT/OFFLINE_SEASALT/v2019-01/0.5x0.625/$YYYY/$MM/seasalt_05.$YYYY$MM$DD.nc SALA_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s          SALAAL  615 3 2
 0 SEASALT_SALACL  -                                                                                     -            -                     - -  -       SALACL  616 3 2
 (((CalcBrSeasalt
 0 SEASALT_BrSALA  -                                                                                     -            -                     - -  -       BrSALA  617 3 2
 )))CalcBrSeasalt
-0 SEASALT_SALC    $ROOT/OFFLINE_SEASALT/v2019-01/0.5x0.625/$YYYY/$MM/seasalt_05.$YYYY$MM$DD.nc SALC_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALC    -   3 2
-0 SEASALT_SALCAL  -                                                                                     -            -                     - -  -       SALCAL  615 3 2
+0 SEASALT_SALCAL  $ROOT/OFFLINE_SEASALT/v2019-01/0.5x0.625/$YYYY/$MM/seasalt_05.$YYYY$MM$DD.nc SALC_TOTAL   1980-2021/1-12/1-31/* C xy kg/m2/s SALC     SALCAL  615 3 2
 0 SEASALT_SALCCL  -                                                                                     -            -                     - -  -       SALCCL  616 3 2
 (((CalcBrSeasalt
 0 SEASALT_BrSALC  -                                                                                     -            -                     - -  -       BrSALC  617 3 2


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard Univ.

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

**This update is for GEOS-Chem within CESM only and only affects CESM rundir.**

Hi GCST,

Because CESM handles seasalt emissions within MAM4, SALA and SALC must not be emitted from HEMCO in order to prevent double-counting. However, MAM4 does not handle GEOS-Chem specific AL/Cl/Br species and thus these have to be emitted by HEMCO through scaling of the original SALA/SALC emissions.

This change diverges the CESM HEMCO_Config.rc OFFLINE_SEASALT entries from mainline to remove the SALA and SALC entries to prevent double-counting, while keeping the other entries.

### Expected changes

For GEOS-Chem within CESM, if `OFFLINE_SEASALT` is enabled in `HEMCO_Config.rc`, seasalt AL/Cl/Br will now be correctly emitted. 

Whether or not to enable seasalt debromination is a science question not covered in this pull request. `OFFLINE_SEASALT` remains disabled by default. Thus, in the default configuration, no runtime changes are expected.

For all other models excluding GEOS-Chem within CESM, no changes are expected.

### Reference(s)

N/A

### Related Github Issue(s)

N/A

Thanks!
Haipeng
