### PR TITLE
Use standard format for AEIC 2019 monthly climatology in ExtData.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 14.2.1]
 ### Added
 - Script `integrationDiffTest.sh`, checks 2 different integration tests for differences
+`SatDiagnEdge` collection to all GEOS-Chem Classic `HISTORY.rc` templates
 
 ### Changed
 - Update `DiagnFreq` in GCClassic integration tests to ensure HEMCO diagnostic output
@@ -17,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Error check to stop run if any `MW_g` values are undefined
 - Explicitly define tagCH4 simulations in `Input_Opt` rather than basing off of number of advected species
 - The `fullchem` mechanism must now be built with KPP 3.0.0 or later
-- Added `SatDiagnEdge` collection to all GEOS-Chem Classic `HISTORY.rc` templates
+- Changed the AEIC 2019 monthly climatology specification format in ExtData.rc to match standard convention for climatology
 
 ### Fixed
 - Add missing mol wt for HgBrO in `run/shared/species_database_hg.yml`

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -373,7 +373,7 @@ CEDS_CO_SHP  kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_shp  ./HcoDir/CEDS/v2
 
 # --- AEIC 2019 aircraft (AEIC) ---
 #AEIC19_DAILY_CO   kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none CO ./HcoDir/AEIC2019/v2022-03/2019/%m2/AEIC_2019%m2%d2.0.5x0.625.36L.nc
-AEIC19_MONMEAN_CO kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none CO ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
+AEIC19_MONMEAN_CO kg/m2/s Y Y F2019-%m2-01T00:00:00 none none CO ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
 
 # --- RCP future emissions scenarios ---
 #RCP3PD_CO   kg/m2/s N Y %y4-01-01T00:00:00 none none ACCMIP ./HcoDir/RCP/v2020-07/RCP_3PD/RCPs_anthro_CO_2005-2100_23474.nc

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -1408,14 +1408,14 @@ AEIC19_DAILY_BCPI   kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none BC       ./Hc
 AEIC19_DAILY_OCPI   kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none OC       ./HcoDir/AEIC2019/v2022-03/2019/%m2/AEIC_2019%m2%d2.0.5x0.625.36L.nc
 AEIC19_DAILY_ACET   kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none HC       ./HcoDir/AEIC2019/v2022-03/2019/%m2/AEIC_2019%m2%d2.0.5x0.625.36L.nc
 # Monthly data
-AEIC19_MONMEAN_NO   kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none NO       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
-AEIC19_MONMEAN_NO2  kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none NO2      ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
-AEIC19_MONMEAN_HONO kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none HONO     ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
-AEIC19_MONMEAN_CO   kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none CO       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
-AEIC19_MONMEAN_SO2  kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none FUELBURN ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
-AEIC19_MONMEAN_BCPI kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none BC       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
-AEIC19_MONMEAN_OCPI kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none OC       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
-AEIC19_MONMEAN_ACET kg/m2/s 2019 Y F%y4-%m2-%d2T00:00:00 none none HC       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
+AEIC19_MONMEAN_NO   kg/m2/s Y    Y F2019-%m2-01T00:00:00 none none NO       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
+AEIC19_MONMEAN_NO2  kg/m2/s Y    Y F2019-%m2-01T00:00:00 none none NO2      ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
+AEIC19_MONMEAN_HONO kg/m2/s Y    Y F2019-%m2-01T00:00:00 none none HONO     ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
+AEIC19_MONMEAN_CO   kg/m2/s Y    Y F2019-%m2-01T00:00:00 none none CO       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
+AEIC19_MONMEAN_SO2  kg/m2/s Y    Y F2019-%m2-01T00:00:00 none none FUELBURN ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
+AEIC19_MONMEAN_BCPI kg/m2/s Y    Y F2019-%m2-01T00:00:00 none none BC       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
+AEIC19_MONMEAN_OCPI kg/m2/s Y    Y F2019-%m2-01T00:00:00 none none OC       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
+AEIC19_MONMEAN_ACET kg/m2/s Y    Y F2019-%m2-01T00:00:00 none none HC       ./HcoDir/AEIC2019/v2022-03/2019_monmean/AEIC_monmean_2019%m2.0.5x0.625.36L.nc
 #
 #==============================================================================
 # --- Emissions from decaying plants (DECAYING_PLANTS) ---


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR changes the `ExtData.rc` specification for AEIC 2019 monthly climatology files. The standard format used for monthly climatology in `ExtData.rc` uses the clim flag `Y` and read frequency in format `F{year}-%m2-01T00:00:00`. The previous specification used clim year (2019) for the climatology flag and included tokens for year, month, and day for read frequency. The old method works but it would be good to use the standard format for consistency and to avoid confusion during the migration from the `ExtData.rc` file to the `ExtData.yml` file when we switch to MAPL 3.

### Expected changes

This is a zero diff update for GCHP since the old and new formats give identical results.

### Reference(s)

none

### Related Github Issue(s)

none
