### PR TITLE
Updates for GEOS-Chem within CESM2 - convective scavenging correction and MPI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased 14.1.2]
+### Added
+- CESM-only update: Added option for correctConvUTLS for correcting buildup of soluble tracers in the UT/LS to match CAM-chem behavior
+
+### Changed
+- CESM-only update: extend existing KppError, KppStop to CESM for model stability
+- CESM-only update: Removed mpi_bcast in ucx_mod NOXCOEFF_INIT to be handled at coupler level to support spectral-element dynamical core
 
 ## [14.1.1] - 2023-03-03
 ### Added

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -3901,9 +3901,6 @@ CONTAINS
     USE State_Chm_Mod,      ONLY : ChmState
 #if defined( MODEL_CESM )
     USE UNITS,              ONLY : freeUnit
-#if defined( SPMD )
-    USE MPISHORTHAND
-#endif
 #endif
 !
 ! !INPUT PARAMETERS:
@@ -3929,9 +3926,6 @@ CONTAINS
     INTEGER            :: I, AS, IOS
     INTEGER            :: IMON, ITRAC, ILEV
     INTEGER            :: IU_FILE
-#if defined( MODEL_CESM ) && defined( SPMD )
-    INTEGER            :: nSize ! Number of elements in State_Chm%NOXCOEFF
-#endif
 
     ! Strings
     CHARACTER(LEN=255) :: NOX_FILE
@@ -4055,7 +4049,6 @@ CONTAINS
     State_Chm%NOXCOEFF = 0.0e+0_fp
 
 #if defined( MODEL_CESM )
-    nSize = State_Chm%JJNOXCOEFF * UCX_NLEVS * 6 * 12
     IF ( Input_Opt%amIRoot ) THEN
 #endif
     ! Fill array
@@ -4136,9 +4129,6 @@ CONTAINS
     ENDDO !IMON
 #if defined( MODEL_CESM )
     ENDIF
-#if defined( SPMD )
-    CALL MPIBCAST( State_Chm%NOXCOEFF, nSize, MPIR8, 0, MPICOM )
-#endif
 #endif
 
   END SUBROUTINE NOXCOEFF_INIT

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -427,10 +427,16 @@ MODULE Input_Opt_Mod
 #endif
 
 #if defined( MODEL_CESM )
-     LOGICAL                     :: onlineAlbedo       = .TRUE. ! Use albedo from land model
-     LOGICAL                     :: onlineLandTypes    = .TRUE. ! Use land types from land model
-     LOGICAL                     :: ddVel_CLM          = .TRUE. ! Use dry deposition velocities as computed by the Community Land Model
-     LOGICAL                     :: applyQtend         = .TRUE. ! Apply water vapor tendency to specific humidity
+     ! Use albedo from land model
+     LOGICAL                     :: onlineAlbedo       = .TRUE.
+     ! Use land types from land model
+     LOGICAL                     :: onlineLandTypes    = .TRUE.
+     ! Use dry deposition velocities as computed by the Community Land Model
+     LOGICAL                     :: ddVel_CLM          = .TRUE.
+     ! Apply water vapor tendency to specific humidity
+     LOGICAL                     :: applyQtend         = .TRUE.
+     ! Apply photolytic correction for convective scavenging of soluble tracers?
+     LOGICAL                     :: correctConvUTLS    = .TRUE.
 #endif
 
 #ifdef ADJOINT

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -422,7 +422,7 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: TurnOffHetRates
 #endif
 
-#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
      LOGICAL                     :: KppStop            = .TRUE. ! Stop KPP if integration fails twice
 #endif
 

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -1181,9 +1181,6 @@ MODULE State_Diag_Mod
 
      !%%%%% Chemistry diagnostics %%%%%
 
-     REAL(f4),           POINTER :: KppError(:,:,:)
-     LOGICAL                     :: Archive_KppError
-
      REAL(f4),           POINTER :: O3concAfterChem(:,:,:)
      LOGICAL                     :: Archive_O3concAfterChem
 
@@ -1234,10 +1231,10 @@ MODULE State_Diag_Mod
      LOGICAL                     :: Archive_CO2photrate
 #endif
 
-#ifdef MODEL_WRF
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
      !----------------------------------------------------------------------
      ! The following diagnostics are only used when
-     ! GEOS-Chem is interfaced into WRF (as WRF-GC)
+     ! GEOS-Chem is interfaced into WRF (as WRF-GC) or CESM
      !----------------------------------------------------------------------
      REAL(f4),           POINTER :: KppError(:,:,:)
      LOGICAL                     :: Archive_KppError
@@ -2385,10 +2382,10 @@ CONTAINS
     State_Diag%Archive_CO2photrate                 = .FALSE.
 #endif
 
-#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
     !=======================================================================
     ! These diagnostics are only activated when running GC
-    ! either in NASA/GEOS or in WRF
+    ! either in NASA/GEOS, WRF, or CESM
     !=======================================================================
     State_Diag%KppError                            => NULL()
     State_Diag%Archive_KppError                    = .FALSE.
@@ -6051,7 +6048,7 @@ CONTAINS
           RETURN
        ENDIF
 
-#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
        !--------------------------------------------------------------------
        ! KPP error flag
        !--------------------------------------------------------------------
@@ -12041,10 +12038,10 @@ CONTAINS
     IF ( RC /= GC_SUCCESS ) RETURN
 #endif
 
-#if defined(MODEL_GEOS) || defined(MODEL_WRF)
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
     !=======================================================================
     ! These fields are only used when GEOS-Chem
-    ! is interfaced to NASA/GEOS or to WRF (as WRF-GC)
+    ! is interfaced to NASA/GEOS, WRF (as WRF-GC), or CESM
     !=======================================================================
     CALL Finalize( diagId   = 'KppError',                                    &
                    Ptr2Data = State_Diag%KppError,                           &
@@ -12955,7 +12952,7 @@ CONTAINS
        IF ( isUnits   ) Units = 'kg m-2 s-1'
        IF ( isRank    ) Rank  = 2
 
-#if defined( MODEL_GEOS ) || defined( MODEL_WRF )
+#if defined( MODEL_GEOS ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
     ELSE IF ( TRIM( Name_AllCaps ) == 'KPPERROR' ) THEN
        IF ( isDesc    ) Desc  = 'KppError'
        IF ( isUnits   ) Units = '1'


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard U.

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

Note, this PR is made based on `14.1.1` as it is targeting a point release under `14.1.x` as well as merging into `main`. Due to changes in `ucx_mod`, there are merge conflicts against `main`.

### Describe the update

* Adds `Input_Opt%correctConvUTLS` for a CESM-only correction of buildup of soluble tracers in the UT/LS due to decoupling of wet scavenging and convective transport
* Extends existing `State_Diag%KppError` to GEOS-Chem within CESM
* Removes MPI_BCast in ucx_mod's NOXCOEFF_INIT in order to move it to a higher level

Changes to the UT/LS correction (implemented in `fullchem_mod.F90`) are important for results to be scientifically correct in GEOS-Chem within CESM (manuscript in prep.)

The changes to UCX_Mod are essential to supporting the spectral-element dynamical core in CESM, as otherwise the model will hang as mpi_bcast is a collective operation, but on the SE dycore not all cores operate on the same number of domain chunks.

### Expected changes

These updates only affect GEOS-Chem within CESM and should be zero-diff for the full-chemistry benchmark simulation.

### Reference(s)

Science updates for GEOS-Chem within CESM2 will be in a paper, in prep.

Photolytic SOA sink used for correcting convective scavenging of soluble tracers solely within CESM2 environment is based on Hodzic et al. (2016) ACP (https://acp.copernicus.org/articles/16/7917/2016/acp-16-7917-2016.pdf)

### Related Github Issue(s)

Companion PR at https://github.com/CESM-GC/CAM/pull/27

Copying @lizziel.

Thanks!
