### PR TITLE
Add missing units in comments of KPP/fullchem/commonIncludeVars.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Added missing units in comments of `KPP/fullchem/commonIncludeVars.H` 
+
 ## [14.2.3] - 2023-12-01
 ### Added
 - GEOS-Chem Classic rundir script `run/GCClassic/setupForRestarts.sh`

--- a/KPP/fullchem/commonIncludeVars.H
+++ b/KPP/fullchem/commonIncludeVars.H
@@ -13,7 +13,7 @@
   ! Species molecular weight [g/mole]
   REAL(dp) :: MW(NSPEC)
 
-  ! Square root of species molecular weight [g/mole]
+  ! Square root of species molecular weight [g/mole]^1/2
   REAL(dp) :: SR_MW(NSPEC)
 
   ! Henry's law constants
@@ -44,14 +44,15 @@
   REAL(dp) :: NUMDEN
   !$OMP THREADPRIVATE( NUMDEN )
 
-  ! Pressure and relative humidity
+  ! Pressure [hPa]
   REAL(dp) :: PRESS
   !$OMP THREADPRIVATE( PRESS )
 
+  ! Relative humidity [%]
   REAL(dp) :: RELHUM
   !$OMP THREADPRIVATE( RELHUM )
 
-  ! Cosine of solar zenith angle
+  ! Cosine of solar zenith angle [unitless]
   REAL(dp) :: SUNCOS
   !$OMP THREADPRIVATE( SUNCOS )
 
@@ -59,7 +60,7 @@
   ! Rate array variables (used by more than one mechanism)
   !=========================================================================
 
-  ! Photolysis rates (increase size if necessary)
+  ! Photolysis rates [1/s] (increase size if necessary)
   ! Used by fullchem and Hg mechanisms
   REAL(dp) :: PHOTOL(200)
   !$OMP THREADPRIVATE( PHOTOL )
@@ -80,7 +81,7 @@
   REAL(dp) :: EIGHT_RSTARG_T
   !$OMP THREADPRIVATE( EIGHT_RSTARG_T )
 
-  ! H2O concentration
+  ! H2O concentration [molec/cm3]
   REAL(dp) :: H2O
   !$OMP THREADPRIVATE( H2O )
 
@@ -210,13 +211,14 @@
   ! Variables specific to the carbon mechanism
   !==========================================================================
 
-  ! Array for strat CH4/CO/CO2 rates
+  ! Array for strat CH4/CO/CO2 rates [1/s]
   REAL(dp) :: K_STRAT(5)
   !$OMP THREADPRIVATE( K_STRAT )
 
-  ! Array for trop CH4/CO/CO2 rates
+  ! Array for trop CH4/CO/CO2 rates [1/s]
   REAL(dp) :: K_TROP(5)
   !$OMP THREADPRIVATE( K_TROP )
 
+  ! Are we in the tropopshere (1=yes, 0=no)
   REAL(dp) :: TROP
   !$OMP THREADPRIVATE( TROP )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update
This is the companion PR for issue #2029 (by @jhaskinsPhD).  This is a documentation update that adds missing units to the comments in `KPP/fullchem/commonIncludeVars.H`:

- Update units (in comment) for SR_MW in comment line
- Add units (in comment) for PRESS, RELHUM, SUNCOS, PHOTOL, H2O, K_STRAT, K_TROP, TROP

### Expected changes
This is a zero-diff update as it only touches comments in an include file.  The KPP mechanisms were not rebuilt.

### Reference(s)
N/A

### Related Github Issue(s)

- Closes #2029 