### PR TITLE
Fix incorrect time slice read as boundary conditions in GC-Classic nested model

### DIFF
--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -2505,7 +2505,7 @@ CONTAINS
    !=================================================================
 
    ! Print header for min/max concentration to log
-   IF ( Input_Opt%amIRoot ) THEN
+   IF ( Input_Opt%amIRoot .AND. (FIRST .or. Input_Opt%Verbose) ) THEN
       WRITE( 6, 110 )
 110   FORMAT( 'Min and Max of each species in BC file [mol/mol]:' )
    ENDIF

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -2627,8 +2627,7 @@ CONTAINS
    ! Echo output
    IF ( Input_Opt%amIRoot ) THEN
       STAMP = TIMESTAMP_STRING()
-      WRITE( 6, 140 ) STAMP
-140   FORMAT( 'GET_BOUNDARY_CONDITIONS: Done applying BCs at ', a )
+      WRITE( 6, * ) 'GET_BOUNDARY_CONDITIONS: Done applying BCs at ', STAMP, ' using ', HHMMSS, t_index
    ENDIF
 
  END SUBROUTINE Get_Boundary_Conditions

--- a/GeosUtil/time_mod.F90
+++ b/GeosUtil/time_mod.F90
@@ -2481,12 +2481,19 @@ CONTAINS
     ELSE
 
        !--------------------------------------------------------------
-       ! Other than the 1st time: Search 180 mins ahead
+       ! Other than the 1st time: Use current time
        !--------------------------------------------------------------
 
-       ! We need to read in the I-3 fields 3h (180 mins, or 10800 secs)
-       ! ahead of time
-       DATE = GET_TIME_AHEAD( 10800 )
+       ! Boundary condition time slices are set to fixed 3-hourly intervals
+       ! starting from 00z, in units of minutes from start. i.e.,
+       ! time = 0, 180, 360, 540, 720, 900, 1080, 1260 ;
+       ! time:units = "minutes since 2019-01-01T00:00:00+00:00" ;
+       !
+       ! The GET_BC_TIME is used to retrieve HHMMSS time slices for use in
+       ! Get_Boundary_Conditions, which performs the calculation
+       !     t_index = ( HHMMSS / 030000 ) + 1
+       ! Thus, HHMMSS must not be offset from the current time. (hplin, 7/27/23)
+       DATE = GET_TIME_AHEAD( 0 )
 
     ENDIF
 

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -3946,7 +3946,7 @@ CONTAINS
 
        CASE( 'BOUNDARYCOND' )
           IF ( isDesc  ) Desc   = 'Transport boundary conditions for species'
-          IF ( isUnits ) Units  = 'v/v'
+          IF ( isUnits ) Units  = 'kg kg-1 dry'
           IF ( isRank  ) Rank   = 3
           IF ( isSpc   ) PerSpc = 'ADV'
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard Univ.

Reported by @nicholasbalasus (Harvard Univ.)

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

Boundary conditions used in the GEOS-Chem "Classic" nested model are being read from the wrong time slices in the source netCDF file.

The error is a forward 3-hour offset (e.g., 03:00 reads 06:00 data instead).

This is due to an incorrect time slice offset used in `GET_BC_TIME` in `time_mod.F90`. This update fixes this issue.

The update also fixes minor metadata issues (`State_Chm%BoundaryCond` is in kg/kg dry) and adds new log output to illustrate and identify the issue.

#### Bug description

`Get_Boundary_Conditions` in `HCO_Utilities_GC_Mod.F90` is responsible for reading in boundary conditions in the GEOS-Chem "Classic" nested model. It uses time slices provided by `GET_BC_TIME()` in `time_mod.F90`, namely `HHMMSS`, to get the correct hour for boundary conditions:

```fortran
   ! Find the proper time-slice to read from disk
   t_index = ( HHMMSS / 030000 ) + 1

...
      ! Get variable from HEMCO and store in local array
      CALL HCO_GC_GetPtr( Input_Opt, State_Grid, TRIM(v_name), Ptr3D, RC, &
                       TIDX=t_index, FOUND=FOUND )
```

The time indices are implied to be 3-hourly spaced throughout a day, with 1..8 corresponding to 00z..21z.

Because the boundary conditions are applied instantaneously, the time slices should align with the **current model time**:

```fortran
...
            ! West BC
            DO I = 1, State_Grid%WestBuffer
               Spc(N)%Conc(I,J,L) = State_Chm%BoundaryCond(I,J,L,N)
            ENDDO
...
```

However, this is not the current behavior. The timestamp at the end of `GET_BOUNDARY_CONDITIONS` is not the actual timestamp used for read. To illustrate this, edit the log output line

```fortran
      WRITE( 6, 140 ) STAMP
140   FORMAT( 'GET_BOUNDARY_CONDITIONS: Done applying BCs at ', a )
```

to this, which uses the actual HHMMSS read in the subroutine:

```fortran
WRITE( 6, * ) 'GET_BOUNDARY_CONDITIONS: Done applying BCs at ', STAMP, ' using ', HHMMSS, t_index
```

The logs show that the incorrect offset is used except in the first hour:
```
Min and Max of each species in BC file [mol/mol]:
Species   1,      CH4: Min = 3.027744242E-07  Max = 2.310302079E-06
 GET_BOUNDARY_CONDITIONS: Done applying BCs at 2019/01/01 00:00using           0
           1
...
********************************************
* B e g i n   T i m e   S t e p p i n g !! *
********************************************

---> DATE: 2019/01/01  UTC: 00:00  X-HRS:      0.000000

...

---> DATE: 2019/01/01  UTC: 03:00  X-HRS:      3.000000
...
Min and Max of each species in BC file [mol/mol]:
 GET_BOUNDARY_CONDITIONS: Done applying BCs at 2019/01/01 03:00using       60000
           3
...
---> DATE: 2019/01/01  UTC: 06:00  X-HRS:      6.000000
...
 GET_BOUNDARY_CONDITIONS: Done applying BCs at 2019/01/01 06:00using       90000
           4

```

The expected choice for BCs is to continuously use slices 1..8, but slice 2 is skipped here. Then, all BCs are offset by 3-hours: at 03:00, HHMMSS = 060000, thus slice 3 and not slice 2 is read.

The cause of this is due to `GET_BC_TIME` using 3-hour ahead time slices:
```fortran
       DATE = GET_TIME_AHEAD( 10800 )
```
instead of the current time.

@nicholasbalasus has helpfully plotted the output of `CHEM_BOUNDARYCOND_CH4` and the underlying boundary condition files before the fix.

The three columns correspond to `CHEM_BOUNDARYCOND_CH4`, current `SpeciesConc_CH4`, and underlying BC files:

Note that `State_Chm%BoundaryCond` here at 07z does not match the 06z boundary conditions. Instead, it matches the 09z data. As `State_Chm%BoundaryCond` is only updated every 3-hours, it can be inferred that the boundary conditions at 06z to 09z are wrong and are being read ahead.
![image](https://github.com/geoschem/geos-chem/assets/123603/ea03d87f-5501-4421-ac0b-34c7da25389b)

![image](https://github.com/geoschem/geos-chem/assets/123603/ea445fba-3921-48ce-a921-b28a3a00f07c)

The 'smearing' of the boundary condition data in the species concentration array in the buffer zone (shown in middle panels) is a separate issue being diagnosed and a fix will be PRd as soon as possible.

### Expected changes

Effects on full-chemistry simulations to be evaluated but may be significant especially over sunrise/sunset boundary.

Effects on methane inversions may affect posterior runs but because the Jacobian is computed on differences, the error introduced by a 3-hour offset in BCs may be minimal.

With this fix, the correct BC time slices are now read and reflected in the logs:
```
---> DATE: 2019/01/01  UTC: 03:00  X-HRS:      3.000000
...
 GET_BOUNDARY_CONDITIONS: Done applying BCs at 2019/01/01 03:00using       30000
           2
```

Other minor fixes are to `State_Chm` metadata. According to code
```fortran
! Read species concentrations from NetCDF [mol/mol] and
! store in State_Chm%BoundaryCond in [kg/kg dry]
```
this was incorrectly noted as v/v.

Also to hide the `Min and Max of each species in BC file [mol/mol]:` header when not necessary (not verbose / FIRST).

### Reference(s)

N/A

### Related Github Issue(s)
Possibly #1889 but might not be the root cause.

Please link to the corresponding Github issue here. If fixing a bug, there should be an issue describing it with steps to reproduce.
