### PR TITLE
Set RUNDIR_GRID_HALF_POLAR when creating run directories 0.25x0.3125 and 0.5x0.625 resolution and global domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed comments in `GeosUtil/unitconv_mod.F90` to reflect code implementation
 - Fixed compilation issues for `KPP/custom`; updated equations in `custom.eqn`
 - Prevent users from creating GCClassic rundirs at 0.25 x 0.3125 resolution for MERRA-2 met
+- Added fix to set `RUNDIR_GRID_HALF_POLAR` option for global grids at 0.25x0.3125 or 0.5x0.625 resolutions
 
 ### Removed
 - Remove references to the obsolete tagged Hg simulation

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -541,6 +541,7 @@ if [[ ${grid_res} = "05x0625" ]] || [[ ${grid_res} = "025x03125" ]]; then
 	valid_domain=1
 	if [[ ${domain_num} = "1" ]]; then
 	    RUNDIR_VARS+="$(cat ${gcdir}/run/shared/settings/global_grid.txt)\n"
+	    RUNDIR_VARS+="RUNDIR_GRID_HALF_POLAR='true '\n"
 	else
 	    RUNDIR_VARS+="$(cat ${gcdir}/run/shared/settings/nested_grid.txt)\n"
 	    if [[ ${domain_num} = "2" ]]; then


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update

Previously when a user selected the global domain for the 0.25x0.3125 or 0.5x0.625 resolutions the `RUNDIR_GRID_HALF_POLAR` option was not defined, so the corresponding token in geoschem_config.yml was not replaced. 

Note: Typically users don't select the entire globe when using these resolutions but selecting these options when setting up a run directory may assist in defining custom regional domains.