### PR TITLE
Hotfix: Exit routine INIT_PHOTOLYSIS before calling SET_AER when doing dry-run simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed operator splitting in CH4 simulation that was biasing diagnostics
 - Fixed GCHP start and elapsed times in time_mod.F90 to use cap_restart value
 - Disabled SpeciesConcMND output for benchmark simulations
-- Exit `Init_Photolysis` before calling `Set_Aer` when doing dry-run simulations
+- Exit `Init_Photolysis` before calling `Calc_AOD` when doing dry-run simulations
 
 ### Removed
 - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,13 +58,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Renamed TransportTracer species for consistency with GMAO's TR_GridComp
 - See `KPP/fullchem/CHANGELOG_fullchem.md` for fullchem-mechanism changes
 
-### Removed
-- `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files
-- Removed the `NcdfUtil/perl` folder
-- Removed `X-HRS` output from log file
-- IONO2 recycling (fullchem, custom mechanisms)
-- Deleted unused file set_prof_o3.F90
-
 ### Fixed
 - Fixed typo in `GCClassic/createRunDir.sh` preventing benchmark run script from being copied to the run directory
 - Fixed divide by zero bug in sulfur chemistry introduced in 14.1.0
@@ -82,6 +75,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed operator splitting in CH4 simulation that was biasing diagnostics
 - Fixed GCHP start and elapsed times in time_mod.F90 to use cap_restart value
 - Disabled SpeciesConcMND output for benchmark simulations
+- Exit `Init_Photolysis` before calling `Set_Aer` when doing dry-run simulations
+
+### Removed
+- `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files
+- Removed the `NcdfUtil/perl` folder
+- Removed `X-HRS` output from log file
+- IONO2 recycling (fullchem, custom mechanisms)
+- Deleted unused file set_prof_o3.F90
 
 ## [14.1.1] - 2023-03-03
 ### Added

--- a/GeosCore/photolysis_mod.F90
+++ b/GeosCore/photolysis_mod.F90
@@ -109,10 +109,10 @@ CONTAINS
     !=======================================================================
 
     ! Initialize
-    RC = GC_SUCCESS
-    notDryRun = ( .not. Input_Opt%DryRun )
-    ErrMsg = ''
-    ThisLoc = ' -> at Init_Photolysis  (in module GeosCore/photolysis_mod.F90)'
+    RC      = GC_SUCCESS
+    ErrMsg  = ''
+    ThisLoc = &
+      ' -> at Init_Photolysis  (in module GeosCore/photolysis_mod.F90)'
 
     ! Set pointers
     GC_Photo_ID => State_Chm%Phot%GC_Photo_ID
@@ -138,10 +138,10 @@ CONTAINS
        ENDIF
     ENDIF
 
-    !--------------------------------------------------------------------
+    !------------------------------------------------------------------------
     ! Read in AOD data even if photolysis disabled
     ! (or just print file name if in dry-run mode)
-    !--------------------------------------------------------------------
+    !------------------------------------------------------------------------
     CALL RD_AOD( Input_Opt, State_Chm, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered in FAST-JX routine "RD_AOD"!'
@@ -149,21 +149,25 @@ CONTAINS
        RETURN
     ENDIF
 
+    !------------------------------------------------------------------------
+    ! Exit without doing any computations if we are doing a dry-run
+    !------------------------------------------------------------------------
+    IF ( Input_Opt%DryRun ) RETURN
+
+    !------------------------------------------------------------------------
     ! Compute the required wavelengths in the LUT to calculate requested AOD
-    IF ( notDryRun ) THEN
-       IF (Input_Opt%amIRoot) WRITE(6,*) 'Wavelength optics read successfully'
-       CALL CALC_AOD( Input_Opt, State_Chm, RC )
-    ENDIF
+    !------------------------------------------------------------------------
+    IF (Input_Opt%amIRoot) WRITE(6,*) 'Wavelength optics read successfully'
+    CALL CALC_AOD( Input_Opt, State_Chm, RC )
 
-    !--------------------------------------------------------------------
-    ! Exit if photolysis disabled (zero J-values) or if dry-run
-    !--------------------------------------------------------------------
+    !------------------------------------------------------------------------
+    ! Exit if photolysis disabled (zero J-values)
+    !------------------------------------------------------------------------
     IF ( .NOT. Input_Opt%Do_Photolysis ) RETURN
-    IF ( Input_Opt%DryRun              ) RETURN
 
-    !--------------------------------------------------------------------
+    !------------------------------------------------------------------------
     ! Set up MIEDX array to interpret between GC and FJX aerosol indexing
-    !--------------------------------------------------------------------
+    !------------------------------------------------------------------------
     CALL SET_AER( Input_Opt, State_Chm, RC )
 
     !========================================================================
@@ -392,7 +396,7 @@ CONTAINS
     ENDIF
 
     ! Skip further processing if we are in dry-run mode
-    IF ( notDryRun ) THEN
+    IF (  .not. Input_Opt%DryRun ) THEN
 
        ! Define species IDs
        id_NIT  = IND_('NIT')

--- a/GeosCore/photolysis_mod.F90
+++ b/GeosCore/photolysis_mod.F90
@@ -150,15 +150,16 @@ CONTAINS
     ENDIF
 
     ! Compute the required wavelengths in the LUT to calculate requested AOD
-    IF ( .not. Input_Opt%DryRun ) THEN
+    IF ( notDryRun ) THEN
        IF (Input_Opt%amIRoot) WRITE(6,*) 'Wavelength optics read successfully'
        CALL CALC_AOD( Input_Opt, State_Chm, RC )
     ENDIF
 
     !--------------------------------------------------------------------
-    ! Exit if photolysis disabled (zero J-values)
+    ! Exit if photolysis disabled (zero J-values) or if dry-run
     !--------------------------------------------------------------------
     IF ( .NOT. Input_Opt%Do_Photolysis ) RETURN
+    IF ( Input_Opt%DryRun              ) RETURN
 
     !--------------------------------------------------------------------
     ! Set up MIEDX array to interpret between GC and FJX aerosol indexing


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is a hotfix for the issue that was described in #1919 by @beckyalexander.  We now exit routine `INIT_PHOTOLYSIS` (in `GeosCore/photolysis_mod.F90`) before doing any computations when we are running a dry-run simulation.  Otherwise we get a segmentation fault (because variables for the photolysis have not been initialized).

### Expected changes

This will prevent segmentation faults when running dry-run simulations with GEOS-Chem 14.2.0.  It will not change any output.

### Reference(s)

N/A

### Related Github Issue(s)

- Closes #1919