### PR TITLE
Add OH perturbation option for CH4 simulations via HEMCO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added warning in GCHP HISTORY.rc about outputting area-dependent variables on custom grids
 - Added option to use a single advected species in the carbon simulation
 - Added option to perturb CH4 boundary conditions in CH4 simulation
+- Added option to perturb OH in CH4 simulation
 
 ### Changed
 - Update `DiagnFreq` in GCClassic integration tests to ensure HEMCO diagnostic output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added warning in GCHP HISTORY.rc about outputting area-dependent variables on custom grids
 - Added option to use a single advected species in the carbon simulation
 - Added option to perturb CH4 boundary conditions in CH4 simulation
-- Added option to perturb OH in CH4 simulation
+- Added option to perturb OH in CH4 simulation using scale factor in HEMCO_Config.rc
 
 ### Changed
 - Update `DiagnFreq` in GCClassic integration tests to ensure HEMCO diagnostic output

--- a/GeosCore/global_ch4_mod.F90
+++ b/GeosCore/global_ch4_mod.F90
@@ -933,11 +933,6 @@ CONTAINS
           ! BOH from HEMCO in units of kg/m3, convert to molec/cm3
           C_OH = State_Chm%BOH(I,J,L) * XNUMOL_OH / CM3PERM3
 
-          ! Apply OH perturbation factor for inversions
-          IF ( Input_Opt%OHPerturbFactor /= 1.0 ) THEN
-             C_OH = C_OH * Input_Opt%OHPerturbFactor
-          ENDIF
-
           ! Apply OH scale factors from a previous inversion
           IF ( Input_Opt%UseOHSF ) THEN
              C_OH = C_OH * OH_SF(I,J)

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -4171,7 +4171,7 @@ CONTAINS
     !-----------------------------------------------------------------------
     IF ( Input_Opt%ITS_A_CH4_SIM .or. Input_Opt%ITS_A_TAGCH4_SIM) THEN
 
-       IF ( Input_Opt%AnalyticalInv ) THEN
+       IF ( Input_Opt%DoAnalyticalInv ) THEN
           CALL GetExtOpt( HcoConfig, -999, 'AnalyticalInv', &
                           OptValBool=LTMP, FOUND=FOUND,  RC=HMRC )
 

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -2576,7 +2576,7 @@ CONTAINS
       ! Each time the boundary conditions are read, they have no longer been perturbed
       ! This value is sometimes set to True in set_boundary_conditions_mod.F90
       IF ( ( Input_Opt%ITS_A_CH4_SIM .OR. Input_Opt%ITS_A_CARBON_SIM ) .AND. & 
-           Input_Opt%PerturbCH4BoundaryConditions ) THEN
+           Input_Opt%DoPerturbCH4BoundaryConditions ) THEN
         State_Chm%IsCH4BCPerturbed = .FALSE.
       ENDIF
 

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -4929,19 +4929,6 @@ CONTAINS
     Input_Opt%EmisPerturbFactor = Cast_and_RoundOff( v_str, places=4 )
 
     !------------------------------------------------------------------------
-    ! OH perturbation factor
-    !------------------------------------------------------------------------
-    key   = "CH4_simulation_options%analytical_inversion%OH_perturbation_factor"
-    v_str = MISSING_STR
-    CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%OHPerturbFactor = Cast_and_RoundOff( v_str, places=4 )
-
-    !------------------------------------------------------------------------
     ! Perturb CH4 boundary conditions?
     !------------------------------------------------------------------------
     key    = "CH4_simulation_options%analytical_inversion%perturb_CH4_boundary_conditions"
@@ -5009,7 +4996,6 @@ CONTAINS
        WRITE(6,100) 'Do analytical inversion? : ', Input_Opt%DoAnalyticalInv
        WRITE(6,120) 'Current state vector elem: ', Input_Opt%StateVectorElement
        WRITE(6,110) 'Emiss perturbation factor: ', Input_Opt%EmisPerturbFactor
-       WRITE(6,110) 'OH    perturbation factor: ', Input_Opt%OHPerturbFactor
        WRITE(6,100) 'Perturb CH4 BCs?         : ', Input_Opt%DoPerturbCH4BoundaryConditions
        WRITE(6,130) 'CH4 BC ppb increase NSEW : ', Input_Opt%CH4BoundaryConditionIncreaseNorth,&
                                                    Input_Opt%CH4BoundaryConditionIncreaseSouth,&

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -4899,20 +4899,7 @@ CONTAINS
        CALL GC_Error( errMsg, RC, thisLoc )
        RETURN
     ENDIF
-    Input_Opt%AnalyticalInv = v_bool
-
-    !------------------------------------------------------------------------
-    ! Emission perturbation
-    !------------------------------------------------------------------------
-    key   = "CH4_simulation_options%analytical_inversion%emission_perturbation"
-    v_str = MISSING_STR
-    CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%PerturbEmis = Cast_and_RoundOff( v_str, places=4 )
+    Input_Opt%DoAnalyticalInv = v_bool
 
     !------------------------------------------------------------------------
     ! Current state vector element number
@@ -4929,31 +4916,30 @@ CONTAINS
     Input_Opt%StateVectorElement = v_int
 
     !------------------------------------------------------------------------
-    ! Use emission scale factor?
+    ! Emission perturbation factor
     !------------------------------------------------------------------------
-    key = &
-     "CH4_simulation_options%analytical_inversion%use_emission_scale_factor"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, TRIM( key ), v_bool, "", RC )
+    key   = "CH4_simulation_options%analytical_inversion%emission_perturbation_factor"
+    v_str = MISSING_STR
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
        errMsg = 'Error parsing ' // TRIM( key ) // '!'
        CALL GC_Error( errMsg, RC, thisLoc )
        RETURN
     ENDIF
-    Input_Opt%UseEmisSF = v_bool
+    Input_Opt%EmisPerturbFactor = Cast_and_RoundOff( v_str, places=4 )
 
     !------------------------------------------------------------------------
-    ! Use OH scale factors?
+    ! OH perturbation factor
     !------------------------------------------------------------------------
-    key    = "CH4_simulation_options%analytical_inversion%use_OH_scale_factors"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, TRIM( key ), v_bool, "", RC )
+    key   = "CH4_simulation_options%analytical_inversion%OH_perturbation_factor"
+    v_str = MISSING_STR
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
        errMsg = 'Error parsing ' // TRIM( key ) // '!'
        CALL GC_Error( errMsg, RC, thisLoc )
        RETURN
     ENDIF
-    Input_Opt%UseOHSF = v_bool
+    Input_Opt%OHPerturbFactor = Cast_and_RoundOff( v_str, places=4 )
 
     !------------------------------------------------------------------------
     ! Perturb CH4 boundary conditions?
@@ -4966,7 +4952,7 @@ CONTAINS
        CALL GC_Error( errMsg, RC, thisLoc )
        RETURN
     ENDIF
-    Input_Opt%PerturbCH4BoundaryConditions = v_bool
+    Input_Opt%DoPerturbCH4BoundaryConditions = v_bool
 
     !------------------------------------------------------------------------
     ! How much to perturb CH4 boundary conditions by?
@@ -4984,25 +4970,53 @@ CONTAINS
     Input_Opt%CH4BoundaryConditionIncreaseEast  = Cast_and_RoundOff( a_str(3), places=4 )
     Input_Opt%CH4BoundaryConditionIncreaseWest  = Cast_and_RoundOff( a_str(4), places=4 )
 
+    !------------------------------------------------------------------------
+    ! Use emission scale factors from a previous inversion?
+    !------------------------------------------------------------------------
+    key = &
+     "CH4_simulation_options%analytical_inversion%use_emission_scale_factor"
+    v_bool = MISSING_BOOL
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_bool, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%UseEmisSF = v_bool
+
+    !------------------------------------------------------------------------
+    ! Use OH scale factors from a previous inversion?
+    !------------------------------------------------------------------------
+    key    = "CH4_simulation_options%analytical_inversion%use_OH_scale_factors"
+    v_bool = MISSING_BOOL
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_bool, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%UseOHSF = v_bool
+
     !========================================================================
     ! Print to screen
     !========================================================================
     IF ( Input_Opt%amIRoot ) THEN
        WRITE(6,90 ) 'CH4 SIMULATION SETTINGS'
        WRITE(6,95 ) '-----------------------'
-       WRITE(6,100) 'Use AIRS obs operator    : ', Input_Opt%AIRS_CH4_OBS
-       WRITE(6,100) 'Use GOSAT obs operator   : ', Input_Opt%GOSAT_CH4_OBS
-       WRITE(6,100) 'Use TCCON obs operator   : ', Input_Opt%TCCON_CH4_OBS
-       WRITE(6,100) 'Do analytical inversion  : ', Input_Opt%AnalyticalInv
-       WRITE(6,110) 'Emission perturbation    : ', Input_Opt%PerturbEmis
+       WRITE(6,100) 'Use AIRS obs operator?   : ', Input_Opt%AIRS_CH4_OBS
+       WRITE(6,100) 'Use GOSAT obs operator?  : ', Input_Opt%GOSAT_CH4_OBS
+       WRITE(6,100) 'Use TCCON obs operator?  : ', Input_Opt%TCCON_CH4_OBS
+       WRITE(6,100) 'Do analytical inversion? : ', Input_Opt%DoAnalyticalInv
        WRITE(6,120) 'Current state vector elem: ', Input_Opt%StateVectorElement
-       WRITE(6,100) 'Use emis scale factors   : ', Input_Opt%UseEmisSF
-       WRITE(6,100) 'Use OH scale factors     : ', Input_Opt%UseOHSF
-       WRITE(6,100) 'Perturb CH4 BCs          : ', Input_Opt%PerturbCH4BoundaryConditions
+       WRITE(6,110) 'Emiss perturbation factor: ', Input_Opt%EmisPerturbFactor
+       WRITE(6,110) 'OH    perturbation factor: ', Input_Opt%OHPerturbFactor
+       WRITE(6,100) 'Perturb CH4 BCs?         : ', Input_Opt%DoPerturbCH4BoundaryConditions
        WRITE(6,130) 'CH4 BC ppb increase NSEW : ', Input_Opt%CH4BoundaryConditionIncreaseNorth,&
                                                    Input_Opt%CH4BoundaryConditionIncreaseSouth,&
                                                    Input_Opt%CH4BoundaryConditionIncreaseEast,&
                                                    Input_Opt%CH4BoundaryConditionIncreaseWest
+       WRITE(6,100) 'Use emis scale factors?  : ', Input_Opt%UseEmisSF
+       WRITE(6,100) 'Use OH scale factors?    : ', Input_Opt%UseOHSF
     ENDIF
 
     ! FORMAT statements

--- a/GeosCore/set_boundary_conditions_mod.F90
+++ b/GeosCore/set_boundary_conditions_mod.F90
@@ -141,7 +141,7 @@ CONTAINS
       ! Convert to [kg/kg dry] (nbalasus, 8/31/2023)
       Perturb_CH4_BC = ( State_Chm%SpcData(N)%Info%Name == "CH4" .AND. &
                          ( Input_Opt%ITS_A_CH4_SIM .OR. Input_Opt%ITS_A_CARBON_SIM ) .AND. &
-                         Input_Opt%PerturbCH4BoundaryConditions .AND. &
+                         Input_Opt%DoPerturbCH4BoundaryConditions .AND. &
                          ( .NOT. State_Chm%IsCH4BCPerturbed ) )
       MW_g_CH4       =   State_Chm%SpcData(N)%Info%MW_g
 

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -368,7 +368,6 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: DoAnalyticalInv
      INTEGER                     :: StateVectorElement
      REAL(fp)                    :: EmisPerturbFactor
-     REAL(fp)                    :: OHPerturbFactor
      LOGICAL                     :: DoPerturbCH4BoundaryConditions
      REAL(fp)                    :: CH4BoundaryConditionIncreaseNorth
      REAL(fp)                    :: CH4BoundaryConditionIncreaseSouth
@@ -910,7 +909,6 @@ CONTAINS
     Input_Opt%DoAnalyticalInv                   = .FALSE.
     Input_Opt%StateVectorElement                = 0
     Input_Opt%EmisPerturbFactor                 = 1.0
-    Input_Opt%OHPerturbFactor                   = 1.0
     Input_Opt%DoPerturbCH4BoundaryConditions    = .FALSE.
     Input_Opt%CH4BoundaryConditionIncreaseNorth = 0.0_fp
     Input_Opt%CH4BoundaryConditionIncreaseSouth = 0.0_fp

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -365,16 +365,17 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: GOSAT_CH4_OBS
      LOGICAL                     :: AIRS_CH4_OBS
      LOGICAL                     :: TCCON_CH4_OBS
-     LOGICAL                     :: AnalyticalInv
-     REAL(fp)                    :: PerturbEmis
+     LOGICAL                     :: DoAnalyticalInv
      INTEGER                     :: StateVectorElement
-     LOGICAL                     :: UseEmisSF
-     LOGICAL                     :: UseOHSF
-     LOGICAL                     :: PerturbCH4BoundaryConditions
+     REAL(fp)                    :: EmisPerturbFactor
+     REAL(fp)                    :: OHPerturbFactor
+     LOGICAL                     :: DoPerturbCH4BoundaryConditions
      REAL(fp)                    :: CH4BoundaryConditionIncreaseNorth
      REAL(fp)                    :: CH4BoundaryConditionIncreaseSouth
      REAL(fp)                    :: CH4BoundaryConditionIncreaseEast
      REAL(fp)                    :: CH4BoundaryConditionIncreaseWest
+     LOGICAL                     :: UseEmisSF
+     LOGICAL                     :: UseOHSF
 
      !----------------------------------------
      ! POPS MENU fields
@@ -906,16 +907,17 @@ CONTAINS
     Input_Opt%GOSAT_CH4_OBS                     = .FALSE.
     Input_Opt%AIRS_CH4_OBS                      = .FALSE.
     Input_Opt%TCCON_CH4_OBS                     = .FALSE.
-    Input_Opt%AnalyticalInv                     = .FALSE.
-    Input_Opt%PerturbEmis                       = 1.0
+    Input_Opt%DoAnalyticalInv                   = .FALSE.
     Input_Opt%StateVectorElement                = 0
-    Input_Opt%UseEmisSF                         = .FALSE.
-    Input_Opt%UseOHSF                           = .FALSE.
-    Input_Opt%PerturbCH4BoundaryConditions      = .FALSE.
+    Input_Opt%EmisPerturbFactor                 = 1.0
+    Input_Opt%OHPerturbFactor                   = 1.0
+    Input_Opt%DoPerturbCH4BoundaryConditions    = .FALSE.
     Input_Opt%CH4BoundaryConditionIncreaseNorth = 0.0_fp
     Input_Opt%CH4BoundaryConditionIncreaseSouth = 0.0_fp
     Input_Opt%CH4BoundaryConditionIncreaseEast  = 0.0_fp
     Input_Opt%CH4BoundaryConditionIncreaseWest  = 0.0_fp
+    Input_Opt%UseEmisSF                         = .FALSE.
+    Input_Opt%UseOHSF                           = .FALSE.
 
     !----------------------------------------
     ! POPS MENU fields

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
@@ -656,7 +656,7 @@ ${RUNDIR_CH4_LOSS}
 
 # --- Global OH from GEOS-Chem v5-07 [kg/m3] ---
 (((GLOBAL_OH
-* GLOBAL_OH  $ROOT/OH/v2014-09/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH           1985/1-12/1/0 C xyz kg/m3 * - 1 1
+* GLOBAL_OH  $ROOT/OH/v2014-09/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH           1985/1-12/1/0 C xyz kg/m3 * 2 1 1
 )))GLOBAL_OH
 
 # --- Global Cl [mol/mol dry air] ---
@@ -883,6 +883,14 @@ ${RUNDIR_GLOBAL_Cl}
 # Multiply soil absorption by -1 to get a "negative" flux.
 #==============================================================================
 1 NEGATIVE       -1.0 - - - xy 1 1
+
+#==============================================================================
+# --- Perturbation factors ---
+#
+# Add factors to perturb OH, emissions, and other fields here for
+# analytical inversions.
+#==============================================================================
+2 OH_pert_factor  1.0 - - - xy 1 1
 
 #==============================================================================
 # --- Seasonal scaling factors ----

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -1296,7 +1296,7 @@ Mask fractions:              false
 #------------------------------------------------------------------------------
 # --- OH from GEOS-Chem v5-07 [kg/m3], needed for CH4/IMI ---
 (((GLOBAL_OH_GCv5
-* GLOBAL_OH  $ROOT/OH/v2022-11/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH  1985/1-12/1/0 C xyz kg/m3 * - 1 1
+* GLOBAL_OH  $ROOT/OH/v2022-11/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH  1985/1-12/1/0 C xyz kg/m3 * 3 1 1
 )))GLOBAL_OH_GCv5
 
 # --- OH from the last 10-yr benchmark [mol/mol dry air] ---
@@ -1375,6 +1375,14 @@ ${RUNDIR_CO2_COPROD}
 # --- Multiply by -1 to get a "negative" flux.
 #==============================================================================
 1 NEGATIVE -1.0 - - - xy 1 1
+
+#==============================================================================
+# --- Perturbation factors ---
+#
+# Add factors to perturb OH, emissions, and other fields here for
+# analytical inversions.
+#==============================================================================
+2 OH_pert_factor  1.0 - - - xy 1 1
 
 #==============================================================================
 # --- Seasonal scaling factors ----

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -1296,7 +1296,7 @@ Mask fractions:              false
 #------------------------------------------------------------------------------
 # --- OH from GEOS-Chem v5-07 [kg/m3], needed for CH4/IMI ---
 (((GLOBAL_OH_GCv5
-* GLOBAL_OH  $ROOT/OH/v2022-11/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH  1985/1-12/1/0 C xyz kg/m3 * 3 1 1
+* GLOBAL_OH  $ROOT/OH/v2022-11/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH  1985/1-12/1/0 C xyz kg/m3 * 2 1 1
 )))GLOBAL_OH_GCv5
 
 # --- OH from the last 10-yr benchmark [mol/mol dry air] ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
@@ -718,7 +718,7 @@ ${RUNDIR_CH4_LOSS}
 
 # --- Global OH from GEOS-Chem v5-07 [kg/m3] ---
 (((GLOBAL_OH
-* GLOBAL_OH  $ROOT/OH/v2014-09/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH           1985/1-12/1/0 C xyz kg/m3 * 3 1 1
+* GLOBAL_OH  $ROOT/OH/v2014-09/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH           1985/1-12/1/0 C xyz kg/m3 * 2 1 1
 )))GLOBAL_OH
 
 # --- Global Cl [mol/mol dry air] ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
@@ -718,7 +718,7 @@ ${RUNDIR_CH4_LOSS}
 
 # --- Global OH from GEOS-Chem v5-07 [kg/m3] ---
 (((GLOBAL_OH
-* GLOBAL_OH  $ROOT/OH/v2014-09/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH           1985/1-12/1/0 C xyz kg/m3 * - 1 1
+* GLOBAL_OH  $ROOT/OH/v2014-09/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH           1985/1-12/1/0 C xyz kg/m3 * 3 1 1
 )))GLOBAL_OH
 
 # --- Global Cl [mol/mol dry air] ---
@@ -945,6 +945,14 @@ ${RUNDIR_GLOBAL_Cl}
 # Multiply soil absorption by -1 to get a "negative" flux.
 #==============================================================================
 1 NEGATIVE       -1.0 - - - xy 1 1
+
+#==============================================================================
+# --- Perturbation factors ---
+#
+# Add factors to perturb OH, emissions, and other fields here for
+# analytical inversions.
+#==============================================================================
+2 OH_pert_factor  1.0 - - - xy 1 1
 
 #==============================================================================
 # --- Seasonal scaling factors ----

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
@@ -1,9 +1,6 @@
 ---
 ### geoschem_config.yml: GEOS-Chem Runtime configuration options.
 ### Customized for simulations using the CH4 mechanism.
-###
-### NOTE: Add quotes around nitrogen oxide ('NO'), because YAML
-### parsers will confuse this with a negative "no" value.
 
 #============================================================================
 # Simulation settings
@@ -79,13 +76,14 @@ CH4_simulation_options:
 
   analytical_inversion:
     activate: false
-    emission_perturbation: 1.0
     state_vector_element_number: 0
-    use_emission_scale_factor: false
-    use_OH_scale_factors: false
+    emission_perturbation_factor: 1.0
+    OH_perturbation_factor: 1.0
     perturb_CH4_boundary_conditions: false
     CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
-      
+    use_emission_scale_factor: false
+    use_OH_scale_factors: false
+
 #============================================================================
 # Settings for diagnostics (other than HISTORY and HEMCO)
 #============================================================================
@@ -103,53 +101,3 @@ extra_diagnostics:
     activate: false
     flight_track_file: Planeflight.dat.YYYYMMDD
     output_file: plane.log.YYYYMMDD
-
-  legacy_bpch:                #          1         2         3
-    output_menu:             # 1234567890123456789012345678901
-      schedule_output_for_JAN: 3000000000000000000000000000000
-      schedule_output_for_FEB: 30000000000000000000000000000
-      schedule_output_for_MAR: 3000000000000000000000000000000
-      schedule_output_for_APR: 300000000000000000000000000000
-      schedule_output_for_MAY: 3000000000000000000000000000000
-      schedule_output_for_JUN: 300000000000000000000000000000
-      schedule_output_for_JUL: 3000000000000000000000000000000
-      schedule_output_for_AUG: 3000000000000000000000000000000
-      schedule_output_for_SEP: 300000000000000000000000000000
-      schedule_output_for_OCT: 3000000000000000000000000000000
-      schedule_output_for_NOV: 300000000000000000000000000000
-      schedule_output_for_DEC: 3000000000000000000000000000000
-
-    gamap:
-      diaginfo_dat_file: ./diaginfo.dat
-      tracerinfo_dat_file: ./tracerinfo.dat
-
-    bpch_diagnostics:
-      TOMAS_aerosol_emissions: "0 all"
-      TOMAS_rate: "0 all"
-      TOMAS_3D_rate: "0 all"
-
-    ND51_satellite:
-      activate: false
-      output_file: ts_satellite.YYYYMMDD.bpch
-      tracers:
-        - 1
-        - 2
-        - 501
-      UTC_hour_for_write: 0
-      averaging_period_in_LT: [9, 11]
-      IMIN_and_IMAX_of_region: [1, 72]
-      JMIN_and_JMAX_of_region: [1, 46]
-      LMIN_and_LMAX_of_region: [1, 1]
-
-    ND51b_satellite:
-      activate: false
-      output_file: ts_13_15_NA..YYYYMMDD.bpch
-      tracers:
-        - 1
-        - 2
-        - 501
-      UTC_hour_for_write: 1
-      averaging_period_in_LT: [13, 15]
-      IMIN_and_IMAX_of_region: [1, 72]
-      JMIN_and_JMAX_of_region: [1, 46]
-      LMIN_and_LMAX_of_region: [1, 1]

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CH4
@@ -78,7 +78,6 @@ CH4_simulation_options:
     activate: false
     state_vector_element_number: 0
     emission_perturbation_factor: 1.0
-    OH_perturbation_factor: 1.0
     perturb_CH4_boundary_conditions: false
     CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
     use_emission_scale_factor: false

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
@@ -79,12 +79,13 @@ CH4_simulation_options:
 
   analytical_inversion:
     activate: false
-    emission_perturbation: 1.0
     state_vector_element_number: 0
-    use_emission_scale_factor: false
-    use_OH_scale_factors: false
+    emission_perturbation_factor: 1.0
+    OH_perturbation_factor: 1.0
     perturb_CH4_boundary_conditions: false
     CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
+    use_emission_scale_factor: false
+    use_OH_scale_factors: false
 
 #============================================================================
 # Options for CO
@@ -115,3 +116,23 @@ CO2_simulation_options:
     tag_land_fossil_fuel_CO2: 
     tag_global_ship_CO2: false
     tag_global_aircraft_CO2: false
+
+#============================================================================
+# Settings for diagnostics (other than HISTORY and HEMCO)
+#============================================================================
+extra_diagnostics:
+
+  obspack:
+    activate: false
+    quiet_logfile_output: false
+    input_file: ./obspack_co2_1_OCO2MIP_2018-11-28.YYYYMMDD.nc
+    output_file: ./OutputDir/GEOSChem.ObsPack.YYYYMMDD_hhmmz.nc4
+    output_species:
+      - CH4
+      - CO
+      - CO2
+
+  planeflight:
+    activate: false
+    flight_track_file: Planeflight.dat.YYYYMMDD
+    output_file: plane.log.YYYYMMDD

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
@@ -81,7 +81,6 @@ CH4_simulation_options:
     activate: false
     state_vector_element_number: 0
     emission_perturbation_factor: 1.0
-    OH_perturbation_factor: 1.0
     perturb_CH4_boundary_conditions: false
     CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
     use_emission_scale_factor: false

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
@@ -1,9 +1,6 @@
 ---
 ### geoschem_config.yml: GEOS-Chem Runtime configuration options.
 ### Customized for simulations using the tagged CH4 mechanism.
-###
-### NOTE: Add quotes around nitrogen oxide ('NO'), because YAML
-### parsers will confuse this with a negative "no" value.
 
 #============================================================================
 # Simulation settings
@@ -83,7 +80,7 @@ operations:
       - CH4_RES
 
 #============================================================================
-# Settings specific to the CH4 simulation / Integrated Methane Inversion
+# Options for CH4
 #============================================================================
 CH4_simulation_options:
 
@@ -94,13 +91,14 @@ CH4_simulation_options:
 
   analytical_inversion:
     activate: false
-    emission_perturbation: 1.0
     state_vector_element_number: 0
-    use_emission_scale_factor: false
-    use_OH_scale_factors: false
+    emission_perturbation_factor: 1.0
+    OH_perturbation_factor: 1.0
     perturb_CH4_boundary_conditions: false
     CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
-      
+    use_emission_scale_factor: false
+    use_OH_scale_factors: false
+
 #============================================================================
 # Settings for diagnostics (other than HISTORY and HEMCO)
 #============================================================================

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCH4
@@ -93,7 +93,6 @@ CH4_simulation_options:
     activate: false
     state_vector_element_number: 0
     emission_perturbation_factor: 1.0
-    OH_perturbation_factor: 1.0
     perturb_CH4_boundary_conditions: false
     CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
     use_emission_scale_factor: false

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -1296,7 +1296,7 @@ Mask fractions:              false
 #------------------------------------------------------------------------------
 # --- OH from GEOS-Chem v5-07 [kg/m3], needed for CH4/IMI ---
 (((GLOBAL_OH_GCv5
-* GLOBAL_OH  $ROOT/OH/v2022-11/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH  1985/1-12/1/0 C xyz kg/m3 * - 1 1
+* GLOBAL_OH  $ROOT/OH/v2022-11/v5-07-08/OH_3Dglobal.geos5.47L.4x5.nc OH  1985/1-12/1/0 C xyz kg/m3 * 2 1 1
 )))GLOBAL_OH_GCv5
 
 # --- OH from the last 10-yr benchmark [mol/mol dry air] ---
@@ -1321,7 +1321,6 @@ ${RUNDIR_GLOBAL_Cl}
 #------------------------------------------------------------------------------
 # --- Quantities needed for CO chemistry ---
 #------------------------------------------------------------------------------
-(((USE_CO_DATA
 
 # -- P(CO) from CH4 and NMVOC from the last 10-yr benchmark [molec/cm3/s] ---
 (((PROD_CO_CH4
@@ -1376,6 +1375,14 @@ ${RUNDIR_CO2_COPROD}
 # --- Multiply by -1 to get a "negative" flux.
 #==============================================================================
 1 NEGATIVE -1.0 - - - xy 1 1
+
+#==============================================================================
+# --- Perturbation factors ---
+#
+# Add factors to perturb OH, emissions, and other fields here for
+# analytical inversions.
+#==============================================================================
+2 OH_pert_factor  1.0 - - - xy 1 1
 
 #==============================================================================
 # --- Seasonal scaling factors ----

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.carbon
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.carbon
@@ -48,8 +48,11 @@ CH4_simulation_options:
 
   analytical_inversion:
     activate: false
-    emission_perturbation: 1.0
     state_vector_element_number: 0
+    emission_perturbation_factor: 1.0
+    OH_perturbation_factor: 1.0
+    perturb_CH4_boundary_conditions: false
+    CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
     use_emission_scale_factor: false
     use_OH_scale_factors: false
 
@@ -102,56 +105,3 @@ extra_diagnostics:
     activate: false
     flight_track_file: Planeflight.dat.YYYYMMDD
     output_file: plane.log.YYYYMMDD
-
-  legacy_bpch:                #          1         2         3
-     output_menu:             # 1234567890123456789012345678901
-       schedule_output_for_JAN: 3000000000000000000000000000000
-       schedule_output_for_FEB: 30000000000000000000000000000
-       schedule_output_for_MAR: 3000000000000000000000000000000
-       schedule_output_for_APR: 300000000000000000000000000000
-       schedule_output_for_MAY: 3000000000000000000000000000000
-       schedule_output_for_JUN: 300000000000000000000000000000
-       schedule_output_for_JUL: 3000000000000000000000000000000
-       schedule_output_for_AUG: 3000000000000000000000000000000
-       schedule_output_for_SEP: 300000000000000000000000000000
-       schedule_output_for_OCT: 3000000000000000000000000000000
-       schedule_output_for_NOV: 300000000000000000000000000000
-       schedule_output_for_DEC: 3000000000000000000000000000000
-
-    gamap:
-      diaginfo_dat_file: ./diaginfo.dat
-      tracerinfo_dat_file: ./tracerinfo.dat
-
-    bpch_diagnostics:
-      TOMAS_aerosol_emissions: "0 all"
-      TOMAS_rate: "0 all"
-      TOMAS_3D_rate: "0 all"
-      ND65_prodloss:
-        activate: true
-        number_of_levels: 72
-
-    ND51_satellite:
-      activate: false
-      output_file: ts_satellite.YYYYMMDD.bpch
-      tracers:
-        - 1
-        - 2
-        - 501
-      UTC_hour_for_write: 0
-      averaging_period_in_LT: [9, 11]
-      IMIN_and_IMAX_of_region: [1, 72]
-      JMIN_and_JMAX_of_region: [1, 46]
-      LMIN_and_LMAX_of_region: [1, 1]
-
-    ND51b_satellite:
-      activate: false
-      output_file: ts_13_15_NA..YYYYMMDD.bpch
-      tracers:
-        - 1
-        - 2
-        - 501
-      UTC_hour_for_write: 1
-      averaging_period_in_LT: [13, 15]
-      IMIN_and_IMAX_of_region: [1, 72]
-      JMIN_and_JMAX_of_region: [1, 46]
-      LMIN_and_LMAX_of_region: [1, 1]


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update

This update defines a new scale factor `OH_pert_factor` in HEMCO_Config.rc for CH4, tagCH4, and carbon simulations. The scale factor is applied to the GLOBAL_OH field, also specified in HEMCO_Config.rc. The default value for the scale factor is 1.0 (i.e. apply no perturbation).

This update was made to facilitate optimization of OH for global inversions within the IMI framework.

### Related Github Issue(s)

- https://github.com/geoschem/integrated_methane_inversion/issues/67
