### PR TITLE
Add new GCHP config file for ESMF logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Script `test/difference/diffTest.sh`, checks 2 different integration tests for differences
 - Added GCHP environment file and export/unset env variables in run script for NASA Pleiades cluster
 `SatDiagnEdge` collection to all GEOS-Chem Classic `HISTORY.rc` templates
+- Added new GCHP config file ESMF.rc for configuring ESMF logging
 
 ### Changed
 - Update `DiagnFreq` in GCClassic integration tests to ensure HEMCO diagnostic output
@@ -19,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Explicitly define tagCH4 simulations in `Input_Opt` rather than basing off of number of advected species
 - The `fullchem` mechanism must now be built with KPP 3.0.0 or later
 - Changed the AEIC 2019 monthly climatology specification format in ExtData.rc to match standard convention for climatology
+- Changed default ESMF logging in GCHP to be ESMF_LOGKIND_NONE (no log)
 
 ### Fixed
 - Add missing mol wt for HgBrO in `run/shared/species_database_hg.yml`

--- a/run/GCHP/ESMF.rc
+++ b/run/GCHP/ESMF.rc
@@ -1,0 +1,7 @@
+logKindFlag: ESMF_LOGKIND_NONE
+
+# ESMF_LOGKIND options for ESMF logging. Options include:
+#    ESMF_LOGKIND_NONE           - no ESMF logging
+#    ESMF_LOGKIND_SINGLE         - one log file (ESMF_LogFile)
+#    ESMF_LOGKIND_MULTI          - one log file per core (PET#.ESMF_LogFile)
+#    ESMF_LOGKIND_MULTI_ON_ERROR - one log file per core if error (PET#.ESMF_LogFile))

--- a/run/GCHP/init_rd.sh
+++ b/run/GCHP/init_rd.sh
@@ -44,6 +44,7 @@ variables=$(echo $variables | sort | uniq)
 envsubst_list="$(printf '${%s} ' $variables)"
 
 COPY_LIST="""
+ESMF.rc
 input.nml
 logging.yml
 HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.${RUNDIR_SIM_NAME}

--- a/run/shared/cleanRunDir.sh
+++ b/run/shared/cleanRunDir.sh
@@ -10,6 +10,7 @@ rm -fv gchp.log
 rm -fv gchp.*.log
 rm -fv HEMCO.log
 rm -fv PET*.log
+rm -fv ESMF_LogFile
 rm -fv multirun.log
 rm -fv warnings_and_errors.log
 rm -fv GC*.log


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This update goes along with an update developed by Matt Thompson (NASA GMAO) to read ESMF logging mode from log file at run-time. Previously the ESMF logging mode was hard-coded in the GCHP main program in `src/GCHPctm.F90`. Changing it required recompiling the model. With this update the logging option is instead specified in new config file `ESMF.rc` in all GCHP run directories and can be changed at run-time. The new config file details what options are available to use.

### Expected changes

There is a new config file in GCHP run directories called `ESMF.rc`. By default a set of ESMF log files will no longer be created if an ESMF error is encountered.

### Reference(s)

None

### Related Github Issue(s)

https://github.com/GEOS-ESM/MAPL/issues/2133
https://github.com/geoschem/GCHP/issues/304

### Related PRs that must be merged at the same time

https://github.com/geoschem/MAPL/pull/29
https://github.com/geoschem/GCHP/pull/330

