### PR TITLE
Convert GEOS-Chem netCDF utility routines to use the netCDF-F90 interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Explicitly define tagCH4 simulations in `Input_Opt` rather than basing off of number of advected species
 - The `fullchem` mechanism must now be built with KPP 3.0.0 or later
 - Changed the AEIC 2019 monthly climatology specification format in ExtData.rc to match standard convention for climatology
+- NetCDF utilities in `NcdfUtil` folder now use the netCDF-F90 API
 
 ### Fixed
 - Add missing mol wt for HgBrO in `run/shared/species_database_hg.yml`

--- a/NcdfUtil/m_netcdf_io_checks.F90
+++ b/NcdfUtil/m_netcdf_io_checks.F90
@@ -45,9 +45,7 @@ CONTAINS
 !
   function Ncdoes_Udim_Exist (ncid)
 !
-    implicit none
-!
-    include "netcdf.inc"
+    use netCDF
 !
 ! !INPUT PARAMETERS:
 !!  ncid : netCDF file id to check
@@ -70,18 +68,11 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-    integer :: ierr
-    integer :: udimid
-!
-    ierr = Nf_Inq_Unlimdim (ncid, udimid)
+    integer :: ierr, udim_id
 
-    if (ierr == NF_NOERR) then
-       Ncdoes_Udim_Exist = .true.
-    else
-       Ncdoes_Udim_Exist = .false.
-    end if
-
-    return
+    Ncdoes_Udim_Exist = .false.
+    ierr = NF90_Inquire(ncid, unlimitedDimId=udim_id)
+    IF ( ierr /= NF90_NOERR ) Ncdoes_Udim_Exist = .true.
 
   end function Ncdoes_Udim_Exist
 !EOC
@@ -96,9 +87,7 @@ CONTAINS
 !
   function Ncdoes_Var_Exist (ncid, varname)
 !
-    implicit none
-!
-    include "netcdf.inc"
+    use netCDF
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id       to check
@@ -126,15 +115,9 @@ CONTAINS
     integer :: ierr
     integer :: varid
 !
-    ierr = Nf_Inq_Varid (ncid, varname, varid)
-
-    if (ierr == NF_NOERR) then
-       Ncdoes_Var_Exist = .true.
-    else
-       Ncdoes_Var_Exist = .false.
-    end if
-
-    return
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
+    Ncdoes_Var_Exist = .false.
+    if (ierr == NF90_NOERR) Ncdoes_Var_Exist = .true.
 
   end function Ncdoes_Var_Exist
 !EOC
@@ -147,11 +130,9 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  function Ncdoes_Attr_Exist (ncid, varname, attname, attType)
+  function Ncdoes_Attr_Exist(ncid, varname, attname, attType)
 !
-    implicit none
-!
-    include "netcdf.inc"
+    use netCDF
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id       to check
@@ -184,21 +165,20 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-    integer :: ierr
-    integer :: varid
-    INTEGER :: attLen
+    INTEGER :: ierr, varId, attLen, attNum
 
     ! Init
     Ncdoes_Attr_Exist = .false.
     attType           = -1
 
     ! First check the variable
-    ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid (ncid, varname, varid)
 
     ! Check the attribute if variable was found
-    IF ( ierr == NF_NOERR ) THEN
-       ierr = Nf_Inq_Att( ncId, varId, attName, attType, attLen )
-       IF ( ierr == NF_NOERR ) THEN
+    IF ( ierr == NF90_NOERR ) THEN
+       ierr = NF90_Inquire_Attribute( ncId,    varId,  attName,  &
+                                      attType, attLen, attNum   )
+       IF ( ierr == NF90_NOERR ) THEN
           NcDoes_Attr_Exist = .TRUE.
        ENDIF
     ENDIF
@@ -218,9 +198,7 @@ CONTAINS
 !
   function Ncdoes_Dim_Exist (ncid, dimname )
 !
-    implicit none
-!
-    include "netcdf.inc"
+    use netCDF
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id        to check
@@ -249,14 +227,11 @@ CONTAINS
     integer :: dimid
 
     ! First check the variable
-    ierr = Nf_Inq_Dimid (ncid, dimname, dimid)
+    ierr = NF90_Inq_Dimid(ncid, dimname, dimid)
 
     ! Check the attribute if variable was found
-    if (ierr == NF_NOERR) then
-       Ncdoes_Dim_Exist = .true.
-    else
-       Ncdoes_Dim_Exist = .false.
-    end if
+    Ncdoes_Dim_Exist = .false.
+    if (ierr == NF90_NOERR) Ncdoes_Dim_Exist = .true.
 
     return
 

--- a/NcdfUtil/m_netcdf_io_create.F90
+++ b/NcdfUtil/m_netcdf_io_create.F90
@@ -45,18 +45,15 @@ CONTAINS
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !   ncid    : opened netCDF file id
 !   filname : name of netCDF file to open for writing
-    integer          , intent(in)   :: ncid
-    character (len=*), intent(in)   :: filname
-    LOGICAL, OPTIONAL, INTENT(IN)   :: WRITE_NC4
+    integer          , intent(INOUT) :: ncid
+    character (len=*), intent(IN)    :: filname
+    LOGICAL, OPTIONAL, INTENT(IN)    :: WRITE_NC4
 !
 ! !DESCRIPTION: Creates a netCDF file for writing and does some error checking.
 !\\
@@ -65,10 +62,10 @@ CONTAINS
 !  John Tannahill (LLNL) and Jules Kouatchou
 !
 ! !REMARKS:
-!  If the netCDF4 library is used, then the NF_CLOBBER flag will write
+!  If the netCDF4 library is used, then the NF90_CLOBBER flag will write
 !  a classic (i.e. netCDF3) file.  Use OR(NF_NETCDF4,NF_CLASSIC_MODEL) to
-!  create netCDF-4 file that supports compression and uses "classic" netcdf data model
-!  (no groups, no user-defined types)
+!  create netCDF-4 file that supports compression and uses "classic"
+!  netcdf data model (no groups, no user-defined types)
 !
 ! !REVISION HISTORY:
 !  See https://github.com/geoschem/ncdfutil for complete history
@@ -91,18 +88,18 @@ CONTAINS
     ENDIF
 
     IF ( TMP_NC4 ) THEN
-#if defined( NC_HAS_COMPRESSION )
-       mode = IOR( NF_NETCDF4, NF_CLASSIC_MODEL )         ! netCDF4 file
-       ierr = Nf_Create (filname, mode, ncid)             !  w/ compression
+#ifdef NC_HAS_COMPRESSION )
+       mode = IOR( NF90_NETCDF4, NF90_CLASSIC_MODEL )       ! netCDF4 file
+       ierr = NF90_Create(filname, mode, ncid)              !  w/ compression
 #else
-       ierr = Nf_Create (filname, NF_64BIT_OFFSET, ncid)  ! netCDF4 file
-                                                          !  w/o compression
+       ierr = NF90_Create(filname, NF90_64BIT_OFFSET, ncid) ! netCDF4 file
+                                                            !  w/o compression
 #endif
     ELSE
-       ierr = Nf_Create (filname, NF_CLOBBER, ncid)       ! netCDF3 file
+       ierr = NF90_Create(filname, NF90_CLOBBER, ncid)      ! netCDF3 file
     ENDIF
 
-    if (ierr /= NF_NOERR) then
+    if (ierr /= NF90_NOERR) then
        err_msg = 'In Nccr_Wr, cannot create:  ' // Trim (filname)
        call Do_Err_Out (err_msg, .true., 0, 0, 0, 0 , 0.0d0, 0.0d0)
     end if
@@ -124,11 +121,8 @@ CONTAINS
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !!  ncid : netCDF file id
@@ -150,14 +144,12 @@ CONTAINS
     character (len=128) :: err_msg
     integer             :: ierr
 !
-    ierr = Nf_Sync (ncid)
+    ierr = NF90_Sync (ncid)
 
-    if (ierr /= NF_NOERR) then
-       err_msg = 'In Ncdo_Sync:  ' // Nf_Strerror (ierr)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncdo_Sync:  ' // NF90_Strerror (ierr)
        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
     end if
-
-    return
 
   end subroutine Ncdo_Sync
 !EOC

--- a/NcdfUtil/m_netcdf_io_define.F90
+++ b/NcdfUtil/m_netcdf_io_define.F90
@@ -12,6 +12,7 @@ MODULE m_netcdf_io_define
 ! !USES:
 !
   IMPLICIT NONE
+  PRIVATE
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
@@ -68,7 +69,7 @@ MODULE m_netcdf_io_define
 !  Jules Kouatchou
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -87,11 +88,8 @@ CONTAINS
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid  : netCDF file id
@@ -114,7 +112,7 @@ CONTAINS
 !  Jules Kouatchou and Maharaj Bhat
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -128,14 +126,14 @@ CONTAINS
     len0 = len
     if (present(unlimited)) then
        if (unlimited) then
-          len0 = NF_UNLIMITED
+          len0 = NF90_UNLIMITED
        endif
     endif
 
-    ierr = Nf_Def_Dim (ncid, name, len0, id)
+    ierr = NF90_Def_Dim(ncid, name, len0, id)
 
-    IF (ierr.ne.NF_NOERR) then
-       err_msg = 'Nf_Def_Dim: can not define dimension : '// Trim (name)
+    IF (ierr.ne.NF90_NOERR) then
+       err_msg = 'NF90_Def_Dim: can not define dimension : '// Trim (name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
     END IF
 
@@ -150,33 +148,31 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_variable(ncid,name,type,ndims,dims,var_id,compress)
+  SUBROUTINE NcDef_variable(ncid, name, xtype, ndims, dims, var_id, compress)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !
 !!  ncid   : netCDF file id
 !!  name   : name of the variable
 !!  type   : type of the variable
-!!           (NF_FLOAT, NF_CHAR, NF_INT, NF_DOUBLE, NF_BYTE, NF_SHORT)
+!!           (NF90_FLOAT,  NF90_CHAR, NF90_INT,
+!!            NF90_DOUBLE, NF90_BYTE, NF90_SHORT)
 !!  ndims  : number of dimensions of the variable
 !!  dims   : netCDF dimension id of the variable
     CHARACTER (LEN=*), INTENT(IN)  :: name
     INTEGER,           INTENT(IN)  :: ncid, ndims
     INTEGER,           INTENT(IN)  :: dims(ndims)
-    INTEGER,           INTENT(IN)  :: type
+    INTEGER,           INTENT(IN)  :: xtype
     LOGICAL, OPTIONAL, INTENT(IN)  :: compress
 !
 ! !OUTPUT PARAMETERS:
 !
-!!  varid  : netCDF variable id returned by NF_DEF_VAR
+!!  varid  : netCDF variable id returned by NF90_DEF_VAR
     INTEGER,           INTENT(OUT) :: var_id
 !
 ! !DESCRIPTION: Defines a netCDF variable.
@@ -186,65 +182,73 @@ CONTAINS
 !  Jules Kouatchou and Maharaj Bhat
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
-    character (len=512) :: err_msg
-    integer ::  ierr
-    logical ::  doStop
-    ! Compression settings
-    ! choose deflate_level=1 for fast, minimal compression.
-    ! Informal testing suggests minimal benefit from higher compression level
-    integer, parameter :: shuffle=1, deflate=1, deflate_level=1
-!
-    ierr = Nf_Def_Var (ncid, name, type, ndims, dims, var_id)
+    character(len=512) :: err_msg
+    integer            :: ierr
+    logical            :: doStop
 
-    IF (ierr.ne.NF_NOERR) THEN
-       err_msg = 'Nf_Def_Var: can not define variable : '// Trim (name)
-       CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
-    END IF
-
-#if defined( NC_HAS_COMPRESSION )
+#ifdef NC_HAS_COMPRESSION
     !=====================================================================
-    ! If the optional "compress" variable is used and set to TRUE,
-    ! then enable variable compression (cdh, 0/17/17)
+    ! Create a compressed (deflated) netCDF variable
     !
     ! NOTE: We need to block this out with an #ifdef because some
-    ! netCDF installations might lack the nf_def_var_deflate function
+    ! netCDF installations might lack the deflation capability,
     ! which would cause a compile-time error. (bmy, 3/1/17)
-    !
-    ! ALSO NOTE: Newer versions of netCDF balk when you try to compress
-    ! a scalar variable.  This generates an annoying warning message.
-    ! To avoid this, only compress array variables. (bmy, 11/30/20)
-    !=====================================================================
-    if (present(Compress) .and. ndims > 0) then
+    !========================================================================
+    IF ( PRESENT( Compress ) ) then
 
-       if (Compress) then
+       !------------------------------------------------------------------
+       ! If COMPRESS is passed as an optional argument, and is TRUE,
+       ! then define the variable with deflate_level=1.  Higher values
+       ! of deflate_level yield minimal additiional benefit.
+       !
+       ! ALSO NOTE: Newer versions of netCDF balk when you try to compress
+       ! a scalar variable.  This generates an annoying warning message.
+       ! To avoid this, only compress array variables. (bmy, 11/30/20)
+       !-------------------------------------------------------------------
+       IF ( Compress .and. ndims > 0 ) THEN
 
-          ! Set compression
-          ierr = nf_def_var_deflate( ncid, var_id,  shuffle,       &
-                                           deflate, deflate_level )
+          ! Create deflated variable
+          ierr = NF90_Def_Var( ncid, name, xtype, dims, var_id,              &
+                               shuffle=.TRUE., deflate_level=1 )
 
           ! Check for errors.
           ! No message will be generated if the error is simply that the
-          ! file is not netCDF-4
-          ! (i.e. netCDF-3 don't support compression)
-          IF ( (ierr.ne.NF_NOERR) .and. (ierr.ne.NF_ENOTNC4)) THEN
+          ! file is not netCDF-4 (as netCDF-3 doesn't support compression)
+          IF ( (ierr.ne.NF90_NOERR) .and. (ierr.ne.NF90_ENOTNC4)) THEN
 
              ! Errors enabling compression will not halt the program
              doStop = .False.
 
              ! Print error
-             err_msg = 'Nf_Def_Var_Deflate: can not compress variable : '// Trim (name)
+             err_msg = 'NF90_Def_Var: can not create compressed variable : '//&
+                        Trim(name)
              CALL Do_Err_Out (err_msg, doStop, 0, 0, 0, 0, 0.0d0, 0.0d0)
           END IF
 
-       endif
-    endif
+          ! Return successfully
+          RETURN
+       ENDIF
+    ENDIF
 #endif
+
+    !========================================================================
+    ! Create an uncompressed netCDF variable if:
+    ! (1) COMPRESS is not passed as an optional argument
+    ! (2) COMPRESS is passed as an optional argument but is FALSE
+    ! (3) The variable is a scalar (ndims == 0)
+    !========================================================================
+    ierr = NF90_Def_Var( ncid, name, xtype, dims, var_id )
+    IF ( ierr /= NF90_NOERR ) THEN
+       err_msg = 'NF90_Def_Var_Deflate: can not create variable : '// &
+            Trim (name)
+       CALL Do_Err_Out (err_msg, doStop, 0, 0, 0, 0, 0.0d0, 0.0d0)
+    ENDIF
 
   END SUBROUTINE NcDef_variable
 !EOC
@@ -257,14 +261,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_var_attributes_c(ncid,var_id,att_name,att_val)
+  SUBROUTINE NcDef_var_attributes_c(ncid, var_id, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT none
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -272,7 +274,7 @@ CONTAINS
 !!  att_name: attribute name
 !!  att_val : attribute value
     CHARACTER (LEN=*), INTENT(IN) :: att_name, att_val
-    INTEGER,           INTENT(IN) :: ncid, var_id
+    INTEGER,           INTENT(IN) :: ncid,     var_id
 !
 ! !DESCRIPTION: Defines a netCDF variable attribute of type: CHARACTER.
 !\\
@@ -281,19 +283,18 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     CHARACTER (LEN=512) :: err_msg
-    INTEGER             :: mylen, ierr
+    INTEGER             :: ierr
 !
-    mylen = LEN(att_val)
-    ierr = Nf_Put_Att_Text (ncid, var_id, att_name, mylen, att_val)
+    ierr = NF90_Put_Att(ncid, var_id, att_name, att_val)
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr /= NF90_NOERR) THEN
        err_msg = 'NcDef_var_attributes_c: can not define attribute : ' // &
             TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -310,14 +311,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_var_attributes_i(ncid,var_id,att_name,att_val)
+  SUBROUTINE NcDef_var_attributes_i(ncid, var_id, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -335,7 +334,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -344,11 +343,9 @@ CONTAINS
     character (len=512) :: err_msg
     integer             :: mylen, ierr
 !
-    mylen = 1
-    ierr  = Nf_Put_Att_Int( ncid,   var_id, att_name, &
-                            NF_INT, mylen,  att_val )
+    ierr  = NF90_Put_Att( ncid, var_id, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_var_attributes_i: can not define attribute : ' // &
             TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -365,14 +362,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_var_attributes_r4(ncid,var_id,att_name,att_val)
+  SUBROUTINE NcDef_var_attributes_r4(ncid, var_id, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-
-    IMPLICIT NONE
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -390,20 +385,18 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     CHARACTER (LEN=512) :: err_msg
-    INTEGER             :: mylen, ierr
+    INTEGER             :: ierr
 !
-    mylen = 1
-    ierr  = Nf_Put_Att_Real( ncid,     var_id, att_name, &
-                             NF_FLOAT, mylen,  att_val )
+    ierr  = NF90_Put_Att( ncid, var_id, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_var_attributes_r4: can not define attribute : ' // &
             TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -420,14 +413,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_var_attributes_r8(ncid,var_id,att_name,att_val)
+  SUBROUTINE NcDef_var_attributes_r8(ncid, var_id, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT none
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -445,20 +436,18 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     CHARACTER (LEN=512) :: err_msg
-    INTEGER             ::  mylen, ierr
+    INTEGER             :: ierr
 !
-    mylen = 1
-    ierr  = Nf_Put_Att_Double( ncid,      var_id, att_name, &
-                               NF_DOUBLE, mylen,  att_val )
+    ierr  = NF90_Put_Att( ncid, var_id, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_var_attributes_r8: can not define attribute : ' // &
             TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -475,14 +464,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_var_attributes_i_arr(ncid,var_id,att_name,att_val)
+  SUBROUTINE NcDef_var_attributes_i_arr(ncid, var_id, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT none
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -500,20 +487,19 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     CHARACTER (LEN=512) :: err_msg
-    INTEGER             :: mylen, ierr
+    INTEGER             :: ierr
 !
-    mylen = SIZE( att_val )
-    ierr  = Nf_Put_Att_Int( ncid,   var_id, att_name, &
-                            NF_INT, mylen,  att_val )
+    ierr  = NF90_Put_Att( ncid, var_id, att_name, att_val )
 
-    iF (ierr.ne.NF_NOERR) THEN
+    iF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_var_attributes_i_arr: can not define attribute : ' &
             // TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -530,14 +516,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_var_attributes_r4_arr(ncid,var_id,att_name,att_val)
+  SUBROUTINE NcDef_var_attributes_r4_arr(ncid, var_id, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT none
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -555,20 +539,18 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     CHARACTER (LEN=512) :: err_msg
-    INTEGER             :: mylen, ierr
+    INTEGER             :: ierr
 !
-    mylen = SIZE( att_val )
-    ierr  = Nf_Put_Att_Real( ncid,     var_id, att_name, &
-                             NF_FLOAT, mylen,  att_val )
+    ierr  = NF90_Put_Att( ncid, var_id, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_var_attributes_r4_arr: can not define attribute : ' &
                     // TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -585,14 +567,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_var_attributes_r8_arr(ncid,var_id,att_name,att_val)
+  SUBROUTINE NcDef_var_attributes_r8_arr(ncid, var_id, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!    ncid    : netCDF file id
@@ -610,20 +590,18 @@ CONTAINS
 !  Jules Kouatchou and Maharaj Bhat
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     character (len=512) :: err_msg
-    integer             ::  mylen, ierr
+    integer             :: ierr
 !
-    mylen = size( att_val )
-    ierr  = Nf_Put_Att_Double( ncid,      var_id, att_name, &
-                               NF_DOUBLE, mylen,  att_val )
+    ierr  = NF90_Put_Att( ncid, var_id, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_var_attributes_r4_arr: can not define attribute : '&
                      // Trim (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -640,15 +618,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_glob_attributes_c(ncid,att_name,att_val)
+  SUBROUTINE NcDef_glob_attributes_c(ncid, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -666,19 +641,18 @@ CONTAINS
 !  Bob Yantosca( based on code by Jules Kouatchou)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     CHARACTER (LEN=512) :: err_msg
-    INTEGER             ::  mylen, ierr
+    INTEGER             :: ierr
 !
-    mylen = len(att_val)
-    ierr = Nf_Put_Att_Text (ncid, NF_GLOBAL, att_name, mylen, att_val)
+    ierr = NF90_Put_Att(ncid, NF90_GLOBAL, att_name, att_val)
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_glob_attributes_c: can not define attribute : ' // &
             TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -695,15 +669,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_glob_attributes_i(ncid,att_name,att_val)
+  SUBROUTINE NcDef_glob_attributes_i(ncid, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT none
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!    ncid    : netCDF file id
@@ -721,20 +692,18 @@ CONTAINS
 !  Bob Yantosca( based on code by Jules Kouatchou)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     CHARACTER (LEN=512) :: err_msg
-    INTEGER             :: mylen, ierr
+    INTEGER             :: ierr
 !
-    mylen = 1
-    ierr  = Nf_Put_Att_Int( ncid,   NF_GLOBAL, att_name, &
-                            NF_INT, mylen,     att_val )
+    ierr  = NF90_Put_Att( ncid, NF90_GLOBAL, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_glob_attributes_i: can not define attribute : ' // &
             TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -751,15 +720,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_glob_attributes_r4(ncid,att_name,att_val)
+  SUBROUTINE NcDef_glob_attributes_r4(ncid, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -777,20 +743,18 @@ CONTAINS
 !  Bob Yantosca( based on code by Jules Kouatchou)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     character (len=512) :: err_msg
-    integer             :: mylen, ierr
+    integer             :: ierr
 !
-    mylen = 1
-    ierr  = Nf_Put_Att_Real( ncid,     NF_GLOBAL, att_name, &
-                             NF_FLOAT, mylen,     att_val )
+    ierr  = NF90_Put_Att( ncid, NF90_GLOBAL, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_glob_attributes_r4: can not define attribute : ' // &
             TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -807,15 +771,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_glob_attributes_r8(ncid,att_name,att_val)
+  SUBROUTINE NcDef_glob_attributes_r8(ncid, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!    ncid    : netCDF file id
@@ -833,20 +794,18 @@ CONTAINS
 !  Bob Yantosca( based on code by Jules Kouatchou)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     character (len=512) :: err_msg
-    integer             :: mylen, ierr
+    integer             :: ierr
 !
-    mylen = 1
-    ierr  = Nf_Put_Att_Double( ncid,     NF_GLOBAL, att_name, &
-                               NF_FLOAT, mylen,     att_val )
+    ierr  = NF90_Put_Att( ncid, NF90_GLOBAL, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_glob_attributes_r8: can not define attribute : ' // &
             TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -863,15 +822,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_glob_attributes_i_arr(ncid,att_name,att_val)
+  SUBROUTINE NcDef_glob_attributes_i_arr(ncid, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!    ncid    : netCDF file id
@@ -889,20 +845,18 @@ CONTAINS
 !  Bob Yantosca( based on code by Jules Kouatchou)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     CHARACTER (LEN=512) :: err_msg
-    INTEGER             :: mylen, ierr
+    INTEGER             :: ierr
 !
-    mylen = SIZE( att_val )
-    ierr  = Nf_Put_Att_Int( ncid,   NF_GLOBAL, att_name, &
-                            NF_INT, mylen,     att_val )
+    ierr  = NF90_Put_Att( ncid, NF90_GLOBAL, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_glob_attributes_i_arr: can not define attribute : ' &
             // Trim (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -923,11 +877,8 @@ CONTAINS
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT none
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -945,20 +896,18 @@ CONTAINS
 !  Bob Yantosca( based on code by Jules Kouatchou)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     character (len=512) :: err_msg
-    integer             :: mylen, ierr
+    integer             :: ierr
 !
-    mylen = SIZE( att_val )
-    ierr  = Nf_Put_Att_Real( ncid,     NF_GLOBAL, att_name, &
-                             NF_FLOAT, mylen,     att_val )
+    ierr  = NF90_Put_Att( ncid, NF90_GLOBAL, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_glob_attributes_r4_arr: can not define attribute : ' &
               // TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -975,15 +924,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcDef_glob_attributes_r8_arr(ncid,att_name,att_val)
+  SUBROUTINE NcDef_glob_attributes_r8_arr(ncid, att_name, att_val)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT none
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  ncid    : netCDF file id
@@ -1001,20 +947,18 @@ CONTAINS
 !  Bob Yantosca( based on code by Jules Kouatchou)
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     character (len=512) :: err_msg
-    integer             :: mylen, ierr
+    integer             :: ierr
 !
-    mylen = SIZE( att_val )
-    ierr  = Nf_Put_Att_Double( ncid,     NF_GLOBAL, att_name, &
-                               NF_FLOAT, mylen,     att_val )
+    ierr  = NF90_Put_Att( ncid, NF90_GLOBAL, att_name, att_val )
 
-    IF (ierr.ne.NF_NOERR) THEN
+    IF (ierr.ne.NF90_NOERR) THEN
        err_msg = 'NcDef_glob_attributes_r8_arr: can not define attribute : ' &
             // TRIM (att_name)
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
@@ -1031,19 +975,17 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  SUBROUTINE NcSetFill(ncid,ifill,omode)
+  SUBROUTINE NcSetFill(ncid, ifill, omode)
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !
-    INTEGER, INTENT(in) :: ncid, ifill,omode
+    INTEGER, INTENT(IN   ) :: ncid, ifill
+    INTEGER, INTENT(INOUT) :: omode
 !
 ! !DESCRIPTION: Sets fill method.
 !\\
@@ -1052,19 +994,19 @@ CONTAINS
 !  Jules Kouatchou
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     character (len=512) :: err_msg
-    integer             ::  mylen, ierr
+    integer             :: ierr
 !
-    ierr = Nf_Set_Fill (ncid, NF_NOFILL, omode)
+    ierr = NF90_Set_Fill(ncid, NF90_NOFILL, omode)
 
-    IF (ierr.ne.NF_NOERR) THEN
-       err_msg = 'Nf_Set_FIll: Error in omode  '
+    IF (ierr.ne.NF90_NOERR) THEN
+       err_msg = 'NF90_Set_FIll: Error in omode  '
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
     END IF
 
@@ -1083,11 +1025,8 @@ CONTAINS
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT NONE
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !
@@ -1100,19 +1039,19 @@ CONTAINS
 !  Jules Kouatchou
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
     CHARACTER (LEN=512) :: err_msg
-    INTEGER             ::  ierr
+    INTEGER             :: ierr
 !
-    ierr = Nf_Enddef (ncid)
+    ierr = NF90_Enddef(ncid)
 
-    IF (ierr.ne.NF_NOERR) THEN
-       err_msg = 'Nf_EndDef: Error in closing netCDF define mode!'
+    IF (ierr.ne.NF90_NOERR) THEN
+       err_msg = 'NF90_EndDef: Error in closing netCDF define mode!'
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
     END IF
 
@@ -1131,11 +1070,8 @@ CONTAINS
 !
 ! !USES:
 !
+    USE netCDF
     USE m_do_err_out
-!
-    IMPLICIT none
-!
-    INCLUDE 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !
@@ -1149,7 +1085,7 @@ CONTAINS
 !  Jules Kouatchou
 !
 ! !REVISION HISTORY:
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
@@ -1158,10 +1094,10 @@ CONTAINS
     character (len=512) :: err_msg
     integer             :: ierr
 !
-    ierr = Nf_Redef (ncid)
+    ierr = NF90_Redef (ncid)
 
-    IF (ierr.ne.NF_NOERR) THEN
-       err_msg = 'Nf_ReDef: Error in opening netCDF define mode!'
+    IF (ierr.ne.NF90_NOERR) THEN
+       err_msg = 'NF90_ReDef: Error in opening netCDF define mode!'
        CALL Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
     END IF
 

--- a/NcdfUtil/m_netcdf_io_get_dimlen.F90
+++ b/NcdfUtil/m_netcdf_io_get_dimlen.F90
@@ -7,14 +7,15 @@
 !
 ! !INTERFACE:
 !
-module m_netcdf_io_get_dimlen
+MODULE m_netcdf_io_get_dimlen
 !
-  implicit none
+  IMPLICIT NONE
+  PRIVATE
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-  public  Ncget_Dimlen
-  public  Ncget_Unlim_Dimlen
+  PUBLIC :: Ncget_Dimlen
+  PUBLIC :: Ncget_Unlim_Dimlen
 !
 ! !DESCRIPTION: Provides routines to obtain the length of a given dimension.
 !\\
@@ -41,15 +42,12 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  subroutine Ncget_Dimlen (ncid, dim_name, dim_len )
+  SUBROUTINE Ncget_Dimlen(ncid, dim_name, dim_len)
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include 'netcdf.inc'
 !
 ! !INPUT PARAMETERS:
 !!  dim_name : netCDF dimension name
@@ -77,27 +75,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-    character (len=512) :: err_msg
-    integer             :: dimid
-    integer             :: ierr
+    CHARACTER(len=512) :: err_msg
+    INTEGER            :: dimid
+    INTEGER            :: ierr
 
-    ierr = Nf_Inq_Dimid  (ncid, dim_name, dimid)
+    ierr = NF90_Inq_Dimid(ncid, dim_name, dimid)
 
-    if (ierr /= NF_NOERR ) then
-       err_msg = 'In Ncget_Dimlen #1:  ' // Trim (dim_name) // &
-                 ', ' // Nf_Strerror (ierr)
-       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-    end if
+    IF (ierr /= NF90_NOERR ) THEN
+       err_msg = 'In Ncget_Dimlen #1:  ' // TRIM(dim_name) // &
+                 ', ' // NF90_Strerror (ierr)
+       CALL Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    ENDIF
 
-    ierr = Nf_Inq_Dimlen (ncid, dimid, dim_len)
+    ierr = NF90_Inquire_Dimension(ncid, dimid, len=dim_len)
 
-    if (ierr /= NF_NOERR) then
-       err_msg = 'In Ncget_Dimlen #2:  ' // Nf_Strerror (ierr)
-       call Do_Err_Out (err_msg, .true., 2, ncid, dimid, 0, 0.0d0, 0.0d0)
-    end if
+    IF (ierr /= NF90_NOERR) THEN
+       err_msg = 'In Ncget_Dimlen #2:  ' // NF90_Strerror (ierr)
+       CALL Do_Err_Out (err_msg, .true., 2, ncid, dimid, 0, 0.0d0, 0.0d0)
+    ENDIF
 
-    return
-  end subroutine Ncget_Dimlen
+  END SUBROUTINE Ncget_Dimlen
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -108,23 +105,20 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-  subroutine Ncget_Unlim_Dimlen (ncid, udim_len)
+  SUBROUTINE Ncget_Unlim_Dimlen (ncid, udim_len)
 !
 ! !USES:
 !
-    use m_do_err_out
-!
-    implicit none
-!
-    include 'netcdf.inc'
+    USE netCDF
+    USE m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !!  ncid     : netCDF file id
-    integer,           intent(in) :: ncid
+    INTEGER, INTENT(IN)  :: ncid
 !
 ! !OUTPUT PARAMETERS:
 !!  udim_len : netCDF unlimited dimension length
-    integer,           intent(out) :: udim_len
+    INTEGER, INTENT(OUT) :: udim_len
 !
 ! !DESCRIPTION: Returns the length of the unlimited netCDF dimension.
 !\\
@@ -139,26 +133,15 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-    character (len=512) :: err_msg
-    integer             :: ierr
-    integer             :: udimid
-!
-    ierr = Nf_Inq_Unlimdim (ncid, udimid)
+    CHARACTER(len=512) :: err_msg
+    INTEGER            :: ierr, udim_id
 
-    if (ierr /= NF_NOERR) then
-       err_msg = 'In Ncget_Unlim_Dimlen #1:  ' // Nf_Strerror (ierr)
-       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-    end if
+    udim_len = -1
+    ierr = NF90_Inquire(ncid, unlimitedDimId=udim_id)
+    IF ( ierr /= NF90_NOERR ) THEN
+       ierr = NF90_Inquire_Dimension( ncid, udim_id, len=udim_len )
+    ENDIF
 
-    ierr = Nf_Inq_Dimlen (ncid, udimid, udim_len)
-
-    if (ierr /= NF_NOERR) then
-       err_msg = 'In Ncget_Unlim_Dimlen #2:  ' // Nf_Strerror (ierr)
-       call Do_Err_Out (err_msg, .true., 2, ncid, udimid, 0, 0.0d0, 0.0d0)
-    end if
-
-    return
-
-  end subroutine Ncget_Unlim_Dimlen
+  END SUBROUTINE Ncget_Unlim_Dimlen
 !EOC
-end module m_netcdf_io_get_dimlen
+END MODULE m_netcdf_io_get_dimlen

--- a/NcdfUtil/m_netcdf_io_handle_err.F90
+++ b/NcdfUtil/m_netcdf_io_handle_err.F90
@@ -44,11 +44,8 @@ CONTAINS
 !
 ! !USES:
 !
+    use netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !   ierr : netCDF error number
@@ -69,7 +66,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
     character (len=512) :: err_msg
 !
-    err_msg = 'In Nchandle_Err:  ' // Nf_Strerror (ierr)
+    err_msg = 'In Nchandle_Err:  ' // NF90_Strerror (ierr)
 
     call Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
 

--- a/NcdfUtil/m_netcdf_io_open.F90
+++ b/NcdfUtil/m_netcdf_io_open.F90
@@ -45,11 +45,8 @@ CONTAINS
 !
 ! !USES:
 !
+    USE netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !!  filname : name of netCDF file to open for reading
@@ -72,17 +69,15 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-    character (len=512) :: err_msg
-    integer             :: ierr
+    character(len=512) :: err_msg
+    integer            :: ierr
 !
-    ierr = Nf_Open (filname, NF_NOWRITE, ncid)
+    ierr = Nf90_Open( filname, NF90_NOWRITE, ncid )
 
-    if (ierr /= NF_NOERR) then
+    if (ierr /= NF90_NOERR) then
        err_msg = 'In Ncop_Rd, cannot open:  ' // Trim (filname)
        call Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
     end if
-
-    return
 
   end subroutine Ncop_Rd
 !EOC
@@ -99,11 +94,8 @@ CONTAINS
 !
 ! !USES:
 !
+    USE netCDF
     use m_do_err_out
-!
-    implicit none
-!
-    include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !!  filname : name of netCDF file to open for reading
@@ -130,9 +122,9 @@ CONTAINS
     character (len=512) :: err_msg
     integer             :: ierr
 !
-    ierr = Nf_Open (filname, NF_WRITE, ncid)
+    ierr = Nf90_Open (filname, NF90_WRITE, ncid)
 
-    if (ierr /= NF_NOERR) then
+    if (ierr /= NF90_NOERR) then
        err_msg = 'In Ncop_Rd, cannot open:  ' // Trim (filname)
        call Do_Err_Out (err_msg, .true., 0, 0, 0, 0, 0.0d0, 0.0d0)
     end if

--- a/NcdfUtil/m_netcdf_io_read.F90
+++ b/NcdfUtil/m_netcdf_io_read.F90
@@ -3,48 +3,48 @@
 !------------------------------------------------------------------------------
 !BOP
 !
-! !MODULE:  m_netcdf_io_read
+! !MODULE: m_netcdf_io_read
 !
 ! !INTERFACE:
 !
-      MODULE m_netcdf_io_read
+MODULE m_netcdf_io_read
 !
 ! !USES:
 !
-      IMPLICIT NONE
-      PRIVATE
+  IMPLICIT NONE
+  PRIVATE
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-      ! Public interface
-      PUBLIC :: NcRd
+  ! Public interface
+  PUBLIC :: NcRd
 
-      ! Private methods overloaded by public interface
-      ! (see below for info about these routines & the arguments they take)
-      INTERFACE NcRd
-         MODULE PROCEDURE Ncrd_Scal
-         MODULE PROCEDURE Ncrd_Scal_Int
-         MODULE PROCEDURE Ncrd_1d_R8
-         MODULE PROCEDURE Ncrd_1d_R4
-         MODULE PROCEDURE Ncrd_1d_Int
-         MODULE PROCEDURE Ncrd_1d_Char
-         MODULE PROCEDURE Ncrd_2d_R8
-         MODULE PROCEDURE Ncrd_2d_R4
-         MODULE PROCEDURE Ncrd_2d_Int
-         MODULE PROCEDURE Ncrd_2d_Char
-         MODULE PROCEDURE Ncrd_3d_R8
-         MODULE PROCEDURE Ncrd_3d_R4
-         MODULE PROCEDURE Ncrd_3d_Int
-         MODULE PROCEDURE Ncrd_4d_R8
-         MODULE PROCEDURE Ncrd_4d_R4
-         MODULE PROCEDURE Ncrd_4d_Int
-         MODULE PROCEDURE Ncrd_5d_R8
-         MODULE PROCEDURE Ncrd_5d_R4
-         MODULE PROCEDURE Ncrd_6d_R8
-         MODULE PROCEDURE Ncrd_6d_R4
-         MODULE PROCEDURE Ncrd_7d_R8
-         MODULE PROCEDURE Ncrd_7d_R4
-      END INTERFACE
+  ! Private methods overloaded by public interface
+  ! (see below for info about these routines & the arguments they take)
+  INTERFACE NcRd
+     MODULE PROCEDURE Ncrd_Scal
+     MODULE PROCEDURE Ncrd_Scal_Int
+     MODULE PROCEDURE Ncrd_1d_R8
+     MODULE PROCEDURE Ncrd_1d_R4
+     MODULE PROCEDURE Ncrd_1d_Int
+     MODULE PROCEDURE Ncrd_1d_Char
+     MODULE PROCEDURE Ncrd_2d_R8
+     MODULE PROCEDURE Ncrd_2d_R4
+     MODULE PROCEDURE Ncrd_2d_Int
+     MODULE PROCEDURE Ncrd_2d_Char
+     MODULE PROCEDURE Ncrd_3d_R8
+     MODULE PROCEDURE Ncrd_3d_R4
+     MODULE PROCEDURE Ncrd_3d_Int
+     MODULE PROCEDURE Ncrd_4d_R8
+     MODULE PROCEDURE Ncrd_4d_R4
+     MODULE PROCEDURE Ncrd_4d_Int
+     MODULE PROCEDURE Ncrd_5d_R8
+     MODULE PROCEDURE Ncrd_5d_R4
+     MODULE PROCEDURE Ncrd_6d_R8
+     MODULE PROCEDURE Ncrd_6d_R4
+     MODULE PROCEDURE Ncrd_7d_R8
+     MODULE PROCEDURE Ncrd_7d_R4
+  END INTERFACE NcRd
 !
 ! !DESCRIPTION: Routines for reading variables in a netCDF file.
 !\\
@@ -71,25 +71,22 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_Scal (varrd_scal, ncid, varname)
+  subroutine Ncrd_Scal(varrd_scal, ncid, varname)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid       : netCDF file id to read variable from
-!!    varname    : netCDF variable name
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
+!!  ncid       : netCDF file id to read variable from
+!!  varname    : netCDF variable name
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_scal : variable to fill
-      real*8           , intent(out)  :: varrd_scal
+!!  varrd_scal : variable to fill
+    real*8           , intent(out)  :: varrd_scal
 !
 ! !DESCRIPTION: Reads in a netCDF scalar variable.
 !\\
@@ -104,31 +101,29 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
-      real*4              :: varrd_scal_tmp
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
+    real*4              :: varrd_scal_tmp
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_Scal #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_Scal #1:  ' // Trim (varname) // &
+            ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Var_Real   (ncid, varid, varrd_scal_tmp)
+    ierr = NF90_Get_Var(ncid, varid, varrd_scal_tmp)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_Scal #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_Scal #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      varrd_scal = varrd_scal_tmp
+    varrd_scal = varrd_scal_tmp
 
-      return
-
-      end subroutine Ncrd_Scal
+  end subroutine Ncrd_Scal
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -139,25 +134,22 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_Scal_Int (varrd_scali, ncid, varname)
+  subroutine Ncrd_Scal_Int(varrd_scali, ncid, varname)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid       : netCDF file id to read variable from
-!!    varname    : netCDF variable name
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
+!!  ncid       : netCDF file id to read variable from
+!!  varname    : netCDF variable name
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_scali : integer variable to fill
-      integer          , intent(out)  :: varrd_scali
+!!  varrd_scali : integer variable to fill
+    integer          , intent(out)  :: varrd_scali
 !
 ! !DESCRIPTION: Reads in a netCDF integer scalar variable.
 !\\
@@ -172,28 +164,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_Scal_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_Scal_Int #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Var_Int (ncid, varid, varrd_scali)
+    ierr = NF90_Get_Var(ncid, varid, varrd_scali)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_Scal_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_Scal_Int #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      return
-
-      end subroutine Ncrd_Scal_Int
+  end subroutine Ncrd_Scal_Int
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -204,33 +194,29 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_1d_R8 (varrd_1d, ncid, varname, strt1d, cnt1d,   &
-                             err_stop, stat)
+  subroutine Ncrd_1d_R8(varrd_1d, ncid, varname, strt1d, cnt1d, err_stop, stat)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varrd_1d where
-!!               the first of the data values will be read
-!!    cnt1d    : varrd_1d dimension
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      logical, optional, intent(in)   :: err_stop
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varrd_1d where
+!!             the first of the data values will be read
+!!  cnt1d    : varrd_1d dimension
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
+    logical, optional, intent(in)   :: err_stop
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_1d : array to fill
-      real*8           , intent(out)  :: varrd_1d(cnt1d(1))
-      integer, optional, intent(out)  :: stat
+!!  varrd_1d : array to fill
+    real*8           , intent(out)  :: varrd_1d(cnt1d(1))
+    integer, optional, intent(out)  :: stat
 !
 ! !DESCRIPTION: Reads in a 1D netCDF real array and does some error checking.
 !\\
@@ -246,49 +232,46 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
-      logical             :: dostop
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
+    logical             :: dostop
 
-      ! set dostop flag
-      if ( present ( err_stop ) ) then
-        dostop = err_stop
-      else
-        dostop = .true.
-      endif
+    ! set dostop flag
+    dostop = .true.
+    if ( present ( err_stop ) ) dostop = err_stop
 
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
           err_msg = 'In Ncrd_1d_R8 #1:  ' // Trim (varname) // &
-                     ', ' // Nf_Strerror (ierr)
+               ', ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1d(:) = -999d0
           if ( present ( stat ) ) stat = 1
           return
-        end if
-      end if
+       end if
+    end if
 
-      ierr =  Nf_Get_Vara_Double (ncid, varid, strt1d, cnt1d, varrd_1d)
+    ierr =  NF90_Get_Var(ncid, varid, varrd_1d, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
-          err_msg = 'In Ncrd_1d_R8 #2:  ' // Nf_Strerror (ierr)
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
+          err_msg = 'In Ncrd_1d_R8 #2:  ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1d(:) = -999d0
           if ( present ( stat ) ) stat = 2
           return
-        endif
-      end if
+       endif
+    end if
 
-      ! set stat to 0 (= success)
-      if ( present ( stat ) ) stat = 0
+    ! set stat to 0 (= success)
+    if ( present ( stat ) ) stat = 0
 
-      end subroutine Ncrd_1d_R8
+  end subroutine Ncrd_1d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -299,33 +282,29 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_1d_R4 (varrd_1d, ncid, varname, strt1d, cnt1d, &
-                             err_stop, stat)
+  subroutine Ncrd_1d_R4(varrd_1d, ncid, varname, strt1d, cnt1d, err_stop, stat)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varrd_1d where
-!!               the first of the data values will be read
-!!    cnt1d    : varrd_1d dimension
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      logical, optional, intent(in)   :: err_stop
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varrd_1d where
+!!             the first of the data values will be read
+!!  cnt1d    : varrd_1d dimension
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
+    logical, optional, intent(in)   :: err_stop
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_1d : array to fill
-      real*4           , intent(out)  :: varrd_1d(cnt1d(1))
-      integer, optional, intent(out)  :: stat
+!!  varrd_1d : array to fill
+    real*4           , intent(out)  :: varrd_1d(cnt1d(1))
+    integer, optional, intent(out)  :: stat
 !
 ! !DESCRIPTION: Reads in a 1D netCDF real array and does some error checking.
 !\\
@@ -341,50 +320,47 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
-      logical             :: dostop
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
+    logical             :: dostop
 
-      ! set dostop flag
-      if ( present ( err_stop ) ) then
-        dostop = err_stop
-      else
-        dostop = .true.
-      endif
+    ! set dostop flag
+    dostop = .true.
+    if ( present ( err_stop ) ) dostop = err_stop
 
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
-           err_msg = 'In Ncrd_1d_R4 #1:  ' // Trim (varname) // &
-                      ', ' // Nf_Strerror (ierr)
-           call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-        else
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
+          err_msg = 'In Ncrd_1d_R4 #1:  ' // Trim (varname) // &
+                     ', ' // NF90_Strerror(ierr)
+          call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+       else
           varrd_1d(:) = -999.0
           if ( present ( stat ) ) stat = 1
           return
-        end if
-      end if
+       end if
+    end if
 
-      ierr =  Nf_Get_Vara_Real (ncid, varid, strt1d, cnt1d, varrd_1d)
+    ierr =  NF90_Get_Var(ncid, varid, varrd_1d, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
-          err_msg = 'In Ncrd_1d_R4 #2:  ' // Nf_Strerror (ierr)
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
+          err_msg = 'In Ncrd_1d_R4 #2:  ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1d(:) = -999.0
           if ( present ( stat ) ) stat = 2
           return
-        endif
-      end if
+       endif
+    end if
 
-      ! set stat to 0 (= success)
-      if ( present ( stat ) ) stat = 0
-      return
+    ! set stat to 0 (= success)
+    if ( present ( stat ) ) stat = 0
+    return
 
-      end subroutine Ncrd_1d_R4
+  end subroutine Ncrd_1d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -395,34 +371,31 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_1d_Int (varrd_1di, ncid, varname, strt1d, cnt1d, &
-                              err_stop, stat)
+  subroutine Ncrd_1d_Int(varrd_1di, ncid,     varname, strt1d, &
+                         cnt1d,     err_stop, stat)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varrd_1di where
-!!               the first of the data values will be read
-!!    cnt1d    : varrd_1di dimension
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      logical, optional, intent(in)   :: err_stop
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varrd_1di where
+!!             the first of the data values will be read
+!!  cnt1d    : varrd_1di dimension
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
+    logical, optional, intent(in)   :: err_stop
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_1di : intger array to fill
-      integer          , intent(out)  :: varrd_1di(cnt1d(1))
-      integer, optional, intent(out)  :: stat
+!!  varrd_1di : intger array to fill
+    integer          , intent(out)  :: varrd_1di(cnt1d(1))
+    integer, optional, intent(out)  :: stat
 !
 ! !DESCRIPTION: Reads in a 1D netCDF integer array and does some error
 !  checking.
@@ -439,51 +412,48 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
-      logical             :: dostop
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
+    logical             :: dostop
 
-      ! set dostop flag
-      if ( present ( err_stop ) ) then
-        dostop = err_stop
-      else
-        dostop = .true.
-      endif
+    ! set dostop flag
+    dostop = .true.
+    if ( present ( err_stop ) ) dostop = err_stop
 
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
           err_msg = 'In Ncrd_1d_Int #1:  ' // Trim (varname) // &
-                    ', ' // Nf_Strerror (ierr)
+                    ', ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1di(:) = -999
           if ( present ( stat ) ) stat = 1
           return
-        end if
-      end if
+       end if
+    end if
 
-      ierr = Nf_Get_Vara_Int (ncid, varid, strt1d, cnt1d, varrd_1di)
+    ierr = NF90_Get_Var(ncid, varid, varrd_1di, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        if ( dostop ) then
-          err_msg = 'In Ncrd_1d_Int #2:  ' // Nf_Strerror (ierr)
+    if (ierr /= NF90_NOERR) then
+       if ( dostop ) then
+          err_msg = 'In Ncrd_1d_Int #2:  ' // NF90_Strerror(ierr)
           call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-        else
+       else
           varrd_1di(:) = -999
           if ( present ( stat ) ) stat = 2
           return
-        endif
-      end if
+       endif
+    end if
 
       ! set stat to 0 (= success)
       if ( present ( stat ) ) stat = 0
 
-      return
+    return
 
-      end subroutine Ncrd_1d_Int
+  end subroutine Ncrd_1d_Int
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -494,30 +464,26 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_2d_R8 (varrd_2d, ncid, varname, strt2d, cnt2d)
+  subroutine Ncrd_2d_R8(varrd_2d, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
-!
-! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varrd_2d where
+    use netCDF
+    use m_do_err_out
+
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varrd_2d where
 !!               the first of the data values will be read
-!!    cnt2d    : varrd_2d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
+!!  cnt2d    : varrd_2d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt2d(2)
+    integer          , intent(in)   :: cnt2d (2)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_2d : array to fill
-      real*8           , intent(out)  :: varrd_2d(cnt2d(1), cnt2d(2))
+!!  varrd_2d : array to fill
+    real*8           , intent(out)  :: varrd_2d(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Reads in a 2D netCDF real array and does some error checking.
 !\\
@@ -532,26 +498,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_R8 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt2d, cnt2d, varrd_2d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_2d, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_2d_R8
+  end subroutine Ncrd_2d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -562,30 +528,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_2d_R4 (varrd_2d, ncid, varname, strt2d, cnt2d)
+  subroutine Ncrd_2d_R4(varrd_2d, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varrd_2d where
-!!               the first of the data values will be read
-!!    cnt2d    : varrd_2d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varrd_2d where
+!!             the first of the data values will be read
+!!  cnt2d    : varrd_2d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt2d(2)
+    integer          , intent(in)   :: cnt2d (2)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_2d : array to fill
-      real*4           , intent(out)  :: varrd_2d(cnt2d(1), cnt2d(2))
+!!  varrd_2d : array to fill
+    real*4           , intent(out)  :: varrd_2d(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Reads in a 2D netCDF real array and does some error checking.
 !\\
@@ -600,26 +563,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_R4 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real (ncid, varid, strt2d, cnt2d, varrd_2d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_2d, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_2d_R4
+  end subroutine Ncrd_2d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -630,30 +593,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_2d_Int (varrd_2di, ncid, varname, strt2d, cnt2d)
+  subroutine Ncrd_2d_Int(varrd_2di, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varrd_2d where
-!!               the first of the data values will be read
-!!    cnt2d    : varrd_2di dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varrd_2d where
+!!             the first of the data values will be read
+!!  cnt2d    : varrd_2di dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt2d(2)
+    integer          , intent(in)   :: cnt2d (2)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_2di : intger array to fill
-      integer          , intent(out)  :: varrd_2di(cnt2d(1), cnt2d(2))
+!!  varrd_2di : intger array to fill
+    integer          , intent(out)  :: varrd_2di(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Reads in a 2D netCDF integer array and does some error
 !  checking.
@@ -669,26 +629,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_Int #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Int (ncid, varid, strt2d, cnt2d, varrd_2di)
+    ierr = NF90_Get_Var(ncid, varid, varrd_2di, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_Int #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_2d_Int
+  end subroutine Ncrd_2d_Int
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -699,31 +659,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_3d_R8 (varrd_3d, ncid, varname, strt3d, cnt3d)
+  subroutine Ncrd_3d_R8(varrd_3d, ncid, varname, strt3d, cnt3d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varrd_3d where
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varrd_3d where
 !!               the first of the data values will be read
-!!    cnt3d    : varrd_3d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt3d(3)
-      integer          , intent(in)   :: cnt3d (3)
+!!  cnt3d    : varrd_3d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt3d(3)
+    integer          , intent(in)   :: cnt3d (3)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_3d : array to fill
-      real*8           , intent(out)  :: varrd_3d(cnt3d(1), cnt3d(2), &
-                                                  cnt3d(3))
+!!  varrd_3d : array to fill
+    real*8           , intent(out)  :: varrd_3d(cnt3d(1), cnt3d(2), &
+                                                cnt3d(3))
 !
 ! !DESCRIPTION: Reads in a 3D netCDF real array and does some error checking.
 !\\
@@ -738,26 +695,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_R8 #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_R8 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt3d, cnt3d, varrd_3d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_3d, start=strt3d, count=cnt3d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_3d_R8
+  end subroutine Ncrd_3d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -768,31 +725,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_3d_R4 (varrd_3d, ncid, varname, strt3d, cnt3d)
+  subroutine Ncrd_3d_R4(varrd_3d, ncid, varname, strt3d, cnt3d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varrd_3d where
-!!               the first of the data values will be read
-!!    cnt3d    : varrd_3d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt3d(3)
-      integer          , intent(in)   :: cnt3d (3)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varrd_3d where
+!!             the first of the data values will be read
+!!  cnt3d    : varrd_3d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt3d(3)
+    integer          , intent(in)   :: cnt3d (3)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_3d : array to fill
-      real*4           , intent(out)  :: varrd_3d(cnt3d(1), cnt3d(2), &
-                                                  cnt3d(3))
+!!  varrd_3d : array to fill
+    real*4           , intent(out)  :: varrd_3d(cnt3d(1), cnt3d(2), &
+                                                cnt3d(3))
 !
 ! !DESCRIPTION: Reads in a 3D netCDF real array and does some error checking.
 !\\
@@ -807,26 +761,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_R4 #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_R4 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real (ncid, varid, strt3d, cnt3d, varrd_3d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_3d, start=strt3d, count=cnt3d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_3d_R4
+  end subroutine Ncrd_3d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -837,31 +791,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_3d_Int (varrd_3di, ncid, varname, strt3d, cnt3d)
+  subroutine Ncrd_3d_Int(varrd_3di, ncid, varname, strt3d, cnt3d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varrd_3d where
-!!               the first of the data values will be read
-!!    cnt3d    : varrd_3di dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt3d(3)
-      integer          , intent(in)   :: cnt3d (3)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varrd_3d where
+!!             the first of the data values will be read
+!!  cnt3d    : varrd_3di dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt3d(3)
+    integer          , intent(in)   :: cnt3d (3)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_3di : intger array to fill
-      integer          , intent(out)  :: varrd_3di(cnt3d(1), cnt3d(2), &
-                                                   cnt3d(3))
+!!  varrd_3di : intger array to fill
+    integer          , intent(out)  :: varrd_3di(cnt3d(1), cnt3d(2), &
+                                                 cnt3d(3))
 !
 ! !DESCRIPTION: Reads in a 3D netCDF integer array and does some error
 !  checking.
@@ -877,26 +828,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_Int #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Int (ncid, varid, strt3d, cnt3d, varrd_3di)
+    ierr = NF90_Get_Var(ncid, varid, varrd_3di, start=strt3d, count=cnt3d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_Int #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_3d_Int
+  end subroutine Ncrd_3d_Int
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -907,31 +858,30 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_4d_R8 (varrd_4d, ncid, varname, strt4d, cnt4d)
+  subroutine Ncrd_4d_R8(varrd_4d, ncid, varname, strt4d, cnt4d)
 !
 ! !USES:
 !
-      use m_do_err_out
+    use netCDF
+    use m_do_err_out
 !
-      implicit none
-!
-      include "netcdf.inc"
+    implicit none
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt4d   : vector specifying the index in varrd_4d where
-!!               the first of the data values will be read
-!!    cnt4d    : varrd_4d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt4d(4)
-      integer          , intent(in)   :: cnt4d (4)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt4d   : vector specifying the index in varrd_4d where
+!!             the first of the data values will be read
+!!  cnt4d    : varrd_4d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt4d(4)
+    integer          , intent(in)   :: cnt4d (4)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_4d : array to fill
-      real*8           , intent(out)  :: varrd_4d(cnt4d(1), cnt4d(2), &
-                                                  cnt4d(3), cnt4d(4))
+!!  varrd_4d : array to fill
+    real*8           , intent(out)  :: varrd_4d(cnt4d(1), cnt4d(2), &
+                                                cnt4d(3), cnt4d(4))
 !
 ! !DESCRIPTION: Reads in a 4D netCDF real array and does some error checking.
 !\\
@@ -946,27 +896,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_4d_R8 #1:  ' // Trim (varname) // &
-                    ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_4d_R8 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
+    ierr =  NF90_Get_Var(ncid, varid, varrd_4d, start=strt4d, count=cnt4d)
 
-      ierr =  Nf_Get_Vara_Double (ncid, varid, strt4d, cnt4d, varrd_4d)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_4d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_4d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
-
-      end subroutine Ncrd_4d_R8
+  end subroutine Ncrd_4d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -977,31 +926,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_4d_R4 (varrd_4d, ncid, varname, strt4d, cnt4d)
+  subroutine Ncrd_4d_R4(varrd_4d, ncid, varname, strt4d, cnt4d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt4d   : vector specifying the index in varrd_4d where
-!!               the first of the data values will be read
-!!    cnt4d    : varrd_4d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt4d(4)
-      integer          , intent(in)   :: cnt4d (4)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt4d   : vector specifying the index in varrd_4d where
+!!             the first of the data values will be read
+!!  cnt4d    : varrd_4d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt4d(4)
+    integer          , intent(in)   :: cnt4d (4)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_4d : array to fill
-      real*4           , intent(out)  :: varrd_4d(cnt4d(1), cnt4d(2), &
-                                                  cnt4d(3), cnt4d(4))
+!!  varrd_4d : array to fill
+    real*4           , intent(out)  :: varrd_4d(cnt4d(1), cnt4d(2), &
+                                                cnt4d(3), cnt4d(4))
 !
 ! !DESCRIPTION: Reads in a 4D netCDF real array and does some error checking.
 !\\
@@ -1016,26 +962,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_4d_R4 #1:  ' // Trim (varname) // &
-                    ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_4d_R4 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr =  Nf_Get_Vara_Real (ncid, varid, strt4d, cnt4d, varrd_4d)
+    ierr =  NF90_Get_Var(ncid, varid, varrd_4d, start=strt4d, count=cnt4d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_4d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_4d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_4d_R4
+  end subroutine Ncrd_4d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1046,31 +992,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_4d_Int (varrd_4di, ncid, varname, strt4d, cnt4d)
+  subroutine Ncrd_4d_Int (varrd_4di, ncid, varname, strt4d, cnt4d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varrd_3d where
-!!               the first of the data values will be read
-!!    cnt3d    : varrd_3di dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt4d(4)
-      integer          , intent(in)   :: cnt4d (4)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varrd_3d where
+!!             the first of the data values will be read
+!!  cnt3d    : varrd_3di dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt4d(4)
+    integer          , intent(in)   :: cnt4d (4)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_3di : intger array to fill
-      integer          , intent(out)  :: varrd_4di(cnt4d(1), cnt4d(2), &
-                                                   cnt4d(3), cnt4d(4))
+!!  varrd_3di : intger array to fill
+    integer          , intent(out)  :: varrd_4di(cnt4d(1), cnt4d(2), &
+                                                 cnt4d(3), cnt4d(4))
 !
 ! !DESCRIPTION: Reads in a 3D netCDF integer array and does some error
 !  checking.
@@ -1086,26 +1029,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_Int #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Int (ncid, varid, strt4d, cnt4d, varrd_4di)
+    ierr = NF90_Get_Var(ncid, varid, varrd_4di, start=strt4d, count=cnt4d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_3d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_3d_Int #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_4d_Int
+  end subroutine Ncrd_4d_Int
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1116,32 +1059,29 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_5d_R8 (varrd_5d, ncid, varname, strt5d, cnt5d)
+  subroutine Ncrd_5d_R8(varrd_5d, ncid, varname, strt5d, cnt5d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varrd_5d where
-!!               the first of the data values will be read
-!!    cnt5d    : varrd_5d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt5d(5)
-      integer          , intent(in)   :: cnt5d (5)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varrd_5d where
+!!             the first of the data values will be read
+!!  cnt5d    : varrd_5d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt5d(5)
+    integer          , intent(in)   :: cnt5d (5)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*8         , intent(out)  :: varrd_5d(cnt5d(1), cnt5d(2), &
-                                                cnt5d(3), cnt5d(4), &
-                                                cnt5d(5))
+!!  varrd_5d : array to fill
+    real*8         , intent(out)  :: varrd_5d(cnt5d(1), cnt5d(2), &
+                                              cnt5d(3), cnt5d(4), &
+                                              cnt5d(5))
 !
 ! !DESCRIPTION: Reads in a 5D netCDF real array and does some error checking.
 !\\
@@ -1156,26 +1096,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
+    if (ierr /= NF90_NOERR) then
         err_msg = 'In Ncrd_5d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
+                  ', ' // NF90_Strerror(ierr)
         call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+     end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt5d, cnt5d, varrd_5d)
+     ierr = NF90_Get_Var(ncid, varid, varrd_5d, start=strt5d, count=cnt5d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_5d_R8 #2:  ' // Nf_Strerror (ierr)
+     if (ierr /= NF90_NOERR) then
+        err_msg = 'In Ncrd_5d_R8 #2:  ' // NF90_Strerror(ierr)
         call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+     end if
 
-      end subroutine Ncrd_5d_R8
+  end subroutine Ncrd_5d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1186,30 +1126,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_5d_R4 (varrd_5d, ncid, varname, strt5d, cnt5d)
+  subroutine Ncrd_5d_R4(varrd_5d, ncid, varname, strt5d, cnt5d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varrd_5d where
-!!               the first of the data values will be read
-!!    cnt5d    : varrd_5d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt5d(5)
-      integer          , intent(in)   :: cnt5d (5)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varrd_5d where
+!!             the first of the data values will be read
+!!  cnt5d    : varrd_5d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt5d(5)
+    integer          , intent(in)   :: cnt5d (5)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*4          , intent(out)  :: varrd_5d(cnt5d(1), cnt5d(2), &
+!!  varrd_5d : array to fill
+    real*4          , intent(out)  :: varrd_5d(cnt5d(1), cnt5d(2), &
                                                 cnt5d(3), cnt5d(4), &
                                                 cnt5d(5))
 !
@@ -1226,62 +1163,57 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_5d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_5d_R4 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real (ncid, varid, strt5d, cnt5d, varrd_5d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_5d, start=strt5d, count=cnt5d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_5d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_5d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_5d_R4
+  end subroutine Ncrd_5d_R4
 !EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
+!-------------------------------------------------------------------------
 !BOP
 !
 ! !IROUTINE: Ncrd_6d_R8
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_6d_R8 (varrd_6d, ncid, varname, strt6d, cnt6d)
+  subroutine Ncrd_6d_R8(varrd_6d, ncid, varname, strt6d, cnt6d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varrd_5d where
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varrd_5d where
 !!               the first of the data values will be read
-!!    cnt5d    : varrd_5d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt6d(6)
-      integer          , intent(in)   :: cnt6d (6)
+!!  cnt5d    : varrd_5d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt6d(6)
+    integer          , intent(in)   :: cnt6d (6)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*8         , intent(out)  :: varrd_6d(cnt6d(1), cnt6d(2), &
-                                                cnt6d(3), cnt6d(4), &
-                                                cnt6d(5), cnt6d(6))
+!!  varrd_5d : array to fill
+    real*8         , intent(out)  :: varrd_6d(cnt6d(1), cnt6d(2), &
+                                              cnt6d(3), cnt6d(4), &
+                                              cnt6d(5), cnt6d(6))
 !
 ! !DESCRIPTION: Reads in a 5D netCDF real array and does some error checking.
 !\\
@@ -1290,33 +1222,32 @@ CONTAINS
 !  John Tannahill (LLNL) and Jules Kouatchou
 !
 ! !REVISION HISTORY:
-!  20 Dec 2011 - R. Yantosca - Initial version
 !  See https://github.com/geoschem/ncdfutil for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_6d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_6d_R8 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt6d, cnt6d, varrd_6d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_6d, start=strt6d, count=cnt6d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_6d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_6d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_6d_R8
+  end subroutine Ncrd_6d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1327,32 +1258,29 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_6d_R4 (varrd_6d, ncid, varname, strt6d, cnt6d)
+  subroutine Ncrd_6d_R4(varrd_6d, ncid, varname, strt6d, cnt6d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varrd_5d where
-!!               the first of the data values will be read
-!!    cnt5d    : varrd_5d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt6d(6)
-      integer          , intent(in)   :: cnt6d (6)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varrd_5d where
+!!             the first of the data values will be read
+!!  cnt5d    : varrd_5d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt6d(6)
+    integer          , intent(in)   :: cnt6d (6)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*4          , intent(out)  :: varrd_6d(cnt6d(1), cnt6d(2), &
-                                                 cnt6d(3), cnt6d(4), &
-                                                 cnt6d(5), cnt6d(6))
+!!  varrd_5d : array to fill
+    real*4          , intent(out)  :: varrd_6d(cnt6d(1), cnt6d(2), &
+                                               cnt6d(3), cnt6d(4), &
+                                               cnt6d(5), cnt6d(6))
 !
 ! !DESCRIPTION: Reads in a 5D netCDF real array and does some error checking.
 !\\
@@ -1367,26 +1295,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_6d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if ( ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_6d_R4 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real   (ncid, varid, strt6d, cnt6d, varrd_6d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_6d, start=strt6d, count=cnt6d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_6d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_6d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_6d_R4
+  end subroutine Ncrd_6d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1397,30 +1325,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_7d_R8 (varrd_7d, ncid, varname, strt7d, cnt7d)
+  subroutine Ncrd_7d_R8(varrd_7d, ncid, varname, strt7d, cnt7d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt7d   : vector specifying the index in varrd_7d where
-!!               the first of the data values will be read
-!!    cnt7d    : varrd_7d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt7d(7)
-      integer          , intent(in)   :: cnt7d (7)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt7d   : vector specifying the index in varrd_7d where
+!!             the first of the data values will be read
+!!  cnt7d    : varrd_7d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt7d(7)
+    integer          , intent(in)   :: cnt7d (7)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_5d : array to fill
-      real*8         , intent(out)  :: varrd_7d(cnt7d(1), cnt7d(2), &
+!!  varrd_5d : array to fill
+    real*8           , intent(out)  :: varrd_7d(cnt7d(1), cnt7d(2), &
                                                 cnt7d(3), cnt7d(4), &
                                                 cnt7d(5), cnt7d(6), &
                                                 cnt7d(7))
@@ -1432,26 +1357,30 @@ CONTAINS
 !  John Tannahill (LLNL) and Jules Kouatchou
 !
 ! !REVISION HISTORY:
-!  20 Dec 2011 - R. Yantosca - Initial version
 !  See https://github.com/geoschem/ncdfutil for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_7d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_7d_R8 #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Double (ncid, varid, strt7d, cnt7d, varrd_7d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_7d, start=strt7d, count=cnt7d)
+
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_7d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
       if (ierr /= NF_NOERR) then
         err_msg = 'In Ncrd_7d_R8 #2:  ' // Nf_Strerror (ierr)
@@ -1469,33 +1398,30 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_7d_R4 (varrd_7d, ncid, varname, strt7d, cnt7d)
+  subroutine Ncrd_7d_R4(varrd_7d, ncid, varname, strt7d, cnt7d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt7d   : vector specifying the index in varrd_7d where
-!!               the first of the data values will be read
-!!    cnt7d    : varrd_7d dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt7d(7)
-      integer          , intent(in)   :: cnt7d (7)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt7d   : vector specifying the index in varrd_7d where
+!!             the first of the data values will be read
+!!  cnt7d    : varrd_7d dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt7d(7)
+    integer          , intent(in)   :: cnt7d (7)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_7d : array to fill
-      real*4          , intent(out)  :: varrd_7d(cnt7d(1), cnt7d(2), &
-                                                 cnt7d(3), cnt7d(4), &
-                                                 cnt7d(5), cnt7d(6), &
-                                                 cnt7d(7))
+!!  varrd_7d : array to fill
+    real*4          , intent(out)  :: varrd_7d(cnt7d(1), cnt7d(2), &
+                                               cnt7d(3), cnt7d(4), &
+                                               cnt7d(5), cnt7d(6), &
+                                               cnt7d(7))
 !
 ! !DESCRIPTION: Reads in a 7D netCDF real array and does some error checking.
 !\\
@@ -1504,33 +1430,32 @@ CONTAINS
 !  John Tannahill (LLNL) and Jules Kouatchou
 !
 ! !REVISION HISTORY:
-!  20 Dec 2011 - R. Yantosca - Initial version
 !  See https://github.com/geoschem/ncdfutil for complete history
 !EOP
 !-------------------------------------------------------------------------
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_7d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_7d_R4 #1:  ' // Trim (varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Real (ncid, varid, strt7d, cnt7d, varrd_7d)
+    ierr = NF90_Get_Var(ncid, varid, varrd_7d, start=strt7d, count=cnt7d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_7d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_7d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_7d_R4
+  end subroutine Ncrd_7d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1541,31 +1466,28 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_1d_Char (varrd_1dc, ncid, varname, strt1d, cnt1d)
+  subroutine Ncrd_1d_Char(varrd_1dc, ncid, varname, strt1d, cnt1d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
 !
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varrd_1dc where
-!!               the first of the data values will be read
-!!    cnt1d    : varrd_1dc dimension
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varrd_1dc where
+!!             the first of the data values will be read
+!!  cnt1d    : varrd_1dc dimension
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_1dc : intger array to fill
-      character (len=1), intent(out)  :: varrd_1dc(cnt1d(1))
+!!  varrd_1dc : intger array to fill
+    character (len=1), intent(out)  :: varrd_1dc(cnt1d(1))
 !
 ! !DESCRIPTION: Reads in a 1D netCDF character array and does some error
 !  checking.
@@ -1580,26 +1502,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_1d_Char #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_1d_Char #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Text (ncid, varid, strt1d, cnt1d, varrd_1dc)
+    ierr = NF90_Get_Var(ncid, varid, varrd_1dc, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_1d_Char #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_1d_Char #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_1d_Char
+  end subroutine Ncrd_1d_Char
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1610,30 +1532,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncrd_2d_Char (varrd_2dc, ncid, varname, strt2d, cnt2d)
+  subroutine Ncrd_2d_Char(varrd_2dc, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to read array input data from
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varrd_2dc where
-!!               the first of the data values will be read
-!!    cnt2d    : varrd_2dc dimensions
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
+!!  ncid     : netCDF file id to read array input data from
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varrd_2dc where
+!!             the first of the data values will be read
+!!  cnt2d    : varrd_2dc dimensions
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt2d(2)
+    integer          , intent(in)   :: cnt2d (2)
 !
 ! !OUTPUT PARAMETERS:
-!!    varrd_2dc : charcter array to fill
-      character        , intent(out)  :: varrd_2dc(cnt2d(1), cnt2d(2))
+!!  varrd_2dc : charcter array to fill
+    character        , intent(out)  :: varrd_2dc(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Reads in a 2D netCDF character array and does some error
 !  checking.
@@ -1649,26 +1568,25 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character (len=512) :: err_msg
+    integer             :: ierr
+    integer             :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_Char #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_Char #1:  ' // Trim (varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Get_Vara_Text (ncid, varid, strt2d, cnt2d, varrd_2dc)
+    ierr = NF90_Get_Var(ncid, varid, varrd_2dc, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_2d_Char #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncrd_2d_Char #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncrd_2d_Char
+  end subroutine Ncrd_2d_Char
 !EOC
 end module m_netcdf_io_read
-

--- a/NcdfUtil/m_netcdf_io_read.F90
+++ b/NcdfUtil/m_netcdf_io_read.F90
@@ -1382,12 +1382,7 @@ CONTAINS
        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
     end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncrd_7d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
-
-      end subroutine Ncrd_7d_R8
+  end subroutine Ncrd_7d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !

--- a/NcdfUtil/m_netcdf_io_readattr.F90
+++ b/NcdfUtil/m_netcdf_io_readattr.F90
@@ -19,6 +19,7 @@ MODULE m_netcdf_io_readattr
   PUBLIC :: NcGet_Var_Attributes
   INTERFACE NcGet_Var_Attributes
      MODULE PROCEDURE NcGet_Var_Attr_C
+     MODULE PROCEDURE NcGet_Var_Attr_C_nostop
      MODULE PROCEDURE NcGet_Var_Attr_I4
      MODULE PROCEDURE NcGet_Var_Attr_R4
      MODULE PROCEDURE NcGet_Var_Attr_R8
@@ -885,6 +886,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Glob_Attr_R4_arr( fid, attName, attValue )
 !
+! !USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId          ! netCDF file ID
@@ -1058,4 +1064,4 @@ CONTAINS
 
   END SUBROUTINE NcGet_Var_Attr_C_nostop
 !EOC
-END MODULE HCO_m_netcdf_io_readattr
+END MODULE m_netcdf_io_readattr

--- a/NcdfUtil/m_netcdf_io_readattr.F90
+++ b/NcdfUtil/m_netcdf_io_readattr.F90
@@ -10,13 +10,9 @@
 MODULE m_netcdf_io_readattr
 !
 ! !USES:
-
-  USE m_do_err_out
-
+!
   IMPLICIT NONE
   PRIVATE
-
-  INCLUDE "netcdf.inc"
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
@@ -72,8 +68,7 @@ MODULE m_netcdf_io_readattr
 !  This file is based on code from NASA/GSFC, SIVO, Code 610.3
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -93,6 +88,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Var_Attr_C( fid, varName, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
@@ -110,8 +110,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -119,26 +118,26 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     CHARACTER(LEN=512) :: errMsg
-    INTEGER            :: status, vId
+    INTEGER            :: status, vId, EC
 
     ! Zero return value
     attValue = ''
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_C: ' // TRIM( varName )        // &
-                 ', '                   // Nf_Strerror( status )
-       CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
+                 ', '                   // NF90_Strerror( status )
+       CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
     ENDIF
 
     !  Get the attribute
-    status = Nf_Get_Att_Text( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_C: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -160,6 +159,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Var_Attr_I4( fid, varName, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
@@ -177,8 +181,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -192,20 +195,20 @@ CONTAINS
     attValue = 0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_I4: ' // TRIM( varName )        // &
-                 ', '                   // Nf_Strerror( status )
+                 ', '                   // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Int( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_I4: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -227,6 +230,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Var_Attr_R4( fid, varName, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
@@ -244,8 +252,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -259,20 +266,20 @@ CONTAINS
     attValue = 0e0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R4: ' // TRIM( varName )        // &
-                 ', '                   // Nf_Strerror( status )
+                 ', '                   // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Real( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R4: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -294,6 +301,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Var_Attr_R8( fid, varName, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
@@ -311,8 +323,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -326,20 +337,20 @@ CONTAINS
     attValue = 0d0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R8: ' // TRIM( varName )        // &
-                 ', '                   // Nf_Strerror( status )
+                 ', '                   // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Double( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R8: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -361,6 +372,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Var_Attr_I4_arr( fid, varName, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId          ! netCDF file ID
@@ -378,8 +394,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -393,20 +408,20 @@ CONTAINS
     attValue = 0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_I4_arr: ' // TRIM( varName )        // &
-                 ', '                        // Nf_Strerror( status )
+                 ', '                        // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Int( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_I4_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -428,6 +443,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Var_Attr_R4_arr( fid, varName, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId          ! netCDF file ID
@@ -445,8 +465,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -460,20 +479,20 @@ CONTAINS
     attValue = 0e0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R4_arr: ' // TRIM( varName )        // &
-                 ', '                        // Nf_Strerror( status )
+                 ', '                        // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Real( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R4_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -495,6 +514,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Var_Attr_R8_arr( fid, varName, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId          ! netCDF file ID
@@ -512,8 +536,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -527,20 +550,20 @@ CONTAINS
     attValue = 0d0
 
     ! Check if VARNAME is a valid variable
-    status = Nf_Inq_Varid ( fId, varName, vId )
+    status = NF90_Inq_VarId( fId, varName, vId )
 
     ! Exit w/ error message if VARNAME is not valid
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R8_arr: ' // TRIM( varName )        // &
-                 ', '                        // Nf_Strerror( status )
+                 ', '                        // NF90_Strerror( status )
        CALL Do_Err_Out ( errMsg, .TRUE., 1, fId, 0, 0, 0.0d0, 0.0d0)
     ENDIF
 
     ! Get the attribute
-    status = Nf_Get_Att_Double( fId, vId, attName, attValue )
+    status = NF90_Get_Att( fId, vId, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Var_Attr_R8_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -562,6 +585,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Glob_Attr_C( fid, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
@@ -578,8 +606,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -593,10 +620,10 @@ CONTAINS
     attValue = ''
 
     ! Get the attribute
-    status = Nf_Get_Att_Text( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_C: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -618,6 +645,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Glob_Attr_I4( fid, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
@@ -634,8 +666,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -649,10 +680,10 @@ CONTAINS
     attValue = 0
 
     ! Get the attribute
-    status = Nf_Get_Att_Int( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_I4: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -674,6 +705,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Glob_Attr_R4( fid, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
@@ -690,8 +726,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -705,10 +740,10 @@ CONTAINS
     attValue = 0e0
 
     ! Get the attribute
-    status = Nf_Get_Att_Real( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_R4: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -730,6 +765,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Glob_Attr_R8( fid, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
@@ -746,8 +786,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -761,10 +800,10 @@ CONTAINS
     attValue = 0d0
 
     ! Get the attribute
-    status = Nf_Get_Att_Double( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_R8: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -786,6 +825,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Glob_Attr_I4_arr( fid, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId          ! netCDF file ID
@@ -802,8 +846,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -817,10 +860,10 @@ CONTAINS
     attValue = 0
 
     ! Get the attribute
-    status = Nf_Get_Att_Int( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_I4_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -858,8 +901,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -873,10 +915,10 @@ CONTAINS
     attValue = 0e0
 
     ! Get the attribute
-    status = Nf_Get_Att_Real( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_R4_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -898,6 +940,11 @@ CONTAINS
 !
   SUBROUTINE NcGet_Glob_Attr_R8_arr( fid, attName, attValue )
 !
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN)  :: fId          ! netCDF file ID
@@ -914,8 +961,7 @@ CONTAINS
 !  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
 !
 ! !REVISION HISTORY:
-!  25 Jan 2012 - R. Yantosca - Initial version
-!  See https://github.com/geoschem/ncdfutil for complete history
+!  See https://github.com/geoschem/geos-chem for complete history
 !EOP
 !------------------------------------------------------------------------------
 !BOC
@@ -929,10 +975,10 @@ CONTAINS
     attValue = 0d0
 
     ! Get the attribute
-    status = Nf_Get_Att_Double( fId, NF_GLOBAL, attName, attValue )
+    status = NF90_Get_Att( fId, NF90_GLOBAL, attName, attValue )
 
     ! Exit w/ error message if unsuccessful
-    IF ( status /= NF_NOERR ) THEN
+    IF ( status /= NF90_NOERR ) THEN
        errMsg = 'In NcGet_Glob_Attr_R8_arr: cannot read attribute : ' // &
                  TRIM( attName )
        CALL Do_Err_Out( errMsg, .TRUE., 0, 0, 0, 0, 0.0d0, 0.0d0 )
@@ -940,4 +986,76 @@ CONTAINS
 
   END SUBROUTINE NcGet_Glob_Attr_R8_arr
 !EOC
-END MODULE m_netcdf_io_readattr
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: NcGet_Var_Attr_C_nostop
+!
+! !DESCRIPTION: Returns a variable attribute of type CHARACTER.  Similar
+!  to NcGet_Var_Attr_C, but does not stop upon error,  Instead, a status
+!  flag is passed back to the calling routine.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE NcGet_Var_Attr_C_nostop( fId, varName, attName, attValue, RC )
+!
+! USES:
+!
+    USE netCDF
+    USE m_do_err_out
+!
+! !INPUT PARAMETERS:
+!
+    INTEGER,          INTENT(IN)  :: fId        ! netCDF file ID
+    CHARACTER(LEN=*), INTENT(IN)  :: varName    ! netCDF variable name
+    CHARACTER(LEN=*), INTENT(IN)  :: attName    ! Name of variable attribute
+!
+! !OUTPUT PARAMETERS:
+!
+    CHARACTER(LEN=*), INTENT(OUT) :: attValue   ! Attribute value
+    INTEGER,          INTENT(OUT) :: RC         ! Success or failure?
+!
+! !DESCRIPTION: Reads a variable attribute (CHARACTER type) from a netCDF file.
+!\\
+!\\
+! !AUTHOR:
+!  Bob Yantosca (based on code by Jules Kouatchou and Maharaj Bhat)
+!
+! !REVISION HISTORY:
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    CHARACTER(LEN=512) :: errMsg
+    INTEGER            :: status, vId
+
+    ! Zero return value
+    attValue = ''
+
+    ! Check if VARNAME is a valid variable
+    status = NF90_Inq_VarId( fId, varName, vId )
+
+    ! Exit w/ error message if VARNAME is not valid
+    IF ( status /= NF90_NOERR ) THEN
+       RC = status
+       RETURN
+    ENDIF
+
+    !  Get the attribute
+    status = NF90_Get_Att( fId, vId, attName, attValue )
+
+    ! Exit w/ error message if unsuccessful
+    IF ( status /= NF90_NOERR ) THEN
+       RC = status
+       RETURN
+    ENDIF
+
+  END SUBROUTINE NcGet_Var_Attr_C_nostop
+!EOC
+END MODULE HCO_m_netcdf_io_readattr

--- a/NcdfUtil/m_netcdf_io_write.F90
+++ b/NcdfUtil/m_netcdf_io_write.F90
@@ -1303,7 +1303,7 @@ CONTAINS
        call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
     end if
 
-    ierr = NF90_Put_Vara(ncid, varid, varwr_1dc, start=strt1d, count=cnt1d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_1dc, start=strt1d, count=cnt1d)
 
     if (ierr /= NF90_NOERR) then
        err_msg = 'In Ncwr_1d_Char #2:  ' // NF90_strerror(ierr)

--- a/NcdfUtil/m_netcdf_io_write.F90
+++ b/NcdfUtil/m_netcdf_io_write.F90
@@ -164,7 +164,7 @@ CONTAINS
        call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
     end if
 
-    ierr = NF90_Put_Var_Double(ncid, varid, varwr_scal)
+    ierr = NF90_Put_Var(ncid, varid, varwr_scal)
 
     if (ierr /= NF90_NOERR) then
        err_msg = 'In Ncwr_Scal_R8 #2:  ' // NF90_strerror(ierr)

--- a/NcdfUtil/m_netcdf_io_write.F90
+++ b/NcdfUtil/m_netcdf_io_write.F90
@@ -7,42 +7,41 @@
 !
 ! !INTERFACE:
 !
-      module m_netcdf_io_write
+MODULE m_netcdf_io_write
 !
-      IMPLICIT NONE
-      PRIVATE
+  IMPLICIT NONE
+  PRIVATE
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
-      ! Public interface
-      PUBLIC :: NcWr
+  ! Public interface
+  PUBLIC :: NcWr
 
-      ! Private methods overloaded by public interface
-      ! (see below for info about these routines & the arguments they take)
-      INTERFACE NcWr
-         MODULE PROCEDURE Ncwr_Scal_R4
-         MODULE PROCEDURE Ncwr_Scal_R8
-         MODULE PROCEDURE Ncwr_Scal_Int
-         MODULE PROCEDURE Ncwr_1d_R8
-         MODULE PROCEDURE Ncwr_1d_R4
-         MODULE PROCEDURE Ncwr_1d_Int
-         MODULE PROCEDURE Ncwr_1d_Char
-         MODULE PROCEDURE Ncwr_2d_R8
-         MODULE PROCEDURE Ncwr_2d_R4
-         MODULE PROCEDURE Ncwr_2d_Int
-         MODULE PROCEDURE Ncwr_2d_Char
-         MODULE PROCEDURE Ncwr_3d_R8
-         MODULE PROCEDURE Ncwr_3d_R4
-         MODULE PROCEDURE Ncwr_3d_Int
-         MODULE PROCEDURE Ncwr_4d_R8
-         MODULE PROCEDURE Ncwr_4d_R4
-         MODULE PROCEDURE Ncwr_4d_Int
-         MODULE PROCEDURE Ncwr_5d_R8
-         MODULE PROCEDURE Ncwr_5d_R4
-         MODULE PROCEDURE Ncwr_6d_R8
-         MODULE PROCEDURE Ncwr_6d_R4
-
-      END INTERFACE
+  ! Private methods overloaded by public interface
+  ! (see below for info about these routines & the arguments they take)
+  INTERFACE NcWr
+     MODULE PROCEDURE Ncwr_Scal_R4
+     MODULE PROCEDURE Ncwr_Scal_R8
+     MODULE PROCEDURE Ncwr_Scal_Int
+     MODULE PROCEDURE Ncwr_1d_R8
+     MODULE PROCEDURE Ncwr_1d_R4
+     MODULE PROCEDURE Ncwr_1d_Int
+     MODULE PROCEDURE Ncwr_1d_Char
+     MODULE PROCEDURE Ncwr_2d_R8
+     MODULE PROCEDURE Ncwr_2d_R4
+     MODULE PROCEDURE Ncwr_2d_Int
+     MODULE PROCEDURE Ncwr_2d_Char
+     MODULE PROCEDURE Ncwr_3d_R8
+     MODULE PROCEDURE Ncwr_3d_R4
+     MODULE PROCEDURE Ncwr_3d_Int
+     MODULE PROCEDURE Ncwr_4d_R8
+     MODULE PROCEDURE Ncwr_4d_R4
+     MODULE PROCEDURE Ncwr_4d_Int
+     MODULE PROCEDURE Ncwr_5d_R8
+     MODULE PROCEDURE Ncwr_5d_R4
+     MODULE PROCEDURE Ncwr_6d_R8
+     MODULE PROCEDURE Ncwr_6d_R4
+  END INTERFACE NcWr
 !
 ! !DESCRIPTION: Routines for writing variables in a netCDF file.
 !\\
@@ -69,24 +68,20 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_Scal_R4(varwr_scal, ncid, varname)
+  subroutine NcWr_Scal_R4(varwr_scal, ncid, varname)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!     ncid       : netCDF file id to write variable to
-!!     varname    : netCDF variable name
-!!     varwr_scal : variable to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      real*4           , intent(in)   :: varwr_scal
-
+!!  ncid       : netCDF file id to write variable to
+!!  varname    : netCDF variable name
+!!  varwr_scal : variable to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    real*4          , intent(in)   :: varwr_scal
 !
 ! !DESCRIPTION: Writes out a netCDF real scalar variable.
 !\\
@@ -101,52 +96,48 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_VarId(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_Scal_R4 #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_Scal_R4 #1:  ' // Trim(varname) // &
+                 ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Var_Real (ncid, varid, varwr_scal)
+    ierr = Nf90_Put_Var(ncid, varid, varwr_scal)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_Scal+R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_Scal+R4 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_Scal_R4
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
+  end subroutine Ncwr_Scal_R4
+
+!-------------------------------------------------------------------------
 !BOP
 !
 ! !IROUTINE: Ncwr_Scal_R8
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_Scal_R8 (varwr_scal, ncid, varname)
+  subroutine Ncwr_Scal_R8(varwr_scal, ncid, varname)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!     ncid       : netCDF file id to write variable to
-!!     varname    : netCDF variable name
-!!     varwr_scal : variable to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      real*8           , intent(in)   :: varwr_scal
+!!  ncid       : netCDF file id to write variable to
+!!  varname    : netCDF variable name
+!!  varwr_scal : variable to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    real*8          , intent(in)   :: varwr_scal
 !
 ! !DESCRIPTION: Writes out a netCDF real scalar variable.
 !\\
@@ -161,26 +152,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_Scal_R8 #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_Scal_R8 #1:  ' // Trim(varname) // &
+                 ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Var_Double(ncid, varid, varwr_scal)
+    ierr = NF90_Put_Var_Double(ncid, varid, varwr_scal)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_Scal_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_Scal_R8 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_Scal_R8
+  end subroutine Ncwr_Scal_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -191,23 +182,20 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_Scal_Int (varwr_scali, ncid, varname)
+  subroutine Ncwr_Scal_Int(varwr_scali, ncid, varname)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid       : netCDF file id to write variable to
-!!    varname    : netCDF variable name
-!!    varwr_scali : integer variable to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: varwr_scali
+!!  ncid       : netCDF file id to write variable to
+!!  varname    : netCDF variable name
+!!  varwr_scali : integer variable to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: varwr_scali
 !
 ! !DESCRIPTION: Writes out a netCDF integer scalar variable.
 !\\
@@ -222,58 +210,53 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_Scal_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_Scal_Int #1:  ' // Trim(varname) // &
+                  ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Var_Int (ncid, varid, varwr_scali)
+    ierr = NF90_Put_Var(ncid, varid, varwr_scali)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_Scal_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_Scal_Int #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_Scal_Int
+  end subroutine Ncwr_Scal_Int
 !EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
+!-------------------------------------------------------------------------
 !BOP
 !
 ! !IROUTINE: Ncwr_1d_R8
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_1d_R8 (varwr_1d, ncid, varname, strt1d, cnt1d)
+  subroutine Ncwr_1d_R8(varwr_1d, ncid, varname, strt1d, cnt1d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varwr_1d where
-!!               the first of the data values will be written
-!!    cnt1d    : varwr_1d dimension
-!!    varwr_1d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      real*8           , intent(in)   :: varwr_1d(cnt1d(1))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varwr_1d where
+!!             the first of the data values will be written
+!!  cnt1d    : varwr_1d dimension
+!!  varwr_1d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt1d(1)
+    integer         , intent(in)   :: cnt1d (1)
+    real*8          , intent(in)   :: varwr_1d(cnt1d(1))
 !
 ! !DESCRIPTION: Writes out a 1D netCDF real array and does some error
 !  checking.
@@ -289,26 +272,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_1d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_1d_R8 #1:  ' // Trim(varname) // &
+                  ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Double (ncid, varid, strt1d, cnt1d, varwr_1d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_1d, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_1d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_1d_R8 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_1d_R8
+  end subroutine Ncwr_1d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -319,28 +302,25 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_1d_R4 (varwr_1d, ncid, varname, strt1d, cnt1d)
+  subroutine Ncwr_1d_R4(varwr_1d, ncid, varname, strt1d, cnt1d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varwr_1d where
-!!               the first of the data values will be written
-!!    cnt1d    : varwr_1d dimension
-!!    varwr_1d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      real*4           , intent(in)   :: varwr_1d(cnt1d(1))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varwr_1d where
+!!             the first of the data values will be written
+!!  cnt1d    : varwr_1d dimension
+!!  varwr_1d : array to write out
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
+    real*4           , intent(in)   :: varwr_1d(cnt1d(1))
 !
 ! !DESCRIPTION: Writes out a 1D netCDF real array and does some error
 !  checking.
@@ -356,26 +336,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_1d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_1d_R4 #1:  ' // Trim(varname) // &
+                  ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Real (ncid, varid, strt1d, cnt1d, varwr_1d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_1d, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_1d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_1d_R4 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_1d_R4
+  end subroutine Ncwr_1d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -386,28 +366,25 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_1d_Int (varwr_1di, ncid, varname, strt1d, cnt1d)
+  subroutine Ncwr_1d_Int(varwr_1di, ncid, varname, strt1d, cnt1d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varwr_1di where
-!!               the first of the data values will be written
-!!    cnt1d    : varwr_1di dimension
-!!    varwr_1di : intger array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      integer          , intent(in)   :: varwr_1di(cnt1d(1))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varwr_1di where
+!!             the first of the data values will be written
+!!  cnt1d    : varwr_1di dimension
+!!  varwr_1di : intger array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt1d(1)
+    integer         , intent(in)   :: cnt1d (1)
+    integer         , intent(in)   :: varwr_1di(cnt1d(1))
 !
 ! !DESCRIPTION: Writes out a 1D netCDF integer array and does some error
 ! checking.
@@ -423,26 +400,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_1d_Int #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_1d_Int #1:  ' // Trim(varname) // &
+                 ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Int (ncid, varid, strt1d, cnt1d, varwr_1di)
+    ierr = NF90_Put_Var(ncid, varid, varwr_1di, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_1d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_1d_Int #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_1d_Int
+  end subroutine Ncwr_1d_Int
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -453,28 +430,25 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_2d_R8 (varwr_2d, ncid, varname, strt2d, cnt2d)
+  subroutine Ncwr_2d_R8(varwr_2d, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varwr_2d where
-!!               the first of the data values will be written
-!!    cnt2d    : varwr_2d dimensions
-!!    varwr_2d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
-      real*8           , intent(in)   :: varwr_2d(cnt2d(1), cnt2d(2))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varwr_2d where
+!!             the first of the data values will be written
+!!  cnt2d    : varwr_2d dimensions
+!!  varwr_2d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt2d(2)
+    integer         , intent(in)   :: cnt2d (2)
+    real*8          , intent(in)   :: varwr_2d(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Writes out a 2D netCDF real array and does some error checking.
 !\\
@@ -489,58 +463,53 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid (ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_2d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_2d_R8 #1:  ' // Trim(varname) // &
+                 ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Double (ncid, varid, strt2d, cnt2d, varwr_2d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_2d, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_2d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_2d_R8 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_2d_R8
+  end subroutine Ncwr_2d_R8
 !EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
+!-------------------------------------------------------------------------
 !BOP
 !
 ! !IROUTINE: Ncwr_2d_R4
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_2d_R4 (varwr_2d, ncid, varname, strt2d, cnt2d)
+  subroutine Ncwr_2d_R4(varwr_2d, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varwr_2d where
-!!               the first of the data values will be written
-!!    cnt2d    : varwr_2d dimensions
-!!    varwr_2d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
-      real*4           , intent(in)   :: varwr_2d(cnt2d(1), cnt2d(2))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varwr_2d where
+!!             the first of the data values will be written
+!!  cnt2d    : varwr_2d dimensions
+!!  varwr_2d : array to write out
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt2d(2)
+    integer          , intent(in)   :: cnt2d (2)
+    real*4           , intent(in)   :: varwr_2d(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Writes out a 2D netCDF real array and does some error checking.
 !\\
@@ -555,26 +524,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_2d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_2d_R4 #1:  ' // Trim(varname) // &
+                  ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Real (ncid, varid, strt2d, cnt2d, varwr_2d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_2d, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_2d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_2d_R4 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_2d_R4
+  end subroutine Ncwr_2d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -585,28 +554,25 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_2d_Int (varwr_2di, ncid, varname, strt2d, cnt2d)
+  subroutine Ncwr_2d_Int(varwr_2di, ncid, varname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt2d   : vector specifying the index in varwr_2di where
-!!               the first of the data values will be written
-!!    cnt2d    : varwr_2di dimensions
-!!    varwr_2di : intger array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
-      integer          , intent(in)   :: varwr_2di(cnt2d(1), cnt2d(2))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt2d   : vector specifying the index in varwr_2di where
+!!             the first of the data values will be written
+!!  cnt2d    : varwr_2di dimensions
+!!  varwr_2di : intger array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt2d(2)
+    integer         , intent(in)   :: cnt2d (2)
+    integer         , intent(in)   :: varwr_2di(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Writes out a 2D netCDF integer array and does some error
 !   checking.
@@ -622,26 +588,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_2d_Int #1:  ' // Trim (varname) //  &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_2d_Int #1:  ' // Trim(varname) //  &
+                 ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Int (ncid, varid, strt2d, cnt2d, varwr_2di)
+    ierr = NF90_Put_Var(ncid, varid, varwr_2di, start=strt2d, count=cnt2d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_2d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_2d_Int #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_2d_Int
+  end subroutine Ncwr_2d_Int
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -652,28 +618,25 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_3d_R8 (varwr_3d, ncid, varname, strt3d, cnt3d)
+  subroutine Ncwr_3d_R8(varwr_3d, ncid, varname, strt3d, cnt3d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varwr_3d where
-!!               the first of the data values will be written
-!!    cnt3d    : varwr_3d dimensions
-!!    varwr_3d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt3d(3)
-      integer          , intent(in)   :: cnt3d (3)
-      real*8           , intent(in)   :: varwr_3d(cnt3d(1), cnt3d(2), cnt3d(3))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varwr_3d where
+!!             the first of the data values will be written
+!!  cnt3d    : varwr_3d dimensions
+!!  varwr_3d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt3d(3)
+    integer         , intent(in)   :: cnt3d (3)
+    real*8          , intent(in)   :: varwr_3d(cnt3d(1), cnt3d(2), cnt3d(3))
 !
 ! !DESCRIPTION: Writes out a 3D netCDF real array and does some error checking.
 !\\
@@ -688,26 +651,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_3d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_3d_R8 #1:  ' // Trim(varname) // &
+                  ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Double (ncid, varid, strt3d, cnt3d, varwr_3d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_3d, start=strt3d, count=cnt3d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_3d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_3d_R8 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_3d_R8
+  end subroutine Ncwr_3d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -718,28 +681,25 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_3d_R4 (varwr_3d, ncid, varname, strt3d, cnt3d)
+  subroutine Ncwr_3d_R4(varwr_3d, ncid, varname, strt3d, cnt3d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varwr_3d where
-!!               the first of the data values will be written
-!!    cnt3d    : varwr_3d dimensions
-!!    varwr_3d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt3d(3)
-      integer          , intent(in)   :: cnt3d (3)
-      real*4           , intent(in)   :: varwr_3d(cnt3d(1), cnt3d(2), cnt3d(3))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varwr_3d where
+!!             the first of the data values will be written
+!!  cnt3d    : varwr_3d dimensions
+!!  varwr_3d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt3d(3)
+    integer         , intent(in)   :: cnt3d (3)
+    real*4          , intent(in)   :: varwr_3d(cnt3d(1), cnt3d(2), cnt3d(3))
 !
 ! !DESCRIPTION: Writes out a 3D netCDF real array and does some error checking.
 !\\
@@ -754,28 +714,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_3d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_3d_R4 #1:  ' // Trim(varname) // &
+                 ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Real (ncid, varid, strt3d, cnt3d, varwr_3d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_3d, start=strt3d, count=cnt3d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_3d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_3d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      return
-
-      end subroutine Ncwr_3d_R4
+  end subroutine Ncwr_3d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -786,28 +744,25 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_3d_Int (varwr_3di, ncid, varname, strt3d, cnt3d)
+  subroutine Ncwr_3d_Int(varwr_3di, ncid, varname, strt3d, cnt3d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varwr_3di where
-!!               the first of the data values will be written
-!!    cnt3d    : varwr_3di dimensions
-!!    varwr_3di : intger array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt3d(3)
-      integer          , intent(in)   :: cnt3d (3)
-      integer          , intent(in)   :: varwr_3di(cnt3d(1), cnt3d(2), cnt3d(3))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varwr_3di where
+!!             the first of the data values will be written
+!!  cnt3d    : varwr_3di dimensions
+!!  varwr_3di : intger array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt3d(3)
+    integer         , intent(in)   :: cnt3d (3)
+    integer         , intent(in)   :: varwr_3di(cnt3d(1), cnt3d(2), cnt3d(3))
 !
 ! !DESCRIPTION: Writes out a 3D netCDF integer array and does some error
 !  checking.
@@ -823,29 +778,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_3d_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_3d_Int #1:  ' // Trim(varname) // &
+                  ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
+    ierr = NF90_Put_Var(ncid, varid, varwr_3di, start=strt3d, count=cnt3d)
 
-      ierr = Nf_Put_Vara_Int (ncid, varid, strt3d, cnt3d, varwr_3di)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_3d_Int #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_3d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
-
-      return
-
-      end subroutine Ncwr_3d_Int
+  end subroutine Ncwr_3d_Int
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -856,29 +808,26 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_4d_R8 (varwr_4d, ncid, varname, strt4d, cnt4d)
+  subroutine Ncwr_4d_R8(varwr_4d, ncid, varname, strt4d, cnt4d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt4d   : vector specifying the index in varwr_4d where
-!!               the first of the data values will be written
-!!    cnt4d    : varwr_4d dimensions
-!!    varwr_4d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt4d(4)
-      integer          , intent(in)   :: cnt4d (4)
-      real*8           , intent(in)   :: varwr_4d(cnt4d(1), cnt4d(2), &
-                                                  cnt4d(3), cnt4d(4))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt4d   : vector specifying the index in varwr_4d where
+!!             the first of the data values will be written
+!!  cnt4d    : varwr_4d dimensions
+!!  varwr_4d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt4d(4)
+    integer         , intent(in)   :: cnt4d (4)
+    real*8          , intent(in)   :: varwr_4d(cnt4d(1), cnt4d(2), &
+                                               cnt4d(3), cnt4d(4))
 !
 ! !DESCRIPTION: Writes out a 4D netCDF real array and does some error checking.
 !\\
@@ -893,27 +842,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_4d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_4d_R8 #1:  ' // Trim(varname) // &
+                  ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
+    ierr = NF90_Put_Var(ncid, varid, varwr_4d, start=strt4d, count=cnt4d)
 
-      ierr = Nf_Put_Vara_Double (ncid, varid, strt4d, cnt4d, varwr_4d)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_4d_R8 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_4d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
-
-      end subroutine Ncwr_4d_R8
+  end subroutine Ncwr_4d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -924,29 +872,26 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_4d_R4 (varwr_4d, ncid, varname, strt4d, cnt4d)
+  subroutine Ncwr_4d_R4(varwr_4d, ncid, varname, strt4d, cnt4d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt4d   : vector specifying the index in varwr_4d where
-!!               the first of the data values will be written
-!!    cnt4d    : varwr_4d dimensions
-!!    varwr_4d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt4d(4)
-      integer          , intent(in)   :: cnt4d (4)
-      real*4           , intent(in)   :: varwr_4d(cnt4d(1), cnt4d(2), &
-                                                  cnt4d(3), cnt4d(4))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt4d   : vector specifying the index in varwr_4d where
+!!             the first of the data values will be written
+!!  cnt4d    : varwr_4d dimensions
+!!  varwr_4d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt4d(4)
+    integer         , intent(in)   :: cnt4d (4)
+    real*4          , intent(in)   :: varwr_4d(cnt4d(1), cnt4d(2), &
+                                               cnt4d(3), cnt4d(4))
 !
 ! !DESCRIPTION: Writes out a 4D netCDF real array and does some error checking.
 !\\
@@ -961,27 +906,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_4d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_4d_R4 #1:  ' // Trim(varname) // &
+                  ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
+    ierr = NF90_Put_Var(ncid, varid, varwr_4d, start=strt4d, count=cnt4d)
 
-      ierr = Nf_Put_Vara_Real (ncid, varid, strt4d, cnt4d, varwr_4d)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_4d_R4 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_4d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
-
-      end subroutine Ncwr_4d_R4
+  end subroutine Ncwr_4d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -992,29 +936,26 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_4d_Int (varwr_4di, ncid, varname, strt4d, cnt4d)
+  subroutine Ncwr_4d_Int(varwr_4di, ncid, varname, strt4d, cnt4d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt3d   : vector specifying the index in varwr_3di where
-!!               the first of the data values will be written
-!!    cnt3d    : varwr_3di dimensions
-!!    varwr_3di : intger array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt4d(4)
-      integer          , intent(in)   :: cnt4d (4)
-      integer          , intent(in)   :: varwr_4di(cnt4d(1), cnt4d(2), &
-                                                   cnt4d(3), cnt4d(4))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt3d   : vector specifying the index in varwr_3di where
+!!             the first of the data values will be written
+!!  cnt3d    : varwr_3di dimensions
+!!  varwr_3di : intger array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt4d(4)
+    integer         , intent(in)   :: cnt4d (4)
+    integer         , intent(in)   :: varwr_4di(cnt4d(1), cnt4d(2), &
+                                                cnt4d(3), cnt4d(4))
 !
 ! !DESCRIPTION: Writes out a 3D netCDF integer array and does some error
 !  checking.
@@ -1030,27 +971,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_4d_Int #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_4d_Int #1:  ' // Trim(varname) // &
+                  ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
+    ierr = NF90_Put_Var(ncid, varid, varwr_4di, start=strt4d, count=cnt4d)
 
-      ierr = Nf_Put_Vara_Int (ncid, varid, strt4d, cnt4d, varwr_4di)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_4d_Int #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_4d_Int #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
-
-      end subroutine Ncwr_4d_Int
+  end subroutine Ncwr_4d_Int
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1061,30 +1001,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_5d_R8 (varwr_5d, ncid, varname, strt5d, cnt5d)
+  subroutine Ncwr_5d_R8(varwr_5d, ncid, varname, strt5d, cnt5d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varwr_5d where
-!!               the first of the data values will be written
-!!    cnt5d    : varwr_5d dimensions
-!!    varwr_5d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt5d(5)
-      integer          , intent(in)   :: cnt5d (5)
-      real*8           , intent(in)   :: varwr_5d(cnt5d(1), cnt5d(2), &
-                                                  cnt5d(3), cnt5d(4), &
-                                                  cnt5d(5))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varwr_5d where
+!!             the first of the data values will be written
+!!  cnt5d    : varwr_5d dimensions
+!!  varwr_5d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt5d(5)
+    integer         , intent(in)   :: cnt5d (5)
+    real*8          , intent(in)   :: varwr_5d(cnt5d(1), cnt5d(2), &
+                                               cnt5d(3), cnt5d(4), &
+                                               cnt5d(5))
 !
 ! !DESCRIPTION: Writes out a 5D netCDF real array and does some error checking.
 !\\
@@ -1099,60 +1036,55 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_5d_R8 #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_5d_R8 #1:  ' // Trim(varname) // &
+                 ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Double (ncid, varid, strt5d, cnt5d, varwr_5d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_5d, start=strt5d, count=cnt5d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_5d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_5d_R8 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_5d_R8
+  end subroutine Ncwr_5d_R8
 !EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
+!-------------------------------------------------------------------------
 !BOP
 !
 ! !IROUTINE: Ncwr_5d_R4
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_5d_R4 (varwr_5d, ncid, varname, strt5d, cnt5d)
+  subroutine Ncwr_5d_R4(varwr_5d, ncid, varname, strt5d, cnt5d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt5d   : vector specifying the index in varwr_5d where
-!!               the first of the data values will be written
-!!    cnt5d    : varwr_5d dimensions
-!!    varwr_5d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt5d(5)
-      integer          , intent(in)   :: cnt5d (5)
-      real*4           , intent(in)   :: varwr_5d(cnt5d(1), cnt5d(2), &
-                                                  cnt5d(3), cnt5d(4), &
-                                                  cnt5d(5))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt5d   : vector specifying the index in varwr_5d where
+!!             the first of the data values will be written
+!!  cnt5d    : varwr_5d dimensions
+!!  varwr_5d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt5d(5)
+    integer         , intent(in)   :: cnt5d (5)
+    real*4          , intent(in)   :: varwr_5d(cnt5d(1), cnt5d(2), &
+                                               cnt5d(3), cnt5d(4), &
+                                               cnt5d(5))
 !
 ! !DESCRIPTION: Writes out a 5D netCDF real array and does some error checking.
 !\\
@@ -1167,26 +1099,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid (ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_5d_R4 #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_5d_R4 #1:  ' // Trim(varname) // &
+                 ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Real (ncid, varid, strt5d, cnt5d, varwr_5d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_5d, start=strt5d, count=cnt5d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_5d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_5d_R4 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_5d_R4
+  end subroutine Ncwr_5d_R4
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1197,30 +1129,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_6d_R8 (varwr_6d, ncid, varname, strt6d, cnt6d)
+  subroutine Ncwr_6d_R8(varwr_6d, ncid, varname, strt6d, cnt6d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt6d   : vector specifying the index in varwr_6d where
-!!               the first of the data values will be written
-!!    cnt6d    : varwr_6d dimensions
-!!    varwr_6d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt6d(6)
-      integer          , intent(in)   :: cnt6d (6)
-      real*8           , intent(in)   :: varwr_6d(cnt6d(1), cnt6d(2), &
-                                                  cnt6d(3), cnt6d(4), &
-                                                  cnt6d(5), cnt6d(6))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt6d   : vector specifying the index in varwr_6d where
+!!             the first of the data values will be written
+!!  cnt6d    : varwr_6d dimensions
+!!  varwr_6d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt6d(6)
+    integer         , intent(in)   :: cnt6d (6)
+    real*8          , intent(in)   :: varwr_6d(cnt6d(1), cnt6d(2), &
+                                               cnt6d(3), cnt6d(4), &
+                                               cnt6d(5), cnt6d(6))
 !
 ! !DESCRIPTION: Writes out a 6D netCDF real array and does some error checking.
 !\\
@@ -1235,26 +1164,26 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_6d_R8 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_6d_R8 #1:  ' // Trim(varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Double (ncid, varid, strt6d, cnt6d, varwr_6d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_6d, start=strt6d, count=cnt6d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_6d_R8 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_6d_R8 #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_6d_R8
+  end subroutine Ncwr_6d_R8
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1265,30 +1194,27 @@ CONTAINS
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_6d_R4 (varwr_6d, ncid, varname, strt6d, cnt6d)
+  subroutine Ncwr_6d_R4(varwr_6d, ncid, varname, strt6d, cnt6d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt6d   : vector specifying the index in varwr_6d where
-!!               the first of the data values will be written
-!!    cnt6d    : varwr_6d dimensions
-!!    varwr_6d : array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt6d(6)
-      integer          , intent(in)   :: cnt6d (6)
-      real*4           , intent(in)   :: varwr_6d(cnt6d(1), cnt6d(2), &
-                                                  cnt6d(3), cnt6d(4), &
-                                                  cnt6d(5), cnt6d(6))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt6d   : vector specifying the index in varwr_6d where
+!!             the first of the data values will be written
+!!  cnt6d    : varwr_6d dimensions
+!!  varwr_6d : array to write out
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: varname
+    integer         , intent(in)   :: strt6d(6)
+    integer         , intent(in)   :: cnt6d (6)
+    real*4          , intent(in)   :: varwr_6d(cnt6d(1), cnt6d(2), &
+                                               cnt6d(3), cnt6d(4), &
+                                               cnt6d(5), cnt6d(6))
 !
 ! !DESCRIPTION: Writes out a 6D netCDF real array and does some error checking.
 !\\
@@ -1303,58 +1229,53 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_6d_R4 #1:  ' // Trim (varname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_6d_R4 #1:  ' // Trim(varname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Real (ncid, varid, strt6d, cnt6d, varwr_6d)
+    ierr = NF90_Put_Var(ncid, varid, varwr_6d, start=strt6d, count=cnt6d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_6d_R4 #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_6d_R4 #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_6d_R4
+  end subroutine Ncwr_6d_R4
 !EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
+!-------------------------------------------------------------------------
 !BOP
 !
 ! !IROUTINE: Ncwr_1d_Char
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_1d_Char (varwr_1dc, ncid, varname, strt1d, cnt1d)
+  subroutine Ncwr_1d_Char(varwr_1dc, ncid, varname, strt1d, cnt1d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write array output data to
-!!    varname  : netCDF variable name for array
-!!    strt1d   : vector specifying the index in varwr_1dc where
-!!               the first of the data values will be written
-!!    cnt1d    : varwr_1dc dimension
-!!    varwr_1dc : intger array to write out
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: varname
-      integer          , intent(in)   :: strt1d(1)
-      integer          , intent(in)   :: cnt1d (1)
-      character (len=1), intent(in)   :: varwr_1dc(cnt1d(1))
+!!  ncid     : netCDF file id to write array output data to
+!!  varname  : netCDF variable name for array
+!!  strt1d   : vector specifying the index in varwr_1dc where
+!!             the first of the data values will be written
+!!  cnt1d    : varwr_1dc dimension
+!!  varwr_1dc : intger array to write out
+    integer          , intent(in)   :: ncid
+    character (len=*), intent(in)   :: varname
+    integer          , intent(in)   :: strt1d(1)
+    integer          , intent(in)   :: cnt1d (1)
+    character (len=1), intent(in)   :: varwr_1dc(cnt1d(1))
 !
 ! !DESCRIPTION: Writes out a 1D netCDF character array and does some error
 !   checking.
@@ -1370,58 +1291,53 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: varid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: varid
 !
-      ierr = Nf_Inq_Varid (ncid, varname, varid)
+    ierr = NF90_Inq_Varid(ncid, varname, varid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_1d_Char #1:  ' // Trim (varname) // &
-                 ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_1d_Char #1:  ' // Trim(varname) // &
+                 ', ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
-      ierr = Nf_Put_Vara_Text (ncid, varid, strt1d, cnt1d, varwr_1dc)
+    ierr = NF90_Put_Vara(ncid, varid, varwr_1dc, start=strt1d, count=cnt1d)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_1d_Char #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_1d_Char #2:  ' // NF90_strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, varid, 0, 0.0d0, 0.0d0)
+    end if
 
-      end subroutine Ncwr_1d_Char
+  end subroutine Ncwr_1d_Char
 !EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
+!-------------------------------------------------------------------------
 !BOP
 !
 ! !IROUTINE: Ncwr_2d_Char
 !
 ! !INTERFACE:
 !
-      subroutine Ncwr_2d_Char (char_2d, ncid, tvarname, strt2d, cnt2d)
+  subroutine Ncwr_2d_Char(char_2d, ncid, tvarname, strt2d, cnt2d)
 !
 ! !USES:
 !
-      use m_do_err_out
-!
-      implicit none
-!
-      include "netcdf.inc"
+    use netCDF
+    use m_do_err_out
 !
 ! !INPUT PARAMETERS:
-!!    ncid     : netCDF file id to write text to
-!!    tvarname : netCDF variable name for text
-!!    strt2d   : vector specifying the index in char_2d where
-!!               the first of the data values will be written
-!!    cnt2d    : char_2d dimensions
-!!    char_2d  : text to write
-      integer          , intent(in)   :: ncid
-      character (len=*), intent(in)   :: tvarname
-      integer          , intent(in)   :: strt2d(2)
-      integer          , intent(in)   :: cnt2d (2)
-      character (len=1), intent(in)   :: char_2d(cnt2d(1), cnt2d(2))
+!!  ncid     : netCDF file id to write text to
+!!  tvarname : netCDF variable name for text
+!!  strt2d   : vector specifying the index in char_2d where
+!!             the first of the data values will be written
+!!  cnt2d    : char_2d dimensions
+!!  char_2d  : text to write
+    integer         , intent(in)   :: ncid
+    character(len=*), intent(in)   :: tvarname
+    integer         , intent(in)   :: strt2d(2)
+    integer         , intent(in)   :: cnt2d (2)
+    character(len=1), intent(in)   :: char_2d(cnt2d(1), cnt2d(2))
 !
 ! !DESCRIPTION: Writes out a 2D netCDF character array and does some error
 !  checking.
@@ -1437,27 +1353,25 @@ CONTAINS
 !BOC
 !
 ! !LOCAL VARIABLES:
-      character (len=512) :: err_msg
-      integer             :: ierr
-      integer             :: tvarid
+    character(len=512) :: err_msg
+    integer            :: ierr
+    integer            :: tvarid
 !
-      ierr = Nf_Inq_Varid (ncid, tvarname, tvarid)
+    ierr = NF90_Inq_Varid(ncid, tvarname, tvarid)
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_2d_Char #1:  ' // Trim (tvarname) // &
-                  ', ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
-      end if
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_2d_Char #1:  ' // Trim(tvarname) // &
+                  ', ' // NF90_Strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 1, ncid, 0, 0, 0.0d0, 0.0d0)
+    end if
 
+    ierr = NF90_Put_Var(ncid, tvarid, char_2d, start=strt2d, count=cnt2d)
 
-      ierr = Nf_Put_Vara_Text (ncid, tvarid, strt2d, cnt2d, char_2d)
+    if (ierr /= NF90_NOERR) then
+       err_msg = 'In Ncwr_2d_Char #2:  ' // NF90_Strerror(ierr)
+       call Do_Err_Out(err_msg, .true., 2, ncid, tvarid, 0, 0.0d0, 0.0d0)
+    end if
 
-      if (ierr /= NF_NOERR) then
-        err_msg = 'In Ncwr_2d_Char #2:  ' // Nf_Strerror (ierr)
-        call Do_Err_Out (err_msg, .true., 2, ncid, tvarid, 0, 0.0d0, 0.0d0)
-      end if
-
-      end subroutine Ncwr_2d_Char
+  end subroutine Ncwr_2d_Char
 !EOC
 end module m_netcdf_io_write
-

--- a/NcdfUtil/ncdf_mod.F90
+++ b/NcdfUtil/ncdf_mod.F90
@@ -16,6 +16,7 @@ MODULE NCDF_MOD
 ! !USES:
 !
   ! Modules for netCDF read
+  USE netCDF
   USE m_netcdf_io_open
   USE m_netcdf_io_get_dimlen
   USE m_netcdf_io_read
@@ -3744,8 +3745,8 @@ CONTAINS
     INTEGER, ALLOCATABLE :: VarDims(:)
 
     ! Scalars
-    INTEGER              :: nDim,     Pos
-    INTEGER              :: NF_TYPE,  tmpIlevId, tmpBoundsId
+    INTEGER              :: nDim,      Pos
+    INTEGER              :: NF90_TYPE, tmpIlevId, tmpBoundsId
     LOGICAL              :: isDefMode
 
     ! Strings
@@ -4927,10 +4928,6 @@ CONTAINS
 !
   FUNCTION NC_IsModelLevel( fID, lev_name ) RESULT ( IsModelLevel )
 !
-! !USES:
-!
-#   include "netcdf.inc"
-!
 ! !INPUT PARAMETERS:
 !
     INTEGER,          INTENT(IN) :: fID        ! file ID
@@ -4992,10 +4989,6 @@ CONTAINS
 ! !INTERFACE:
 !
   FUNCTION NC_IsSigmaLevel( fID, lev_name ) RESULT ( IsSigmaLevel )
-!
-! !USES:
-!
-#   include "netcdf.inc"
 !
 ! !INPUT PARAMETERS:
 !


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This PR is the analog to [geoschem/HEMCO PR #226](https://github.com/geoschem/HEMCO/pull/226).  It updates the GEOS-Chem netCDF I/O utilities (located in the `NcdfUtil` folder) to use the netCDF-F90 interface rather than netCDF-F77.   This is a requirement for eventually merging GEOS-Chem into the CESM model.

### Expected changes

This is a zero-diff update, as it does not touch any science code.

### Reference(s)

N/A

### Related Github Issue(s)

- https://github.com/geoschem/HEMCO/pull/227
- https://github.com/geoschem/HEMCO/pull/226
- https://github.com/geoschem/HEMCO/issues/225