### PR TITLE
[feature] add config variable to perturb CH4 boundary conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added new GCHP config file ESMF.rc for configuring ESMF logging
 - Added several new run directory files for use with GEOS-Chem in GEOS
 - Stopped OCEAN_CONC from needlessly being pushed through vertical regridding for Hg simulations
+- Added option to perturb CH4 boundary conditions in CH4 simulation
 
 ### Changed
 - Update `DiagnFreq` in GCClassic integration tests to ensure HEMCO diagnostic output

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -2573,6 +2573,13 @@ CONTAINS
       ! Free pointer
       SpcInfo => NULL()
 
+      ! Each time the boundary conditions are read, they have no longer been perturbed
+      ! This value is sometimes set to True in set_boundary_conditions_mod.F90
+      IF ( ( Input_Opt%ITS_A_CH4_SIM .OR. Input_Opt%ITS_A_CARBON_SIM ) .AND. & 
+           Input_Opt%PerturbCH4BoundaryConditions ) THEN
+        State_Chm%IsCH4BCPerturbed = .FALSE.
+      ENDIF
+
    ENDDO
 
    ! Reset FIRST flag

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -4837,6 +4837,9 @@ CONTAINS
     CHARACTER(LEN=QFYAML_NamLen) :: key
     CHARACTER(LEN=QFYAML_StrLen) :: v_str
 
+    ! String arrays
+    CHARACTER(LEN=QFYAML_NamLen) :: a_str(4)
+
     !========================================================================
     ! Config_CH4 begins here!
     !========================================================================
@@ -4952,6 +4955,35 @@ CONTAINS
     ENDIF
     Input_Opt%UseOHSF = v_bool
 
+    !------------------------------------------------------------------------
+    ! Perturb CH4 boundary conditions?
+    !------------------------------------------------------------------------
+    key    = "CH4_simulation_options%analytical_inversion%perturb_CH4_boundary_conditions"
+    v_bool = MISSING_BOOL
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_bool, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM ( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%PerturbCH4BoundaryConditions = v_bool
+
+    !------------------------------------------------------------------------
+    ! How much to perturb CH4 boundary conditions by?
+    !------------------------------------------------------------------------
+    key    = "CH4_simulation_options%analytical_inversion%CH4_boundary_condition_ppb_increase_NSEW"
+    a_str = MISSING_STR
+    CALL QFYAML_Add_Get( Config, TRIM( key ), a_str, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM ( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%CH4BoundaryConditionIncreaseNorth = Cast_and_RoundOff( a_str(1), places=4 )
+    Input_Opt%CH4BoundaryConditionIncreaseSouth = Cast_and_RoundOff( a_str(2), places=4 )
+    Input_Opt%CH4BoundaryConditionIncreaseEast  = Cast_and_RoundOff( a_str(3), places=4 )
+    Input_Opt%CH4BoundaryConditionIncreaseWest  = Cast_and_RoundOff( a_str(4), places=4 )
+
     !========================================================================
     ! Print to screen
     !========================================================================
@@ -4966,6 +4998,11 @@ CONTAINS
        WRITE(6,120) 'Current state vector elem: ', Input_Opt%StateVectorElement
        WRITE(6,100) 'Use emis scale factors   : ', Input_Opt%UseEmisSF
        WRITE(6,100) 'Use OH scale factors     : ', Input_Opt%UseOHSF
+       WRITE(6,100) 'Perturb CH4 BCs          : ', Input_Opt%PerturbCH4BoundaryConditions
+       WRITE(6,130) 'CH4 BC ppb increase NSEW : ', Input_Opt%CH4BoundaryConditionIncreaseNorth,&
+                                                   Input_Opt%CH4BoundaryConditionIncreaseSouth,&
+                                                   Input_Opt%CH4BoundaryConditionIncreaseEast,&
+                                                   Input_Opt%CH4BoundaryConditionIncreaseWest
     ENDIF
 
     ! FORMAT statements
@@ -4974,6 +5011,7 @@ CONTAINS
 100 FORMAT( A, L5   )
 110 FORMAT( A, f6.2 )
 120 FORMAT( A, I5   )
+130 FORMAT( A, F10.4, 1X, F10.4, 1X, F10.4, 1X, F10.4)
 
   END SUBROUTINE Config_CH4
 !EOC

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -370,6 +370,11 @@ MODULE Input_Opt_Mod
      INTEGER                     :: StateVectorElement
      LOGICAL                     :: UseEmisSF
      LOGICAL                     :: UseOHSF
+     LOGICAL                     :: PerturbCH4BoundaryConditions
+     REAL(fp)                    :: CH4BoundaryConditionIncreaseNorth
+     REAL(fp)                    :: CH4BoundaryConditionIncreaseSouth
+     REAL(fp)                    :: CH4BoundaryConditionIncreaseEast
+     REAL(fp)                    :: CH4BoundaryConditionIncreaseWest
 
      !----------------------------------------
      ! POPS MENU fields
@@ -898,14 +903,19 @@ CONTAINS
     !----------------------------------------
     ! CH4 MENU fields
     !----------------------------------------
-    Input_Opt%GOSAT_CH4_OBS          = .FALSE.
-    Input_Opt%AIRS_CH4_OBS           = .FALSE.
-    Input_Opt%TCCON_CH4_OBS          = .FALSE.
-    Input_Opt%AnalyticalInv          = .FALSE.
-    Input_Opt%PerturbEmis            = 1.0
-    Input_Opt%StateVectorElement     = 0
-    Input_Opt%UseEmisSF              = .FALSE.
-    Input_Opt%UseOHSF                = .FALSE.
+    Input_Opt%GOSAT_CH4_OBS                     = .FALSE.
+    Input_Opt%AIRS_CH4_OBS                      = .FALSE.
+    Input_Opt%TCCON_CH4_OBS                     = .FALSE.
+    Input_Opt%AnalyticalInv                     = .FALSE.
+    Input_Opt%PerturbEmis                       = 1.0
+    Input_Opt%StateVectorElement                = 0
+    Input_Opt%UseEmisSF                         = .FALSE.
+    Input_Opt%UseOHSF                           = .FALSE.
+    Input_Opt%PerturbCH4BoundaryConditions      = .FALSE.
+    Input_Opt%CH4BoundaryConditionIncreaseNorth = 0.0_fp
+    Input_Opt%CH4BoundaryConditionIncreaseSouth = 0.0_fp
+    Input_Opt%CH4BoundaryConditionIncreaseEast  = 0.0_fp
+    Input_Opt%CH4BoundaryConditionIncreaseWest  = 0.0_fp
 
     !----------------------------------------
     ! POPS MENU fields

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -331,6 +331,7 @@ MODULE State_Chm_Mod
      REAL(fp),          POINTER :: BCl        (:,:,:  ) ! Cl values [v/v]
      REAL(fp),          POINTER :: CH4_EMIS   (:,:,:  ) ! CH4 emissions [kg/m2/s].
                                                         ! third dim is cat, total 15
+     LOGICAL                    :: IsCH4BCPerturbed     ! Is CH4 BC perturbed?
 
 #ifdef APM
      !-----------------------------------------------------------------------
@@ -602,6 +603,9 @@ CONTAINS
     ! FALSE = use KPP computations
     State_Chm%Do_SulfateMod_Cld     = .FALSE.
     State_Chm%Do_SulfateMod_SeaSalt = .FALSE.
+
+   ! Flag if CH4 BC has been perturbed or not
+    State_Chm%IsCH4BCPerturbed  = .FALSE.
 
 #if defined( MODEL_GEOS )
     State_Chm%COmesosphere      = .FALSE.

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
@@ -83,6 +83,8 @@ CH4_simulation_options:
     state_vector_element_number: 0
     use_emission_scale_factor: false
     use_OH_scale_factors: false
+    perturb_CH4_boundary_conditions: false
+    CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
       
 #============================================================================
 # Settings for diagnostics (other than HISTORY and HEMCO)

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
@@ -83,6 +83,8 @@ CH4_simulation_options:
     state_vector_element_number: 0
     use_emission_scale_factor: false
     use_OH_scale_factors: false
+    perturb_CH4_boundary_conditions: false
+    CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
 
 #============================================================================
 # Options for CO

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
@@ -85,7 +85,7 @@ operations:
 #============================================================================
 # Settings specific to the CH4 simulation / Integrated Methane Inversion
 #============================================================================
-ch4_simulation_options:
+CH4_simulation_options:
 
   use_observational_operators:
     AIRS: false
@@ -98,6 +98,8 @@ ch4_simulation_options:
     state_vector_element_number: 0
     use_emission_scale_factor: false
     use_OH_scale_factors: false
+    perturb_CH4_boundary_conditions: false
+    CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
       
 #============================================================================
 # Settings for diagnostics (other than HISTORY and HEMCO)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

Adds a variable to `gesochem_config.yml.CH4` allowing for the perturbation of boundary conditions edges by a certain number of ppb.

### Expected changes

No changes to any simulations.

### Reference(s)

n/a

### Related Github Issue(s)

n/a
