### PR TITLE
Change relative tolerance back to 0.5e-2 to address model slowdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `AUTHORS.txt` for version 14.2.0
 - Updated links in `README.md` to point to `http://geos-chem.org`
 - Changed GCHP default settings to use dry pressure rather than total pressure in advection and correct native mass fluxes for humidity
+- Change RTOL value from 0.5e-3 back to 0.5e-2 to address model slowdown
 
 ### Removed
 - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -443,9 +443,7 @@ CONTAINS
     ATOL      = 1e-2_dp
 
     ! Relative tolerance
-    ! Changed to 0.5e-3 to avoid integrate errors by halogen chemistry
-    !  -- Becky Alexander & Bob Yantosca (24 Jan 2023)
-    RTOL      = 0.5e-3_dp
+    RTOL      = 0.5e-2_dp
 
     !=======================================================================
     ! %%%%% SOLVE CHEMISTRY -- This is the main KPP solver loop %%%%%


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

In GEOS-Chem 14.2.0, 1-month benchmarks have shown a large increase in wall time beginning around 14.2.0-alpha.4 when PR #1620 for restoring the Iy sink reactions was merged. That pull request also included changing the relative tolerance value (RTOL in fullchem_mod.F90) from 0.5e-2 to 0.5e-3 to avoid integration errors in halogen chemistry. However, many other chemistry fixes and updates have gone into 14.2.0 since then so we may be able to restore the RTOL value in an attempt to reduce wall time.

### Expected changes

This fix will improve wall time and should have a small impact on model output.

### Related Github Issue(s)

#1814 
