### PR TITLE
Update MPI usage when using CESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - GEOS-only updates for running GEOS-Chem in GEOS
 - Boundary conditions for nested-grid simulations are now imposed at every time step instead of 3-hourly
 - Update `GeosCore/carbon_gases_mod.F90` for consistency with config file updates in PR #1916
+- Update MPI usage in CESM-only code to match new conventions in CAM
 
 ### Fixed
 - Add missing mol wt for HgBrO in `run/shared/species_database_hg.yml`

--- a/GeosCore/fjx_interface_mod.F90
+++ b/GeosCore/fjx_interface_mod.F90
@@ -18,10 +18,6 @@ MODULE FJX_INTERFACE_MOD
 !
   USE FJX_Mod
   USE PRECISION_MOD    ! For GEOS-Chem Precision (fp)
-#if defined( MODEL_CESM ) && defined( SPMD )
-  USE MPISHORTHAND
-  USE SPMD_UTILS
-#endif
 
   IMPLICIT NONE
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This pull request updates CESM-only code to use new MPI conventions in CESM. It has no impact on GEOS-Chem Classic or GCHP.

### Expected changes

SPMD ifdefs are removed in MODEL_CESM code blocks and calls to subroutine MPIBCAST are changed to use MPI_BCAST. Module USE statements and subroutine arguments are changed accordingly. Error handling is also added for the MPI broadcast calls.

### Related Github Issue(s)

This update is associated with a pull request to ESCOMP/CAM to bring GEOS-Chem chemistry into CESM. https://github.com/ESCOMP/CAM/pull/484
