### PR TITLE
Remove double-counting of IONO2 loss (cf geoschem/geos-chem #1880)

### DIFF
--- a/KPP/fullchem/fullchem_RateLawFuncs.F90
+++ b/KPP/fullchem/fullchem_RateLawFuncs.F90
@@ -2570,24 +2570,32 @@ CONTAINS
     k    = 0.0_dp
     srMw = SR_MW(ind_IONO2)
     !
-    ! Tropopsheric sulfate (use T-dependent gamma, cf Deiber et al 2004)
-    area  = H%ClearFr * H%xArea(SUL)
-    gamma = MAX( ( 0.0021_dp * TEMP - 0.561_dp ), 0.0_dp )
-    k     = k + Ars_L1K( area, H%xRadi(SUL), gamma, srMw )
+    !########################################################################
+    ! Prevent double-counting of IONO2 loss by alkaline SALA and SALC
+    ! aerosols. See the discussion at:
+    ! https://github.com/geoschem/geos-chem/issues/1880#issuecomment-1655958296
+    ! https://github.com/geoschem/geos-chem/issues/1880#issuecomment-1655971484
     !
-    ! Alkaline fine sea salt (use gamma from Sherwen et al 2016)
-    IF ( H%SSA_is_Alk ) THEN
-       area  = H%ClearFr * H%xArea(SSA) * H%f_Alk_SSA
-       gamma = 0.01_dp
-       k = k + Ars_L1K( area, H%xRadi(SSA), gamma, srMw )
-    ENDIF
-    !
-    ! Alkaline coarse sea salt (use gamma from Sherwen et al 2016)
-    IF ( H%SSC_is_Alk ) THEN
-       area  = H%ClearFr * H%xArea(SSC) * H%f_Alk_SSA
-       gamma = 0.01_dp
-       k = k + Ars_L1K( area, H%xRadi(SSC), gamma, srMw )
-    ENDIF
+    !IF ( H%SSA_is_Alk ) THEN
+    !! Tropopsheric sulfate (use T-dependent gamma, cf Deiber et al 2004)
+    !area  = H%ClearFr * H%xArea(SUL)
+    !gamma = MAX( ( 0.0021_dp * TEMP - 0.561_dp ), 0.0_dp )
+    !k     = k + Ars_L1K( area, H%xRadi(SUL), gamma, srMw )
+    !!
+    !! Alkaline fine sea salt (use gamma from Sherwen et al 2016)
+    !IF ( H%SSA_is_Alk ) THEN
+    !   area  = H%ClearFr * H%xArea(SSA) * H%f_Alk_SSA
+    !   gamma = 0.01_dp
+    !   k = k + Ars_L1K( area, H%xRadi(SSA), gamma, srMw )
+    !ENDIF
+    !!
+    !! Alkaline coarse sea salt (use gamma from Sherwen et al 2016)
+    !IF ( H%SSC_is_Alk ) THEN
+    !   area  = H%ClearFr * H%xArea(SSC) * H%f_Alk_SSA
+    !   gamma = 0.01_dp
+    !   k = k + Ars_L1K( area, H%xRadi(SSC), gamma, srMw )
+    !ENDIF
+    !########################################################################
     !
     ! Stratospheric liquid aerosol
     k = k + H%xArea(SLA) * H%KHETI_SLA(BrNO3_plus_H2O)
@@ -3300,7 +3308,7 @@ CONTAINS
     !
     ! Exit if in the stratosphere
     k = 0.0_dp
-    IF ( H%stratBox ) RETURN    
+    IF ( H%stratBox ) RETURN
     !
     ! Compute uptake; gamma is from cf Knipping & Dabdub, 2002
     gamma = 0.04_dp * H%Cl_conc_SSC


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

In #1880, @viral211 suggested that we are performing loss of IONO2 by alkaline SALA and SALC in hetchem routines:

- `IuptkByAlkSALA1stOrd`
- `IuptkByAlkSALC1stOrd`

and then again in routine

- IONO2uptkByH2O

which is double-counting.

To prevent this double-counting, we have removed the code that handles the removal of IONO2 by alkaline sea salt aerosol in routine `IONO2uptkByH2O` (corresponding to lines 2574-2590 in [this code snippet](https://github.com/geoschem/geos-chem/blob/9aa18fdc89f782c535a711638812d30dea174eca/KPP/fullchem/fullchem_RateLawFuncs.F90#L2561-L2590).

A more permanent solution by @beckyalexander may be forthcoming in the future, pending further validation.

### Expected changes

We hope that this update (along with other fixes) will help to reduce the instability of the full-chemistry mechanism that has been observed recently.  This may help in the over-titration of O3 that has been observed at high latitudes in the winter hemisphere.

### Reference(s)

N/A

### Related Github Issue(s)

- #1880