### PR TITLE
Fix broken links to CONTRIBUTING.html and SUPPORT.html in GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-feature-or-discussion.md
+++ b/.github/ISSUE_TEMPLATE/new-feature-or-discussion.md
@@ -10,7 +10,7 @@ Institution:
 
 ### Confirm you have reviewed the following documentation
 
-- [ ] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)
+- [ ] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)
 
 ### New GEOS-Chem feature or discussion
 

--- a/.github/ISSUE_TEMPLATE/question-issue.md
+++ b/.github/ISSUE_TEMPLATE/question-issue.md
@@ -10,7 +10,7 @@ Institution:
 
 ### Confirm you have reviewed the following documentation
 
-- [ ] [Support guidelines](https://geos-chem.readthedocs.io/en/stable/reference/SUPPORT.html)
+- [ ] [Support guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/SUPPORT.html)
 - [ ] [User manuals](https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/supplemental-guides/related-docs.html)
 - [ ] [Debugging GEOS-Chem and HEMCO errors](https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/supplemental-guides/debug-guide.html)
 - [ ] [Current and past Github issues](https://github.com/geoschem/geos-chem/issues)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Institution:
 
 ### Confirm you have reviewed the following documentation
 
-- [ ] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)
+- [ ] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)
 
 ### Describe the update
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

The links to ReadTheDoics pages "Contributing guidelines (CONTRIBUTING.html) and "Support guidelines" (SUPPORT.html) on thin the GitHub issue templates were broken.  The text "reference" in the URL should now be "help-and-reference".

NOTE: The corresponding update in the geoschem/GCClassic repo has been added into docs/dev.

Thanks to @sdeastham for raising this issue.

### Expected changes
The links should now work properly

### Reference(s)
N/A

### Related Github Issue(s)
N/A
