### PR TITLE
Adjust relative tolerance after first KPP integrate failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change RTOL value from 0.5e-3 back to 0.5e-2 to address model slowdown
 - Allow the use of OFFLINE_SEASALT for seasalt alkalinity, Cl, and Br in GEOS-Chem within CESM
 - Renamed TransportTracer species for consistency with GMAO's TR_GridComp
+- Adjusted relative tolerance value if first KPP integration attempt fails
 
 ### Removed
 - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -436,14 +436,6 @@ CONTAINS
     TIN       = T
     TOUT      = T + DT
 
-    !%%%%% CONVERGENCE CRITERIA %%%%%
-
-    ! Absolute tolerance
-    ATOL      = 1e-2_dp
-
-    ! Relative tolerance
-    RTOL      = 0.5e-2_dp
-
     !=======================================================================
     ! %%%%% SOLVE CHEMISTRY -- This is the main KPP solver loop %%%%%
     !=======================================================================
@@ -539,6 +531,14 @@ CONTAINS
        Thread    = OMP_GET_THREAD_NUM() + 1 ! OpenMP thread number
 #endif
 #endif
+
+       !%%%%% CONVERGENCE CRITERIA %%%%%
+
+       ! Absolute tolerance
+       ATOL      = 1e-2_dp
+
+       ! Relative tolerance
+       RTOL      = 0.5e-2_dp
 
        ! Per discussions for Lin et al., force keepActive throughout the
        ! atmosphere if keepActive option is enabled. (hplin, 2/9/22)

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -1131,7 +1131,8 @@ CONTAINS
           ! Reset C with concentrations prior to the 1st call to "Integrate"
           C         = C_before_integrate
 
-          ! Adjust relative tolerance
+          ! Adjust relative tolerance after first failure for
+          ! this grid box and time step only (mps, 7/13/23)
           RTOL      = 0.5e-3_dp
 
           ! Disable auto-reduce solver for the second iteration for safety

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -52,7 +52,6 @@ MODULE FullChem_Mod
 #endif
   INTEGER               :: id_SALAAL, id_SALCAL, id_SO4, id_SALC, id_SALA
   LOGICAL               :: ok_OH,     ok_HO2,    ok_O1D, ok_O3P
-  LOGICAL               :: Failed2x
 
   ! Diagnostic flags
   LOGICAL               :: Do_Diag_OH_HO2_O1D_O3P
@@ -1126,10 +1125,14 @@ CONTAINS
        !=====================================================================
        IF ( IERR < 0 ) THEN
 
-          ! Zero the first time step (Hstart, used by Rosenbrock).  Also reset
-          ! C with concentrations prior to the 1st call to "Integrate".
+          ! Zero the first time step (Hstart, used by Rosenbrock)
           RCNTRL(3) = 0.0_dp
+
+          ! Reset C with concentrations prior to the 1st call to "Integrate"
           C         = C_before_integrate
+
+          ! Adjust relative tolerance
+          RTOL      = 0.5e-3_dp
 
           ! Disable auto-reduce solver for the second iteration for safety
           IF ( Input_Opt%Use_AutoReduce ) THEN

--- a/KPP/fullchem/gckpp_Global.F90
+++ b/KPP/fullchem/gckpp_Global.F90
@@ -76,8 +76,10 @@ MODULE gckpp_Global
   REAL(kind=dp) :: DT
 ! ATOL - Absolute tolerance
   REAL(kind=dp) :: ATOL(NVAR)
+  !$OMP THREADPRIVATE( ATOL )
 ! RTOL - Relative tolerance
   REAL(kind=dp) :: RTOL(NVAR)
+  !$OMP THREADPRIVATE( RTOL )
 ! STEPMIN - Lower bound for integration step
   REAL(kind=dp) :: STEPMIN
 ! STEPMAX - Upper bound for integration step


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

Following the chemistry updates in 14.2.0, users are encountering KPP convergence errors more frequently. To fix this, RTOL was changed from 0.5e-2 to 0.5e-3, but this drastically slowed down simulations so it was changed back to 0.5e-2. Because we are still seeing these convergence errors, one workaround is to adjust the RTOL value to 0.5e-3 after the KPP integration fails the first time. If it fails twice, GEOS-Chem will still crash as usual. The RTOL value resets to 0.5e-2 for the next grid box in the loop.

### Expected changes

The differences for this fix should be on the level of numerical noise when a KPP integration error occurs.

### Related Github Issue(s)

- https://github.com/geoschem/geos-chem/issues/1768
