### PR TITLE
Now read the Hg restart file from GEOSCHEM_RESTARTS/v2013-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Now read the Hg restart file from `ExtData/GEOSCHEM_RESTARTS/v2023-12`
+
 ## [14.2.3] - 2023-12-01
 ### Added
 - GEOS-Chem Classic rundir script `run/GCClassic/setupForRestarts.sh`

--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -45,7 +45,7 @@ restarts:
     remote: v2021-06/GEOSChem.Restart.metals.20110101_0000z.nc4
     local:  GEOSChem.Restart.20110101_0000z.nc4
   mercury:
-    remote: v2021-12/GEOSChem.Restart.Hg.20190101_0000z.nc4
+    remote: v2023-12/GEOSChem.Restart.Hg.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   pops:
     remote: v2020-02/GEOSChem.Restart.POPs_BaP.20190701_0000z.nc4


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update
This is the companion PR to #2055 (by @angothelene).  We now use a well-spun up restart file from the Hg simulation. 
 We obtained a well-spun-up restart file for 20160101 from @viral211, and then spun up to 20190101.  The remote restart file path in `download_data.yml` has been updated accordingly.

NOTE: @viral211 recommends that Hg simulation users further spin up their simulations for at least 1 year.

### Expected changes
This should prevent the simulation from having too-low concentrations w/r/t observations, as shown in [this plot from #2055](https://private-user-images.githubusercontent.com/25373985/287748572-d65f9c8e-4fa7-42da-882a-c40bd9096b40.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDE4MDM1ODcsIm5iZiI6MTcwMTgwMzI4NywicGF0aCI6Ii8yNTM3Mzk4NS8yODc3NDg1NzItZDY1ZjljOGUtNGZhNy00MmRhLTg4MmEtYzQwYmQ5MDk2YjQwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFJV05KWUFYNENTVkVINTNBJTJGMjAyMzEyMDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjMxMjA1VDE5MDgwN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTYzZGVmZmI5NTQ5OTU2MWNiNmQyNjAyZGE2ZTdhNTVmYWY5YjdhNWU1ODU4NjA1MTEwZjZkMTA0NDI2NTk1YTcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.j1uRnjoototFyhl80t1HysY5X7pm7jbt2r9faIwRCig).

### Reference(s)
N/A

### Related Github Issue(s)
- Closes #2055