### PR TITLE
Dry deposition to snow and ice

### DIFF
--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -479,7 +479,7 @@ CONTAINS
           !-----------------------------------------------------------
           ! Special treatment for snow vs. ice
           !-----------------------------------------------------------
-          IF ( State_Met%isSnow(I,J) ) THEN
+          IF ( (State_Met%isSnow(I,J)) .OR. (State_Met%isIce(I,J))) THEN
 
              !-------------------------------------
              ! %%% SURFACE IS SNOW OR ICE %%%
@@ -1465,7 +1465,7 @@ CONTAINS
           !** If the surface to be snow or ice;
           !** set II to 1 instead.
           !
-          IF(State_Met%isSnow(I,J)) II=1
+          IF((State_Met%isSnow(I,J)).OR.(State_Met%isIce(I,J))) II=1
 
           !* Read the internal resistance RI (minimum stomatal resistance for
           !* water vapor,per unit area of leaf) from the IRI array; a '9999'
@@ -1610,9 +1610,9 @@ CONTAINS
 
                 ENDIF
 
-             ! currently messy test for if surface is snow/ice to change O3
-             ! surface resistance to an updated value
-             ELSE IF ((N_SPC .EQ. ID_O3) .AND. (State_Met%isSnow(I,J))) THEN
+             ! Test for if surface is snow/ice to change O3
+             ! surface resistance to an observation derived value
+             ELSE IF ((N_SPC .EQ. ID_O3) .AND. (II .EQ. 1)) THEN
                  RSURFC(K,LDT) = 10000.0_f8
              ELSE
                 ! Check latitude and longitude, alter F0 only for Amazon


### PR DESCRIPTION
### Name and Institution (Required)

Name: Ryan Pound
Institution: University of York

### Confirm you have reviewed the following documentation

- [Y] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

With the changes made in 13.4.0 (commit e593ccb, pull request #945) the method of calculating array IsSnow and other majority land cover types for grid boxes changed to use the native GEOS meteorological fields. 

The result of switching from IsSnow being determined by surface albedo to the fraction of land covered with snow (FRSNO) has changed the behaviour of this array. Previously (due to surface albedo) this would be true for any grid box containing a majority of snow, land ice or sea ice. 

This is no longer the case and only represents grid boxes with a majority of snow cover. Several sections of drydep_mod.f90 have historically used the IsSnow array to update dry deposition calculations to account for special cases of dry deposition to snow/ice. However since the land cover arrays were updated to use the native fields, these special case determinations have not been updated to reflect the current state of these arrays, apart from `Update drydep code for assigning pH over land, ocean, and ice` (pull request #1435) which updated the code to reflect the need to use both IsSnow and IsIce to determine if the tile is a majority snow or ice cover. 

### Expected changes

For the dry deposition of ozone, this restores dry deposition velocity calculation behaviour to that expected from #997. This increases surface ozone over predominantly ice and snow-covered regions, with everywhere else experiencing negligible change. 

![image](https://github.com/geoschem/geos-chem/assets/32539507/a1ef8aae-0723-4058-82ad-66c691f50483)

![image](https://github.com/geoschem/geos-chem/assets/32539507/12f52f83-f3c2-4d07-968a-8d8a5406c45b)

This also results in similar changes for other species, however, this should be reverting model behaviour back to that of pre-version 13.4.0 where IsSnow was calculated based on surface albedo. 

I also recommend the inclusion of change in dry deposition plots within the benchmarks. I can supply the Python script used to generate this analysis if that would help. 