### PR TITLE
Prevent segfault errors when the SatDiagnConc diagnostic is requested; Add SatDiagnEdge collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Added `SatDiagnEdge` collection to all GEOS-Chem Classic `HISTORY.rc` templates
+
+### Fixed
+- Prevent `State_Diag%SatDiagnCount` from not being allocated
+- For satellite diagnostics, do not test for `id_OH` if OH is not a species
+
 ## [Unreleased 14.2.0]
 ### Added
 - Added a printout of GEOS-Chem species and indices

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1329,11 +1329,14 @@ CONTAINS
 
     ! Get the species ID for OH if this is the first call
     IF ( first ) THEN
-       id_OH  = Ind_('OH')
-       IF ( id_OH < 0 ) THEN
-          errMsg = 'OH is not a defined species in this simulation!!!'
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
+       IF ( Input_Opt%ITS_A_CARBON_SIM     .or.                              &
+            Input_Opt%ITS_A_FULLCHEM_SIM ) THEN
+          id_OH  = Ind_('OH')
+          IF ( id_OH < 0 ) THEN
+             errMsg = 'OH is not a defined species in this simulation!!!'
+             CALL GC_Error( errMsg, RC, thisLoc )
+             RETURN
+          ENDIF
        ENDIF
        first= .FALSE.
     ENDIF

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -4494,37 +4494,42 @@ CONTAINS
 
     !------------------------------------------------------------------------
     ! Set a single logical for SatDiagn output
+    ! For ease of comparison, place fields in alphabetical order
     !------------------------------------------------------------------------
     State_Diag%Archive_SatDiagn = (                                          &
-         State_Diag%Archive_SatDiagnColEmis                             .or. &
-         State_Diag%Archive_SatDiagnSurfFlux                            .or. &
-         State_Diag%Archive_SatDiagnOH                                  .or. &
-         State_Diag%Archive_SatDiagnRH                                  .or. &
          State_Diag%Archive_SatDiagnAirDen                              .or. &
          State_Diag%Archive_SatDiagnBoxHeight                           .or. &
-         State_Diag%Archive_SatDiagnPEdge                               .or. &
-         State_Diag%Archive_SatDiagnTROPP                               .or. &
-         State_Diag%Archive_SatDiagnPBLHeight                           .or. &
-         State_Diag%Archive_SatDiagnPBLTop                              .or. &
-         State_Diag%Archive_SatDiagnTAir                                .or. &
+         State_Diag%Archive_SatDiagnColEmis                             .or. &
+         State_Diag%Archive_SatDiagnConc                                .or. &
+         State_Diag%Archive_SatDiagnDryDep                              .or. &
+         State_Diag%Archive_SatDiagnDryDepVel                           .or. &
          State_Diag%Archive_SatDiagnGWETROOT                            .or. &
          State_Diag%Archive_SatDiagnGWETTOP                             .or. &
-         State_Diag%Archive_SatDiagnPARDR                               .or. &
-         State_Diag%Archive_SatDiagnPARDF                               .or. &
-         State_Diag%Archive_SatDiagnPRECTOT                             .or. &
-         State_Diag%Archive_SatDiagnSLP                                 .or. &
-         State_Diag%Archive_SatDiagnSPHU                                .or. &
-         State_Diag%Archive_SatDiagnTS                                  .or. &
-         State_Diag%Archive_SatDiagnPBLTOPL                             .or. &
-         State_Diag%Archive_SatDiagnMODISLAI                            .or. &
-         State_Diag%Archive_SatDiagnWetLossLS                           .or. &
-         State_Diag%Archive_SatDiagnWetLossConv                         .or. &
          State_Diag%Archive_SatDiagnJval                                .or. &
          State_Diag%Archive_SatDiagnJvalO3O1D                           .or. &
          State_Diag%Archive_SatDiagnJvalO3O3P                           .or. &
-         State_Diag%Archive_SatDiagnDryDep                              .or. &
-         State_Diag%Archive_SatDiagnDryDepVel                           .or. &
-         State_Diag%Archive_SatDiagnOHreactivity                            )
+         State_Diag%Archive_SatDiagnLoss                                .or. &
+         State_Diag%Archive_SatDiagnMODISLAI                            .or. &
+         State_Diag%Archive_SatDiagnOH                                  .or. &
+         State_Diag%Archive_SatDiagnOHreactivity                        .or. &
+         State_Diag%Archive_SatDiagnPARDF                               .or. &
+         State_Diag%Archive_SatDiagnPARDR                               .or. &
+         State_Diag%Archive_SatDiagnPBLHeight                           .or. &
+         State_Diag%Archive_SatDiagnPBLTop                              .or. &
+         State_Diag%Archive_SatDiagnPBLTopL                             .or. &
+         State_Diag%Archive_SatDiagnPEdge                               .or. &
+         State_Diag%Archive_SatDiagnPRECTOT                             .or. &
+         State_Diag%Archive_SatDiagnProd                                .or. &
+         State_Diag%Archive_SatDiagnRH                                  .or. &
+         State_Diag%Archive_SatDiagnRxnRate                             .or. &
+         State_Diag%Archive_SatDiagnSLP                                 .or. &
+         State_Diag%Archive_SatDiagnSPHU                                .or. &
+         State_Diag%Archive_SatDiagnSurfFlux                            .or. &
+         State_Diag%Archive_SatDiagnTAir                                .or. &
+         State_Diag%Archive_SatDiagnTROPP                               .or. &
+         State_Diag%Archive_SatDiagnTS                                  .or. &
+         State_Diag%Archive_SatDiagnWetLossLS                           .or. &
+         State_Diag%Archive_SatDiagnWetLossConv                             )
 
     !------------------------------------------------------------------------
     ! Satellite diagnostic: Counter

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
@@ -36,6 +36,7 @@ COLLECTIONS: 'Restart',
              #'ConcAfterChem',
              #'LevelEdgeDiags',
 	     #'SatDiagn',
+	     #'SatDiagnEdge',
              #'StateMet',
              #'BoundaryConditions',
 ::
@@ -230,6 +231,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnColEmis_CH4            ',
                               'SatDiagnSurfFlux_CH4           ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges) during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -34,6 +34,7 @@ COLLECTIONS: 'Restart',
              #'CloudConvFlux',
              #'LevelEdgeDiags',
              #'SatDiagn',
+             #'SatDiagnEdge',
              #'StateMet',
              #'BoundaryConditions',
 ::
@@ -188,6 +189,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnColEmis_CO2            ',
                               'SatDiagnSurfFlux_CO2           ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges) during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
@@ -38,6 +38,7 @@ COLLECTIONS: 'Restart',
              #'LevelEdgeDiags',
              #'ProdLoss',
              #'SatDiagn',
+             #'SatDiagnEdge',
              #'StateMet',
              #'WetLossConv',
              #'WetLossLS',
@@ -289,6 +290,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnSurfFlux_NO            ',
                               'SatDiagnProd_?PRD?             ',
                               'SatDiagnLoss_?LOS?             ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges) during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -35,6 +35,7 @@ COLLECTIONS: 'Restart',
              'DryDep',
              'LevelEdgeDiags',
 	     #'SatDiagn',
+	     #'SatDiagnEdge',
              'StateMet',
              'WetLossConv',
              'WetLossLS',
@@ -229,6 +230,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnSurfFlux_Pb210         ',
                               'SatDiagnColEmis_Be7            ',
                               'SatDiagnSurfFlux_Be7           ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges)  during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
@@ -293,7 +293,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% THE SatDiagn COLLECTION %%%%%
 #
-# GEOS-Chem data (on level edges) during satellite overpass
+# GEOS-Chem data during satellite overpass
 #
 # Available for all simulations
 #==============================================================================
@@ -335,7 +335,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% THE SatDiagnEdge COLLECTION %%%%%
 #
-# GEOS-Chem data during satellite overpass
+# GEOS-Chem data (on level edges) during satellite overpass
 #
 # Available for all simulations
 #==============================================================================

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
@@ -7,7 +7,7 @@
 # EXPID allows you to specify the beginning of the file path corresponding
 # to each diagnostic collection.  For example:
 #
-#   EXPID: ./GEOSChem 
+#   EXPID: ./GEOSChem
 #      Will create netCDF files whose names begin "GEOSChem",
 #      in this run directory.
 #
@@ -37,8 +37,9 @@ COLLECTIONS: 'Restart',
              #'LevelEdgeDiags',
              #'ProdLoss',
 	     #'SatDiagn',
-             #'StateChm',     
-             #'StateMet',      
+	     #'SatDiagnEdge',
+             #'StateChm',
+             #'StateMet',
              #'WetLossConv',
              #'WetLossLS',
              #'BoundaryConditions',
@@ -101,24 +102,24 @@ COLLECTIONS: 'Restart',
   Budget.frequency:    ${RUNDIR_HIST_TIME_AVG_FREQ}
   Budget.duration:     ${RUNDIR_HIST_TIME_AVG_DUR}
   Budget.mode:         'time-averaged'
-  Budget.fields:       'BudgetEmisDryDepFull_?ADV?           ',  
-                       'BudgetEmisDryDepTrop_?ADV?           ',  
-                       'BudgetEmisDryDepPBL_?ADV?            ',  
+  Budget.fields:       'BudgetEmisDryDepFull_?ADV?           ',
+                       'BudgetEmisDryDepTrop_?ADV?           ',
+                       'BudgetEmisDryDepPBL_?ADV?            ',
                        'BudgetChemistryFull_?ADV?            ',
                        'BudgetChemistryTrop_?ADV?            ',
-                       'BudgetChemistryPBL_?ADV?             ',  
+                       'BudgetChemistryPBL_?ADV?             ',
                        'BudgetTransportFull_?ADV?            ',
                        'BudgetTransportTrop_?ADV?            ',
-                       'BudgetTransportPBL_?ADV?             ',  
+                       'BudgetTransportPBL_?ADV?             ',
                        'BudgetMixingFull_?ADV?               ',
                        'BudgetMixingTrop_?ADV?               ',
-                       'BudgetMixingPBL_?ADV?                ',    
+                       'BudgetMixingPBL_?ADV?                ',
                        'BudgetConvectionFull_?ADV?           ',
                        'BudgetConvectionTrop_?ADV?           ',
-                       'BudgetConvectionPBL_?ADV?            ',  
+                       'BudgetConvectionPBL_?ADV?            ',
                        'BudgetWetDepFull_?WET?               ',
                        'BudgetWetDepTrop_?WET?               ',
-                       'BudgetWetDepPBL_?WET?                ',  
+                       'BudgetWetDepPBL_?WET?                ',
 ::
 #==============================================================================
 # %%%%% THE AerosolMass COLLECTION %%%%%
@@ -274,7 +275,7 @@ COLLECTIONS: 'Restart',
   ProdLoss.frequency:         ${RUNDIR_HIST_TIME_AVG_FREQ}
   ProdLoss.duration:          ${RUNDIR_HIST_TIME_AVG_DUR}
   ProdLoss.mode:              'time-averaged'
-  ProdLoss.fields:            'ProdBCPIfromBCPO              ', 
+  ProdLoss.fields:            'ProdBCPIfromBCPO              ',
                               'ProdOCPIfromOCPO              ',
 			      'ProdSO2fromDMSandOH           ',
 			      'ProdSO2fromDMSandNO3          ',
@@ -292,7 +293,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% THE SatDiagn COLLECTION %%%%%
 #
-# GEOS-Chem data during satellite overpass
+# GEOS-Chem data (on level edges) during satellite overpass
 #
 # Available for all simulations
 #==============================================================================
@@ -330,6 +331,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnSurfFlux_BCPI          ',
                               'SatDiagnProd_?PRD?             ',
                               'SatDiagnLoss_?LOS?             ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% THE StateChm COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -35,6 +35,8 @@ COLLECTIONS: 'Restart',
              #'CloudConvFlux',
              #'ConcAfterChem',
              #'LevelEdgeDiags',
+             #'SatDiagn',
+             #'SatDiagnEdge',
              #'StateMet',
              #'BoundaryConditions',
 ::
@@ -143,9 +145,9 @@ COLLECTIONS: 'Restart',
   Carbon.duration:       ${RUNDIR_HIST_TIME_AVG_DUR}
   Carbon.mode:           'time-averaged'
   Carbon.fields:         'OHconcAfterChem               ',
-                         'ProdCOfromCH4                 ', 
-                         'ProdCOfromNMVOC               ', 
-                         'ProdCO2fromCO                 ',  
+                         'ProdCOfromCH4                 ',
+                         'ProdCOfromNMVOC               ',
+                         'ProdCO2fromCO                 ',
 ::
 #==============================================================================
 # %%%%% THE CloudConvFlux COLLECTION %%%%%
@@ -192,6 +194,59 @@ COLLECTIONS: 'Restart',
                               'Met_PFILSAN                   ',
                               'Met_PFLCU                     ',
                               'Met_PFLLSAN                   ',
+::
+#==============================================================================
+# %%%%% THE SatDiagn COLLECTION %%%%%
+#
+# GEOS-Chem data during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagn.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagn.format:            'CFIO',
+  SatDiagn.frequency:         00000001 000000
+  SatDiagn.duration:          00000100 000000
+  SatDiagn.hrrange:           11.98 15.02
+  SatDiagn.mode:              'time-averaged'
+  SatDiagn.fields:            'SatDiagnConc_CH4               ',
+                              'SatDiagnConc_CO                ',
+                              'SatDiagnConc_CO2               ',
+                              'SatDiagnConc_OCS               ',
+                              'SatDiagnRH                     ',
+                              'SatDiagnAirDen                 ',
+                              'SatDiagnBoxHeight              ',
+                              'SatDiagnPEdge                  ',
+                              'SatDiagnTROPP                  ',
+                              'SatDiagnPBLHeight              ',
+                              'SatDiagnPBLTop                 ',
+                              'SatDiagnTAir                   ',
+                              'SatDiagnGWETROOT               ',
+                              'SatDiagnGWETTOP                ',
+                              'SatDiagnPARDR                  ',
+                              'SatDiagnPARDF                  ',
+                              'SatDiagnPRECTOT                ',
+                              'SatDiagnSLP                    ',
+                              'SatDiagnSPHU                   ',
+                              'SatDiagnTS                     ',
+                              'SatDiagnPBLTOPL                ',
+                              'SatDiagnMODISLAI               ',
+                              'SatDiagnColEmis_CH4            ',
+                              'SatDiagnSurfFlux_CH4           ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges) during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -47,6 +47,7 @@ COLLECTIONS: 'Restart',
              ##'RxnRates',
              ##'RxnConst',
              ##'SatDiagn',
+             ##'SatDiagnEdge',
              ##'StateChm',
              #'StateMet',
              ##'StratBM',
@@ -652,6 +653,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnRxnRate_EQ386          ',
                               'SatDiagnRxnRate_EQ387          ',
                               'SatDiagnRxnRate_EQ388          ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges) during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% THE StateChm COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
@@ -34,6 +34,7 @@ COLLECTIONS: 'Restart',
              #'DryDep',
              #'LevelEdgeDiags',
              #'SatDiagn',
+             #'SatDiagnEdge',
              #'StateMet',
              #'WetLossConv',
              #'WetLossLS',
@@ -196,6 +197,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnDryDepVel_AlF1         ',
                               'SatDiagnColEmis_AlF1           ',
                               'SatDiagnSurfFlux_AlF1          ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges) during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCH4
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCH4
@@ -35,6 +35,7 @@ COLLECTIONS: 'Restart',
              #'ConcAfterChem',
              #'LevelEdgeDiags',
              #'SatDiagn',
+             #'SatDiagnEdge',
              #'StateMet',
              #'BoundaryConditions',
 ::
@@ -190,6 +191,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnColEmis_CH4            ',
                               'SatDiagnSurfFlux_CH4           ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges) during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
@@ -35,6 +35,7 @@ COLLECTIONS: 'Restart',
              #'LevelEdgeDiags',
              #'ProdLoss',
              #'SatDiagn',
+             #'SatDiagnEdge',
              #'StateMet',
              #'BoundaryConditions',
 ::
@@ -75,7 +76,7 @@ COLLECTIONS: 'Restart',
   SpeciesConc.frequency:      ${RUNDIR_HIST_TIME_AVG_FREQ}
   SpeciesConc.duration:       ${RUNDIR_HIST_TIME_AVG_DUR}
   SpeciesConc.mode:           'time-averaged'
-  SpeciesConc.fields:         'SpeciesConcVV_?ALL?           ', 
+  SpeciesConc.fields:         'SpeciesConcVV_?ALL?           ',
                               #'SpeciesConcMND_?ALL?          ',
 ::
 #==============================================================================
@@ -203,6 +204,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnColEmis_CO             ',
                               'SatDiagnSurfFlux_CO            ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges) during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
@@ -36,6 +36,7 @@ COLLECTIONS: 'Restart',
              #'LevelEdgeDiags',
              #'ProdLoss',
              #'SatDiagn',
+             #'SatDiagnEdge',
              #'StateMet',
              #'BoundaryConditions',
 ::
@@ -229,6 +230,21 @@ COLLECTIONS: 'Restart',
                               'SatDiagnDryDepVel_O3           ',
                               'SatDiagnColEmis_O3             ',
                               'SatDiagnSurfFlux_O3            ',
+::
+#==============================================================================
+# %%%%% THE SatDiagnEdge COLLECTION %%%%%
+#
+# GEOS-Chem data (on level edges) during satellite overpass
+#
+# Available for all simulations
+#==============================================================================
+  SatDiagnEdge.template:      '%y4%m2%d2_%h2%n2z.nc4',
+  SatDiagnEdge.format:        'CFIO',
+  SatDiagnEdge.frequency:     00000001 000000
+  SatDiagnEdge.duration:      00000100 000000
+  SatDiagnEdge.hrrange:       11.98 15.02
+  SatDiagnEdge.mode:          'time-averaged'
+  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard+GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to issue #1805, in which @lfeng89089 reported that simulations requesting the `SatDiagnConc` diagnostic field ended with a segfault error.  The root cause of this was that the `State_Diag%Archive_SatDiagnConc` was not included in the statement where `State_Diag%Archive_SatDiagn` is determined to be true or false.  Long story short, this side effect prevented the `State_Diag%SatDiagCount` array (which contains the # of updates per grid box) from being allocated when the `SatDiagnConc` diagnostic field was requested in the `SatDiagn` diagnostic collection.

We have made the following updates.

1. Make sure that the statement where `State_Diag%SatDiagn` is set to true or false uses all currently-defined `State_Diag%Archive_SatDiagn*` fields.

2. Fixed a bug where an error would be thrown in `GeosCore/diagnostics_mod.F90` if OH was not a species.  Now we restrict this error trap to the carbon and fullchem simulations (which use OH).

3. Added the `SatDiagnEdge` collection to all GEOS-Chem Classic `HISTORY.rc` template files.  This allows the user to archive e.g. `SatDiagnPEDGE`, which is placed on level edges.  Level edge fields must be saved to as separate collection than fields placed on level centesr, as there can only be one level dimension per netCDF file.

### Expected changes

This will be a zero-diff update as it only affects optional diagnostics.

### Reference(s)

N/A

### Related Github Issue(s)

Closes #1805.  This can go into a patch version such as 14.2.1.