### PR TITLE
Don't allow user to create MERRA-2 0.25 x 0.3125 run directories for GCClassic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed initialization of advected species missing in GCHP restart file
 - Fixed comments in `GeosUtil/unitconv_mod.F90` to reflect code implementation
 - Fixed compilation issues for `KPP/custom`; updated equations in `custom.eqn`
+- Prevent users from creating GCClassic rundirs at 0.25 x 0.3125 resolution for MERRA-2 met
 
 ### Removed
 - Remove references to the obsolete tagged Hg simulation

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -453,7 +453,7 @@ else
 # Ask user to select horizontal resolution
 #-----------------------------------------------------------------
 printf "${thinline}Choose horizontal resolution:${thinline}"
-if [[ ${met} = "ModelE2.1" ]] || [[ ${met} = "ModelE2.2" ]]; then
+if [[ "x${met}" == "xModelE2.1" || "x${met}" == "xModelE2.2" ]]; then
     printf "  1. 4.0  x 5.0 *\n"
     printf "  2. 2.0  x 2.5\n"
     printf "  3. 0.5  x 0.625 *\n"
@@ -463,7 +463,7 @@ else
     printf "  1. 4.0  x 5.0\n"
     printf "  2. 2.0  x 2.5\n"
     printf "  3. 0.5  x 0.625\n"
-    if [[ ${met} = "geosfp" ]]; then
+    if [[ "x${met}" == "xgeosfp" ]]; then
 	printf "  4. 0.25 x 0.3125\n"
     fi
 fi
@@ -472,21 +472,29 @@ valid_res=0
 while [ "${valid_res}" -eq 0 ]; do
     read -p "${USER_PROMPT}" res_num
     valid_res=1
-    if [[ ${res_num} = "1" ]]; then
+    if [[ "x${res_num}" == "x1" ]]; then
 	grid_res='4x5'
 	RUNDIR_VARS+="$(cat ${gcdir}/run/shared/settings/4x5.txt)\n"
-    elif [[ ${res_num} = "2" ]]; then
+    elif [[ "x${res_num}" == "x2" ]]; then
 	grid_res='2x25'
 	RUNDIR_VARS+="$(cat ${gcdir}/run/shared/settings/2x25.txt)\n"
-    elif [[ ${res_num} = "3" ]]; then
+    elif [[ "x${res_num}" == "x3" ]]; then
 	grid_res='05x0625'
 	RUNDIR_VARS+="$(cat ${gcdir}/run/shared/settings/05x0625.txt)\n"
-    elif [[ ${res_num} = "4" ]]; then
+    elif [[ "x${res_num}" == "x4" ]]; then
+	# Error check: Don't allow a 0.25 x 0.3125 MERRA-2 rundir.
+	#  -- Melissa Sulprizio, Bob Yantosca (12 Sep 2023)
+	if [[ "x${met}" == "xmerra2" ]]; then
+	    valid_res=0
+	    printf "Cannot create a MERRA-2 rundir at 0.25 x 0.3125 "
+	    printf "resolution!\nPlease make another selection.\n"
+	fi
 	grid_res='025x03125'
 	RUNDIR_VARS+="$(cat ${gcdir}/run/shared/settings/025x03125.txt)\n"
     else
 	valid_res=0
-	printf "Invalid horizontal resolution option. Try again.\n"
+	printf "Invalid horizontal resolution option.\n"
+	printf "Please make another selection.\n"
     fi
 done
 
@@ -978,7 +986,7 @@ ${srcrundir}/init_rd.sh ${rundir_config_log}
 printf "\n  See ${rundir_config}/rundir_vars.txt for run directory settings.\n\n"
 
 printf "\n  -- This run directory has been set up to start on $state_date and"
-printf "\n     restart files for this date are in the Restarts subdirectory.\n" 
+printf "\n     restart files for this date are in the Restarts subdirectory.\n"
 printf "\n  -- Update start and end dates in geoschem_config.yml.\n"
 
 printf "\n  -- Add restart files to Restarts as GEOSChem.Restart.YYYYMMDD_HHmmz.nc4.\n"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
This is the companion PR to #1944,  We have updated the `run/GCClassic/createRunDir.sh` script to:
- Add error trap to prompt user to make another selection if a 0.25 x 0.3125 horizontal resolution is selected w/ MERRA-2 met
- Increase robustness of bash if tests to prevent undefined variables between the `if [[ ]]` brackets
- Trim trailing whitespace

### Expected changes
The loophole described by @msulprizio in #1944 is now closed:

```console
===========================================================
GEOS-CHEM RUN DIRECTORY CREATION
===========================================================

-----------------------------------------------------------
Choose simulation type:
-----------------------------------------------------------
   1. Full chemistry
   2. Aerosols only
   3. CH4
   4. CO2
   5. Hg
   6. POPs
   7. Tagged CH4
   8. Tagged CO
   9. Tagged O3
  10. TransportTracers
  11. Trace metals
  12. Carbon
>>> 1

-----------------------------------------------------------
Choose additional simulation option:
-----------------------------------------------------------
  1. Standard
  2. Benchmark
  3. Complex SOA
  4. Marine POA
  5. Acid uptake on dust
  6. TOMAS
  7. APM
  8. RRTMG
>>> 2

-----------------------------------------------------------
Choose meteorology source:
-----------------------------------------------------------
  1. MERRA-2 (Recommended)
  2. GEOS-FP 
  3. GISS ModelE2.1 (GCAP 2.0)
>>> 1

-----------------------------------------------------------
Choose horizontal resolution:
-----------------------------------------------------------
  1. 4.0  x 5.0
  2. 2.0  x 2.5
  3. 0.5  x 0.625
>>> 4
Cannot create a MERRA-2 rundir at 0.25 x 0.3125 resolution!
Please make another selection.
>>> 1
... etc ...
```

### Reference(s)
N/A

### Related Github Issue(s)
- Closes #1944 
