### PR TITLE
Lower GCHP timestep threshold if > C180 rather than if >= C180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 14.2.2] - 2023-10-23
 ### Changed
 - Updated sample restart files for fullchem and TransportTracers simulations to files saved out from the 14.2.0 1-year benchmarks
+- Change GCHP grid resolution threshold for lowering timesteps from C180 inclusive to C180 exclusive
 
 ## [14.2.1] - 2023-10-10
 ### Added

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -131,7 +131,7 @@ CS_RES_EFFECTIVE=${CS_RES}
 if [[ ${STRETCH_GRID} == 'ON' ]]; then
     CS_RES_EFFECTIVE=$( echo $CS_RES $STRETCH_FACTOR | awk '{printf "%.0f",$1*$2}' )
 fi
-if [[ $CS_RES_EFFECTIVE -lt 180 ]]; then
+if [[ $CS_RES_EFFECTIVE -le 180 ]]; then
     ChemEmiss_Timestep_sec=1200
     TransConv_Timestep_sec=600
     TransConv_Timestep_HHMMSS=001000


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update change the default timesteps for GCHP run at C180 grid resolution. It makes GCHP timesteps at C180 equivalent to GC-Classic timesteps used for 1/2 degree runs.

### Expected changes

C180 GCHP runs will use a 10 minute dynamic timestep and 20 minute chemistry timestep by default. Previously C180 used a 5 minute dynamic timestep and 10 minute chemistry timestep. This update is no diff for benchmark simulations which use C24 grid resolution.

### Reference(s)

None

### Related Github Issue(s)

None
