### PR TITLE
Impose boundary conditions at every timestep in GC-Classic nested-grid simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed default ESMF logging in GCHP to be ESMF_LOGKIND_NONE (no log)
 - NetCDF utilities in `NcdfUtil` folder now use the netCDF-F90 API
 - GEOS-only updates for running GEOS-Chem in GEOS
+- Boundary conditions for nested-grid simulations are now imposed at every time step instead of 3-hourly
 
 ### Fixed
 - Add missing mol wt for HgBrO in `run/shared/species_database_hg.yml`

--- a/GeosCore/CMakeLists.txt
+++ b/GeosCore/CMakeLists.txt
@@ -102,7 +102,7 @@ add_library(GeosCore
   YuIMN_Code.F90
 
   # Files only included for special cases
-  $<$<BOOL:${MODEL_CLASSIC}>:flexgrid_read_mod.F90 get_met_mod.F90>
+  $<$<BOOL:${MODEL_CLASSIC}>:flexgrid_read_mod.F90 get_met_mod.F90 set_boundary_conditions_mod.F90>
   $<$<BOOL:${RRTMG}>:rrtmg_rad_transfer_mod.F90>
   $<$<BOOL:${TOMAS}>:tomas_mod.F90>
   $<$<BOOL:${APM}>:apm_driv_mod.F90>

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -1035,6 +1035,11 @@ CONTAINS
 
     !=======================================================================
     ! Get boundary conditions from HEMCO (GEOS-Chem "Classic" only)
+    ! This only retrieves boundary conditions from HEMCO and puts them into
+    ! State_Chm%BoundaryCond. It no longer applies the boundary conditions
+    ! to the species array, which is handled by Set_Boundary_Conditions().
+    ! This is so that boundary conditions can be updated at a higher frequency
+    ! than the emissions timestep. (hplin, 7/28/23)
     !=======================================================================
 
     ! Assume BCs are 3-hourly and only get from HEMCO when needed

--- a/GeosCore/set_boundary_conditions_mod.F90
+++ b/GeosCore/set_boundary_conditions_mod.F90
@@ -1,0 +1,168 @@
+#if defined( MODEL_CLASSIC )
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: set_boundary_condition_mod.F90
+!
+! !DESCRIPTION: Module SET\_BOUNDARY\_CONDITION\_MOD sets boundary conditions
+!  for the GEOS-Chem "Classic" nested-grid model.
+!\\
+!\\
+! !INTERFACE:
+
+MODULE Set_Boundary_Conditions_Mod
+!
+! !USES:
+!
+  USE Precision_Mod    ! For GEOS-Chem Precision (fp)
+
+  IMPLICIT NONE
+!
+! !PUBLIC MEMBER FUNCTIONS:
+!
+  PUBLIC :: Set_Boundary_Conditions
+!
+! !REMARKS:
+!  This module was split for two purposes:
+!  (1) avoid subroutine creep in HCO_Utilities_GC_Mod as this is purely GC code.
+!  (2) allow for future extension if handling of boundary conditions will change
+!      (for example introducing rate-of-change)
+!
+! !REVISION HISTORY:
+!  28 Jul 2023 - H.P. Lin   - Initial version
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+CONTAINS
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: set_boundary_conditions
+!
+! !DESCRIPTION: Subroutine SET\_BOUNDARY\_CONDITIONS sets the boundary conditions
+!  using the boundary conditions read from HEMCO for nested-grid simulations.
+!\\
+!\\
+! !INTERFACE:
+!
+ SUBROUTINE Set_Boundary_Conditions( Input_Opt, State_Chm, State_Grid, RC )
+!
+! !USES:
+!
+   USE ErrCode_Mod,      ONLY : GC_SUCCESS, GC_Error
+   USE Input_Opt_Mod,    ONLY : OptInput
+   USE Species_Mod,      ONLY : Species, SpcConc
+   USE State_Chm_Mod,    ONLY : ChmState
+   USE State_Grid_Mod,   ONLY : GrdState
+   USE Time_Mod,         ONLY : TIMESTAMP_STRING
+!
+! !INPUT PARAMETERS:
+!
+   TYPE(OptInput),   INTENT(IN   )          :: Input_Opt  ! Input options
+   TYPE(GrdState),   INTENT(IN   )          :: State_Grid ! Grid State
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+   TYPE(ChmState),   INTENT(INOUT)          :: State_Chm  ! Chemistry State
+   INTEGER,          INTENT(INOUT)          :: RC         ! Failure or success
+!
+! !REMARKS:
+!  Split off from HEMCO code (Get\_Boundary\_Conditions) in order to be called
+!  more frequently throughout timesteps.
+!
+! !REVISION HISTORY:
+!  28 Jul 2023 - H.P. Lin    - Initial version
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+   INTEGER              :: I, J, L, N, NA     ! lon, lat, lev, spc indexes
+   CHARACTER(LEN=255)   :: LOC                ! routine location
+   CHARACTER(LEN=16)    :: STAMP
+
+   !=================================================================
+   ! SET_BOUNDARY_CONDITIONS begins here!
+   !=================================================================
+
+   ! Name of this routine
+   LOC = ' -> at Set_Boundary_Conditions (in GeosCore/set_boundary_conditions_mod.F90)'
+
+   ! Assume success
+   RC        = GC_SUCCESS
+
+   ! We only need to get boundary conditions if this is a nested-grid
+   ! simulation.  Otherwise the BoundaryCond field won't be allocated.
+   IF ( .not. State_Grid%NestedGrid ) RETURN
+
+   ! Ensure species array is in kg/kg as State_Chm%BoundaryCond is in kg/kg dry
+   IF ( TRIM(State_Chm%Spc_Units) /= 'kg/kg dry' ) THEN
+      IF ( Input_Opt%amIRoot ) THEN
+          WRITE(6,*) 'Unit check failure: Current units are ', State_Chm%Spc_Units, ', expected kg/kg dry'
+      ENDIF
+      CALL GC_Error( 'Unit check failure: Cannot apply nested-grid boundary conditions if units are not kg/kg dry. Your run may have failed previous to this error.', RC, LOC )
+      RETURN
+   ENDIF
+
+   ! Loop over advected species
+   DO NA = 1, State_Chm%nAdvect
+      ! Get the species ID from the advected species ID
+      N = State_Chm%Map_Advect(NA)
+
+      ! Loop over grid boxes and apply BCs to the specified buffer zone
+      !$OMP PARALLEL DO       &
+      !$OMP DEFAULT( SHARED ) &
+      !$OMP PRIVATE( I, J, L )
+      DO L = 1, State_Grid%NZ
+
+         ! First loop over all latitudes of the nested domain
+         DO J = 1, State_Grid%NY
+
+            ! West BC
+            DO I = 1, State_Grid%WestBuffer
+               State_Chm%Species(N)%Conc(I,J,L) = State_Chm%BoundaryCond(I,J,L,N)
+            ENDDO
+
+            ! East BC
+            DO I = (State_Grid%NX-State_Grid%EastBuffer)+1, State_Grid%NX
+               State_Chm%Species(N)%Conc(I,J,L) = State_Chm%BoundaryCond(I,J,L,N)
+            ENDDO
+
+         ENDDO
+
+         ! Then loop over the longitudes of the nested domain
+         DO I = 1+State_Grid%WestBuffer,(State_Grid%NX-State_Grid%EastBuffer)
+
+            ! South BC
+            DO J = 1, State_Grid%SouthBuffer
+               State_Chm%Species(N)%Conc(I,J,L) = State_Chm%BoundaryCond(I,J,L,N)
+            ENDDO
+
+            ! North BC
+            DO J = (State_Grid%NY-State_Grid%NorthBuffer)+1, State_Grid%NY
+               State_Chm%Species(N)%Conc(I,J,L) = State_Chm%BoundaryCond(I,J,L,N)
+            ENDDO
+         ENDDO
+
+      ENDDO
+      !OMP END PARALLEL DO
+   ENDDO
+
+   ! Echo output. This will be at every time step, so comment this out when unnecessary.
+   IF ( Input_Opt%amIRoot .and. Input_Opt%Verbose ) THEN
+      STAMP = TIMESTAMP_STRING()
+      WRITE( 6, * ) 'SET_BOUNDARY_CONDITIONS: Done applying BCs at ', STAMP
+   ENDIF
+
+ END SUBROUTINE Set_Boundary_Conditions
+!EOC
+END MODULE Set_Boundary_Conditions_Mod
+#endif


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard Univ.

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

Previously, @nicholasbalasus reported artifacting in the buffer region due to the transport code still running within the buffer zone. Thus, a change to impose boundary conditions at every time step in the buffer zone, as opposed to only at every 3-hours, will resolve this artifact and prevent transport effects from taking place.

This will allow for a consistent flow of boundary conditions between the 3-hourly boundary condition updates.

A new module set_boundary_conditions_mod.F90 has been introduced to separate non-HEMCO logic from hco_utilities_gc_mod.F90 and allow for it to be called more frequently than the emissions/3-hourly BC timesteps.

### Expected changes

Mainly, species concentrations in the buffer zone will be affected. They will no longer reflect transport artifacts and instead more closely reflect the underlying boundary conditions provided to the nested-grid model.

@nicholasbalasus has as always provided a useful figure to illustrate the effects:
![image](https://github.com/geoschem/geos-chem/assets/123603/fbcfb976-e2a3-4d87-bfa8-198078fc4b5e)

Notice the removal of transport artifacts (top-left panel - old version) in the new version (top-middle panel)

### Reference(s)

N/A

### Related Github Issue(s)

No prior issue reported

Steps to reproduce: run any GC-Classic nested-grid simulation and observe buffer zone which includes transport artifacts. Because the boundary conditions in the buffer zone should be provided from a coarse simulation, this region should not have any 'extraneous' detail introduced by finer-scale processes in the nested-grid simulation.
