### PR TITLE
Update minimum KPP version required for the fullchem mechanism from 2.5.0 to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- The `fullchem` mechanism must now be built with KPP 3.0.0 or later
+
 ## [Unreleased 14.2.0]
 ### Added
 - Added a printout of GEOS-Chem species and indices

--- a/KPP/fullchem/CHANGELOG_fullchem.md
+++ b/KPP/fullchem/CHANGELOG_fullchem.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Mechanism history
 
+## [Unreleased]
+### Changed
+- The `fullchem` mechanism must now be built with KPP 3.0.0 or later
+
 ## [Unreleased 14.2.0]
 ### Added
 - Added lumped furan chemistry following Carter2020

--- a/KPP/fullchem/fullchem.kpp
+++ b/KPP/fullchem/fullchem.kpp
@@ -1,4 +1,4 @@
-#MINVERSION   2.5.0                  { Need this version of KPP or later          }
+#MINVERSION   3.0.0                  { Need this version of KPP or later          }
 #INTEGRATOR   rosenbrock_autoreduce  { Use Rosenbrock integration method          }
 #AUTOREDUCE   on                     { ... with autoreduce enabled but optional   }
 #LANGUAGE     Fortran90              { Generate solver code in Fortran90 ...      }


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This update changes the tag `#MINVERSION 2.5.0` to `#MINVERSION 3.0.0` in the `KPP/fullchem/fullchem.kpp` file.  This is necessary because the `rosenbrock_autoreduce` integrator is not present in KPP versions prior to 3.0.0.  

The fullchem mechanism does not need to be rebuilt.  

### Expected changes

This is a zero-diff update, so no changes are expected.

However, users who try to build the fullchem mechanism older KPP versions than 3.0.0 will be given an error message.

### Reference(s)

N/A

### Related Github Issue(s)

Fixes #1819 