### PR TITLE
Fix incorrect comment on static H2O option

### DIFF
--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -2466,7 +2466,7 @@ CONTAINS
     Input_Opt%LACTIVEH2O = v_bool
 
     !------------------------------------------------------------------------
-    ! Turn on online stratospheric H2O?
+    ! Use a more conservative boundary condition for strat. H2O?
     !------------------------------------------------------------------------
     key    = "operations%chemistry%active_strat_H2O%use_static_bnd_cond"
     v_bool = MISSING_BOOL


### PR DESCRIPTION
The comment describing the static H2O option in input_mod.F90 was erroneously copied from the "active H2O" descriptor. This fix corrects that issue.

### Name and Institution (Required)

Name: Sebastian Eastham
Institution: Massachusetts Institute of Technology

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

Fixes an incorrect comment in input_mod.F90.

### Expected changes

No change - superficial to the code only.