### PR TITLE
Disable SpeciesConcMND output for benchmark simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed selection of troposphere-stratosphere boundary in `global_ch4_mod.F90`
 - Removed operator splitting in CH4 simulation that was biasing diagnostics
 - Fixed GCHP start and elapsed times in time_mod.F90 to use cap_restart value
+- Disabled SpeciesConcMND output for benchmark simulations
 
 ## [14.1.1] - 2023-03-03
 ### Added

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -123,7 +123,7 @@ COLLECTIONS: 'Restart',
   SpeciesConc.duration:       ${RUNDIR_HIST_TIME_AVG_DUR}
   SpeciesConc.mode:           'time-averaged'
   SpeciesConc.fields:         'SpeciesConcVV_?ALL?           ',
-                              #'SpeciesConcMND_?ALL?          ',
+                              ##'SpeciesConcMND_?ALL?          ',
 ::
 #==============================================================================
 # %%%%% THE AdvFluxVert COLLECTION %%%%%


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

Both SpeciesConcVV and SpeciesConcMND diagnostics were being saved out to the GEOSChem.SpeciesConc*.nc4 files in benchmark simulations. The SpeciesConcMND diagnostics are not actually needed for benchmarking, so we can disable this output to reduce file size.

### Expected changes

This change will reduce the size of the GEOSChem.SpeciesConc*.nc4 files, but will not change model output otherwise.

