### PR TITLE
Rename GCHP mid-run restart files in run scripts even if run crashes

### DIFF
--- a/run/GCHP/runScriptSamples/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/gchp.batch_job.sh
@@ -144,17 +144,6 @@ source checkRunSettings.sh
 #
 # POST-RUN COMMANDS
 #
-# If new start time in cap_restart is okay, rename restart file
-# and update restart symlink
-new_start_str=$(sed 's/ /_/g' cap_restart)
-if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
-   exit 1
-else
-    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
-    source setRestartLink.sh
-fi
 
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds
 # to run start time since duplicate with initial restart file.
@@ -171,3 +160,16 @@ do
        fi
     fi
 done
+
+# If new start time in cap_restart is okay, rename restart file
+# and update restart symlink
+new_start_str=$(sed 's/ /_/g' cap_restart)
+if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
+    echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
+    rm -f Restarts/gcchem_internal_checkpoint
+    exit 1
+else
+    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    source setRestartLink.sh
+fi

--- a/run/GCHP/runScriptSamples/gchp.local.run
+++ b/run/GCHP/runScriptSamples/gchp.local.run
@@ -34,17 +34,6 @@ nCores=$( grep -oP 'TOTAL_CORES=\s*\K\d+' setCommonRunSettings.sh )
 #--------------------------------------------------
 time mpirun -np ${nCores} ./gchp 2>&1 | tee -a ${log}
 
-# Rename restart file and update restart symlink if new start time ok
-new_start_str=$(sed 's/ /_/g' cap_restart)
-if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
-   exit 1
-else
-    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
-    source setRestartLink.sh 2>&1 | tee -a ${log}
-fi
-
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds
 # to run start time since duplicate with initial restart file.
 chkpnts=$(ls Restarts)
@@ -60,3 +49,15 @@ do
        fi
     fi
 done
+
+# Rename restart file and update restart symlink if new start time ok
+new_start_str=$(sed 's/ /_/g' cap_restart)
+if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
+   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
+   rm Restarts/gcchem_internal_checkpoint
+   exit 1
+else
+    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    source setRestartLink.sh 2>&1 | tee -a ${log}
+fi

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -35,17 +35,6 @@ if [[ $(( ${coreCount} % ${SLURM_NNODES} )) > 0 ]]; then
 fi
 time srun -n ${coreCount} -N ${SLURM_NNODES} -m plane=${planeCount} --mpi=pmix ./gchp >> ${log}
 
-# Rename restart file and update restart symlink if new start time ok
-new_start_str=$(sed 's/ /_/g' cap_restart)
-if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
-   exit 1
-else
-    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
-    source setRestartLink.sh
-fi
-
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds
 # to run start time since duplicate with initial restart file.
 chkpnts=$(ls Restarts)
@@ -61,5 +50,17 @@ do
        fi
     fi
 done
+
+# Rename restart file and update restart symlink if new start time ok
+new_start_str=$(sed 's/ /_/g' cap_restart)
+if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
+   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
+   rm -f Restarts/gcchem_internal_checkpoint
+   exit 1
+else
+    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    source setRestartLink.sh
+fi
 
 exit 0

--- a/run/GCHP/runScriptSamples/operational_examples/mit_hex/gchp.run_HEX
+++ b/run/GCHP/runScriptSamples/operational_examples/mit_hex/gchp.run_HEX
@@ -33,17 +33,6 @@ coreCount=$(( ${NX} * ${NY} ))
 
 mpirun ./gchp >> $log
 
-# Rename restart file and update restart symlink if new start time ok
-new_start_str=$(sed 's/ /_/g' cap_restart)
-if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: cap_restart either did not change or is empty."
-   exit 1
-else
-    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
-    source setRestartLink.sh
-fi
-
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds
 # to run start time since duplicate with initial restart file.
 chkpnts=$(ls Restarts)
@@ -59,5 +48,17 @@ do
        fi
     fi
 done
+
+# Rename restart file and update restart symlink if new start time ok
+new_start_str=$(sed 's/ /_/g' cap_restart)
+if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
+   echo "ERROR: cap_restart either did not change or is empty."
+   rm -f Restarts/gcchem_internal_checkpoint
+   exit 1
+else
+    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    source setRestartLink.sh
+fi
 
 exit 0

--- a/run/GCHP/runScriptSamples/operational_examples/mit_svante/gchp.run_SVANTE.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/mit_svante/gchp.run_SVANTE.sh
@@ -26,17 +26,6 @@ NY=$( grep NY GCHP.rc | awk '{print $2}' )
 coreCount=$(( ${NX} * ${NY} ))
 time mpirun -n ${coreCount} ./gchp >> ${log}
 
-# Rename restart file and update restart symlink if new start time ok
-new_start_str=$(sed 's/ /_/g' cap_restart)
-if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: cap_restart either did not change or is empty."
-   exit 1
-else
-    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
-    source setRestartLink.sh
-fi
-
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds
 # to run start time since duplicate with initial restart file.
 chkpnts=$(ls Restarts)
@@ -52,5 +41,17 @@ do
        fi
     fi
 done
+
+# Rename restart file and update restart symlink if new start time ok
+new_start_str=$(sed 's/ /_/g' cap_restart)
+if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
+   echo "ERROR: cap_restart either did not change or is empty."
+   rm -f Restarts/gcchem_internal_checkpoint
+   exit 1
+else
+    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    source setRestartLink.sh
+fi
 
 exit 0

--- a/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
@@ -53,17 +53,6 @@ tail --pid=$! -f $log
 #mpiexec dplace -s1 -c 4-11 ./grinder < run_input > output
 rc=$?
 
-# Rename restart file and update restart symlink if new start time ok
-new_start_str=$(sed 's/ /_/g' cap_restart)
-if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
-   exit 1
-else
-    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
-    source setRestartLink.sh
-fi
-
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds
 # to run start time since duplicate with initial restart file.
 chkpnts=$(ls Restarts)
@@ -79,6 +68,18 @@ do
        fi
     fi
 done
+
+# Rename restart file and update restart symlink if new start time ok
+new_start_str=$(sed 's/ /_/g' cap_restart)
+if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
+    echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
+    rm -f Restarts/gcchem_internal_checkpoint
+    exit 1
+else
+    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    source setRestartLink.sh
+fi
 
 # Echo end date
 echo '===> Run ended at' `date` >> ${log}

--- a/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
@@ -33,17 +33,6 @@ source checkRunSettings.sh >> ${log}
 # Run the code
 mpirun ./gchp >> $log
 
-# Rename restart file and update restart symlink if new start time ok
-new_start_str=$(sed 's/ /_/g' cap_restart)
-if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
-   exit 1
-else
-    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
-    source setRestartLink.sh
-fi
-
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds
 # to run start time since duplicate with initial restart file.
 chkpnts=$(ls Restarts)
@@ -59,6 +48,18 @@ do
        fi
     fi
 done
+
+# Rename restart file and update restart symlink if new start time ok
+new_start_str=$(sed 's/ /_/g' cap_restart)
+if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
+   echo "ERROR: GCHP failed to run to completion. Check the log file for more information."
+   rm -f Restarts/gcchem_internal_checkpoint
+   exit 1
+else
+    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    source setRestartLink.sh
+fi
 
 trap times EXIT
 

--- a/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
@@ -58,17 +58,6 @@ source checkRunSettings.sh
 #
 # POST-RUN COMMANDS
 #
-# If new start time in cap_restart is okay, rename restart file
-# and update restart symlink
-new_start_str=$(sed 's/ /_/g' cap_restart)
-if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
-   echo "ERROR: cap_restart either did not change or is empty."
-   exit 1
-else
-    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
-    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
-    source setRestartLink.sh
-fi
 
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds
 # to run start time since duplicate with initial restart file.
@@ -85,3 +74,16 @@ do
        fi
     fi
 done
+
+# If new start time in cap_restart is okay, rename restart file
+# and update restart symlink
+new_start_str=$(sed 's/ /_/g' cap_restart)
+if [[ "${new_start_str}" = "${start_str}" || "${new_start_str}" = "" ]]; then
+   echo "ERROR: cap_restart either did not change or is empty."
+   rm -f Restarts/gcchem_internal_checkpoint
+   exit 1
+else
+    N=$(grep "CS_RES=" setCommonRunSettings.sh | cut -c 8- | xargs )    
+    mv Restarts/gcchem_internal_checkpoint Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
+    source setRestartLink.sh
+fi


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR moves the renaming of mid-run restart files in GCHP run scripts to after the renaming of the end-of-run restart file. This prevents mid-run checkpoint files from having non-standard names if the run crashes at some point. Previously the renaming of mid-run checkpoint files did not happen if the run crashed because the run script would exit prior to reaching execution of that code.

This update also include deletion of the end-of-run restart file `Restarts/gcchem_internal_checkpoint` if the run fails. Depending on where in the run the failure occurs this file may exist. Its presence will prevent a future run and so it must be deleted.

### Expected changes

No changes for a normal run. If a run crashes and mid-run checkpoints are enabled then all of them will be renamed to the expected naming convention in the `Restarts` subdirectory.

### Reference(s)

none

### Related Github Issue(s)

closes https://github.com/geoschem/geos-chem/issues/1866
