### PR TITLE
Improve missing ch4 emissions error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Added the `-n` aka `--no-bootstrap` option to integration tests to disable bootstrapping missing species in restart files
 - Use integer parameters for species units instead of strings (for computational efficiency)
+- Update error message for missing surface CH4 emissions with instructions on how to resolve the problem
 
 ### Fixed
 - Prevent `POAEMISS` from being assigned a value if not allocated (in `carbon_mod.F90`)

--- a/GeosCore/set_global_ch4_mod.F90
+++ b/GeosCore/set_global_ch4_mod.F90
@@ -169,7 +169,9 @@ CONTAINS
        ErrMsg = 'Cannot retrieve data for NOAA_GMD_CH4, CMIP6_Sfc_CH4, or ' // &
                 'SfcVMR_CH4 from HEMCO! Make sure the data source ' // &
                 'corresponds to your emissions year in HEMCO_Config.rc ' // &
-                '(NOAA GMD for 1978 and later; else CMIP6).'
+                '(NOAA GMD for 1978 and later; else CMIP6). To use the last year ' // &
+                'available you can change the time cycle flag in HEMCO_Config.rc for ' // &
+                'the inventory from RY to CY.'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR simply updates the error message printed when surface CH4 emissions are not found. It is expanded to tell uses to change the time cycle flag in HEMCO_Config.rc from RY to CY to use the most recently available year. This is useful if running a GC-Classic simulation for years after 2020 since the model will crash with this error unless the emissions are modified.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue(s)

None
