### PR TITLE
Update sample restart files for fullchem and TransportTracers to 14.2.0 benchmark files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 14.2.2] - TBD
+### Changed
+- Updated sample restart files for fullchem and TransportTracers simulations to files saved out from the 14.2.0 1-year benchmarks
+
 ## [14.2.1] - 2023-10-10
 ### Added
 - Script `test/difference/diffTest.sh`, checks 2 different integration tests for differences

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -1057,13 +1057,14 @@ if [[ ${met} = "merra2" ]] || [[ ${met} = "geosfp" ]]; then
 	elif [[ "x${sim_extra_option}" == "xTOMAS40" ]]; then
 	    sample_rst=${rst_root}/v2021-12/GEOSChem.Restart.TOMAS40.${startdate}_0000z.nc4
 	else
-	    sample_rst=${rst_root}/GC_14.0.0/GEOSChem.Restart.fullchem.${startdate}_0000z.nc4
+	    # Use restart file from the latest 1-year benchmark
+	    sample_rst=${rst_root}/GC_14.2.0/GEOSChem.Restart.fullchem.${startdate}_0000z.nc4
 	fi
 
     elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
 
-	# For TransportTracers, use restart from latest benchmark
-	sample_rst=${rst_root}/GC_14.0.0/GEOSChem.Restart.TransportTracers.${startdate}_0000z.nc4
+	# Use restart file from the latest 1-year TransportTracers benchmark
+	sample_rst=${rst_root}/GC_14.2.0/GEOSChem.Restart.TransportTracers.${startdate}_0000z.nc4
 
     elif [[ "x${sim_name}" == "xHg" ]]; then
 

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -476,16 +476,16 @@ ln -s ${wrapperdir}/run/runScriptSamples ${rundir}/runScriptSamples
 restarts=${GC_DATA_ROOT}/GEOSCHEM_RESTARTS
 if [[ "x${sim_name}" == "xfullchem" ]]; then
     start_date='20190701'
-    restart_dir='GC_14.0.0'
+    restart_dir='GC_14.2.0'
     restart_name="${sim_name}"
 elif [[ "x${sim_name}" == "xtagO3" ]]; then
     # NOTE: we use the fullchem restart file for tagO3
     start_date='20190701'
-    restart_dir='GC_14.0.0'
+    restart_dir='GC_14.2.0'
     restart_name="fullchem"
 elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
     start_date='20190101'
-    restart_dir='GC_14.0.0'
+    restart_dir='GC_14.2.0'
     restart_name="${sim_name}"
 elif [[ ${sim_name} = "carbon" ]]; then
     start_date='20190101'


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update

Out-of-the-box fullchem and TransportTracers simulations for 14.2.0 and 14.2.1 are failing because additional species were added in 14.2.0. The time cycle flag used in HEMCO_Config.rc (EYFO) forces GEOS-Chem to crash with an error when species are not found in the restart file. To avoid this, we need to update the sample restart files for these simulations to restart files saved out from the 14.2.0 1-year benchmark simulations.

### Expected changes

This will cause changes to the benchmark simulations due to changing initial conditions.

### Related Github Issue(s)

Closes #1986
