### PR TITLE
Prevent POAEMISS variable from being assigned if not allocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Prevent `POAEMISS` from being assigned a value if not allocated (in `carbon_mod.F90`)
+
 ## [14.2.1] - 2023-10-10
 ### Added
 - Script `test/difference/diffTest.sh`, checks 2 different integration tests for differences

--- a/GeosCore/carbon_mod.F90
+++ b/GeosCore/carbon_mod.F90
@@ -4793,9 +4793,6 @@ CONTAINS
    ! Assume success
    RC = GC_SUCCESS
 
-   ! Initialize
-   POAEMISS =  0e+0_fp
-
    ! Check if using complex SOA scheme
    IF ( Input_Opt%LSOA ) THEN
 
@@ -4834,6 +4831,9 @@ CONTAINS
 
    ! Nothing to do if none of the species are defined
    IF ( SESQID <= 0 .AND. HCOPOG1 <= 0 .AND. HCOPOG2 <=0 ) RETURN
+
+   ! Initialize
+   POAEMISS =  0.0_fp
 
    ! Maximum extent of PBL [model levels]
    PBL_MAX = State_Met%PBL_MAX_L


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
This is the companion PR to #1771.  It fixes the problem reported by @sdeastham, where the `POAEMISS` variable in `carbon_mod.F90` can potentially be assigned a value if not allocated.    The solution is to move the assignment statement in question so that is is placed after after an error check.

This would only occur when carbonaceous aerosols are disabled in fullchem simulations, so this is not a common use case.

### Expected changes

This should result in no differences to GEOS-Chem Classic and GCHP fullchem benchmark simulations, which all use carbonaceous aerosols.  Thus I have labeled this as "no-diff-to-benchmark".

### Reference(s)
N/A

### Related Github Issue(s)

- #1771
