### PR TITLE
Updates from GMAO for GEOS

### DIFF
--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -411,7 +411,10 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: FJX_EXTRAL_ERR     = .TRUE.
      ! Toggle for het rates. If true, turns off three Cl producing het reactions
      ! in the stratosphere. In MODEL_GEOS, this flag is set in GEOSCHEMchem_GridComp.rc
-     LOGICAL                     :: TurnOffHetRates = .FALSE.
+     LOGICAL                     :: TurnOffHetRates    = .TRUE.
+     INTEGER                     :: KppCheckNegatives  = -1      ! Check for negatives after KPP integration
+     REAL(fp)                    :: KppTolScale        = 1.0_fp  ! Tolerance scale factor for 2nd KPP integration
+     LOGICAL                     :: applyQtend         = .FALSE. ! Apply water vapor tendency
 #else
      LOGICAL                     :: AlwaysSetH2O
      LOGICAL                     :: TurnOffHetRates

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -669,6 +669,12 @@ MODULE State_Diag_Mod
      REAL(f4),           POINTER :: KppSmDecomps(:,:,:)
      LOGICAL                     :: Archive_KppSmDecomps
 
+     REAL(f4),           POINTER :: KppNegatives(:,:,:)
+     LOGICAL                     :: Archive_KppNegatives
+
+     REAL(f4),           POINTER :: KppNegatives0(:,:,:)
+     LOGICAL                     :: Archive_KppNegatives0
+
      !%%%%% KPP auto-reduce solver diagnostics %%%%%
      REAL(f4),           POINTER :: KppAutoReducerNVAR(:,:,:)
      LOGICAL                     :: Archive_KppAutoReducerNVAR
@@ -1894,6 +1900,12 @@ CONTAINS
 
     State_Diag%KppSmDecomps                        => NULL()
     State_Diag%Archive_KppSmDecomps                = .FALSE.
+
+    State_Diag%KppNegatives                        => NULL()
+    State_Diag%Archive_KppNegatives                = .FALSE.
+
+    State_Diag%KppNegatives0                       => NULL()
+    State_Diag%Archive_KppNegatives0               = .FALSE.
 
     State_Diag%KppAutoReducerNVAR                  => NULL()
     State_Diag%Archive_KppAutoReducerNVAR          = .FALSE.
@@ -5997,6 +6009,50 @@ CONTAINS
        ENDIF
 
        !-------------------------------------------------------------------
+       ! Number of negative concentrations after KPP integration 
+       !-------------------------------------------------------------------
+       diagID  = 'KppNegatives'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppNegatives,                        &
+            archiveData    = State_Diag%Archive_KppNegatives,                &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! Number of negative concentrations after first KPP integration try
+       !-------------------------------------------------------------------
+       diagID  = 'KppNegatives0'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppNegatives0,                       &
+            archiveData    = State_Diag%Archive_KppNegatives0,               &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
        ! AR only -- Number of species in reduced mechanism (NVAR - NRMV)
        !-------------------------------------------------------------------
        diagID = 'KppAutoReducerNVAR'
@@ -6119,7 +6175,7 @@ CONTAINS
        ! being requested as diagnostic output when the corresponding
        ! array has not been allocated.
        !-------------------------------------------------------------------
-       DO N = 1, 35
+       DO N = 1, 41
           ! Select the diagnostic ID
           SELECT CASE( N )
              CASE( 1  )
@@ -6200,6 +6256,10 @@ CONTAINS
                 diagID = 'KppAutoReduceThres'
              CASE( 39 )
                 diagID = 'RxnConst'
+             CASE( 40 )
+                diagID = 'KppNegatives'
+             CASE( 41 )
+                diagID = 'KppNegatives0'
           END SELECT
 
           ! Exit if any of the above are in the diagnostic list
@@ -10460,6 +10520,9 @@ CONTAINS
                                     State_Diag%Archive_KppLuDecomps       .or. &
                                     State_Diag%Archive_KppSubsts          .or. &
                                     State_Diag%Archive_KppSmDecomps       .or. &
+                                    State_Diag%Archive_KppNegatives       .or. &
+                                    State_Diag%Archive_KppNegatives0      .or. &
+                                    State_Diag%Archive_KppAutoReducerNVAR .or. &
                                     State_Diag%Archive_KppAutoReducerNVAR .or. &
                                     State_Diag%Archive_KppAutoReduceThres .or. &
                                     State_Diag%Archive_KppcNONZERO        .or. &
@@ -11893,6 +11956,16 @@ CONTAINS
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
+    CALL Finalize( diagId   = 'KppNegatives',                                &
+                   Ptr2Data = State_Diag%KppNegatives,                       &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'KppNegatives0',                               &
+                   Ptr2Data = State_Diag%KppNegatives0,                      &
+                   RC       = RC                                            )
+
+    IF ( RC /= GC_SUCCESS ) RETURN
     CALL Finalize( diagId   = 'AirMassColumnFull',                            &
                    Ptr2Data = State_Diag%AirMassColumnFull,                   &
                    RC       = RC                                            )
@@ -13559,6 +13632,16 @@ CONTAINS
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'KPPSMDECOMPS' ) THEN
        IF ( isDesc    ) Desc  = 'Number of KPP singular matrix decompositions'
+       IF ( isUnits   ) Units = 'count'
+       IF ( isRank    ) Rank  =  3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'KPPNEGATIVES' ) THEN
+       IF ( isDesc    ) Desc  = 'Number of negative concentrations after KPP integration'
+       IF ( isUnits   ) Units = 'count'
+       IF ( isRank    ) Rank  =  3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'KPPNEGATIVES0' ) THEN
+       IF ( isDesc    ) Desc  = 'Number of negative concentrations after first KPP integration attempt'
        IF ( isUnits   ) Units = 'count'
        IF ( isRank    ) Rank  =  3
 

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -10523,7 +10523,6 @@ CONTAINS
                                     State_Diag%Archive_KppNegatives       .or. &
                                     State_Diag%Archive_KppNegatives0      .or. &
                                     State_Diag%Archive_KppAutoReducerNVAR .or. &
-                                    State_Diag%Archive_KppAutoReducerNVAR .or. &
                                     State_Diag%Archive_KppAutoReduceThres .or. &
                                     State_Diag%Archive_KppcNONZERO        .or. &
                                     State_Diag%Archive_KppTime            .or. &

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -145,6 +145,7 @@ MODULE Chem_GridCompMod
   ! When to do the analysis
   INTEGER                          :: ANAPHASE
   INTEGER, PARAMETER               :: CHEMPHASE = 2
+  INTEGER, PARAMETER               :: RATSPHASE = 2
 #endif
 
   ! Number of run phases, 1 or 2. Set in the rc file; else default is 2.
@@ -925,64 +926,40 @@ CONTAINS
     IF ( SimType == 'fullchem' ) THEN
        !-- Add two exra advected species for use in family transport  (Manyin)
        CALL MAPL_AddInternalSpec(GC,                                    &
-          SHORT_NAME         = 'SPC_Bry',                               &
-          LONG_NAME          = 'Bromine group for use in transport',    &
-          UNITS              = 'kg kg-1',                               &
-!!!       PRECISION          = ESMF_KIND_R8,                            &
-          DIMS               = MAPL_DimsHorzVert,                       &
-          FRIENDLYTO         = 'DYNAMICS',                              &
-          RESTART            = MAPL_RestartSkip,                        &
-          VLOCATION          = MAPL_VLocationCenter,                    &
-                                               __RC__ )
+            SHORT_NAME         = 'SPC_Bry',                               &
+            LONG_NAME          = 'Bromine group for use in transport',    &
+            UNITS              = 'kg kg-1',                               &
+!!!          PRECISION          = ESMF_KIND_R8,                            &
+            DIMS               = MAPL_DimsHorzVert,                       &
+            FRIENDLYTO         = 'DYNAMICS',                              &
+            RESTART            = MAPL_RestartSkip,                        &
+            VLOCATION          = MAPL_VLocationCenter,                    &
+            __RC__ )
        if(MAPL_am_I_Root()) write(*,*) 'GCC added to internal: SPC_Bry; Friendly to: DYNAMICS'
-
+       
        CALL MAPL_AddInternalSpec(GC,                                    &
-          SHORT_NAME         = 'SPC_Cly',                               &
-          LONG_NAME          = 'Chlorine group for use in transport',   &
-          UNITS              = 'kg kg-1',                               &
-!!!       PRECISION          = ESMF_KIND_R8,                            &
-          DIMS               = MAPL_DimsHorzVert,                       &
-          FRIENDLYTO         = 'DYNAMICS',                              &
-          RESTART            = MAPL_RestartSkip,                        &
-          VLOCATION          = MAPL_VLocationCenter,                    &
-                                               __RC__ )
+            SHORT_NAME         = 'SPC_Cly',                               &
+            LONG_NAME          = 'Chlorine group for use in transport',   &
+            UNITS              = 'kg kg-1',                               &
+!!!          PRECISION          = ESMF_KIND_R8,                            &
+            DIMS               = MAPL_DimsHorzVert,                       &
+            FRIENDLYTO         = 'DYNAMICS',                              &
+            RESTART            = MAPL_RestartSkip,                        &
+            VLOCATION          = MAPL_VLocationCenter,                    &
+            __RC__ )
        if(MAPL_am_I_Root()) write(*,*) 'GCC added to internal: SPC_Cly; Friendly to: DYNAMICS'
-!
-       ! Add additional RATs/ANOX exports
-!       call MAPL_AddExportSpec(GC,                                  &
-!          SHORT_NAME         = 'OX_TEND',                           &
-!          LONG_NAME          = 'tendency_of_odd_oxygen_mixing_ratio_due_to_chemistry', &
-!          UNITS              = 'mol mol-1 s-1',                     &
-!          DIMS               = MAPL_DimsHorzVert,                   &
-!          VLOCATION          = MAPL_VLocationCenter,                &
-!                                                     __RC__ )
-
-       call MAPL_AddExportSpec(GC,                                     &
-             SHORT_NAME         = 'GCC_O3',                            &
-             LONG_NAME          = 'ozone_mass_mixing_ratio_total_air', &
-             UNITS              = 'kg kg-1',                           &
-             DIMS               = MAPL_DimsHorzVert,                   &
-             VLOCATION          = MAPL_VLocationCenter,                &
-                                                       __RC__ )
-
-       call MAPL_AddExportSpec(GC,                                       &
-             SHORT_NAME         = 'GCC_O3PPMV',                          &
-             LONG_NAME          = 'ozone_volume_mixing_ratio_total_air', &
-             UNITS              = 'ppmv',                                &
-             DIMS               = MAPL_DimsHorzVert,                     &
-             VLOCATION          = MAPL_VLocationCenter,                  &
-                                                 __RC__  )
     ENDIF
+    
     ! Include specific humidity in transport tracers simulation checkpoints for
     ! post-processing unit conversions
     IF ( SimType == 'TransportTracers' ) THEN
        CALL MAPL_AddInternalSpec(GC,                                    &
-          SHORT_NAME         = 'SpecificHumidity',                      &
-          LONG_NAME          = 'specific_humidity',                     &
-          UNITS              = 'kg kg-1',                               &
-          DIMS               = MAPL_DimsHorzVert,                       &
-          VLOCATION          = MAPL_VLocationCenter,                    &
-                                               __RC__ )
+            SHORT_NAME         = 'SpecificHumidity',                      &
+            LONG_NAME          = 'specific_humidity',                     &
+            UNITS              = 'kg kg-1',                               &
+            DIMS               = MAPL_DimsHorzVert,                       &
+            VLOCATION          = MAPL_VLocationCenter,                    &
+            __RC__ )
     ENDIF
 #endif
 
@@ -1381,12 +1358,30 @@ CONTAINS
     ENDIF
 
     ! Turn off three heterogenous reactions in stratosphere
-    CALL ESMF_ConfigGetAttribute( GeosCF, DoIt, Default = 0, &
+    CALL ESMF_ConfigGetAttribute( GeosCF, DoIt, Default = 1, &
                                   Label = "TurnOffHetRates:", __RC__ )
     Input_Opt%TurnOffHetRates = ( DoIt == 1 )
     IF ( Input_Opt%AmIRoot ) THEN
        WRITE(*,*) 'Disable selected het. reactions in stratosphere: ', &
                   Input_Opt%TurnOffHetRates
+    ENDIF
+
+    ! Check for negatives after KPP integration
+    CALL ESMF_ConfigGetAttribute( GeosCF, DoIt, Default = -1, &
+                                  Label = "KppCheckNegatives:", __RC__ )
+    Input_Opt%KppCheckNegatives = DoIt 
+    IF ( Input_Opt%AmIRoot ) THEN
+       WRITE(*,*) 'Check for negative concentrations after KPP integration: ', &
+                  Input_Opt%KppCheckNegatives
+    ENDIF
+
+    ! KPP tolerance inflation factor for second attempt
+    CALL ESMF_ConfigGetAttribute( GeosCF, Val, Default = 1.0, &
+                                  Label = "KppTolScale:", __RC__ )
+    Input_Opt%KppTolScale = Val 
+    IF ( Input_Opt%AmIRoot ) THEN
+       WRITE(*,*) 'Scale KPP tolerances in second integration attempt: ', &
+                  Input_Opt%KppTolScale
     ENDIF
 #endif
 
@@ -1810,6 +1805,18 @@ CONTAINS
           IF ( am_I_Root ) WRITE(*,*) 'GCC: Bry and Cly family transport disabled'
     END SELECT
 
+    ! Apply H2O tendency to Q?
+    ! Options: -1=never do it; 0=only if GCC is RATS provider; 1=always do it
+    Input_Opt%applyQtend = .FALSE.
+    CALL ESMF_ConfigGetAttribute( GeosCF, DoIt, Label="ApplyQtend:", Default=0, __RC__ )
+    IF ( DoIt == 1 ) THEN
+       Input_Opt%applyQtend = .TRUE. 
+    ELSEIF ( DoIt == 0 ) THEN
+       CALL ESMF_ConfigGetAttribute( MaplCF, FieldName, Label="RATS_PROVIDER:", Default="PCHEM", __RC__ ) 
+       IF ( TRIM(FieldName) == "GEOSCHEMCHEM" ) Input_Opt%applyQtend = .TRUE.
+    ENDIF
+    IF ( am_I_Root ) WRITE(*,*) '- Apply H2O tendency to Q (SPHU): ', Input_Opt%applyQtend
+
     ! Add Henry law constants and scavenging coefficients to internal state.
     ! These are needed by MOIST for wet scavenging (if this is enabled).
     CALL GEOS_AddSpecInfoForMoist ( am_I_Root, GC, GeosCF, Input_Opt, State_Chm, __RC__ )
@@ -2013,7 +2020,8 @@ CONTAINS
                                         GEOS_CalcTotOzone,         &
                                         GEOS_InitFromFile,         &
                                         GEOS_RATSandOxDiags,       &
-                                        GEOS_PreRunChecks
+                                        GEOS_PreRunChecks,         &
+                                        GEOS_SetH2O
     USE GEOS_AeroCoupler,        ONLY : GEOS_FillAeroBundle
     USE GEOS_CarbonInterface,    ONLY : GEOS_CarbonSetConc,        &
                                         GEOS_CarbonRunPhoto
@@ -2652,6 +2660,10 @@ CONTAINS
 #endif
 
 #if defined( MODEL_GEOS )
+       ! Set H2O from Q (=SPHU)
+       CALL GEOS_SetH2O( GC, Input_Opt, State_Met, State_Chm, State_Grid, Q, 1, __RC__ ) 
+
+       ! Set appropriate met fields for lightning
        CALL MetVars_For_Lightning_Run( GC, Import=IMPORT, Export=EXPORT, &
              State_Met=State_Met, State_Grid=State_Grid, __RC__ )
 
@@ -2671,7 +2683,7 @@ CONTAINS
        ENDIF
 
        ! Initialize RATS and OX tendency diagnostics
-       IF ( PHASE == ANAPHASE ) THEN
+       IF ( PHASE == RATSPHASE ) THEN
           CALL GEOS_RATSandOxDiags( GC, INTSTATE, Export, Input_Opt, State_Met, &
                                     State_Chm, State_Grid, Q, 1, tsChem, __RC__ ) 
        ENDIF
@@ -2917,10 +2929,17 @@ CONTAINS
           ! GEOS Diagnostics. This includes the 'default' GEOS-Chem diagnostics.
           CALL GEOS_Diagnostics( GC, IMPORT, EXPORT, Clock, Phase, Input_Opt, &
                                  State_Met, State_Chm, State_Diag, State_Grid, __RC__ )
+       ENDIF
 
-          ! Fill RATS and OX diagnostics
+       ! Fill RATS and OX diagnostics
+       IF ( PHASE == RATSPHASE ) THEN
           CALL GEOS_RATSandOxDiags( GC, INTSTATE, Export, Input_Opt, State_Met, &
                                     State_Chm, State_Grid, Q, 2, tsChem, __RC__ ) 
+       ENDIF
+
+       ! Set H2O from Q (=SPHU)
+       IF ( Input_Opt%applyQtend ) THEN
+          CALL GEOS_SetH2O( GC, Input_Opt, State_Met, State_Chm, State_Grid, Q, -1, __RC__ ) 
        ENDIF
 
        ! Update internal state fields 

--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -978,28 +978,18 @@ CONTAINS
          RC         = RC                                                    )
     _ASSERT(RC==GC_SUCCESS, 'Error calling CONVERT_SPC_UNITS')
 
+    !=======================================================================
+    ! Always prescribe H2O in both the stratosphere and troposhere in GEOS.
+    ! This is now done right after passing the species from the internal
+    ! state to State_Chm (in Chem_GridCompMod.F90). It is important to do it 
+    ! there to make sure that any H2O tendencies are properly calculated
+    ! cakelle2, 2023/10/14 
+    !=======================================================================
+#if !defined( MODEL_GEOS )
     ! SDE 05/28/13: Set H2O to STT if relevant
     IF ( IND_('H2O','A') > 0 ) THEN
        SetStratH2O = .FALSE.
-#if defined( MODEL_GEOS )
-       !=======================================================================
-       ! Tropospheric H2O is always prescribed (using GEOS Q). For strat H2O
-       ! there are three options, controlled by toggles 'set initial global MR'
-       ! in geoschem_config.yml and 'Prescribe_strat_H2O' in GEOSCHEMchem_GridComp.rc:
-       ! (A) never prescribe strat H2O -> both toggles off
-       ! (B) prescribe strat H2O on init time step -> toggle in input.goes on
-       ! (C) always prescribe strat H2O -> toggle in GEOSCHEMchem_GridComp.rc on
-       !=======================================================================
-       IF ( FIRST ) THEN
-          LSETH2O_orig = Input_Opt%LSETH2O
-       ENDIF
-       IF ( FIRST .OR. FrstRewind ) THEN
-          Input_Opt%LSETH2O = LSETH2O_orig
-       ENDIF
-       IF ( Input_Opt%LSETH2O .OR. Input_Opt%AlwaysSetH2O ) THEN
-#else
        IF ( Input_Opt%LSETH2O ) THEN
-#endif
           SetStratH2O = .TRUE.
        ENDIF
        CALL SET_H2O_TRAC( SetStratH2O, Input_Opt, State_Chm, &
@@ -1009,6 +999,7 @@ CONTAINS
       ! Only force strat once
        IF ( Input_Opt%LSETH2O ) Input_Opt%LSETH2O = .FALSE.
     ENDIF
+#endif
 
     ! Compute the cosine of the solar zenith angle array:
     !    State_Met%SUNCOS     => COS(SZA) at the current time

--- a/Interfaces/GEOS/geos_CarbonInterface.F90
+++ b/Interfaces/GEOS/geos_CarbonInterface.F90
@@ -94,17 +94,18 @@ CONTAINS
     INTEGER                      :: STATUS
 
     ! Methane field from GEOS.
-    CALL ESMF_ConfigGetAttribute( CF, DoIt, Label="CH4_from_GEOS:", Default=0, __RC__ )
-    IF ( DoIt == 1 ) THEN
-       call MAPL_AddImportSpec(GC,                               &
-               SHORT_NAME         = 'GEOS_CH4',                  &
-               LONG_NAME          = 'GEOS_CH4_dry_mixing_ratio', &
-               UNITS              = 'v/v',                       &
-               DIMS               = MAPL_DimsHorzVert,           &
-               VLOCATION          = MAPL_VLocationCenter,        &
-               RC=STATUS  )
-       _VERIFY(STATUS)
-    ENDIF
+    ! This is not yet fully implemented. Need corresponding connectivity in Chem_GridComp.
+!    CALL ESMF_ConfigGetAttribute( CF, DoIt, Label="CH4_from_GEOS:", Default=0, __RC__ )
+!    IF ( DoIt == 1 ) THEN
+!       call MAPL_AddImportSpec(GC,                               &
+!               SHORT_NAME         = 'GEOS_CH4',                  &
+!               LONG_NAME          = 'GEOS_CH4_dry_mixing_ratio', &
+!               UNITS              = 'v/v',                       &
+!               DIMS               = MAPL_DimsHorzVert,           &
+!               VLOCATION          = MAPL_VLocationCenter,        &
+!               RC=STATUS  )
+!       _VERIFY(STATUS)
+!    ENDIF
 
     ! If enabled, create import field 
     CALL ESMF_ConfigGetAttribute( CF, DoIt, Label="Import_CO2_from_GOCART:", Default=0, __RC__ )

--- a/Interfaces/GEOS/geos_analysis.F90
+++ b/Interfaces/GEOS/geos_analysis.F90
@@ -89,6 +89,7 @@ MODULE GEOS_Analysis
      INTEGER                      :: nSpec2
      TYPE(Spec2Opt), POINTER      :: Spec2(:) => NULL()
      INTEGER                      :: ErrorMode
+     INTEGER                      :: PrintNeg 
   END TYPE AnaOptions
 
   ! List holding all analysis information
@@ -817,7 +818,7 @@ CONTAINS
        ENDDO
 
        ! Print warning if at least one negative cell
-       IF ( NNEG > 0 ) THEN
+       IF ( NNEG > 0 .and. iopt%PrintNeg==1 ) THEN
           WRITE(*,*) '*** DoAnalysis_ warning: encountered concentration below threshold, set to minimum: ',TRIM(SpecName),NNEG,MinConc,' ***'
        ENDIF
 
@@ -1219,6 +1220,7 @@ CONTAINS
     CALL ESMF_ConfigGetAttribute( CF, AnaConfig(ispec)%ObsHourName,    Label='ObsHourName:'   , Default='ana_hour', __RC__ )
     CALL ESMF_ConfigGetAttribute( CF, AnaConfig(ispec)%MinConc,        Label='MinConc:'       , Default=1.0e-20, __RC__ )
     CALL ESMF_ConfigGetAttribute( CF, AnaConfig(ispec)%ErrorMode,      Label='ErrorMode:'     , Default=1   ,  __RC__ )
+    CALL ESMF_ConfigGetAttribute( CF, AnaConfig(ispec)%PrintNeg,       Label='PrintNeg:'      , Default=1   ,  __RC__ )
 
     ! Check for "dependent" species
     CALL ESMF_ConfigGetAttribute( CF, nSpec2,                          Label='HasSpec2:'      , Default=0,     __RC__ )
@@ -1314,6 +1316,7 @@ CONTAINS
              ENDDO
           ENDIF
           WRITE(*,*) '- Error mode                    : ', AnaConfig(ispec)%ErrorMode
+          WRITE(*,*) '- Print # negative cocentrations: ', AnaConfig(ispec)%PrintNeg
        ENDIF ! Active 
     ENDIF
 

--- a/Interfaces/GEOS/geos_interface.F90
+++ b/Interfaces/GEOS/geos_interface.F90
@@ -336,7 +336,7 @@ CONTAINS
     ! Make sure that species are in kg/kg total. This should be the case already,
     ! but better be safe!
     CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
-                             'kg/kg total', RC, OrigUnit=OrigUnit )
+                             outUnit=KG_SPECIES_PER_KG_TOTAL_AIR, OrigUnit=OrigUnit, RC=RC )
 
     !=======================================================================
     ! Fill RATS export states if GC is the RATS provider
@@ -437,7 +437,7 @@ CONTAINS
 
     ! Convert back to original unit
     CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
-                             OrigUnit, RC )
+                             OutUnit=OrigUnit, RC=RC )
 
     ! All done
     RETURN_(ESMF_SUCCESS)
@@ -499,7 +499,7 @@ CONTAINS
        ! Make sure that species are in kg/kg total. This should be the case already,
        ! but better be safe!
        CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
-                                'kg/kg total', RC, OrigUnit=OrigUnit )
+                                outUnit=KG_SPECIES_PER_KG_TOTAL_AIR, OrigUnit=OrigUnit, RC=RC )
   
        ! Sync Q and H2O concentration array. Q is in kg/kg total, so is H2O. 
        LM = State_Grid%NZ
@@ -514,7 +514,7 @@ CONTAINS
 
        ! Convert back to original unit
        CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
-                                OrigUnit, RC )
+                                outUnit=OrigUnit, RC=RC )
     ENDIF
 
     ! All done
@@ -1312,13 +1312,13 @@ CONTAINS
     ! make sure that these diagnostics see any post-run updates.
     ! Diagnostics routine expects units of kg/kg dry. 
     CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
-                             'kg/kg dry', RC, OrigUnit=OrigUnit )
+                             outUnit=KG_SPECIES_PER_KG_DRY_AIR, OrigUnit=OrigUnit, RC=RC )
     _ASSERT(RC==GC_SUCCESS, 'Error calling CONVERT_SPC_UNITS')
     CALL Set_Diagnostics_EndofTimestep( Input_Opt,  State_Chm, State_Diag, &
                                         State_Grid, State_Met, RC )
     _ASSERT(RC==GC_SUCCESS, 'Error calling Set_Diagnostics_EndofTimestep')
     CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
-                             OrigUnit, RC )
+                             outUnit=OrigUnit, RC=RC )
     _ASSERT(RC==GC_SUCCESS, 'Error calling CONVERT_SPC_UNITS')
 
     !=======================================================================

--- a/Interfaces/GEOS/geos_interface.F90
+++ b/Interfaces/GEOS/geos_interface.F90
@@ -38,6 +38,7 @@ MODULE GEOS_Interface
   PUBLIC   :: MetVars_For_Lightning_Run  
   PUBLIC   :: GEOS_CheckRATSandOx
   PUBLIC   :: GEOS_RATSandOxDiags
+  PUBLIC   :: GEOS_SetH2O
   PUBLIC   :: GEOS_Diagnostics 
   PUBLIC   :: GEOS_CalcTotOzone
   PUBLIC   :: GEOS_InitFromFile
@@ -193,7 +194,7 @@ CONTAINS
            RESTART            = MAPL_RestartSkip,                           &
            VLOCATION          = MAPL_VLocationCenter,                       &
                                                   __RC__ )
-        if(am_I_Root) write(*,*) 'OX added to internal: Friendly to: ANALYSIS, DYNAMICS, TURBULENCE'
+        if(am_I_Root) write(*,*) 'OX added to internal: Friendly to: ANALYSIS, DYNAMICS, TURBULENCE, MOIST'
 
        call MAPL_AddExportSpec(GC,                 &
           SHORT_NAME = 'O3',                       &
@@ -220,6 +221,41 @@ CONTAINS
                                            __RC__ )
     ENDIF !DoANOX
 
+    !============================================
+    ! General diagnostics that can always be used
+    !============================================
+    call MAPL_AddExportSpec(GC,                                  &
+        SHORT_NAME = 'GCC_H2O_TEND',                             &
+        LONG_NAME  = 'GEOSCHEMCHEM_tendency_of_water_vapor_mixing_ratio',&
+        UNITS      = 'kg kg-1 s-1',                               &
+        DIMS       = MAPL_DimsHorzVert,                           &
+        VLOCATION  = MAPL_VLocationCenter,                        &
+                                            __RC__ )
+
+    call MAPL_AddExportSpec(GC,                                     &
+        SHORT_NAME         = 'GCC_O3',                            &
+        LONG_NAME          = 'GEOSCHEMCHEM_ozone_mass_mixing_ratio_total_air', &
+        UNITS              = 'kg kg-1',                           &
+        DIMS               = MAPL_DimsHorzVert,                   &
+        VLOCATION          = MAPL_VLocationCenter,                &
+                                            __RC__ )
+
+    call MAPL_AddExportSpec(GC,                                       &
+        SHORT_NAME         = 'GCC_O3PPMV',                          &
+        LONG_NAME          = 'GEOSCHEMCHEM_ozone_volume_mixing_ratio_total_air', &
+        UNITS              = 'ppmv',                                &
+        DIMS               = MAPL_DimsHorzVert,                     &
+        VLOCATION          = MAPL_VLocationCenter,                  &
+                                            __RC__  )
+
+    call MAPL_AddExportSpec(GC,                 &
+        SHORT_NAME = 'GCC_OX_TEND',                  &
+        LONG_NAME  = 'GEOSCHEMCHEM_tendency_of_odd_oxygen_mixing_ratio',&
+        UNITS      = 'mol mol-1 s-1',            &
+        DIMS       = MAPL_DimsHorzVert,          &
+        VLOCATION  = MAPL_VLocationCenter,       &
+                                            __RC__ )
+
     ! All done
     RETURN_(ESMF_SUCCESS)
 
@@ -242,6 +278,7 @@ CONTAINS
 !
 ! !USES:
 !
+    USE UnitConv_Mod,       ONLY : Convert_Spc_Units
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -276,23 +313,30 @@ CONTAINS
     REAL, PARAMETER              :: OMW = 16.0
     ! 
     INTEGER                      :: I, LM, IndSpc, IndO3
-    REAL, POINTER                :: Ptr3D(:,:,:)    => NULL()
-    REAL(fp), POINTER            :: PTR_O3(:,:,:)   => NULL()
-    REAL, POINTER                :: OX_TEND(:,:,:)  => NULL()
-    REAL, POINTER                :: OX(:,:,:)       => NULL()
-    REAL, POINTER                :: O3(:,:,:)       => NULL()
-    REAL, POINTER                :: O3PPMV(:,:,:)   => NULL()
-    REAL, POINTER                :: GCO3(:,:,:)     => NULL()
-    REAL, POINTER                :: GCO3PPMV(:,:,:) => NULL()
-    REAL, POINTER                :: PTR_O3P(:,:,:)  => NULL()
-    REAL, POINTER                :: PTR_O1D(:,:,:)  => NULL()
+    REAL, POINTER                :: Ptr3D(:,:,:)       => NULL()
+    REAL(fp), POINTER            :: PTR_O3(:,:,:)      => NULL()
+    REAL, POINTER                :: OX_TEND(:,:,:)     => NULL()
+    REAL, POINTER                :: GCC_OX_TEND(:,:,:) => NULL()
+    REAL, POINTER                :: OX(:,:,:)          => NULL()
+    REAL, POINTER                :: O3(:,:,:)          => NULL()
+    REAL, POINTER                :: O3PPMV(:,:,:)      => NULL()
+    REAL, POINTER                :: GCO3(:,:,:)        => NULL()
+    REAL, POINTER                :: GCO3PPMV(:,:,:)    => NULL()
+    REAL, POINTER                :: PTR_O3P(:,:,:)     => NULL()
+    REAL, POINTER                :: PTR_O1D(:,:,:)     => NULL()
     REAL, ALLOCATABLE            :: OXLOCAL(:,:,:)
     LOGICAL                      :: NeedO3
+    CHARACTER(LEN=ESMF_MAXSTR)   :: OrigUnit
 
     __Iam__('GEOS_RATSandOxDiags')
 
     ! Start here
     LM = State_Grid%NZ
+
+    ! Make sure that species are in kg/kg total. This should be the case already,
+    ! but better be safe!
+    CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
+                             'kg/kg total', RC, OrigUnit=OrigUnit )
 
     !=======================================================================
     ! Fill RATS export states if GC is the RATS provider
@@ -322,6 +366,15 @@ CONTAINS
        IF ( Stage == 2 ) Ptr3D = ( State_Chm%Species(IndSpc)%Conc(:,:,LM:1:-1)-Ptr3D ) / tsChem 
     ENDIF 
 
+    ! Check for H2O tendency
+    CALL MAPL_GetPointer ( EXPORT, Ptr3D, 'GCC_H2O_TEND', NotFoundOK=.TRUE., __RC__ )
+    IF ( ASSOCIATED(Ptr3D) ) THEN
+       IndSpc = Ind_('H2O')
+       ASSERT_(IndSpc>0)
+       IF ( Stage == 1 ) Ptr3D = State_Chm%Species(IndSpc)%Conc(:,:,LM:1:-1) 
+       IF ( Stage == 2 ) Ptr3D = ( State_Chm%Species(IndSpc)%Conc(:,:,LM:1:-1)-Ptr3D ) / tsChem 
+    ENDIF 
+
     !=======================================================================
     ! Ozone diagnostics for GEOS coupling with other components. Do these
     ! via the export state directly, rather than using the State_Diag obj.
@@ -335,7 +388,8 @@ CONTAINS
     !      O3: mass mixing ratio
     !  O3PPMV: volume mixing ratio in ppm
     ! Get pointers to analysis OX exports
-    CALL MAPL_GetPointer ( EXPORT,  OX_TEND, 'OX_TEND'    , NotFoundOK=.TRUE., __RC__ )
+    CALL MAPL_GetPointer ( EXPORT,      OX_TEND, 'OX_TEND'     , NotFoundOK=.TRUE., __RC__ )
+    CALL MAPL_GetPointer ( EXPORT,  GCC_OX_TEND, 'GCC_OX_TEND' , NotFoundOK=.TRUE., __RC__ )
     IF ( Stage == 2 ) THEN
        CALL MAPL_GetPointer ( INTERNAL,     OX, 'OX'         , NotFoundOK=.TRUE., __RC__ )
        CALL MAPL_GetPointer ( EXPORT,       O3, 'O3'         , NotFoundOK=.TRUE., __RC__ )
@@ -344,12 +398,13 @@ CONTAINS
        CALL MAPL_GetPointer ( EXPORT, GCO3PPMV, 'GCC_O3PPMV' , NotFoundOK=.TRUE., __RC__ )
     ENDIF
     NeedO3 = .FALSE.
-    IF ( ASSOCIATED(OX      )) NeedO3 = .TRUE.
-    IF ( ASSOCIATED(OX_TEND )) NeedO3 = .TRUE.
-    IF ( ASSOCIATED(O3      )) NeedO3 = .TRUE.
-    IF ( ASSOCIATED(O3PPMV  )) NeedO3 = .TRUE.
-    IF ( ASSOCIATED(GCO3    )) NeedO3 = .TRUE.
-    IF ( ASSOCIATED(GCO3PPMV)) NeedO3 = .TRUE.
+    IF ( ASSOCIATED(OX          )) NeedO3 = .TRUE.
+    IF ( ASSOCIATED(OX_TEND     )) NeedO3 = .TRUE.
+    IF ( ASSOCIATED(GCC_OX_TEND )) NeedO3 = .TRUE.
+    IF ( ASSOCIATED(O3          )) NeedO3 = .TRUE.
+    IF ( ASSOCIATED(O3PPMV      )) NeedO3 = .TRUE.
+    IF ( ASSOCIATED(GCO3        )) NeedO3 = .TRUE.
+    IF ( ASSOCIATED(GCO3PPMV    )) NeedO3 = .TRUE.
     IF ( NeedO3 ) THEN
        IndO3 = Ind_('O3')
        ASSERT_(IndO3>0)
@@ -359,7 +414,7 @@ CONTAINS
     IF ( ASSOCIATED(GCO3)     ) GCO3     = PTR_O3
     IF ( ASSOCIATED(O3PPMV  ) ) O3PPMV   = PTR_O3 * MAPL_AIRMW / MAPL_O3MW * 1.00E+06
     IF ( ASSOCIATED(GCO3PPMV) ) GCO3PPMV = PTR_O3 * MAPL_AIRMW / MAPL_O3MW * 1.00E+06
-    IF ( ASSOCIATED(OX) .OR. ASSOCIATED(OX_TEND) ) THEN
+    IF ( ASSOCIATED(OX) .OR. ASSOCIATED(OX_TEND) .OR. ASSOCIATED(GCC_OX_TEND) ) THEN
        ALLOCATE(OXLOCAL(State_Grid%NX,State_Grid%NY,State_Grid%NZ))
        OXLOCAL = PTR_O3 * MAPL_AIRMW / MAPL_O3MW
        IndSpc = Ind_('O')
@@ -373,13 +428,99 @@ CONTAINS
           IF ( Stage==1 ) OX_TEND = OXLOCAL
           IF ( Stage==2 ) OX_TEND = ( OXLOCAL - OX_TEND ) / tsChem 
        ENDIF
+       IF ( ASSOCIATED(GCC_OX_TEND) ) THEN
+          IF ( Stage==1 ) GCC_OX_TEND = OXLOCAL
+          IF ( Stage==2 ) GCC_OX_TEND = ( OXLOCAL - GCC_OX_TEND ) / tsChem 
+       ENDIF
        DEALLOCATE(OXLOCAL)
     ENDIF
+
+    ! Convert back to original unit
+    CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
+                             OrigUnit, RC )
 
     ! All done
     RETURN_(ESMF_SUCCESS)
 
   END SUBROUTINE GEOS_RATSandOxDiags
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Model                            !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: GEOS_SetH2O
+!
+! !DESCRIPTION: GEOS_SetH2O sets the GEOS-Chem H2O species to Q or vice versa.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE GEOS_SetH2O( GC, Input_Opt, State_Met, &
+                          State_Chm, State_Grid, Q, Direction, RC ) 
+!
+! !USES:
+!
+    USE UnitConv_Mod,       ONLY : Convert_Spc_Units
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(ESMF_GridComp), INTENT(INOUT)         :: GC        ! Ref. to this GridComp
+    TYPE(OptInput)                             :: Input_Opt
+    TYPE(MetState)                             :: State_Met
+    TYPE(ChmState)                             :: State_Chm
+    TYPE(GrdState)                             :: State_Grid
+    REAL,                INTENT(INOUT)         :: Q(:,:,:)
+    INTEGER,             INTENT(IN)            :: Direction ! 1:Q-->H2O; -1:H2O-->Q 
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,             INTENT(OUT)           :: RC       ! Success or failure?
+!
+! !REMARKS:
+!
+! !REVISION HISTORY:
+!  13 Jul 2022 - C. Keller   - Initial version (from Chem_GridCompMod)
+!  See https://github.com/geoschem/geos-chem for history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! LOCAL VARIABLES:
+!
+    INTEGER                      :: IndH2O, LM 
+    CHARACTER(LEN=ESMF_MAXSTR)   :: OrigUnit
+
+    __Iam__('GEOS_SetH2O')
+
+    ! Only do if H2O is a species 
+    IndH2O = Ind_('H2O')
+    IF ( IndH2O > 0 ) THEN
+       ! Make sure that species are in kg/kg total. This should be the case already,
+       ! but better be safe!
+       CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
+                                'kg/kg total', RC, OrigUnit=OrigUnit )
+  
+       ! Sync Q and H2O concentration array. Q is in kg/kg total, so is H2O. 
+       LM = State_Grid%NZ
+       ! Set GEOS-Chem H2O from Q
+       IF ( Direction == 1 ) THEN
+          State_Chm%Species(IndH2O)%Conc(:,:,LM:1:-1) = Q(:,:,1:LM)
+       ! Set Q to GEOS-Chem H2O. This is possible because Q is friendly to
+       ! CHEMISTRY
+       ELSEIF ( Direction == -1 ) THEN
+          Q(:,:,1:LM) = State_Chm%Species(IndH2O)%Conc(:,:,LM:1:-1)
+       ENDIF   
+
+       ! Convert back to original unit
+       CALL Convert_Spc_Units ( Input_Opt, State_Chm, State_Grid, State_Met, &
+                                OrigUnit, RC )
+    ENDIF
+
+    ! All done
+    RETURN_(ESMF_SUCCESS)
+
+  END SUBROUTINE GEOS_SetH2O
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Model                            !

--- a/KPP/fullchem/commonIncludeVars.H
+++ b/KPP/fullchem/commonIncludeVars.H
@@ -203,6 +203,11 @@
      LOGICAL  :: cloudBox       ! Are we in a box with cloud?
      REAL(dp) :: fracOrgAer     ! Fraction of organic aerosol [1]
      REAL(dp) :: fracInorgAer   ! Fraction of organic aerosol [1]
+     !
+     ! Additional fields for GEOS runs
+     !    
+     LOGICAL  :: TurnOffHetRates ! Turn off heterogeneous reactions in stratosphere?
+
   END TYPE HetState
   TYPE(HetState), TARGET, PUBLIC :: State_Het
   !$OMP THREADPRIVATE( State_Het )

--- a/KPP/fullchem/fullchem_HetStateFuncs.F90
+++ b/KPP/fullchem/fullchem_HetStateFuncs.F90
@@ -238,6 +238,9 @@ CONTAINS
     ! ... check if there is surface NAT at this grid box
     H%natSurface = ( H%pscBox .and. ( C(ind_NIT) > 0.0_dp )                 )
 
+    ! Flag to turn off heterogeneous reactions in stratosphere
+    H%TurnOffHetRates = Input_Opt%TurnOffHetRates
+
   END SUBROUTINE FullChem_SetStateHet
 !EOC
 !------------------------------------------------------------------------------

--- a/KPP/fullchem/fullchem_RateLawFuncs.F90
+++ b/KPP/fullchem/fullchem_RateLawFuncs.F90
@@ -898,6 +898,10 @@ CONTAINS
 
     ! Assume BrNO3 is limiting, so update the removal rate accordingly
     k = kIIR1Ltd( C(ind_BrNO3), C(ind_HCl), k )
+
+    ! Force to zero if HetRate flag is turned on
+    IF ( H%TurnOffHetRates ) k = 0.0_dp
+
   END FUNCTION BrNO3uptkByHCl
 
   !=========================================================================
@@ -1328,6 +1332,10 @@ CONTAINS
     !
     ! Assume ClNO3 is limiting, so recompute reaction rate accordingly
     k = kIIR1Ltd( C(ind_ClNO3), C(ind_HBr), k )
+
+    ! Force to zero if HetRate flag is turned on
+    IF ( H%TurnOffHetRates ) k = 0.0_dp
+
   END FUNCTION ClNO3uptkByHBr
 
   FUNCTION ClNO3uptkByBrSALA( H ) RESULT( k )
@@ -1360,6 +1368,10 @@ CONTAINS
     !
     ! Assume ClNO3 is limiting, so recompute reaction rate accordingly
     k = kIIR1Ltd( C(ind_ClNO3), C(ind_BrSALA), k )
+
+    ! Force to zero if HetRate flag is turned on
+    IF ( H%TurnOffHetRates ) k = 0.0_dp
+
   END FUNCTION ClNO3uptkByBrSALA
 
   FUNCTION ClNO3uptkByBrSALC( H ) RESULT( k )
@@ -1392,6 +1404,10 @@ CONTAINS
     !
     ! Assume ClNO3 is limiting, so recompute reaction rate accordingly
     k = kIIR1Ltd( C(ind_ClNO3), C(ind_BrSALC), k )
+
+    ! Force to zero if HetRate flag is turned on
+    IF ( H%TurnOffHetRates ) k = 0.0_dp
+
   END FUNCTION ClNO3uptkByBrSALC
 
   FUNCTION ClNO3uptkBySALACL( H ) RESULT( k )
@@ -1416,6 +1432,7 @@ CONTAINS
     !
     ! Assume ClNO3 is limiting, so recompute reaction rate accordingly
     k = kIIR1Ltd( C(ind_ClNO3), C(ind_SALACL), k )
+
   END FUNCTION ClNO3uptkBySALACL
 
   FUNCTION ClNO3uptkBySALCCL( H ) RESULT( k )
@@ -2255,6 +2272,10 @@ CONTAINS
     !
     ! Assume HOCl is limiting, so recompute reaction rate accordingly
     k = kIIR1Ltd( C(ind_HOCl), C(ind_HBr), k )
+
+    ! Force to zero if HetRate flag is turned on
+    IF ( H%TurnOffHetRates ) k = 0.0_dp
+
   END FUNCTION HOClUptkByHBr
 
   FUNCTION HOClUptkBySALACL( H ) RESULT( k )

--- a/run/CESM/HISTORY.rc
+++ b/run/CESM/HISTORY.rc
@@ -544,6 +544,8 @@ COLLECTIONS: 'Metrics',
                               'KppLuDecomps                  ',
                               'KppSubsts                     ',
                               'KppSmDecomps                  ',
+                              'KppNegatives                  ',
+                              'KppNegatives0                 ',
 ::
 #==============================================================================
 # %%%%% THE LevelEdgeDiags COLLECTION %%%%%

--- a/run/CESM/HISTORY.rc
+++ b/run/CESM/HISTORY.rc
@@ -544,8 +544,8 @@ COLLECTIONS: 'Metrics',
                               'KppLuDecomps                  ',
                               'KppSubsts                     ',
                               'KppSmDecomps                  ',
-                              'KppNegatives                  ',
-                              'KppNegatives0                 ',
+                              #'KppNegatives                  ',
+                              #'KppNegatives0                 ',
 ::
 #==============================================================================
 # %%%%% THE LevelEdgeDiags COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -411,6 +411,8 @@ COLLECTIONS: 'Restart',
                               'KppSubsts                     ',
                               'KppSmDecomps                  ',
                               'KppTime                       ',
+                              'KppNegatives                  ',
+                              'KppNegatives0                 ',
 ::
 #==============================================================================
 # %%%%% THE KppARDiags COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -411,8 +411,8 @@ COLLECTIONS: 'Restart',
                               'KppSubsts                     ',
                               'KppSmDecomps                  ',
                               'KppTime                       ',
-                              'KppNegatives                  ',
-                              'KppNegatives0                 ',
+                              #'KppNegatives                  ',
+                              #'KppNegatives0                 ',
 ::
 #==============================================================================
 # %%%%% THE KppARDiags COLLECTION %%%%%

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -4710,8 +4710,8 @@ COLLECTIONS: @#'DefaultCollection',
                           'KppLuDecomps                  ', 'GCHPchem',
                           'KppSubsts                     ', 'GCHPchem',
                           'KppSmDecomps                  ', 'GCHPchem',
-                          'KppNegatives                  ', 'GCHPchem',
-                          'KppNegatives0                 ', 'GCHPchem',
+                          #'KppNegatives                  ', 'GCHPchem',
+                          #'KppNegatives0                 ', 'GCHPchem',
 ::
 #==============================================================================
 # %%%%% THE KppARDiags COLLECTION %%%%%

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -4710,6 +4710,8 @@ COLLECTIONS: @#'DefaultCollection',
                           'KppLuDecomps                  ', 'GCHPchem',
                           'KppSubsts                     ', 'GCHPchem',
                           'KppSmDecomps                  ', 'GCHPchem',
+                          'KppNegatives                  ', 'GCHPchem',
+                          'KppNegatives0                 ', 'GCHPchem',
 ::
 #==============================================================================
 # %%%%% THE KppARDiags COLLECTION %%%%%

--- a/run/GEOS/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/GEOSCHEMchem_ExtData.yaml
@@ -1,11 +1,10 @@
 Samplings:
   gcc_persist:           {extrapolation: persist_closest}
   gcc_daily:             {update_reference_time: "0", update_frequency: PT24H, update_offset: PT12H}
-  gcc_daily_clim:        {update_reference_time: "0", update_frequency: PT24H, time_interpolation: False, extrapolation: clim}
-  gcc_8day_interp_clim:  {update_reference_time: "0", update_frequency: P8D, update_offset: P1D, time_interpolation: True, extrapolation: clim}
+  gcc_daily_clim:        {update_reference_time: "0", update_frequency: PT24H, update_offset: PT12H, time_interpolation: False, extrapolation: clim}
+  gcc_8day_interp_clim:  {update_reference_time: "0", update_frequency: P8D, update_offset: P1D, time_interpolation: False, extrapolation: clim}
   gcc_3hr:               {time_interpolation: True, extrapolation: clim}
-  gcc_monthly_clim:      {update_reference_time: "0", update_frequency: P1M, time_interpolation: False, extrapolation: clim}
-
+  gcc_monthly_clim:      {update_reference_time: "0", update_frequency: PT24H, update_offset: PT12H, time_interpolation: False, extrapolation: clim}
 
 Collections:
   GCC_ACET_seawater:

--- a/run/GEOS/GEOSCHEMchem_GridComp.rc
+++ b/run/GEOS/GEOSCHEMchem_GridComp.rc
@@ -76,8 +76,16 @@ RUN_PHASES:        2
 #
 # %%% Stop if KPP integration fails (default: 1) %%% 
 #
-KPP_STOP_IF_FAIL:  0
+KPP_STOP_IF_FAIL:   0
 
+# Checks to prevent negative concentrations after KPP integration. These can create
+# problems with mass balance. KppCheckNegatives checks for negatives in the N top 
+# layers. I.e., if set to 5 it will check for negatives in the top 5 model levels.
+# If set to 0, it will perform the check in the entire stratosphere and mesosphere.
+# If negatives are found, a second integration attempt will be made using HSTART=0 
+# and by relaxing the KPP tolerances using the scale factor provided in KppTolScale.
+KppCheckNegatives: -1
+KppTolScale:        1.0
 
 #
 # %%% HEMCO configuration file %%%
@@ -102,7 +110,7 @@ ARCHIVED_CONV:        0
 
 # %%% Use MOIST module for convective transport (including washout)
 # Make species friendly to moist? If turned on, convection must be turned off in in geoschem_config.yml
-Species_friendly_to_moist: 0
+Species_friendly_to_moist: 1
 # Turn off washout for SO2?
 TurnOff_SO2_washout: 1
 # Calculate CLDLIQ and CLDICE online based on current conditions (use default GEOS-Chem parameterization otherwise)?
@@ -233,5 +241,5 @@ CO_Mesosphere_FieldName: CO_CMAM
 
 #
 # To set CH4 boundary condition from GEOS 
-# Note: if set to 1, need to make sure that an import named 'GEOS_CH4' is set in ExtData.
+# This is not yet implemented. Set to zero for now. If you want GEOS CH4, need to activate GEOS_CH4 in HEMCO_Config.rc
 CH4_from_GEOS: 0

--- a/run/GEOS/HEMCO_Config.rc
+++ b/run/GEOS/HEMCO_Config.rc
@@ -80,8 +80,9 @@ VerboseOnCores:              root       # Accepted values: root all
     --> GMI_PROD_LOSS          :       false
     --> UCX_PROD_LOSS          :       false
     --> OMOC_RATIO             :       false
-    --> GMD_SFC_CH4            :       true
+    --> GMD_SFC_CH4            :       false
     --> CMIP6_SFC_CH4          :       false
+    --> GEOS_3HR_CH4           :       true
 # OLSON and MODIS read via MAPL not HEMCO in GEOS
     --> OLSON_LANDMAP          :       false
     --> YUAN_MODIS_LAI         :       false
@@ -1358,6 +1359,13 @@ VerboseOnCores:              root       # Accepted values: root all
 (((GMD_SFC_CH4
 * NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
 )))GMD_SFC_CH4
+
+#==============================================================================
+# --- GEOS 3-hourly CH4 (within PBL) ---
+#==============================================================================
+(((GEOS_3HR_CH4
+* GEOS_CH4 /see/extdata CH4_total_dry 1979-2024/1-12/1-31/0 C xyz ppbv * - 1 1
+)))GEOS_3HR_CH4
 
 (((SfcVMR
 #==============================================================================

--- a/run/GEOS/geoschem_config.yml
+++ b/run/GEOS/geoschem_config.yml
@@ -43,7 +43,7 @@ operations:
       append_in_internal_timestep: false
 
   convection:
-    activate: true
+    activate: false
 
   dry_deposition:
     activate: true
@@ -60,7 +60,7 @@ operations:
   photolysis:
     activate: true
     input_directories:
-      fastjx_input_dir: /discover/nobackup/ewlundgr/data/ExtData/FAST_JX/v2021-10/
+      fastjx_input_dir: /gpfsm/dnb52/projects/p10/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/FAST_JX/v2023-10/
     overhead_O3:
       use_online_O3_from_model: true
       use_column_O3_from_met: true


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

Updates include the following:

- Updates impacting the standard offline model:
  - Two new optional diagnostics to track number of negative concentrations after KPP integration
    - State_Diag%KPPNegatives is number of grid cells with negative concentration after KPP integration
    - State_Diag%KPPNegatives0 is number of grid cells with negative concentration after first KPP integration attempt
- GEOS-only updates:
  - Add run-time option to check for negatives after KPP integration (Input_Opt%KppCheckNegatives)
  - Add run-time parameter for KPP tolerance inflation factor for second KPP integration attempt (Input_Opt%KppTolScale) 
  - Turn off 3 heterogeneous reactions in stratosphere by default (previously default was not to do this)
  - Add parameter to define RATS phase
  - Move GEOS diagnostic exports to geos_interface.F90
  - Always prescribe H2O in both the stratosphere and troposphere in GEOS
  - Updates for GEOS H2O tendency and Ox diagnostics
  - Add logic to determine whether to apply H2O tendency to Q
  - Add subroutine to set H2O from specific humidity (GEOS_SetH2O)
  - Use absolute data paths in GEOS-Chem ExtData yaml file used in GEOS
  - Set species friendly to moist by default
  - Add inventory for GEOS 3-hourly methane within PBL
  - Turn off GEOS-Chem convection by default
  - Update Fast-JX input directory
 
### Expected changes

This is a zero diff update for offline GEOS-Chem.

### Reference(s)

None

### Related Github Issue(s)

None
