### PR TITLE
Update code in carbon_gases_mod.F90 for consistency with config file updates from PR #1916

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - NetCDF utilities in `NcdfUtil` folder now use the netCDF-F90 API
 - GEOS-only updates for running GEOS-Chem in GEOS
 - Boundary conditions for nested-grid simulations are now imposed at every time step instead of 3-hourly
+- Update `GeosCore/carbon_gases_mod.F90` for consistency with config file updates in PR #1916
 
 ### Fixed
 - Add missing mol wt for HgBrO in `run/shared/species_database_hg.yml`

--- a/GeosCore/carbon_gases_mod.F90
+++ b/GeosCore/carbon_gases_mod.F90
@@ -53,7 +53,8 @@ MODULE Carbon_Gases_Mod
 !@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
   ! Scalars
-  LOGICAL               :: useGlobOH,  useGlobOHv5
+  LOGICAL               :: useGlobOHbmk10yr
+  LOGICAL               :: useGlobOHv5
   INTEGER               :: id_CH4,     id_CO,      id_COch4,   id_COnmvoc
   INTEGER               :: id_COisop,  id_COch3oh, id_COmono,  id_COacet
   INTEGER               :: id_CO2,     id_CO2ch,   id_OCS,     id_OH
@@ -1088,7 +1089,7 @@ CONTAINS
     !------------------------------------------------------------------------
     ! OH concentration: from GEOS-Chem v5 or GEOS-Chem 10yr benchmark
     !------------------------------------------------------------------------
-    IF ( useGlobOH ) THEN
+    IF ( useGlobOHv5 .or. useGlobOHbmk10yr ) THEN
 
        ! NOTE: Container name is GLOBAL_OH for both data sets!
        DgnName = 'GLOBAL_OH'
@@ -1099,21 +1100,18 @@ CONTAINS
           CALL GC_Error( errMsg, RC, thisLoc )
           RETURN
        ENDIF
+    ENDIF
 
-       IF ( useGlobOHv5 ) THEN
+    ! If we are using OH from recent a 10-year benchmark ("SpeciesConc")
+    ! then convert OH [mol/mol dry air] to [molec/cm3].
+    IF ( useGlobOHbmk10yr ) THEN
+       Global_OH = ( Global_OH * State_Met%AirDen ) * toMolecCm3
+    ENDIF
 
-          ! If we are using Global_OH from GEOS-Chem v5 (e.g. for the IMI or
-          ! methane simulations) then convert OH from [kg/m3] to [molec/cm3]
-          Global_OH = Global_OH * xnumol_OH / CM3perM3
-
-       ELSE
-
-          ! If we are using OH from a 10-year benchmark ("SpeciesConc")
-          ! then convert OH [mol/mol dry air] to [molec/cm3]
-          Global_OH = ( Global_OH * State_Met%AirDen ) * toMolecCm3
-
-       ENDIF
-
+    ! If we are using Global_OH from GEOS-Chem v5 (e.g. for the IMI or
+    ! methane simulations) then convert OH from [kg/m3] to [molec/cm3].
+    IF ( useGlobOHv5 ) THEN
+       Global_OH = Global_OH * xnumol_OH / CM3perM3
     ENDIF
 
     !------------------------------------------------------------------------
@@ -1699,7 +1697,8 @@ CONTAINS
      ' -> at InquireGlobalOHversion (in module GeosCore/carbon_gases_mod.F90)'
 
     ! Test if any Global OH option is on
-    optVal   = HCO_GC_GetOption( "GLOBAL_OH", extNr=0 )
+    ! NOTE: Update the option name with each major version!!!
+    optVal   = HCO_GC_GetOption( "GLOBAL_OH_GC14", extNr=0 )
     isOHon   = ( To_UpperCase( TRIM( optVal ) ) == 'TRUE' )
 
     ! Test for GEOS-Chem v5 OH
@@ -1708,18 +1707,14 @@ CONTAINS
     isOHv5On = ( To_UpperCase( TRIM( optVal ) ) == 'TRUE' )
 
     ! Set a global variable to determine which OH to use
-    useGlobOH   = isOHon
-    useGlobOHv5 = isOHv5on
+    useGlobOHbmk10yr = isOHon
+    useGlobOHv5      = isOHv5on
 
     IF ( Input_Opt%amIRoot ) THEN
-       IF ( useGlobOH ) THEN
-          IF ( useGlobOHv5 ) THEN
-             WRITE( 6, 100 ) 'GLOBAL_OH_GCv5'
-          ELSE
-             WRITE( 6, 100 ) 'GLOBAL_OH'
-          ENDIF
- 100   FORMAT( 'Carbon_Gases: Using global OH oxidant field option: ', a )
-
+       IF ( useGlobOHv5 .or. useGlobOHbmk10yr ) THEN
+          IF ( useGlobOHbmk10yr ) WRITE( 6, 100 ) 'GLOBAL_OH_GC14'
+          IF ( useGlobOHv5      ) WRITE( 6, 100 ) 'GLOBAL_OH_GCv5'
+ 100      FORMAT( 'Carbon_Gases: Using global OH oxidant field option: ', a )
        ELSE
           WRITE( 6, 110 )
  110      FORMAT( 'Carbon_Gases: Global OH is set to zero!' )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
While integration testing with PR #1916 and PR https://github.com/geoschem/HEMCO/pull/235, we encountered an error in the carbon simulation:

```console
gc_4x5_merra2_carbon................................Execute Simulation....FAIL
...
********************************************
* B e g i n   T i m e   S t e p p i n g !! *
********************************************

---> DATE: 2019/01/01  UTC: 00:00
 HEMCO already called for this timestep. Returning.
Carbon_Gases: Global OH is set to zero!
```
This issue was traced to code in `GeosCore/carbon_gases_mod.F90` that had not been updated to be consistent with the new `GLOBAL_OH_GC14` container that was introduced in PR #1916. 

We have now added updates so that the code in `GeosCore/carbon_gases_mod.F90` now recognizes the `GLOBAL_OH_GC14` container.  Some if-block logic has also been reworked.

### Expected changes
This will allow the carbon simulation to finish normally.

### Related Github Issue(s)

- Builds atop PR #1916
- Also see PR https://github.com/geoschem/HEMCO/pull/235
