### PR TITLE
Restore consideration of sea salt alkalinity to heterogenerous acid-catalyzed reactions of halogens on sea salt aerosols (now fixing typos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Disabled SpeciesConcMND output for benchmark simulations
 - Exit `Init_Photolysis` before calling `Calc_AOD` when doing dry-run simulations
 - Make sure `State_Het%f_Alk_SSA` and `State_Het%f_Alk_SSC` are in the range 0..1
+- Restore seasalt alkalinity to heterogeneous acid-catalyzed reactions of halogens on seasalt aerosols
 
 ### Removed
 - `Warnings: 1` is now removed from `HEMCO_Config.rc.*` template files

--- a/KPP/fullchem/fullchem_RateLawFuncs.F90
+++ b/KPP/fullchem/fullchem_RateLawFuncs.F90
@@ -2439,7 +2439,7 @@ CONTAINS
     !
     IF ( H%SSA_is_Alk ) THEN
        ssarea = H%f_Alk_SSA * H%xArea(SSA)
-       k = Ars_L1k( ssarea, H%xRadi(SSA), srMw, gamma )
+       k = Ars_L1k( ssarea, H%xRadi(SSA), gamma, srMw )
     ENDIF
   END FUNCTION IuptkbyAlkSALA1stOrd
 
@@ -2475,7 +2475,7 @@ CONTAINS
     !
     IF ( H%SSC_is_Alk ) THEN
        ssarea = H%f_Alk_SSC * H%xArea(SSC)
-       k = Ars_L1K( ssarea, H%xRadi(SSC), srMw, gamma )
+       k = Ars_L1K( ssarea, H%xRadi(SSC), gamma, srMw )
     ENDIF
   END FUNCTION IuptkByAlkSALC1stOrd
 
@@ -2495,7 +2495,7 @@ CONTAINS
     !
     IF ( H%SSA_is_Acid ) THEN
        ssarea = H%f_Acid_SSA * H%xArea(SSA)
-       k = 0.15_dp * Ars_L1K( ssarea, H%xRadi(SSA), srMw, gamma )
+       k = 0.15_dp * Ars_L1K( ssarea, H%xRadi(SSA), gamma, srMw )
        k = kIIR1Ltd( conc, C(ind_BrSALA), k ) ! conc is limiting, so update k
     ENDIF
   END FUNCTION IbrkdnbyAcidBrSALA
@@ -2516,7 +2516,7 @@ CONTAINS
     !
     IF ( H%SSC_is_Acid ) THEN
        ssarea = H%f_Acid_SSC * H%xArea(SSC)
-       k = 0.15_dp * Ars_L1K( ssarea, H%xRadi(SSC), srMw, gamma )
+       k = 0.15_dp * Ars_L1K( ssarea, H%xRadi(SSC), gamma, srMw )
        k = kIIR1Ltd( conc, C(ind_BrSALC), k ) ! conc is limiting, so update k
     ENDIF
   END FUNCTION IbrkdnbyAcidBrSALC
@@ -2537,7 +2537,7 @@ CONTAINS
     !
     IF ( H%SSA_is_Acid ) THEN
        ssarea = H%f_Acid_SSA * H%xArea(SSA)
-       k = 0.85_dp * Ars_L1K( ssarea, H%xRadi(SSA), srMw, gamma )
+       k = 0.85_dp * Ars_L1K( ssarea, H%xRadi(SSA), gamma, srMw )
        k = kIIR1Ltd( conc, C(ind_SALACl), k ) ! conc is limiting, so update k
     ENDIF
   END FUNCTION IbrkdnbyAcidSALACl
@@ -2558,7 +2558,7 @@ CONTAINS
     !
     IF ( H%SSC_is_Acid ) THEN
        ssarea = H%f_Acid_SSC * H%xArea(SSC)
-       k = 0.85_dp * ARs_L1K( ssarea, H%xRAdi(SSC), srMw, gamma )
+       k = 0.85_dp * ARs_L1K( ssarea, H%xRAdi(SSC), gamma, srMw )
        k = kIIR1Ltd( conc, C(ind_SALCCl), k ) ! conc is limiting, so update k
     ENDIF
   END FUNCTION IbrkdnbyAcidSALCCl

--- a/KPP/stubs/stub_fullchem_HetStateFuncs.F90
+++ b/KPP/stubs/stub_fullchem_HetStateFuncs.F90
@@ -11,8 +11,9 @@ MODULE fullchem_HetStateFuncs
 CONTAINS
   !
   SUBROUTINE fullchem_SetStateHet( I,         J,         L,                  &
-                                   Input_Opt, State_Chm, State_Met,          &
-                                   H,         RC                 )
+                                   id_SALA,   id_SALAAL, id_SALC,            &
+                                   id_SALCAL, Input_Opt, State_Chm,          &
+                                   State_Met, H,         RC                 )
     !
     ! Stub routine to avoid compilation errors
     !
@@ -25,6 +26,10 @@ CONTAINS
     INTEGER,        INTENT(IN)    :: I
     INTEGER,        INTENT(IN)    :: J
     INTEGER,        INTENT(IN)    :: L
+    INTEGER,        INTENT(IN)    :: id_SALA
+    INTEGER,        INTENT(IN)    :: id_SALAAL
+    INTEGER,        INTENT(IN)    :: id_SALC
+    INTEGER,        INTENT(IN)    :: id_SALCAL
     TYPE(OptInput), INTENT(IN)    :: Input_Opt
     TYPE(ChmState), INTENT(IN)    :: State_Chm
     TYPE(MetState), INTENT(IN)    :: State_Met


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard/ GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the corresponding pull request to #1547, now fixing typos in the calls to Ars_L1K. In several calls to that routine the gamma and SrMW arguments were swapped, leading to integration errors in KPP. Fixing these, seems to get rid of the errors and allows us to properly restore consideration of sea salt alkalinity to heterogenerous acid-catalyzed reactions of halogens on sea salt aerosols. 

Tagging @beckyalexander @viral211 @yantosca. 

### Expected changes

See the original description of the issue and fix in #1547.

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue(s)

- #1547 
- #1880
