### PR TITLE
Update NOAA GMD surface CH4 boundary conditions through 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 14.3.0] - TBD
+### Changed
+- Updated NOAA GMD surface CH4 boundary conditions through 2022
+
 ## [Unreleased 14.2.1] - TBD
 ### Added
 - Script `test/difference/diffTest.sh`, checks 2 different integration tests for differences

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -157,7 +157,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> GMI_OH                 :       true     # 2005
     --> GMI_PROD_LOSS          :       true     # 2005
     --> OMOC_RATIO             :       false    # 2010
-    --> GMD_SFC_CH4            :       ${RUNDIR_USE_GMDCH4}    # 1979-2022
+    --> GMD_SFC_CH4            :       ${RUNDIR_USE_GMDCH4}    # 1975-2022
     --> CMIP6_SFC_CH4          :       false    # 1750-1978
     --> OLSON_LANDMAP          :       true     # 1985
     --> YUAN_MODIS_LAI         :       true     # 2000-2020
@@ -3747,7 +3747,7 @@ VerboseOnCores:              root       # Accepted values: root all
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
 (((GMD_SFC_CH4
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1979-2022.1x1.nc SFC_CH4 1979-2022/1-12/1/0 RY xy ppbv * - 1 1
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1975-2022.1x1.nc SFC_CH4 1975-2022/1-12/1/0 RY xy ppbv * - 1 1
 )))GMD_SFC_CH4
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -157,7 +157,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> GMI_OH                 :       true     # 2005
     --> GMI_PROD_LOSS          :       true     # 2005
     --> OMOC_RATIO             :       false    # 2010
-    --> GMD_SFC_CH4            :       ${RUNDIR_USE_GMDCH4}    # 1979-2020
+    --> GMD_SFC_CH4            :       ${RUNDIR_USE_GMDCH4}    # 1979-2022
     --> CMIP6_SFC_CH4          :       false    # 1750-1978
     --> OLSON_LANDMAP          :       true     # 1985
     --> YUAN_MODIS_LAI         :       true     # 2000-2020
@@ -3747,7 +3747,7 @@ VerboseOnCores:              root       # Accepted values: root all
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
 (((GMD_SFC_CH4
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 RY xy ppbv * - 1 1
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1979-2022.1x1.nc SFC_CH4 1979-2022/1-12/1/0 RY xy ppbv * - 1 1
 )))GMD_SFC_CH4
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCO
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCO
@@ -125,7 +125,7 @@ Mask fractions:              false
     --> PROD_CO_CH4            :       true     # 2010-2019
     --> PROD_CO_NMVOC          :       true     # 2010-2019
     --> GMI_PROD_LOSS          :       true     # 2005
-    --> GMD_SFC_CH4            :       true     # 1979-2022
+    --> GMD_SFC_CH4            :       true     # 1975-2022
     --> CMIP6_SFC_CH4          :       false    # 1750-1978
     --> OLSON_LANDMAP          :       true     # 1985
     --> YUAN_MODIS_LAI         :       true     # 2000-2020
@@ -900,7 +900,7 @@ ${RUNDIR_GMI_PROD_CO}
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
 (((GMD_SFC_CH4
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1979-2022.1x1.nc SFC_CH4 1979-2022/1-12/1/0 RY xy ppbv * - 1 1
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1975-2022.1x1.nc SFC_CH4 1975-2022/1-12/1/0 RY xy ppbv * - 1 1
 )))GMD_SFC_CH4
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCO
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCO
@@ -125,7 +125,7 @@ Mask fractions:              false
     --> PROD_CO_CH4            :       true     # 2010-2019
     --> PROD_CO_NMVOC          :       true     # 2010-2019
     --> GMI_PROD_LOSS          :       true     # 2005
-    --> GMD_SFC_CH4            :       true     # 1979-2020
+    --> GMD_SFC_CH4            :       true     # 1979-2022
     --> CMIP6_SFC_CH4          :       false    # 1750-1978
     --> OLSON_LANDMAP          :       true     # 1985
     --> YUAN_MODIS_LAI         :       true     # 2000-2020
@@ -900,7 +900,7 @@ ${RUNDIR_GMI_PROD_CO}
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
 (((GMD_SFC_CH4
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 RY xy ppbv * - 1 1
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1979-2022.1x1.nc SFC_CH4 1979-2022/1-12/1/0 RY xy ppbv * - 1 1
 )))GMD_SFC_CH4
 
 #==============================================================================

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -2069,7 +2069,7 @@ GMI_PROD_VRP  v/v/s Y Y F2000-%m2-01T00:00:00 none none prod ./HcoDir/GMI/v2015-
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 (GMD_SFC_CH4) ---
 #==============================================================================
-NOAA_GMD_CH4 ppbv N Y F%y4-%m2-01T00:00:00 none none SFC_CH4 ./HcoDir/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1979-2022.1x1.nc
+NOAA_GMD_CH4 ppbv N Y F%y4-%m2-01T00:00:00 none none SFC_CH4 ./HcoDir/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1975-2022.1x1.nc
 #
 #==============================================================================
 # --- CMIP6 monthly mean surface CH4 (pre 1970) (CMIP6_SFC_CH4) ---

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -2069,7 +2069,7 @@ GMI_PROD_VRP  v/v/s Y Y F2000-%m2-01T00:00:00 none none prod ./HcoDir/GMI/v2015-
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 (GMD_SFC_CH4) ---
 #==============================================================================
-NOAA_GMD_CH4 ppbv N Y F%y4-%m2-01T00:00:00 none none SFC_CH4 ./HcoDir/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc
+NOAA_GMD_CH4 ppbv N Y F%y4-%m2-01T00:00:00 none none SFC_CH4 ./HcoDir/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1979-2022.1x1.nc
 #
 #==============================================================================
 # --- CMIP6 monthly mean surface CH4 (pre 1970) (CMIP6_SFC_CH4) ---

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -156,7 +156,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> GMI_OH                 :       true     # 2005
     --> GMI_PROD_LOSS          :       true     # 2005
     --> OMOC_RATIO             :       false    # 2010
-    --> GMD_SFC_CH4            :       ${RUNDIR_USE_GMDCH4}    # 1979-2022
+    --> GMD_SFC_CH4            :       ${RUNDIR_USE_GMDCH4}    # 1975-2022
     --> CMIP6_SFC_CH4          :       false    # 1750-1978
     --> OLSON_LANDMAP          :       false    # 1985
     --> YUAN_MODIS_LAI         :       false    # 2000-2020
@@ -3737,7 +3737,7 @@ VerboseOnCores:              root       # Accepted values: root all
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
 (((GMD_SFC_CH4
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1979-2022.1x1.nc SFC_CH4 1979-2022/1-12/1/0 RY xy ppbv * - 1 1
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1975-2022.1x1.nc SFC_CH4 1975-2022/1-12/1/0 RY xy ppbv * - 1 1
 )))GMD_SFC_CH4
 
 #==============================================================================

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -156,7 +156,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> GMI_OH                 :       true     # 2005
     --> GMI_PROD_LOSS          :       true     # 2005
     --> OMOC_RATIO             :       false    # 2010
-    --> GMD_SFC_CH4            :       ${RUNDIR_USE_GMDCH4}    # 1979-2020
+    --> GMD_SFC_CH4            :       ${RUNDIR_USE_GMDCH4}    # 1979-2022
     --> CMIP6_SFC_CH4          :       false    # 1750-1978
     --> OLSON_LANDMAP          :       false    # 1985
     --> YUAN_MODIS_LAI         :       false    # 2000-2020
@@ -3737,7 +3737,7 @@ VerboseOnCores:              root       # Accepted values: root all
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
 (((GMD_SFC_CH4
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 RY xy ppbv * - 1 1
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1979-2022.1x1.nc SFC_CH4 1979-2022/1-12/1/0 RY xy ppbv * - 1 1
 )))GMD_SFC_CH4
 
 #==============================================================================


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update

Lee Murray provided updated NOAA GMD surface CH4 boundary conditions for GEOS-Chem through December 2022. The file can be found in `ExtData/HEMCO/NOAA_GMD/v2023-10/`. 

### Expected changes

This update will cause changes to the full-chemistry benchmark due to the updated dataset.

### Related Github Issue(s)

- https://github.com/geoschem/geos-chem/issues/1626
