### PR TITLE
12.9.3+bugfix budget diagnostic

### DIFF
--- a/GeosCore/pbl_mix_mod.F90
+++ b/GeosCore/pbl_mix_mod.F90
@@ -274,7 +274,7 @@ CONTAINS
 ! !USES:
 !
     USE ErrCode_Mod
-    USE PhysConstants            ! Scale height
+    USE PhysConstants            ! g0, Rd
     USE State_Grid_Mod,     ONLY : GrdState
     USE State_Met_Mod,      ONLY : MetState
 !
@@ -301,7 +301,7 @@ CONTAINS
 !
     LOGICAL  :: Bad_Sum
     INTEGER  :: I,     J,      L,    LTOP
-    REAL(fp) :: BLTOP, BLTHIK, DELP
+    REAL(fp) :: BLTOP, BLTHIK, DELP, Lower_Edge_Height
     REAL(fp) :: P(0:State_Grid%NZ)
 
     !=================================================================
@@ -312,158 +312,74 @@ CONTAINS
     RC              = GC_SUCCESS
     Bad_Sum         = .FALSE.
     State_Met%InPbl = .FALSE.
+    State_Met%F_Under_PBLTop = 0d0
+    State_Met%F_of_PBL       = 0d0
 
     !$OMP PARALLEL DO       &
     !$OMP DEFAULT( SHARED ) &
-    !$OMP PRIVATE( I, J, L, P, BLTOP, BLTHIK, LTOP, DELP )
+    !$OMP PRIVATE( I, J, L, P, BLTOP, BLTHIK, LTOP, DELP ) &
+    !$OMP Private( Lower_Edge_Height )
     DO J = 1, State_Grid%NY
     DO I = 1, State_Grid%NX
 
-       !----------------------------------------------
-       ! Define pressure edges:
-       ! P(L-1) = P at bottom edge of box (I,J,L)
-       ! P(L  ) = P at top    edge of box (I,J,L)
-       !----------------------------------------------
+       ! PBL height above surface, m 
+       State_Met%PBL_Top_m(I,J) = State_Met%PBLH(I,J)
 
-       ! Pressure at level edges [hPa]
-       DO L = 0, State_Grid%NZ
-          P(L) = State_Met%PEDGE(I,J,L+1)
-       ENDDO
+       ! Height of lower edge above surface, m
+       Lower_Edge_Height = 0d0
 
-       !----------------------------------------------
-       ! Find PBL top and thickness [hPa]
-       !----------------------------------------------
+       ! Find PBL top level (L) and pressure (hPa)
+       Do L=1, State_Grid%NZ
 
-       ! BLTOP = pressure at PBL top [hPa]
-       ! Use barometric law since PBL is in [m]
-       BLTOP  = P(0) * EXP( -State_Met%PBLH(I,J) / SCALE_HEIGHT )
+         If ( Lower_Edge_Height + State_Met%BXHEIGHT(I,J,L) > State_Met%PBLH(I,J) ) then
 
-       ! BLTHIK is PBL thickness [hPa]
-       BLTHIK = P(0) - BLTOP
+            ! PBL top is in this level
+            LTOP = L
 
-       !----------------------------------------------
-       ! Find model level where BLTOP occurs
-       !----------------------------------------------
+            ! Pressure at the PBL top altitude, hPa
+            ! Use pressure lapse equation: p(PBLH) = p(z1) * exp( -(PBLH-z1) / Scale_Height )
+            ! p(z1) = State_Met%PEDGE(I,J,L) = Pressure at the lower level edge
+            ! PBLH - z1 = (State_Met%PBLH(I,J,L) - Lower_Edge_Height) = Height above the lower level edge
+            ! Scale_Height = Rd * Tv / g0
+            State_Met%PBL_Top_hPa(I,J) = State_Met%PEdge(I,J,L) * &
+                  EXP( -(State_Met%PBLH(I,J) - Lower_Edge_Height) * g0 / ( Rd * State_Met%Tv(I,J,L) ) )
 
-       ! Initialize
-       LTOP = 0
+            ! Fraction of PBL mass in layer L, will be normalized below
+            State_Met%F_of_PBL(I,J,L) = State_Met%PEdge(I,J,L) - State_Met%PBL_Top_hPa(I,J)
+      
+            ! Fraction of the grid cell mass under PBL top
+            State_Met%F_Under_PBLTop(I,J,L) =   State_Met%F_of_PBL(I,J,L) / &
+                                              ( State_Met%PEdge(I,J,L) - State_Met%PEdge(I,J,L+1) )
 
-       ! Loop over levels
-       DO L = 1, State_Grid%NZ
+            ! Model level of PBL top (integer+fraction). The top is within level CEILING(PBL_Top_L) 
+            State_Met%PBL_Top_L(I,J) = (LTOP-1) + State_Met%F_Under_PBLTop(I,J,L)
 
-          ! Exit when we get to the PBL top level
-          IF ( BLTOP > P(L) ) THEN
-             LTOP = L
-             EXIT
-          ELSE
-             State_Met%InPbl(I,J,L) = .TRUE.
-          ENDIF
+            ! PBL Thickness from surface to top, hPa
+            State_Met%PBL_Thick(I,J) = State_Met%PEdge(I,J,1) - State_Met%PBL_Top_hPa(I,J)
 
-       ENDDO
+            !! Exit Do loop after we found PBL top level
+            Exit
 
-       !----------------------------------------------
-       ! Define various related quantities
-       !----------------------------------------------
+         Else 
 
-       ! IMIX(I,J)   is the level where the PBL top occurs at (I,J)
-       ! IMIX(I,J)-1 is the number of whole levels below the PBL top
-       IMIX(I,J)  = LTOP
+            ! Grid cell fully within PBL
+            State_Met%inPBL(I,J,L) = .True.
 
-       ! Fraction of the IMIXth level underneath the PBL top
-       FPBL(I,J) = 1e+0_fp - ( BLTOP - P(LTOP) ) / &
-                         ( P(LTOP-1) - P(LTOP) )
+            ! Fraction of the grid cell mass under PBL top
+            State_Met%F_Under_PBLTop(I,J,L) = 1.0d0
 
-       ! PBL top [model layers]
-       State_Met%PBL_TOP_L(I,J) = FLOAT( IMIX(I,J) - 1 ) + FPBL(I,J)
+            ! Fraction of PBL mass in layer L, will be normalized below
+            State_Met%F_of_PBL(I,J,L) = State_Met%PEdge(I,J,L) - State_Met%PEdge(I,J,L+1)
 
-       ! PBL top [hPa]
-       State_Met%PBL_TOP_hPa(I,J) = BLTOP
+            ! Update lower edge height, m
+            Lower_Edge_Height = Lower_Edge_Height + State_Met%BXHeight(I,J,L)
 
-       ! Zero PBL top [m] -- compute below
-       State_Met%PBL_TOP_m(I,J) = 0e+0_fp
+         EndIf
+         
+       EndDo
 
-       ! PBL thickness [hPa]
-       State_Met%PBL_THICK(I,J) = BLTHIK
-
-       !==============================================================
-       ! Loop up to edge of chemically-active grid
-       !==============================================================
-       DO L = 1, State_Grid%MaxChemLev
-
-          ! Thickness of grid box (I,J,L) [hPa]
-          DELP = P(L-1) - P(L)
-
-          IF ( L < IMIX(I,J) ) THEN
-
-             !--------------------------------------------
-             ! (I,J,L) lies completely below the PBL top
-             !--------------------------------------------
-
-             ! Fraction of grid box (I,J,L) w/in the PBL
-             State_Met%F_OF_PBL(I,J,L) = DELP / BLTHIK
-
-             ! Fraction of grid box (I,J,L) underneath PBL top
-             State_Met%F_UNDER_PBLTOP(I,J,L) = 1e+0_fp
-
-             ! PBL height [m]
-             State_Met%PBL_TOP_m(I,J) = State_Met%PBL_TOP_m(I,J) + &
-                                        State_Met%BXHEIGHT(I,J,L)
-
-          ELSE IF ( L == IMIX(I,J) ) THEN
-
-             !--------------------------------------------
-             ! (I,J,L) straddles the PBL top
-             !--------------------------------------------
-
-             ! Fraction of grid box (I,J,L) w/in the PBL
-             State_Met%F_OF_PBL(I,J,L) = ( P(L-1) - BLTOP ) / BLTHIK
-
-             ! Fraction of grid box (I,J,L) underneath PBL top
-             State_Met%F_UNDER_PBLTOP(I,J,L) = FPBL(I,J)
-
-             ! PBL height [m]
-             State_Met%PBL_TOP_m(I,J) = State_Met%PBL_TOP_m(I,J) + &
-                                      ( State_Met%BXHEIGHT(I,J,L) * &
-                                        FPBL(I,J) )
-
-          ELSE
-
-             !--------------------------------------------
-             ! (I,J,L) lies completely above the PBL top
-             !--------------------------------------------
-
-             ! Fraction of grid box (I,J,L) w/in the PBL
-             State_Met%F_OF_PBL(I,J,L)    = 0e+0_fp
-
-             ! Fraction of grid box (I,J,L) underneath PBL top
-             State_Met%F_UNDER_PBLTOP(I,J,L) = 0e+0_fp
-
-          ENDIF
-
-          !### Debug
-          !IF ( I==23 .and. J==34 .and. L < 6 ) THEN
-          !   PRINT*, '###--------------------------------------'
-          !   PRINT*, '### COMPUTE_PBL_HEIGHT'
-          !   PRINT*, '### I, J, L     : ', I, J, L
-          !   PRINT*, '### P(L-1)      : ', P(L-1)
-          !   PRINT*, '### P(L)        : ', P(L)
-          !   PRINT*, '### F_OF_PBL    : ', State_Met%F_OF_PBL(I,J,L)
-          !   PRINT*, '### F_UNDER_TOP : ', &
-          !            State_Met%F_UNDER_PBLTOP(I,J,L)
-          !   PRINT*, '### IMIX        : ', IMIX(I,J)
-          !   PRINT*, '### FPBL        : ', FPBL(I,J)
-          !   PRINT*, '### PBL_TOP_hPa : ', State_Met%PBL_TOP_hPa(I,J)
-          !   PRINT*, '### PBL_TOP_L   : ', State_Met%PBL_TOP_L(I,J)
-          !   PRINT*, '### DELP        : ', DELP
-          !   PRINT*, '### BLTHIK      : ', BLTHIK
-          !   PRINT*, '### BLTOP       : ', BLTOP
-          !   PRINT*, '### BXHEIGHT    : ', State_Met%BXHEIGHT(I,J,L)
-          !   PRINT*, '### PBL_TOP_m   : ', State_Met%PBL_TOP_m(I,J)
-          !   PRINT*, '### other way m : ', &
-          !    P(0) * EXP( -State_Met%PBL_TOP_hPa(I,J) / SCALE_HEIGHT )
-          !ENDIF
-
-       ENDDO
+       ! Fraction of PBL mass in layer L, now normalize to sum of 1
+       State_Met%F_of_PBL(I,J,:) = State_Met%F_of_PBL(I,J,:) / State_Met%PBL_Thick(I,J)
 
        ! Error check
        IF ( ABS( SUM( State_Met%F_OF_PBL(I,J,:) ) - 1.e+0_fp) > 1.e-3_fp) THEN
@@ -472,6 +388,7 @@ CONTAINS
           Bad_Sum = .TRUE.
           !$OMP END CRITICAL
        ENDIF
+
     ENDDO
     ENDDO
     !$OMP END PARALLEL DO
@@ -484,7 +401,7 @@ CONTAINS
     ENDIF
 
     ! Model level where PBL top occurs
-    State_Met%PBL_MAX_L = MAXVAL( IMIX )
+    State_Met%PBL_MAX_L = MAXVAL( CEILING( State_Met%PBL_Top_L ) )
 
   END SUBROUTINE COMPUTE_PBL_HEIGHT
 !EOC


### PR DESCRIPTION
### Name and Institution (Required)

Name: Christopher Holmes
Institution: Florida State University

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

With this update, the budget diagnostics include the troposphere and PBL mass tendencies associated with changes in the PBL height and tropopause height. The effect of changing tropopause height is now included in the "BudgetTransportTrop" diagnostic. The effect of changing PBL height is now included in the "BudgetMixingPBL" diagnostic.

A second update improves the way that the model level number corresponding to the PBL depth is determined. The meteorological input files provide the PBL height. The previous method computed the pressure at the PBL top using a globally constant scale height. The revised method determines the level from the local grid cell heights, which is more appropriate. As a result of this change the mixing increases up to 1 level near the poles and decreases up to 1 or 2 levels in the tropics.

### Expected changes

Figures show changes in the PBL due to the improved calculation.

Change in PBL top level (MERRA-2 2015-07-01 18z)
![image](https://github.com/geoschem/geos-chem/assets/2147719/26c64df6-82d3-4418-a3ee-14a0fb3a10fe)

Change in PBL thickness, hPa (MERRA-2 2015-07-01 18z)
![image](https://github.com/geoschem/geos-chem/assets/2147719/37851c25-15b5-4ece-adc3-9ddd0758e653)

### Reference(s)

none 

### Related Github Issue(s)

The budget diagnostic bug was discussed by GCSC. I corresponded with Lizzie about the issue.