### PR TITLE
Application of FRSNO in land cover arrays

### DIFF
--- a/GeosCore/calc_met_mod.F90
+++ b/GeosCore/calc_met_mod.F90
@@ -293,7 +293,8 @@ CONTAINS
                           LocTimeSec(I,J) + Dt_Sec >= 43200 )
 
        ! Land without snow or ice
-       FRLAND_NOSNO_NOICE = State_Met%FRLAND(I,J) - State_Met%FRSNO(I,J)
+       FRLAND_NOSNO_NOICE = State_Met%FRLAND(I,J) -                &
+               (State_Met%FRLAND(I,J)*State_Met%FRSNO(I,J))
 
        ! Water without sea ice
        FRWATER = State_Met%FRLAKE(I,J) + State_Met%FROCEAN(I,J) - State_Met%FRSEAICE(I,J)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Ryan Pound
Institution: University of York

### Confirm you have reviewed the following documentation

- [Y] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

Fractional land cover is used in calc_met_mod to compute the logical arrays IsLand, IsWater, IsIce, IsSnow. These are calculated from the constant fields FRLAND (fraction of land in a grid box), FRLAKE (fraction of fresh water in a grid box), FROCEAN (fraction of ocean in a grid box) and FRLANDIC (fraction of permanent ice/glacier-covered land in grid box). 

These are defined in such a way that 

`FRLAND + FRLAKE + FROCEAN + FRLANDIC = 1`

Two time-varying fields are also used. The first is FRSEAICE (“ice covered fraction of tile” where tile can be interpreted as the grid box). The second is FRSNO from the native GEOS meteorological fields is defined as the “fractional area of land snow cover”. This is currently being applied to calculate the fraction of land without snow or ice 

`FRLAND_NOSNO_NOICE =  FRLAND - FRSNO`

However, plotting the values of this globally results in localised negative values of the fractional land cover. This occurs where there is a very low fraction of land cover in that grid box. In the case of the points in the southern ocean, these correspond to the locations of small islands. 

![image](https://github.com/geoschem/geos-chem/assets/32539507/81958bfc-ea0f-4981-b114-90c9bd38bb77)

I believe that this is from FRSNO being applied incorrectly, and FRSNO actually should be interpreted as the fraction of land in that grid box that is covered by snow. Hence the correct way to calculate 

FRLAND_NOSNO_NOICE = FRLAND - (FRLAND*FRSNO)

 This does not result in a negative fractional cover. 

![image](https://github.com/geoschem/geos-chem/assets/32539507/d5d96269-d180-4d45-8993-7045790462cd)

FRSEAICE  does not have the same negative values when calculating the fraction of water coverage `FRWATER = FRLAKE + FROCEAN - FRSEAICE`

### Expected changes

From my testing at 4x5, this doesn't currently cause any errors in the model calculations of the land cover arrays or any unexpected behaviour. However, this does remove the chance of a negative land fraction being calculated which may cause issues at higher model resolutions. If I have interpreted this met field correctly I believe the documentation of this met field could be updated to better reflect this. 

### Reference(s)

https://wiki.seas.harvard.edu/geos-chem/index.php/List_of_GEOS-FP_met_fields#:~:text=FRSNO,Hg%20simulation
