### PR TITLE
Add fix for CH4 analytical inversions to convert state vector values read from file to nearest integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed incorrect time-slice when reading nested-grid boundary conditions
 - Fixed initialization of advected species missing in GCHP restart file
 - Fixed comments in `GeosUtil/unitconv_mod.F90` to reflect code implementation
+- Added fix for CH4 analytical inversions to convert the state vector value read from file to the nearest integer before comparing to the `Input_Opt%StateVectorElement` read from geoschem_config.yml
 
 ### Removed
 - Remove references to the obsolete tagged Hg simulation

--- a/GeosCore/global_ch4_mod.F90
+++ b/GeosCore/global_ch4_mod.F90
@@ -537,7 +537,9 @@ CONTAINS
              ! Only apply emission perturbation to current state vector
              ! element number
              IF ( Input_Opt%StateVectorElement .GT. 0 ) THEN
-                IF ( STATE_VECTOR(I,J) == Input_Opt%StateVectorElement ) THEN
+
+                ! Convert STATE_VECTOR value to nearest integer for comparison
+                IF ( NINT(STATE_VECTOR(I,J)) == Input_Opt%StateVectorElement) THEN
                    State_Chm%CH4_EMIS(I,J,1) = State_Chm%CH4_EMIS(I,J,1) * Input_Opt%PerturbEmis
                    !Print*, 'Analytical Inversion: Scaled state vector element ', &
                    !        Input_Opt%StateVectorElement, ' by ', &


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio 
Institution: Harvard / GCST

### Describe the update

In global_ch4_mod.F90, the state vector elements read from a netCDF file via HEMCO are defined as REAL(fp). To determine if an emissions perturbation needs to be applied, that value is compared to Input_Opt%StateVectorElement which is an INTEGER read from geoschem_config.yml. Roundoff error in the STATE_VECTOR array occasionally led to elements not correctly being identified. The solution is to round the STATE_VECTOR value to the nearest integer before comparing to Input_Opt%StateVectorElement.

### Related Github Issue(s)

- https://github.com/geoschem/integrated_methane_inversion/issues/167

