### PR TITLE
Bugfix to initialize advected species to background values if not in restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed parallelization in Luo wetdep simulations caused by uninitialized variable
 - Fixed parallelization for Hg0 species in `GeosCore/drydep_mod.F90`
 - Fixed incorrect time-slice when reading nested-grid boundary conditions
+- Fixed initialization of advected species missing in GCHP restart file
 
 ### Removed
 - Remove references to the obsolete tagged Hg simulation


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update corrects an issue that appeared early in version 13 but went undetected until now. Advected species should be initialized to values in the species database if not found in the restart file. However, this was only happened for non-advected species in GCHP. It is unclear why advected species were removed. The update that removed it came in with GCHP adjoint code in development.

This update also removes GCHP code no longer needed that is in the same section as initializing to background values. That code retrieved a pointer to the MAPL internal state to copy to the State_chm concentration arrays. This is no longer needed since the State_Chm concentration arrays are now pointers to the internal state. It also removes setting the concentration array to a small value if the internal state pointer is not found. This is also not necessary since all concentrations arrays point to the internal state.

This update also removes outdated code no longer needed now that the State_Chm species concentration arrays point to the MAPL internal state.

### Expected changes

This update impacts GCHP only. It only applies if an advected species is missing from the restart file.

### Reference(s)

none

### Related Github Issue(s)

closes https://github.com/geoschem/geos-chem/issues/1930
