### PR TITLE
Bug fixes for GEOS-only runs

### DIFF
--- a/GeosCore/fjx_interface_mod.F90
+++ b/GeosCore/fjx_interface_mod.F90
@@ -527,10 +527,10 @@ CONTAINS
 #if defined( MODEL_GEOS )
        ! Initialize diagnostics arrays
        IF ( State_Diag%Archive_EXTRALNLEVS ) THEN
-          State_Diag%EXTRALNLEVS(ILON,ILAT) = 0.0
+          State_Diag%EXTRALNLEVS(NLON,NLAT) = 0.0
        ENDIF
        IF ( State_Diag%Archive_EXTRALNITER ) THEN
-          State_Diag%EXTRALNITER(ILON,ILAT) = 0.0
+          State_Diag%EXTRALNITER(NLON,NLAT) = 0.0
        ENDIF
 #endif
 

--- a/Headers/CMN_FJX_MOD.F90
+++ b/Headers/CMN_FJX_MOD.F90
@@ -240,9 +240,6 @@ CONTAINS
     JXL1_  = JXL_+1        ! Vertical levs edges for J-values
     JXL2_  = 2*JXL_+2      ! Max # levs in the basic Fast-JX grid (mid-level)
 
-    JTAUMX = ( N_ - 4*JXL_ ) / 2  ! Maximum number of divisions ( i.e., may
-                                  ! not get to ATAUMN)
-
 #ifdef MODEL_GEOS
     ! N_  = no. of levels in Mie scattering arrays
     IF ( Input_Opt%LLFASTJX > 0 ) THEN
@@ -251,6 +248,9 @@ CONTAINS
        N_ = 601
     ENDIF
 #endif
+
+    JTAUMX = ( N_ - 4*JXL_ ) / 2  ! Maximum number of divisions ( i.e., may
+                                  ! not get to ATAUMN)
 
     AN_       = 37  ! # of separate aerosols per layer; Including PSCs
     W_        = 18  ! # of wavelength bins


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren (Harvard) and Viral Shah (GMAO)

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR includes two fixes for GEOS related to the restructuring of photolysis in the 14.2 development branch.
1) ILON/ILAT should be NLON/NLAT to avoid build error in fjx_interface_mod.F90
2) CMN_FJX_MOD.F90 variable JTAUMX must be set after N_ is assigned, not before, to prevent segmentation fault while running.

### Expected changes

This update is zero diff for GCHP and GC-Classic.

### Related Github Issue(s) and PRs

No issues. These fixes do not apply to any existing release.

Somewhat related HEMCO PR here, since HEMCO 3.7.0 is meant to be used with GEOS-Chem 14.2.0: https://github.com/geoschem/HEMCO/pull/219
