### PR TITLE
Prevent run-time crash if using GEOS-IT meteorolology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added GCHP run-time option in GCHP.rc to correct native mass fluxes for humidity
 - Added new tracer_mod.F90 containing subroutines for applying sources and sinks for the TransportTracer simulation
 - Added new species to the TransportTracer simulation: aoa (replaces CLOCK), aoa_bl, aoa_nh, st80_25, stOX
+- Added GEOS-IT and GEOSIT as allowable meteorology source options in geoschem_config.yml
 
 ### Changed
 - Most printout has been converted to debug printout (toggled by `debug_printout: true` in `geoschem_config.yml`

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -792,6 +792,8 @@ CONTAINS
           Input_Opt%MetField = 'GEOSFP'
        CASE( 'MERRA-2', 'MERRA2' )
           Input_Opt%MetField = 'MERRA2'
+       CASE( 'GEOS-IT', 'GEOSIT' )
+          Input_Opt%MetField = 'GEOSIT'
        CASE( 'MODELE2.1' )
           Input_Opt%MetField = 'MODELE2.1'
        CASE( 'MODELE2.2' )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR makes updates to allow setting GEOS-IT or GEOSIT as possible met sources in `geoschem_config.yml` without the model crashing. This update facilitates in progress development to include GEOS-IT as a standard GEOS-Chem meteorology option. 

### Expected changes

None

### Reference(s)

None

### Related Github Issue(s)

https://github.com/geoschem/HEMCO/pull/220
