### PR TITLE
Skip SALAAL+SO2 and SALCAL+SO2 rxns if O3 < 1e10 molec/cm3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change RTOL value from 0.5e-3 back to 0.5e-2 to address model slowdown
 - Allow the use of OFFLINE_SEASALT for seasalt alkalinity, Cl, and Br in GEOS-Chem within CESM
 - Renamed TransportTracer species for consistency with GMAO's TR_GridComp
+- See `KPP/fullchem/CHANGELOG_fullchem.md` for fullchem-mechanism changes
 
 ### Removed
 - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files

--- a/KPP/fullchem/CHANGELOG_fullchem.md
+++ b/KPP/fullchem/CHANGELOG_fullchem.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Restored sink reactions for HOI, IONO, IONO2
 - Added S(IV)+HOBr and S(IV)+HOCl rxns (they had been inadvertently omitted)
 
+### Changed
+- Set `k(SALAAL+SO2)` and `k(SALCAL+SO2)` to zero if O3 < 1e10 molec/cm3
+
 ### Fixed
 - Fix bugs in HOBr uptake rate calculation in `fullchem_RateLawFuncs.F90`
 - Now cap `State_Het%f_Alk_SSA` and `State_Het%f_Alk_SSC` at 1.0

--- a/KPP/fullchem/fullchem_SulfurChemFuncs.F90
+++ b/KPP/fullchem/fullchem_SulfurChemFuncs.F90
@@ -165,7 +165,7 @@ CONTAINS
     ! Scalars
     LOGICAL            :: SALAAL_gt_0_1
     LOGICAL            :: SALCAL_gt_0_1
-    LOGICAL            :: O3_gt_0
+    LOGICAL            :: O3_gt_1e10
     REAL(fp)           :: k_ex
 
     ! Strings
@@ -177,12 +177,24 @@ CONTAINS
     !======================================================================
 
     ! Initialize
-    RC            = GC_SUCCESS
-    k_ex          = 0.0_dp
-    K_MT          = 0.0_dp
-    SALAAL_gt_0_1 = ( C(ind_SALAAL) > 0.1_dp )
-    SALCAL_gt_0_1 = ( C(ind_SALCAL) > 0.1_dp )
-    O3_gt_0       = ( C(ind_O3) > 0.0_dp )
+    RC   = GC_SUCCESS
+    k_ex = 0.0_dp
+    K_MT = 0.0_dp
+
+    !----------------------------------------------------------------------
+    ! In order to prevent div-by-zero errors, we set thresholds 
+    ! to skip the SALAAL + SO2 and SALCAL + SO2 reactions if:
+    !
+    ! (1) SALAAL <= 0.1 molec/cm3
+    ! (2) SALCAL <= 0.1 molec/cm3
+    ! (3) O3 <= 1e10 molec/cm3
+    !
+    ! An ozone concentration of 1e10 molec/cm3 ~= 0.5 ppbv, which is
+    ! lower than ozone should ever get (according to D. Jacob).
+    !----------------------------------------------------------------------
+    SALAAL_gt_0_1 = ( C(ind_SALAAL) > 0.1_dp     )
+    SALCAL_gt_0_1 = ( C(ind_SALCAL) > 0.1_dp     )
+    O3_gt_1e10    = ( C(ind_O3)     > 1.0e+10_dp )
 
     !======================================================================
     ! Reaction rates [1/s] for fine sea salt alkalinity (aka SALAAL)
@@ -190,14 +202,12 @@ CONTAINS
     ! K_MT(1) : SALAAL + SO2 + O3 = SO4 - SALAAL
     ! K_MT(2) : SALAAL + HCl      = SALACL
     ! K_MT(3) : SALAAL + HNO3     = NIT
-    !
-    ! NOTE: SALAAL_gt_0_1 prevents div-by-zero errors
     !======================================================================
 
     !------------------------------------------------------------------------
     ! SALAAL + SO2 + O3 = SO4 - SALAAL
     !------------------------------------------------------------------------
-    IF ( SALAAL_gt_0_1 .AND. O3_gt_0 ) THEN
+    IF ( SALAAL_gt_0_1 .AND. O3_gt_1e10 ) THEN
 
        ! 1st order uptake
        k_ex = Ars_L1K( area   = State_Chm%WetAeroArea(I,J,L,11),             &
@@ -245,14 +255,12 @@ CONTAINS
     ! K_MT(4) : SALCAL + SO2 + O3 = SO4s - SALCAL
     ! K_MT(5) : SALCAL + HCl      = SALCCL
     ! K_MT(6) : SALCAL + HNO3     = NITs
-    !
-    ! NOTE: SALCAL_gt_0_1 prevents div-by-zero errors
     !========================================================================
 
     !------------------------------------------------------------------------
     ! SALCAL + SO2 + O3 = SO4s - SALCAL
     !------------------------------------------------------------------------
-    IF ( SALCAL_gt_0_1 .AND. O3_gt_0 ) THEN
+    IF ( SALCAL_gt_0_1 .AND. O3_gt_1e10 ) THEN
 
        ! 1st order uptake
        k_ex = Ars_L1K( area   = State_Chm%WetAeroArea(I,J,L,12),             &


### PR DESCRIPTION


### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

As suggested by Daniel Jacob, we now skip the SALAAL + SO2 and SALCAL + SO2 reactions if O3 < 1e10 molec/cm3.  This concentration is equivalent to 0.5 ppbv, which should be lower than ozone should ever get in the atmosphere.  This may help stabilize the full-chemistry mechanism by preventing reaction rates from blowing up.

### Expected changes

We hope that this will prevent several KPP integration errors from occurring in the full-chemistry mechanism.

Tagging @viral211 @msl3v @beckyalexander @msulprizio @lizziel

### Related Github Issue(s)

- #1880 
