### PR TITLE
Fix bug in state_chm_mod that printed line of equals signs to log from every core

### DIFF
--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -2668,7 +2668,7 @@ CONTAINS
     ENDDO
 
     ! Write closing line
-    WRITE( 6,'(  a)'   ) REPEAT( '=', 79)
+    IF ( Input_Opt%amIRoot ) WRITE( 6,'(  a)'   ) REPEAT( '=', 79)
 
     !------------------------------------------------------------------------
     ! Set up the mapping for UVFlux Diagnostics


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR puts a log write statement into an `IF ( Input_Opt%amIRoot )` block so a certain line is not printed from every core. The print is a line of repeated `= `to end a table otherwise printed to root thread only.

### Expected changes

Log file will be more concise when running with MPI.

### Reference(s)

none

### Related Github Issue(s)

none
