### PR TITLE
Seasalt alkalinity bug fix

### DIFF
--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -38,6 +38,7 @@ MODULE FullChem_Mod
   ! Species ID flags (and logicals to denote if species are present)
   INTEGER               :: id_OH,  id_HO2,  id_O3P,  id_O1D, id_CH4
   INTEGER               :: id_PCO, id_LCH4, id_NH3,  id_SO4
+  INTEGER               :: id_SALAAL, id_SALCAL, id_SALC, id_SALA
 #ifdef MODEL_GEOS
   INTEGER               :: id_O3
   INTEGER               :: id_A3O2, id_ATO2, id_B3O2, id_BRO2
@@ -851,6 +852,10 @@ CONTAINS
        CALL fullchem_SetStateHet( I         = I,                             &
                                   J         = J,                             &
                                   L         = L,                             &
+                                  id_SALA   = id_SALA,                       &
+                                  id_SALAAL = id_SALAAL,                     &
+                                  id_SALC   = id_SALC,                       &
+                                  id_SALCAL = id_SALCAL,                     &
                                   Input_Opt = Input_Opt,                     &
                                   State_Chm = State_Chm,                     &
                                   State_Met = State_Met,                     &
@@ -2619,6 +2624,10 @@ CONTAINS
     id_O1D      = Ind_( 'O1D'          )
     id_OH       = Ind_( 'OH'           )
     id_SO4      = Ind_( 'SO4'          )
+    id_SALA     = Ind_( 'SALA'         )
+    id_SALAAL   = Ind_( 'SALAAL'       )
+    id_SALC     = Ind_( 'SALC'         )
+    id_SALCAL   = Ind_( 'SALCAL'       )
 
 #ifdef MODEL_GEOS
     ! ckeller

--- a/KPP/fullchem/commonIncludeVars.H
+++ b/KPP/fullchem/commonIncludeVars.H
@@ -180,7 +180,10 @@
      REAL(dp) :: qLIq           ! Water mixing ratio [kg/kg]
      REAL(dp) :: rIce           ! Ice radius
      REAL(dp) :: rLiq           ! Liquid radius
-     REAL(dp) :: ssAlk(2)       ! Sea salt alk'nty (1=fine, 2=coarse)
+     REAL(dp) :: f_Acid_SSA     ! Fraction of fine sea salt that is acidic
+     REAL(dp) :: f_Acid_SSC     ! Fraction of coarse sea salt that is acidic
+     REAL(dp) :: f_Alk_SSA      ! Fraction of fine sea salt that is alkaline
+     REAL(dp) :: f_Alk_SSC      ! Fraction of coarse sea salt that is alkaline
      LOGICAL  :: SSA_is_Alk     ! Is fine sea-salt alkaline?
      LOGICAL  :: SSA_is_Acid    ! Is fine sea-salt acidic?
      LOGICAL  :: SSC_is_Alk     ! Is coarse sea-salt alkaline?

--- a/KPP/fullchem/fullchem_HetStateFuncs.F90
+++ b/KPP/fullchem/fullchem_HetStateFuncs.F90
@@ -46,8 +46,9 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE fullChem_SetStateHet( I,         J,         L,                  &
-                                   Input_Opt, State_Chm, State_Met,          &
-                                   H,         RC                 )
+                                   id_SALA,   id_SALAAL, id_SALC,            &
+                                   id_SALCAL, Input_Opt, State_Chm,          &
+                                   State_Met, H,         RC                 )
 !
 ! !USES:
 !
@@ -57,14 +58,20 @@ CONTAINS
     USE PhysConstants,    ONLY : AVO, PI
     USE Input_Opt_Mod,    ONLY : OptInput
     USE rateLawUtilFuncs
-    USE State_Chm_Mod,    ONLY : ChmState
+    USE State_Chm_Mod,    ONLY : ChmState, Ind_
     USE State_Met_Mod,    ONLY : MetState
+
+  ! Species ID flags
 !
 ! !INPUT PARAMETERS:
 !
     INTEGER,        INTENT(IN)    :: I          ! Lon (or X-dim) gridbox index
     INTEGER,        INTENT(IN)    :: J          ! Lat (or Y-dim) gridbox index
     INTEGER,        INTENT(IN)    :: L          ! Vertical level index
+    INTEGER ,       INTENT(IN)    :: id_SALA    ! Indices of SALA, SALAAL
+    INTEGER,        INTENT(IN)    :: id_SALAAL  !  SALC, and SALCAL species
+    INTEGER,        INTENT(IN)    :: id_SALC    !  in the State_Chm%Species
+    INTEGER,        INTENT(IN)    :: id_SALCAL  !  object
     TYPE(OptInput), INTENT(IN)    :: Input_Opt  ! Input Options object
     TYPE(ChmState), INTENT(IN)    :: State_Chm  ! Chemistry State object
     TYPE(MetState), INTENT(IN)    :: State_Met  ! Meterology State object
@@ -146,11 +153,20 @@ CONTAINS
     H%H_conc_ICl    = 10.0**( -4.5_dp              )
     H%H_conc_SSA    = H%H_conc_Sul
     H%H_conc_SSC    = 10.0**( -5.0_dp              )
-    H%ssAlk         = State_Chm%SSAlk(I,J,L,:)
-    H%SSA_is_Alk    = ( H%ssAlk(1) > 0.05_dp       )
-    H%SSA_is_Acid   = ( .not.  H%SSA_is_Alk        )
-    H%SSC_is_Alk    = ( H%ssAlk(2) > 0.05_dp       )
-    H%SSC_is_Acid   = ( .not.  H%SSC_is_Alk        )
+    H%f_Alk_SSA     = SafeDiv( State_Chm%Species(id_SALAAL)%Conc(I,J,L),     &
+                               State_Chm%Species(id_SALA  )%Conc(I,J,L),     &
+                               0.0_dp                                       )
+    H%f_Alk_SSA     = MIN( H%f_Alk_SSA, 1.0_dp )
+    H%f_Acid_SSA    = 1.0_dp - H%f_Alk_SSA
+    H%f_Alk_SSC     = SafeDiv( State_Chm%Species(id_SALCAL)%Conc(I,J,L),     &
+                               State_Chm%Species(id_SALC  )%Conc(I,J,L),     &
+                               0.0_dp                                       )
+    H%f_Alk_SSC     = MIN( H%f_Alk_SSC, 1.0_dp )
+    H%f_Acid_SSC    = 1.0_dp - H%f_Alk_SSC
+    H%SSA_is_Alk    = ( ABS( H%f_Alk_SSA ) > 0.01_dp )
+    H%SSA_is_Acid   = ( .not.  H%SSA_is_Alk          )
+    H%SSC_is_Alk    = ( ABS( H%f_Alk_SSC ) > 0.01_dp )
+    H%SSC_is_Acid   = ( .not.  H%SSC_is_Alk          )
 
     ! Other fields
     H%gamma_HO2     = Input_Opt%gamma_HO2


### PR DESCRIPTION
Bug fix to properly calculate sea salt aerosol alkalinity for heterogeneous reactions

### Name and Institution (Required)

Name: Viral Shah
Institution: NASA GMAO

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is a bug fix to correctly account for sea salt aerosol alkalinity in the heterogeneous reaction rate calculation. Without this fix, the sea salt aerosol alkalinity is fixed to zero which leads to errors in the halogen chemistry. This fix was originally proposed by @beckyalexander (PR #1702). The original fix also modified the aerosol area that is used in the heterogeneous uptake calculations (multiplied it by the fraction of alkaline or acidic aerosols), but that is not included here since it doesn't make much of a difference. I have tested the fix in a one-year GEOS-Chem Classic (4 deg x 5 deg) simulation and I did not get any KPP integration errors.

### Expected changes

This directly affects halogen chemistry with downstream effects on oxidants. Sea salt debromination will be slower since it does not happen on alkaline sea salt aerosols. The changes will be most noticeable in the southern hemisphere, where BrO should reduce and ozone should increase.

### Reference(s)

None

### Related Github Issue(s)
#1880 

