### PR TITLE
Fix GC-Classic run directory runScriptSamples symbolic link

### DIFF
--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -855,7 +855,7 @@ fi
 
 # Create symbolic link to code directory
 ln -s ${wrapperdir} ${rundir}/CodeDir
-ln -s ${wrapperdir}/run/GCHP/runScriptSamples ${rundir}/runScriptSamples
+ln -s ${wrapperdir}/run/GCClassic/runScriptSamples ${rundir}/runScriptSamples
 
 #--------------------------------------------------------------------
 # Navigate to run directory and set up input files


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

The GC-Classic run directory symlink `runScriptSamples` is pointing to the run scripts for GCHP. This PR fixes the link to point to GC-Classic instead.

### Expected changes

`runScriptSamples` symlink in GC-Classic run directories will point to `run/GCClassic/runScriptSamples`.

### Reference(s)

None

### Related Github Issue(s)

None. This bug was introduced in 14.2.0 development.
