### PR TITLE
Update directory change instructions in integration test/parallel test README.md files

### DIFF
--- a/test/difference/README.md
+++ b/test/difference/README.md
@@ -12,6 +12,7 @@
 Run the `difftest.sh` script as follows:
 
 ```console
+$ cd test/difference
 $ ./diffTest.sh /path/to/<REF> /path/to/<DEV>
 ```
 where `<REF>` and `<DEV>` indicate the names of the integration tests that are being compared.

--- a/test/integration/GCClassic/README.md
+++ b/test/integration/GCClassic/README.md
@@ -43,7 +43,7 @@ Before you submit any GEOS-Chem Classic integration tests, please take a moment 
 
 ```console
 $ cd /path/to/GCClassic     # Path to GCClassic superproject directory
-$ cd test/integration
+$ cd test/integration/GCClassic
 $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file -s slurm -p partition
 ```
 
@@ -51,7 +51,7 @@ $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file -s slurm -p par
 
 ```console
 $ cd /path/to/GCClassic     # Path to GCClassic superproject directory
-$ cd test/integration
+$ cd test/integration/GCClassic
 $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file -s lsf -p partition
 ```
 
@@ -59,7 +59,7 @@ $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file -s lsf -p parti
 
 ```console
 $ cd /path/to/GCClassic     # Path to GCClassic superproject directory
-$ cd test/integration
+$ cd test/integration/GCClassic
 $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file
 ```
 

--- a/test/integration/GCHP/README.md
+++ b/test/integration/GCHP/README.md
@@ -43,7 +43,7 @@ Before you submit any GCHP integration tests, please take a moment to:
 
 ```console
 $ cd /path/to/GCHP     # Path to GCHP superproject directory
-$ cd test/integration
+$ cd test/integration/GCClassic
 $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file -s slurm -p partition
 ```
 
@@ -51,7 +51,7 @@ $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file -s slurm -p par
 
 ```console
 $ cd /path/to/GCHP     # Path to GCHP superproject directory
-$ cd test/integration
+$ cd test/integration/GCClassic
 $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file -s lsf -p partition
 ```
 
@@ -59,7 +59,7 @@ $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file -s lsf -p parti
 
 ```console
 $ cd /path/to/GCHP     # Path to GCHP superproject directory
-$ cd test/integration
+$ cd test/integration/GCClassic
 $ ./integrationTest.sh -d /path/to/test/dir -e /path/to/env-file
 ```
 

--- a/test/parallel/GCClassic/README.md
+++ b/test/parallel/GCClassic/README.md
@@ -35,7 +35,7 @@ Before you submit any GEOS-Chem Classic parallelization tests, please take a mom
 
 ```console
 $ cd /path/to/GCClassic     # Path to GCClassic superproject directory
-$ cd test/parallel
+$ cd test/parallel/GCClassic
 $ ./parallelTest.sh -d /path/to/test/dir -e /path/to/env-file -s slurm -p partition
 ```
 
@@ -43,7 +43,7 @@ $ ./parallelTest.sh -d /path/to/test/dir -e /path/to/env-file -s slurm -p partit
 
 ```console
 $ cd /path/to/GCClassic     # Path to GCClassic superproject directory
-$ cd test/parallel
+$ cd test/parallel/GCClassic
 $ ./parallelTest.sh -d /path/to/test/dir -e /path/to/env-file -s lsf -p partition
 ```
 
@@ -51,7 +51,7 @@ $ ./parallelTest.sh -d /path/to/test/dir -e /path/to/env-file -s lsf -p partitio
 
 ```console
 $ cd /path/to/GCClassic     # Path to GCClassic superproject directory
-$ cd test/parallel
+$ cd test/parallel/GCClassic
 $ ./parallelTest.sh -d /path/to/test/dir -e /path/to/env-file
 ```
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
This is a documentation-only (zero science difference) update that fixes some erroneous directory change commands in the following readme files:

- `test/difference/README.md`
- `test/integration/GCClassic/README.md`
- `test/integration/GCHP/README.md`
- `test/parallel/GCClassic/README.md`

No changelog update has been made as this is a fix for a feature that was also added into the 14.2.1 development stream.

### Expected changes
None

### Reference(s)
N/A

### Related Github Issue(s)
N/A