### PR TITLE
Add a --no-bootstrap option to integration tests to prevent switching EFYO -> CYS in HEMCO_Config.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Added the `-n` aka `--no-bootstrap` option to integration tests to disable bootstrapping missing species in restart files
+
 ## [14.2.1] - 2023-10-10
 ### Added
 - Script `test/difference/diffTest.sh`, checks 2 different integration tests for differences

--- a/test/integration/GCClassic/README.md
+++ b/test/integration/GCClassic/README.md
@@ -77,9 +77,16 @@ The integration test scripts accept the following command-line arguments
 
 `-s` specifies that the SLURM scheduler will be used to run the integration test scripts.
 
+`-n` specifies that missing species in restart files will not be bootstrapped to a missing value.  This can be used to test if "out-of-the-box" simulations will fail before a version release.
+
+`-h` displays a help screeen.
+
+
 You can also use long names for the option switches:
 - `--directory` instead of `-d`
 - `--env-file` instead of `-e`
+- `--help` instead of `h`
+- `--no-bootstrap` instead of `n`
 - `--partition partition` instead of `-p`
 - `--scheduler scheduler` instead of `-s`
 

--- a/test/integration/GCClassic/integrationTest.sh
+++ b/test/integration/GCClassic/integrationTest.sh
@@ -193,39 +193,11 @@ fi
 # Define local convenience variables
 logsDir="${itRoot}/${LOGS_DIR}"
 scriptsDir="${itRoot}/${SCRIPTS_DIR}"
+rundirsDir="${itRoot}/${RUNDIRS_DIR}"
 
-# If --no-bootstrap is selected, make sure HEMCO_Config.rc entries for
-# boundary conditions and restart files do not allow missing values.
-if [[ "x${bootStrap}" == "xno" ]]; then
-    line="\# Change time cycle flags in HEMCO_Config.rc from CYS to EFY(O),"
-    sed_ie "s/REPLACE1/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-
-    line="\# to prevent missing species from being set to a default value."
-    sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-
-    line="sed_ie 's\/CYS.*xyz 1\/EFY xyz 1\/' HEMCO_Config.rc  \# GC_BCs"
-    sed_ie "s/REPLACE3/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-
-    line="sed_ie 's\/CYS\/EFYO\/'             HEMCO_Config.rc  \# GC_RESTART"
-    sed_ie "s/REPLACE4/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-
-    line="sed_ie 's\/EY.*xyz 1\/EFYO xyz 1\/' HEMCO_Config.rc  \# GC_RESTART"
-    sed_ie "s/REPLACE5/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-else
-    line="\# Change time cycle flags in HEMCO_Config.rc from EFYO to CYS,"
-    sed_ie "s/REPLACE1/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-
-    line="\# to allow missing species to be set a default value."
-    sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-
-    line="sed_ie 's\/EFYO\/CYS\/'             HEMCO_Config.rc  \# GC_RESTART"
-    sed_ie "s/REPLACE3/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-
-    line="sed_ie 's\/EFY.*xyz 1\/CYS xyz 1\/' HEMCO_Config.rc  \# GC_BCs"
-    sed_ie "s/REPLACE4/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-
-    sed_ie "/REPLACE5$/d"        "${scriptsDir}/integrationTestExecute.sh"
-fi
+# Edit HEMCO_Config.rc files to enable or disable bootstrapping
+# (i.e. to allow missing species in restart files or not)
+gcc_enable_or_disable_bootstrap "${bootStrap}" "${rundirsDir}"
 
 # Navigate to the logs directory (so all output will be placed there)
 cd "${logsDir}"

--- a/test/integration/GCClassic/integrationTest.sh
+++ b/test/integration/GCClassic/integrationTest.sh
@@ -203,13 +203,13 @@ if [[ "x${bootStrap}" == "xno" ]]; then
     line="\# to prevent missing species from being set to a default value."
     sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 
-    line="sed_ie 's\/CYS xyz 1\/EFY xyz 1\/'  HEMCO_Config.rc  \# GC_BCs"
+    line="sed_ie 's\/CYS.*xyz 1\/EFY xyz 1\/' HEMCO_Config.rc  \# GC_BCs"
     sed_ie "s/REPLACE3/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 
     line="sed_ie 's\/CYS\/EFYO\/'             HEMCO_Config.rc  \# GC_RESTART"
     sed_ie "s/REPLACE4/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 
-    line="sed_ie 's\/EY  xyz 1\/EFYO xyz 1\/' HEMCO_Config.rc  \# GC_RESTART"
+    line="sed_ie 's\/EY.*xyz 1\/EFYO xyz 1\/' HEMCO_Config.rc  \# GC_RESTART"
     sed_ie "s/REPLACE5/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 else
     line="\# Change time cycle flags in HEMCO_Config.rc from EFYO to CYS,"
@@ -218,10 +218,10 @@ else
     line="\# to allow missing species to be set a default value."
     sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 
-    line="sed_ie 's\/EFYO\/CYS\/'            HEMCO_Config.rc  \# GC_RESTART"
+    line="sed_ie 's\/EFYO\/CYS\/'             HEMCO_Config.rc  \# GC_RESTART"
     sed_ie "s/REPLACE3/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 
-    line="sed_ie 's\/EFY xyz 1\/CYS xyz 1\/' HEMCO_Config.rc  \# GC_BCs"
+    line="sed_ie 's\/EFY.*xyz 1\/CYS xyz 1\/' HEMCO_Config.rc  \# GC_BCs"
     sed_ie "s/REPLACE4/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 
     sed_ie "/REPLACE5$/d"        "${scriptsDir}/integrationTestExecute.sh"

--- a/test/integration/GCClassic/integrationTest.sh
+++ b/test/integration/GCClassic/integrationTest.sh
@@ -199,27 +199,32 @@ scriptsDir="${itRoot}/${SCRIPTS_DIR}"
 if [[ "x${bootStrap}" == "xno" ]]; then
     line="\# Change time cycle flags in HEMCO_Config.rc from CYS to EFY(O),"
     sed_ie "s/REPLACE1/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-    
+
     line="\# to prevent missing species from being set to a default value."
     sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 
-    line="sed_ie 's\/CYS xyz 1\/EFY xyz 1\/' HEMCO_Config.rc  \# GC_BCs"
+    line="sed_ie 's\/CYS xyz 1\/EFY xyz 1\/'  HEMCO_Config.rc  \# GC_BCs"
     sed_ie "s/REPLACE3/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 
-    line="sed_ie 's\/CYS\/EFYO\/'            HEMCO_Config.rc  \# GC_RESTART"
-    sed_ie "s/REPLACE4/${line}/" "${scriptsDir}/integrationTestExecute.sh"    
-else    
+    line="sed_ie 's\/CYS\/EFYO\/'             HEMCO_Config.rc  \# GC_RESTART"
+    sed_ie "s/REPLACE4/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+
+    line="sed_ie 's\/EY  xyz 1\/EFYO xyz 1\/' HEMCO_Config.rc  \# GC_RESTART"
+    sed_ie "s/REPLACE5/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+else
     line="\# Change time cycle flags in HEMCO_Config.rc from EFYO to CYS,"
     sed_ie "s/REPLACE1/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-    
+
     line="\# to allow missing species to be set a default value."
     sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 
     line="sed_ie 's\/EFYO\/CYS\/'            HEMCO_Config.rc  \# GC_RESTART"
     sed_ie "s/REPLACE3/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-    
+
     line="sed_ie 's\/EFY xyz 1\/CYS xyz 1\/' HEMCO_Config.rc  \# GC_BCs"
     sed_ie "s/REPLACE4/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+
+    sed_ie "/REPLACE5$/d"        "${scriptsDir}/integrationTestExecute.sh"
 fi
 
 # Navigate to the logs directory (so all output will be placed there)

--- a/test/integration/GCClassic/integrationTest.sh
+++ b/test/integration/GCClassic/integrationTest.sh
@@ -46,8 +46,8 @@ itRoot="none"
 envFile="none"
 scheduler="none"
 sedPartitionCmd="none"
-sedBootStrapCmd="none"
 quick="no"
+bootStrap="yes"
 
 #=============================================================================
 # Parse command-line arguments
@@ -89,7 +89,7 @@ while [ : ]; do
 	# -n or --no-bootstrap prevents bootstrapping missing variables in
         # restart files (i.e. do not change EFYO -> CYS in HEMCO_Config.rc)
 	-n | --no-bootstrap)
-            sedBootStrapCmd='/\/EFY/d'
+            bootStrap="no"
 	    shift
             ;;
 
@@ -190,10 +190,11 @@ scriptsDir="${itRoot}/${SCRIPTS_DIR}"
 
 # If --no-bootstrap is selected, also remove the lines in
 # integrationTestExecute that reset EFYO -> CYS and EFY -> CYS
-if [[ "x${sedBootStrapCmd}" != "xnone" ]]; then
-    sed_ie "/time cycle flags/d" "${scriptsDir}/integrationTestExecute.sh"
-    sed_ie "/missing species/d"  "${scriptsDir}/integrationTestExecute.sh"
-    sed_ie "${sedBootStrapCmd}"  "${scriptsDir}/integrationTestExecute.sh"
+if [[ "x${bootStrap}" == "xno" ]]; then
+    sed_ie '/HEMCO_Config.rc  \# GC_RESTART$/d' \
+	   "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie '/HEMCO_Config.rc  \# GC_BCs$/d' \
+	   "${scriptsDir}/integrationTestExecute.sh"
 fi
 
 # Navigate to the logs directory (so all output will be placed there)
@@ -288,6 +289,10 @@ elif [[ "x${scheduler}" == "xLSF" ]]; then
     exeId=${exeId/<}
     exeId=${exeId/>}
 
+    echo ""
+    echo "Compilation tests submitted as LSF job ${cmpId}"
+    echo "Execution   tests submitted as LSF job ${exeId}"
+
 else
 
     #-------------------------------------------------------------------------
@@ -303,7 +308,6 @@ fi
 
 # Change back to this directory
 cd "${thisDir}"
-
 
 #=============================================================================
 # Cleanup and quit

--- a/test/integration/GCClassic/integrationTest.sh
+++ b/test/integration/GCClassic/integrationTest.sh
@@ -194,13 +194,32 @@ fi
 logsDir="${itRoot}/${LOGS_DIR}"
 scriptsDir="${itRoot}/${SCRIPTS_DIR}"
 
-# If --no-bootstrap is selected, also remove the lines in
-# integrationTestExecute that reset EFYO -> CYS and EFY -> CYS
+# If --no-bootstrap is selected, make sure HEMCO_Config.rc entries for
+# boundary conditions and restart files do not allow missing values.
 if [[ "x${bootStrap}" == "xno" ]]; then
-    sed_ie '/HEMCO_Config.rc  \# GC_RESTART$/d' \
-	   "${scriptsDir}/integrationTestExecute.sh"
-    sed_ie '/HEMCO_Config.rc  \# GC_BCs$/d' \
-	   "${scriptsDir}/integrationTestExecute.sh"
+    line="\# Change time cycle flags in HEMCO_Config.rc from CYS to EFY(O),"
+    sed_ie "s/REPLACE1/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+    
+    line="\# to prevent missing species from being set to a default value."
+    sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+
+    line="sed_ie 's\/CYS xyz 1\/EFY xyz 1\/' HEMCO_Config.rc  \# GC_BCs"
+    sed_ie "s/REPLACE3/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+
+    line="sed_ie 's\/CYS\/EFYO\/'            HEMCO_Config.rc  \# GC_RESTART"
+    sed_ie "s/REPLACE4/${line}/" "${scriptsDir}/integrationTestExecute.sh"    
+else    
+    line="\# Change time cycle flags in HEMCO_Config.rc from EFYO to CYS,"
+    sed_ie "s/REPLACE1/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+    
+    line="\# to allow missing species to be set a default value."
+    sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+
+    line="sed_ie 's\/EFYO\/CYS\/'            HEMCO_Config.rc  \# GC_RESTART"
+    sed_ie "s/REPLACE3/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+    
+    line="sed_ie 's\/EFY xyz 1\/CYS xyz 1\/' HEMCO_Config.rc  \# GC_BCs"
+    sed_ie "s/REPLACE4/${line}/" "${scriptsDir}/integrationTestExecute.sh"
 fi
 
 # Navigate to the logs directory (so all output will be placed there)

--- a/test/integration/GCClassic/integrationTest.sh
+++ b/test/integration/GCClassic/integrationTest.sh
@@ -169,6 +169,12 @@ fi
 # Convert integration test root folder to an absolute path
 itRoot=$(absolute_path "${itRoot}")
 
+# Prevent running integration tests in the source code directory tree
+if [[ "$(absolute_path ${thisDir})" =~ "${itRoot}" ]]; then
+    echo "ERROR: You cannot run integration tests in the source code directory!"
+    exit 1
+fi
+
 # Create GEOS-Chem run directories in the integration test root folder
 ./integrationTestCreate.sh "${itRoot}" "${envFile}" "${quick}"
 if [[ $? -ne 0 ]]; then

--- a/test/integration/GCClassic/integrationTestExecute.sh
+++ b/test/integration/GCClassic/integrationTestExecute.sh
@@ -200,6 +200,7 @@ for runDir in *; do
 	    REPLACE2
 	    REPLACE3
 	    REPLACE4
+	    REPLACE5
 
             # Run the code if the executable is present.  Then update the
             # pass/fail counters and write a message to the results log file.

--- a/test/integration/GCClassic/integrationTestExecute.sh
+++ b/test/integration/GCClassic/integrationTestExecute.sh
@@ -196,12 +196,6 @@ for runDir in *; do
             # Remove any leftover files in the run dir
             ./cleanRunDir.sh --no-interactive >> "${log}" 2>&1
 
-	    REPLACE1
-	    REPLACE2
-	    REPLACE3
-	    REPLACE4
-	    REPLACE5
-
             # Run the code if the executable is present.  Then update the
             # pass/fail counters and write a message to the results log file.
             if [[ "x${scheduler}" == "xSLURM" ]]; then

--- a/test/integration/GCClassic/integrationTestExecute.sh
+++ b/test/integration/GCClassic/integrationTestExecute.sh
@@ -196,10 +196,10 @@ for runDir in *; do
             # Remove any leftover files in the run dir
             ./cleanRunDir.sh --no-interactive >> "${log}" 2>&1
 
-            # Change time cycle flags in HEMCO_Config.rc from EFYO to CYS,
-            # to allow missing species to be set a default value.
-            sed_ie "s/EFYO/CYS/"            HEMCO_Config.rc  # GC_RESTART
-            sed_ie "s/EFY xyz 1/CYS xyz 1/" HEMCO_Config.rc  # GC_BCs
+	    REPLACE1
+	    REPLACE2
+	    REPLACE3
+	    REPLACE4
 
             # Run the code if the executable is present.  Then update the
             # pass/fail counters and write a message to the results log file.

--- a/test/integration/GCHP/README.md
+++ b/test/integration/GCHP/README.md
@@ -77,9 +77,15 @@ The integration test scripts accept the following command-line arguments
 
 `-s` specifies that the SLURM scheduler will be used to run the integration test scripts.
 
+`-n` specifies that missing species in restart files will not be bootstrapped to a missing value.  This can be used to test if "out-of-the-box" simulations will fail before a version release.
+
+`-h` displays a help screeen.
+
 You can also use long names for the option switches:
 - `--directory` instead of `-d`
 - `--env-file` instead of `-e`
+- `--help` instead of `h`
+- `--no-bootstrap` instead of `n`
 - `--partition partition` instead of `-p`
 - `--scheduler scheduler` instead of `-s`
 

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -193,11 +193,17 @@ fi
 logsDir="${itRoot}/${LOGS_DIR}"
 scriptsDir="${itRoot}/${SCRIPTS_DIR}"
 
-# If --no-bootstrap is selected, also remove the lines in
-# commonFunctionsForTests.sh that allows missing species in restart files
+# If --no-bootstrap is selected, then add a line to integrateTestExecute.sh
+# that will tell GCHP to require all species in the restart file.
 if [[ "x${bootStrap}" == "xno" ]]; then
-    sed_ie '/Require_Species_in_Restart$/d' \
-	   "${scriptsDir}/commonFunctionsForTests.sh"
+    line="\# Edit setCommonRunSettings.sh to disable bootstrapping"
+    sed_ie "s/REPLACE1/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+
+    line="sed_ie 's\/Require_Species_in_Restart\=0\/Require_Species_in_Restart\=1\/' setCommonRunSettings.sh"
+    sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
+else
+    sed_ie '/REPLACE1$/d' "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie '/REPLACE2$/d' "${scriptsDir}/integrationTestExecute.sh"
 fi
 
 # Navigate to the logs directory (so all output will be placed there)

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -192,19 +192,11 @@ fi
 # Define local convenience variables
 logsDir="${itRoot}/${LOGS_DIR}"
 scriptsDir="${itRoot}/${SCRIPTS_DIR}"
+rundirsDir="${itRoot}/${RUNDIRS_DIR}"
 
-# If --no-bootstrap is selected, then add a line to integrateTestExecute.sh
-# that will tell GCHP to require all species in the restart file.
-if [[ "x${bootStrap}" == "xno" ]]; then
-    line="\# Edit setCommonRunSettings.sh to disable bootstrapping"
-    sed_ie "s/REPLACE1/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-
-    line="sed_ie 's\/Require_Species_in_Restart\=0\/Require_Species_in_Restart\=1\/' setCommonRunSettings.sh"
-    sed_ie "s/REPLACE2/${line}/" "${scriptsDir}/integrationTestExecute.sh"
-else
-    sed_ie '/REPLACE1$/d' "${scriptsDir}/integrationTestExecute.sh"
-    sed_ie '/REPLACE2$/d' "${scriptsDir}/integrationTestExecute.sh"
-fi
+# Edit setCommonRunSettingss.sh scripts to enable or disable bootstrapping
+# (i.e. to allow missing species in restart files or not)
+gchp_enable_or_disable_bootstrap "${bootStrap}" "${rundirsDir}"
 
 # Navigate to the logs directory (so all output will be placed there)
 cd "${logsDir}"

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -19,18 +19,20 @@
 #    -d root-dir  : Specify the root folder for integration tests
 #    -e env-file  : Specify the environment file (w/ module loads)
 #    -h           : Display a help message
+#    -n           : Do not bootstrap missing restart file variables
 #    -p partition : Select partition for SLURM or LSF schedulers
 #    -q           : Run a quick set of integration tests (for testing)
 #    -s scheduler : Specify the scheduler (SLURM or LSF)
 #
 #  NOTE: you can also use the following long name options:
 #
-#    --directory root-dir  (instead of -d root-directory)
-#    --env-file  env-file  (instead of -e env-file      )
-#    --help                (instead of -h               )
-#    --partition partition (instead of -p partition     )
-#    --quick               (instead of -q               )
-#    --scheduler scheduler (instead of -s scheduler     )
+#    --directory root-dir  (instead of -d root-dir )
+#    --env-file  env-file  (instead of -e env-file )
+#    --help   #    --help                (instead of -h          )
+#    --no-bootstrap        (instead of -n          )
+#    --partition partition (instead of -p partition)
+#    --quick               (instead of -q          )
+#    --scheduler scheduler (instead of -s scheduler)
 #EOP
 #------------------------------------------------------------------------------
 #BOC
@@ -43,7 +45,8 @@ usage="Usage: ${this} -d root-dir -e env-file [-h] [-p partition] [-q] [-s sched
 itRoot="none"
 envFile="none"
 scheduler="none"
-sedCmd="none"
+sedPartitionCmd="none"
+sedBootStrapCmd="none"
 quick="no"
 
 #=============================================================================
@@ -53,8 +56,8 @@ quick="no"
 
 # Call Linux getopt function to specify short & long input options
 # (e.g. -d or --directory, etc).  Exit if not succesful
-validArgs=$(getopt --options d:e:hp:qs: \
-  --long directory:,env-file:,help,partition:,quick,scheduler: -- "$@")
+validArgs=$(getopt --options d:e:hnp:qs: \
+  --long directory:,env-file:,help,no-bootstrap,partition:,quick,scheduler: -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
 fi
@@ -65,15 +68,15 @@ eval set -- "${validArgs}"
 while [ : ]; do
     case "${1}" in
 
-	# -d or --directory specifies the root folder for tests
-	-d | --directory)
-	    itRoot="${2}"
+        # -d or --directory specifies the root folder for tests
+        -d | --directory)
+            itRoot="${2}"
             shift 2
             ;;
 
 	# -e or --env-file specifies the environment file
 	-e | --env-file)
-	    envFile="${2}"
+            envFile="${2}"
             shift 2
             ;;
 
@@ -83,15 +86,22 @@ while [ : ]; do
             exit 1
             ;;
 
+	# -n or --no-bootstrap prevents bootstrapping missing variables in
+        # restart files (i.e. do not change EFYO -> CYS in HEMCO_Config.rc)
+	-n | --no-bootstrap)
+            sedBootStrapCmd='/\/EFY/d'
+	    shift
+            ;;
+
 	# -p or --partition replaces REQUESTED_PARTITION with the user's choice
 	-p | --partition)
-	    sedCmd="s/REQUESTED_PARTITION/${2}/"
-	    shift 2
-	    ;;
+            sedPartitionCmd="s/REQUESTED_PARTITION/${2}/"
+            shift 2
+            ;;
 
 	# -q or --quick runs a quick set of integration tests (for testing)
 	-q | --quick)
-	    quick="yes"
+            quick="yes"
             shift
 	    ;;
 
@@ -125,14 +135,14 @@ if [[ "x${scheduler}" != "xLSF" ]]; then
 fi
 
 # Exit if no partition has been selected for SLURM
-if [[ "x${scheduler}" == "xSLURM" && "x${sedCmd}" == "xnone" ]]; then
+if [[ "x${scheduler}" == "xSLURM" && "x${sedPartitionCmd}" == "xnone" ]]; then
     echo "ERROR: You must specify a partition for SLURM."
     echo "${usage}"
     exit 1
 fi
 
 # Exit if no partition has been selected for SLURM
-if [[ "x${scheduler}" == "xLSF" && "x${sedCmd}" == "xnone" ]]; then
+if [[ "x${scheduler}" == "xLSF" && "x${sedPartitionCmd}" == "xnone" ]]; then
     echo "ERROR: You must specify a partition for LSF."
     echo "${usage}"
     exit 1
@@ -178,6 +188,14 @@ fi
 logsDir="${itRoot}/${LOGS_DIR}"
 scriptsDir="${itRoot}/${SCRIPTS_DIR}"
 
+# If --no-bootstrap is selected, also remove the lines in
+# integrationTestExecute that reset EFYO -> CYS and EFY -> CYS
+if [[ "x${sedBootStrapCmd}" != "xnone" ]]; then
+    sed_ie "/time cycle flags/d" "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie "/missing species/d"  "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie "${sedBootStrapCmd}"  "${scriptsDir}/integrationTestExecute.sh"
+fi
+
 # Navigate to the logs directory (so all output will be placed there)
 cd "${logsDir}"
 
@@ -213,8 +231,8 @@ if [[ "x${scheduler}" == "xSLURM" ]]; then
 	"${scriptsDir}/integrationTestExecute.sh"
 
     # Replace "REQUESTED_PARTITION" with the partition name
-    sed_ie "${sedCmd}" "${scriptsDir}/integrationTestCompile.sh"
-    sed_ie "${sedCmd}" "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie "${sedPartitionCmd}" "${scriptsDir}/integrationTestCompile.sh"
+    sed_ie "${sedPartitionCmd}" "${scriptsDir}/integrationTestExecute.sh"
 
     # Submit compilation tests script
     output=$(sbatch ${scriptsDir}/integrationTestCompile.sh)
@@ -252,8 +270,8 @@ elif [[ "x${scheduler}" == "xLSF" ]]; then
     sed_ie '/#SBATCH --mail-type=END/d'        "${scriptsDir}/integrationTestExecute.sh"
 
     # Replace "REQUESTED_PARTITION" with the partition name
-    sed_ie "${sedCmd}" "${scriptsDir}/integrationTestCompile.sh"
-    sed_ie "${sedCmd}" "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie "${sedPartitionCmd}" "${scriptsDir}/integrationTestCompile.sh"
+    sed_ie "${sedPartitionCmd}" "${scriptsDir}/integrationTestExecute.sh"
 
     # Submit compilation tests script
     output=$(bsub ${scriptsDir}/integrationTestCompile.sh)

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -194,12 +194,10 @@ logsDir="${itRoot}/${LOGS_DIR}"
 scriptsDir="${itRoot}/${SCRIPTS_DIR}"
 
 # If --no-bootstrap is selected, also remove the lines in
-# integrationTestExecute that reset EFYO -> CYS and EFY -> CYS
+# commonFunctionsForTests.sh that allows missing species in restart files
 if [[ "x${bootStrap}" == "xno" ]]; then
-    sed_ie '/HEMCO_Config.rc  \# GC_RESTART$/d' \
-	   "${scriptsDir}/integrationTestExecute.sh"
-    sed_ie '/HEMCO_Config.rc  \# GC_BCs$/d' \
-	   "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie '/Require_Species_in_Restart$/d' \
+	   "${scriptsDir}/commonFunctionsForTests.sh"
 fi
 
 # Navigate to the logs directory (so all output will be placed there)

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -169,6 +169,11 @@ fi
 # Convert integration test root folder to an absolute path
 itRoot=$(absolute_path "${itRoot}")
 
+# Prevent running integration tests in the source code directory tree
+if [[ "$(absolute_path ${thisDir})" =~ "${itRoot}" ]]; then
+    echo "ERROR: You cannot run integration tests in the source code directory!"
+    exit 1
+fi
 # Create GEOS-Chem run directories in the integration test root folder
 ./integrationTestCreate.sh "${itRoot}" "${envFile}" "${quick}"
 if [[ $? -ne 0 ]]; then

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -28,7 +28,7 @@
 #
 #    --directory root-dir  (instead of -d root-dir )
 #    --env-file  env-file  (instead of -e env-file )
-#    --help   #    --help                (instead of -h          )
+#    --help                (instead of -h          )
 #    --no-bootstrap        (instead of -n          )
 #    --partition partition (instead of -p partition)
 #    --quick               (instead of -q          )
@@ -46,8 +46,8 @@ itRoot="none"
 envFile="none"
 scheduler="none"
 sedPartitionCmd="none"
-sedBootStrapCmd="none"
 quick="no"
+bootStrap="yes"
 
 #=============================================================================
 # Parse command-line arguments
@@ -89,7 +89,7 @@ while [ : ]; do
 	# -n or --no-bootstrap prevents bootstrapping missing variables in
         # restart files (i.e. do not change EFYO -> CYS in HEMCO_Config.rc)
 	-n | --no-bootstrap)
-            sedBootStrapCmd='/\/EFY/d'
+            bootStrap="no"
 	    shift
             ;;
 
@@ -176,7 +176,7 @@ if [[ $? -ne 0 ]]; then
    exit 1
 fi
 
-# Change to the integration test root folder
+# Navigate to the root test folder
 if [[ -d "${itRoot}" ]]; then
     cd "${itRoot}"
 else
@@ -190,10 +190,11 @@ scriptsDir="${itRoot}/${SCRIPTS_DIR}"
 
 # If --no-bootstrap is selected, also remove the lines in
 # integrationTestExecute that reset EFYO -> CYS and EFY -> CYS
-if [[ "x${sedBootStrapCmd}" != "xnone" ]]; then
-    sed_ie "/time cycle flags/d" "${scriptsDir}/integrationTestExecute.sh"
-    sed_ie "/missing species/d"  "${scriptsDir}/integrationTestExecute.sh"
-    sed_ie "${sedBootStrapCmd}"  "${scriptsDir}/integrationTestExecute.sh"
+if [[ "x${bootStrap}" == "xno" ]]; then
+    sed_ie '/HEMCO_Config.rc  \# GC_RESTART$/d' \
+	   "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie '/HEMCO_Config.rc  \# GC_BCs$/d' \
+	   "${scriptsDir}/integrationTestExecute.sh"
 fi
 
 # Navigate to the logs directory (so all output will be placed there)
@@ -302,10 +303,10 @@ else
     echo "Compiliation tests are running..."
     ${scriptsDir}/integrationTestCompile.sh &
 
-    # Change back to this directory
-    cd "${thisDir}"
-
 fi
+
+# Change back to this directory
+cd "${thisDir}"
 
 #=============================================================================
 # Cleanup and quit

--- a/test/integration/GCHP/integrationTestExecute.sh
+++ b/test/integration/GCHP/integrationTestExecute.sh
@@ -203,6 +203,9 @@ for runDir in *; do
             # Link to the environment file
             ./setEnvironmentLink.sh "${envDir}/gchp.env"
 
+	    REPLACE1
+	    REPLACE2
+
             # Update config files, set links, load environment, sanity checks
             . setCommonRunSettings.sh >> "${log}" 2>&1
             . setRestartLink.sh       >> "${log}" 2>&1

--- a/test/integration/GCHP/integrationTestExecute.sh
+++ b/test/integration/GCHP/integrationTestExecute.sh
@@ -203,9 +203,6 @@ for runDir in *; do
             # Link to the environment file
             ./setEnvironmentLink.sh "${envDir}/gchp.env"
 
-	    REPLACE1
-	    REPLACE2
-
             # Update config files, set links, load environment, sanity checks
             . setCommonRunSettings.sh >> "${log}" 2>&1
             . setRestartLink.sh       >> "${log}" 2>&1

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -70,9 +70,9 @@ function sed_ie() {
     regex="${1}"
     file="${2}"
     if [[ "x$(uname -s)" == "xDarwin" ]]; then
-	sed -i '' -e "${regex}" "${file}"          # MacOS/Darwin
+        sed -i '' -e "${regex}" "${file}"          # MacOS/Darwin
     else
-	sed -i -e "${regex}" "${file}"             # GNU/Linux
+        sed -i -e "${regex}" "${file}"             # GNU/Linux
     fi
 }
 
@@ -84,9 +84,9 @@ function absolute_path() {
     # 1st argument = relative path
     #========================================================================
     if [[ -d "${1}" ]]; then
-	absPath=$(readlink -f "${1}")   # If directory exists, use readlink
+        absPath=$(readlink -f "${1}")   # If directory exists, use readlink
     else
-	absPath="${1/#\~/$HOME}"        # Otherwise, replace ~ with $HOME
+        absPath="${1/#\~/$HOME}"        # Otherwise, replace ~ with $HOME
     fi
     echo "${absPath}"
 }
@@ -99,11 +99,11 @@ function is_valid_rundir() {
     # 1st argument: File or directory to be tested
     #========================================================================
     if [[ -d "${1}" ]]; then
-	if [[ -f "${1}/geoschem_config.yml" && \
-	      -f "${1}/HEMCO_Config.rc" ]]; then
-	    echo "TRUE"
-	    return
-	fi
+        if [[ -f "${1}/geoschem_config.yml" && \
+          -f "${1}/HEMCO_Config.rc" ]]; then
+            echo "TRUE"
+            return
+        fi
     fi
     echo "FALSE"
 }
@@ -117,10 +117,10 @@ function is_gchp_rundir() {
     #========================================================================
     expr=$(is_valid_rundir "${1}")
     if [[ "x${expr}" == "xTRUE" ]]; then
-	if [[ -f "${1}/CAP.rc" ]]; then
-	    echo "TRUE"
-	    return
-	fi
+        if [[ -f "${1}/CAP.rc" ]]; then
+            echo "TRUE"
+            return
+        fi
     fi
     echo "FALSE"
 }
@@ -139,10 +139,10 @@ function count_rundirs() {
     cd "${rundirsDir}"
     declare -i x=0
     for runDir in *; do
-	expr=$(is_valid_rundir "${runDir}")
-	if [[ "x${expr}" == "xTRUE" ]]; then
-	    let x++
-	fi
+        expr=$(is_valid_rundir "${runDir}")
+        if [[ "x${expr}" == "xTRUE" ]]; then
+            let x++
+        fi
     done
     cd "${thisDir}"
 
@@ -200,8 +200,8 @@ function update_config_files() {
     # For nested-grid fullchem runs, change simulation time to 20 minutes
     # in order to reduce the run time of the whole set of integration tests.
     if grep -q "05x0625" <<< "${runPath}"; then
-	sed_ie "${SED_CONFIG_N1}" "${runPath}/geoschem_config.yml"
-	sed_ie "${SED_CONFIG_N2}" "${runPath}/geoschem_config.yml"
+        sed_ie "${SED_CONFIG_N1}" "${runPath}/geoschem_config.yml"
+        sed_ie "${SED_CONFIG_N2}" "${runPath}/geoschem_config.yml"
     fi
 
     # Other text replacements
@@ -219,10 +219,10 @@ function update_config_files() {
     # For all nested-grid rundirs, add a NA into the entries for met fields
     # Also update the DiagnFreq for nested or global simulations
     if grep -q "05x0625" <<< "${runPath}"; then
-	sed_ie "${SED_HEMCO_CONF_N}" "${runPath}/HEMCO_Config.rc"
-	sed_ie "${SED_HEMCO_CONF_4}" "${runPath}/HEMCO_Config.rc"
+        sed_ie "${SED_HEMCO_CONF_N}" "${runPath}/HEMCO_Config.rc"
+        sed_ie "${SED_HEMCO_CONF_4}" "${runPath}/HEMCO_Config.rc"
     else
-	sed_ie "${SED_HEMCO_CONF_3}" "${runPath}/HEMCO_Config.rc"
+        sed_ie "${SED_HEMCO_CONF_3}" "${runPath}/HEMCO_Config.rc"
     fi
 
     # Other text replacements
@@ -234,14 +234,15 @@ function update_config_files() {
     #------------------------------------------------------------------------
 
     if [[ -f "${runPath}/HEMCO_Config.rc.gmao_metfields" ]]; then
-	# For all nested-grid rundirs, add a NA into the entries for met fields
-	if grep -q "05x0625" <<< "${runPath}"; then
-	    sed_ie "${SED_HEMCO_CONF_N}" "${runPath}/HEMCO_Config.rc.gmao_metfields"
-	fi
+        # For all nested-grid rundirs, add a NA into the entries for met fields
+        if grep -q "05x0625" <<< "${runPath}"; then
+            sed_ie "${SED_HEMCO_CONF_N}" \
+           "${runPath}/HEMCO_Config.rc.gmao_metfields"
+        fi
 
-	# Other text replacements
-	sed_ie "${SED_HEMCO_CONF_1}" "${runPath}/HEMCO_Config.rc.gmao_metfields"
-	sed_ie "${SED_HEMCO_CONF_2}" "${runPath}/HEMCO_Config.rc.gmao_metfields"
+        # Other text replacements
+        sed_ie "${SED_HEMCO_CONF_1}" "${runPath}/HEMCO_Config.rc.gmao_metfields"
+        sed_ie "${SED_HEMCO_CONF_2}" "${runPath}/HEMCO_Config.rc.gmao_metfields"
     fi
 
     #------------------------------------------------------------------------
@@ -251,7 +252,7 @@ function update_config_files() {
     # For nested-grid fullchem runs, change frequency and duration to 20 mins
     # in order to reduce the run time of the whole set of integration tests.
     if grep -q "05x0625" <<< "${runPath}"; then
-	sed_ie "${SED_HISTORY_RC_N}" "${runPath}/HISTORY.rc"
+        sed_ie "${SED_HISTORY_RC_N}" "${runPath}/HISTORY.rc"
     fi
 
     # Other text replacements
@@ -286,11 +287,11 @@ function create_rundir() {
     # Now concatenate the temporary log into the log file
     # (Or create the log file if it doesn't yet exist)
     if [[ -f "${log}" ]]; then
-	cat "${log}" "${logTmp}" >> "${logTmp2}"
-	mv -f "${logTmp2}" "${log}"
-	rm -f "${logTmp}"
+        cat "${log}" "${logTmp}" >> "${logTmp2}"
+        mv -f "${logTmp2}" "${log}"
+        rm -f "${logTmp}"
     else
-	mv "${logTmp}" "${log}"
+        mv "${logTmp}" "${log}"
     fi
 
     # Change start & end dates etc. in rundir configuration files
@@ -300,7 +301,7 @@ function create_rundir() {
     # GCHP-specific rundir configuration files etc.
     expr=$(is_gchp_rundir "${runPath}")
     if [[ "x${expr}" == "xTRUE" ]]; then
-	update_gchp_config_files "${runPath}"
+        update_gchp_config_files "${runPath}"
     fi
 
     # Remove temporary logs
@@ -317,28 +318,28 @@ function cleanup_files() {
     itRoot="${1}"
     if [[ "x${itRoot}" != "x" ]]; then
 
-	# Exit if directory is already empty
-	if [[ ! $(ls -A "${itRoot}") ]]; then
-	    echo "${itRoot} is empty... nothing to clean up!"
-	    return 0
-	fi
+    # Exit if directory is already empty
+    if [[ ! $(ls -A "${itRoot}") ]]; then
+        echo "${itRoot} is empty... nothing to clean up!"
+        return 0
+    fi
 
-	# Give user a chance to avoid removing files
-	printf "\nRemoving files and directories in ${itRoot}:\n"
-	printf "If this is OK, type 'yes to proceed or 'no' to quit:\n"
-	read answer
-	if [[ ! "${answer}" =~ [Yy][Ee][Ss] ]]; then
-	    printf "Exiting...\n"
-	    exit 1
-	fi
+    # Give user a chance to avoid removing files
+    printf "\nRemoving files and directories in ${itRoot}:\n"
+    printf "If this is OK, type 'yes to proceed or 'no' to quit:\n"
+    read answer
+    if [[ ! "${answer}" =~ [Yy][Ee][Ss] ]]; then
+        printf "Exiting...\n"
+        exit 1
+    fi
 
-	# Remove files and unlink links
-	printf "Removing ...\n"
-	for entry in ${itRoot}/*; do
-	    printf " ... ${entry}\n";
-	    [[ -L ${entry} ]] && unlink ${entry}
-	    [[ -e ${entry} ]] && rm -rf ${entry}
-	done
+    # Remove files and unlink links
+    printf "Removing ...\n"
+    for entry in ${itRoot}/*; do
+        printf " ... ${entry}\n";
+        [[ -L ${entry} ]] && unlink ${entry}
+        [[ -e ${entry} ]] && rm -rf ${entry}
+    done
     fi
 }
 
@@ -374,19 +375,19 @@ function exe_name() {
 
     # Append a suffix to the executable file name for specific directories
     if [[ "x${model}" == "xgcclassic" ]]; then
-	for suffix in ${EXE_GCC_BUILD_LIST[@]}; do
-	    if [[ "${buildDir}" =~ "${suffix}" ]]; then
-		exeFileName+=".${suffix}"
-		break
-	    fi
-	done
+    for suffix in ${EXE_GCC_BUILD_LIST[@]}; do
+        if [[ "${buildDir}" =~ "${suffix}" ]]; then
+        exeFileName+=".${suffix}"
+        break
+        fi
+    done
     elif [[ "x${model}" == "xgchp" ]]; then
-	for suffix in ${EXE_GCHP_BUILD_LIST[@]}; do
-	    if [[ "${buildDir}" =~ "${suffix}" ]]; then
-		exeFileName+=".${suffix}"
-		break
-	    fi
-	done
+    for suffix in ${EXE_GCHP_BUILD_LIST[@]}; do
+        if [[ "${buildDir}" =~ "${suffix}" ]]; then
+        exeFileName+=".${suffix}"
+        break
+        fi
+    done
     fi
 
     # Turn off case-insensitivity
@@ -419,21 +420,21 @@ function config_options() {
 
     # Pick the proper build options
     if [[ ${dir} =~ "apm" ]]; then
-	options="${baseOptions} -DAPM=y -DEXE_FILE_NAME=${exeFileName}"
+        options="${baseOptions} -DAPM=y -DEXE_FILE_NAME=${exeFileName}"
     elif [[ ${dir} =~ "carbon" ]]; then
-	options="${baseOptions} -DMECH=carbon -DEXE_FILE_NAME=${exeFileName}"
+        options="${baseOptions} -DMECH=carbon -DEXE_FILE_NAME=${exeFileName}"
     elif [[ ${dir} =~ "hg" ]]; then
-	options="${baseOptions} -DMECH=Hg -DEXE_FILE_NAME=${exeFileName}"
+        options="${baseOptions} -DMECH=Hg -DEXE_FILE_NAME=${exeFileName}"
     elif [[ ${dir} =~ "luowd" ]]; then
-	options="${baseOptions} -DLUO_WETDEP=y -DEXE_FILE_NAME=${exeFileName}"
+        options="${baseOptions} -DLUO_WETDEP=y -DEXE_FILE_NAME=${exeFileName}"
     elif [[ ${dir} =~ "rrtmg" ]]; then
-	options="${baseOptions} -DRRTMG=y -DEXE_FILE_NAME=${exeFileName}"
+        options="${baseOptions} -DRRTMG=y -DEXE_FILE_NAME=${exeFileName}"
     elif [[ ${dir} =~ "tomas15" ]]; then
-	options="${baseOptions} -DTOMAS=y -DTOMAS_BINS=15 -DBPCH_DIAG=y -DEXE_FILE_NAME=${exeFileName}"
+        options="${baseOptions} -DTOMAS=y -DTOMAS_BINS=15 -DBPCH_DIAG=y -DEXE_FILE_NAME=${exeFileName}"
     elif [[ ${dir} =~ "tomas40" ]]; then
-	options="${baseOptions} -DTOMAS=y -DTOMAS_BINS=40 -DBPCH_DIAG=y -DEXE_FILE_NAME=${exeFileName}"
+        options="${baseOptions} -DTOMAS=y -DTOMAS_BINS=40 -DBPCH_DIAG=y -DEXE_FILE_NAME=${exeFileName}"
     else
-	options="${baseOptions}"
+        options="${baseOptions}"
     fi
 
     # Turn off case-insensitivity
@@ -463,21 +464,21 @@ function compiletest_name() {
 
     # Pick the proper build options
     if [[ "${buildDir}" =~ "apm" ]]; then
-	result="${displayName} with APM"
+        result="${displayName} with APM"
     elif [[ "${buildDir}" =~ "carbon" ]]; then
-	result="${displayName} w/ carbon gases (as a KPP mechanism)"
+        result="${displayName} w/ carbon gases (as a KPP mechanism)"
     elif [[ "${buildDir}" =~ "luowd" ]]; then
-	result="${displayName} with Luo et al wetdep"
+        result="${displayName} with Luo et al wetdep"
     elif [[ "${buildDir}" =~ "hg" ]]; then
-	result="${displayName} with Hg (as a KPP mechanism)"
+        result="${displayName} with Hg (as a KPP mechanism)"
     elif [[ "${buildDir}" =~ "rrtmg" ]]; then
-	result="${displayName} with RRTMG"
+        result="${displayName} with RRTMG"
     elif [[ "${buildDir}" =~ "tomas15" ]]; then
-	result="${displayName} with TOMAS15"
+        result="${displayName} with TOMAS15"
     elif [[ "${buildDir}" =~ "tomas40" ]]; then
-	result="${displayName} with TOMAS40"
+        result="${displayName} with TOMAS40"
     else
-	result="${displayName}"
+        result="${displayName}"
     fi
 
     # Turn off case-insensitivity
@@ -511,9 +512,9 @@ function build_model() {
 
     # Stop with error if the model name is invalid
     if [[ "x${model}" != "xgcclassic" && "x${model}" != "xgchp" ]]; then
-	echo "ERROR: '${model}' is an invalid model name!"
-	echo "Exiting in 'build_model' (in 'commonFunctionsForTests.sh')"
-	exit 1
+        echo "ERROR: '${model}' is an invalid model name!"
+        echo "Exiting in 'build_model' (in 'commonFunctionsForTests.sh')"
+        exit 1
     fi
 
     # Local variables
@@ -533,10 +534,10 @@ function build_model() {
     # it as a single string rather than individual options.
     cmake "${codeDir}" ${configOptions} >> "${log}" 2>&1
     if [[ $? -ne 0 ]]; then
-	if [[ "x${results}" != "x" ]]; then
-	    print_to_log "${failMsg}" "${results}"
-	fi
-	return 1
+        if [[ "x${results}" != "x" ]]; then
+            print_to_log "${failMsg}" "${results}"
+        fi
+        return 1
     fi
 
     #----------------------------------------
@@ -544,10 +545,10 @@ function build_model() {
     #----------------------------------------
     make -j install >> "${log}" 2>&1
     if [[ $? -ne 0 ]]; then
-	if [[ "x${results}" != "x" ]]; then
-	    print_to_log "${failMsg}" "${results}"
-	fi
-	return 1
+        if [[ "x${results}" != "x" ]]; then
+            print_to_log "${failMsg}" "${results}"
+        fi
+        return 1
     fi
 
     #----------------------------------------
@@ -571,11 +572,11 @@ function rename_end_restart_file() {
 
     # Rename the ending restart file
     for r in Restarts/*.nc4; do
-	if [[ "${r}" =~ "${END_hhmm_1h}" || "${r}" =~ "${END_hhmm_20m}" ]]; then
-	    newRstFile="${r}.${suffix}"
-	    mv -f "${r}" "${newRstFile}"
-	    [[ -f "${newRstFile}" ]] && return 0
-	fi
+        if [[ "${r}" =~ "${END_hhmm_1h}" || "${r}" =~ "${END_hhmm_20m}" ]]; then
+            newRstFile="${r}.${suffix}"
+            mv -f "${r}" "${newRstFile}"
+            [[ -f "${newRstFile}" ]] && return 0
+        fi
     done
     return 1
 }
@@ -601,4 +602,96 @@ function score_parallelization_test() {
     # If the files are bitwise identical then the parallel test is successful
     diff "$rstFile1" "$rstFile2"
     return $?
+}
+
+
+function print_bootstrap_info_message() {
+    #========================================================================
+    # Prints a message to indicate if species bootstrapping is enabled.
+    #
+    # 1st argument: Enable ("yes") or disable ("no") bootstrapping
+    #========================================================================
+    if [[ "x${1}" == "xyes" ]]; then
+        echo ""
+        echo "%%%%% Species not found in the restart file will   %%%%%"
+        echo "%%%%% be bootstrapped (i.e. set to default values) %%%%%"
+    else
+        echo ""
+        echo "%%%%% Integration tests will fail unless all %%%%%"
+        echo "%%%%% species are found in the restart file! %%%%%"
+    fi
+}
+
+
+function gcc_enable_or_disable_bootstrap() {
+    #========================================================================
+    # Edits HEMCO_Config.rc files to enable or disable "bootstrapping",
+    # which is setting missing restart file variables to default values.
+    #
+    # 1st argument: Enable ("yes") or disable ("no") bootstrapping
+    # 2nd argument: Directory containing integration test rundirs
+    #========================================================================
+    bootStrap="${1}"
+    rundirsDir="${2}"
+
+    print_bootstrap_info_message "${bootStrap}"
+
+    # Loop over rundirs
+    for runDir in ${rundirsDir}/*; do
+
+        # Do the following if for only valid GEOS-Chem run dirs
+        expr=$(is_valid_rundir "${runDir}")
+        if [[ "x${expr}" == "xTRUE" ]]; then
+
+            # Specify path HEMCO_Config.rc
+            hcoCfg="${runDir}/HEMCO_Config.rc"
+
+            if [[ "x${bootStrap}" == "xyes" ]]; then
+                # Set missing restart file variables to defaults
+                sed_ie "s/EFYO/CYS/"             "${hcoCfg}"
+                sed_ie "s/EFY.*xyz 1/CYS xyz 1/" "${hcoCfg}"
+                sed_ie "s/EY.*xyz 1/CYS xyz 1/"  "${hcoCfg}"
+            else
+                # Don't set missing restart file variables to defaults
+                sed_ie "s/CYS.*xyz 1/EFY xyz 1/" "${hcoCfg}"
+                sed_ie "s/CYS/EFYO/"             "${hcoCfg}"
+                sed_ie "s/EY.*xyz 1/EFYO xyz 1/" "${hcoCfg}"
+            fi
+        fi
+    done
+}
+
+
+function gchp_enable_or_disable_bootstrap() {
+    #========================================================================
+    # Edits HEMCO_Config.rc files to enable or disable "bootstrapping",
+    # which is setting missing restart file variables to default values.
+    #
+    # 1st argument: Enable ("yes") or disable ("no") bootstrapping
+    # 2nd argument: Directory containing integration test rundirs
+    #========================================================================
+    bootStrap="${1}"
+    rundirsDir="${2}"
+
+    print_bootstrap_info_message "${bootStrap}"
+
+    # Loop over rundirs
+    for runDir in ${rundirsDir}/*; do
+
+        # Do the following if for only valid GEOS-Chem run dirs
+        expr=$(is_gchp_rundir "${runDir}")
+        if [[ "x${expr}" == "xTRUE" ]]; then
+
+            # Specify path HEMCO_Config.rc
+            script="${runDir}/setCommonRunSettings.sh"
+
+            if [[ "x${bootStrap}" == "xyes" ]]; then
+                # Set missing restart file variables to defaults
+                sed_ie "s/_in_Restart=./_in_Restart=0/" "${script}"
+            else
+                # Don't set missing restart file variables to defaults
+                sed_ie "s/_in_Restart=./_in_Restart=1/" "${script}"
+            fi
+        fi
+    done
 }

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -648,14 +648,14 @@ function gcc_enable_or_disable_bootstrap() {
 
             if [[ "x${bootStrap}" == "xyes" ]]; then
                 # Set missing restart file variables to defaults
-                sed_ie "s/EFYO/CYS/"             "${hcoCfg}"
-                sed_ie "s/EFY.*xyz 1/CYS xyz 1/" "${hcoCfg}"
-                sed_ie "s/EY.*xyz 1/CYS xyz 1/"  "${hcoCfg}"
+		grep -l "SPC_ " "${hcoCfg}" | xargs sed -i "s/EY/CYS/"   2>/dev/null
+		grep -l "SPC_ " "${hcoCfg}" | xargs sed -i "s/EFYO/CYS/" 2>/dev/null
+		grep -l "BC_ "  "${hcoCfg}" | xargs sed -i "s/EFY/CYS/"  2>/dev/null
             else
-                # Don't set missing restart file variables to defaults
-                sed_ie "s/CYS.*xyz 1/EFY xyz 1/" "${hcoCfg}"
-                sed_ie "s/CYS/EFYO/"             "${hcoCfg}"
-                sed_ie "s/EY.*xyz 1/EFYO xyz 1/" "${hcoCfg}"
+		# Don't set missing restart file variables to defaults
+		grep -l "SPC_ " "${hcoCfg}" | xargs sed -i "s/CYS/EFYO/" 2>/dev/null
+		grep -l "SPC_ " "${hcoCfg}" | xargs sed -i "s/EY/EFYO/"  2>/dev/null
+		grep -l "BC_ "  "${hcoCfg}" | xargs sed -i "s/CYS/EFY/"  2>/dev/null
             fi
         fi
     done
@@ -687,10 +687,10 @@ function gchp_enable_or_disable_bootstrap() {
 
             if [[ "x${bootStrap}" == "xyes" ]]; then
                 # Set missing restart file variables to defaults
-                sed_ie "s/_in_Restart=./_in_Restart=0/" "${script}"
+                sed_ie "s/Require_Species_in_Restart=./Require_Species_in_Restart=0/" "${script}"
             else
                 # Don't set missing restart file variables to defaults
-                sed_ie "s/_in_Restart=./_in_Restart=1/" "${script}"
+                sed_ie "s/Require_Species_in_Restart=./Require_Species_in_Restart=1/" "${script}"
             fi
         fi
     done


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

We have updated the integration test scripts to accept the `-n` (aka `--no-bootstrap`) option.  This will tell the integration test scripts not to change the HEMCO time cycle flags from `EFYO` to `CYS` (which allows tests to proceed even if there are missing species in the restart file).  This can be a useful check to run just before a version release , and serves as a reminder to update restart files.

In this PR, we have also added an error check to prevent integration tests from being run within the source code directory tree.  This will prevent removing source code files.

### Expected changes
- For those simulations in which all species are present in the restart file: no change
- For those simulations in which there are species missing from the restart file: tests fail

For example, for GEOS-Chem 14.2.1, the fullchem simulations will fail as they are using restart files that have not been updated with the Furans species (BUTDI, FURA).
```console
==============================================================================
GEOS-Chem Classic: Execution Test Results

GCClassic #ad68c48 GEOS-Chem 14.2.1 and HEMCO 3.7.1 release
GEOS-Chem #086a3eddc Adjust text replacement algorithm in integration test scripts
HEMCO     #00aaf65 Update HEMCO 3.7.1 release date in CHANGELOG.md

Using 24 OpenMP threads
Number of execution tests: 27

Submitted as SLURM job: 4721769
==============================================================================
 
Execution tests:
------------------------------------------------------------------------------
gc_05x0625_NA_47L_merra2_CH4........................Execute Simulation....PASS
gc_05x0625_NA_47L_merra2_fullchem...................Execute Simulation....FAIL
gc_4x5_47L_merra2_fullchem..........................Execute Simulation....FAIL
gc_4x5_47L_merra2_fullchem_TOMAS15..................Execute Simulation....FAIL
```

### Reference(s)
N/A

### Related Github Issue(s)
- See #714
