### PR TITLE
Reduce timers to essential list only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Removed
+- Reduced timers saved out to essential list used for benchmarking model performance
+
 ## [14.2.3] - 2023-12-01
 ### Added
 - GEOS-Chem Classic rundir script `run/GCClassic/setupForRestarts.sh`

--- a/GeosCore/carbon_gases_mod.F90
+++ b/GeosCore/carbon_gases_mod.F90
@@ -391,7 +391,6 @@ CONTAINS
     USE State_Diag_Mod,       ONLY : DgnState
     USE State_Met_Mod,        ONLY : MetState
     USE Time_Mod,             ONLY : Get_Ts_Chem
-    USE Timers_Mod
 !
 ! !INPUT PARAMETERS:
 !
@@ -442,7 +441,7 @@ CONTAINS
     INTEGER                :: HcoID,    I
     INTEGER                :: J,        L
     INTEGER                :: NA,       N
-    INTEGER                :: IERR,     threadNum
+    INTEGER                :: IERR
     REAL(fp)               :: dtChem,   facDiurnal
     REAL(fp)               :: tsPerDay
 
@@ -474,14 +473,6 @@ CONTAINS
     !@@@ PrevCH4 stores CH4 before chemistry, for later distribution
     !@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     REAL(fp) :: PREVCH4(     State_Grid%NX, State_Grid%NY, State_Grid%NZ)
-#endif
-
-
-#ifdef MODEL_CLASSIC
-#ifndef NO_OMP
-    ! For GEOS-Chem Classic timers
-    INTEGER,     EXTERNAL  :: OMP_GET_THREAD_NUM
-#endif
 #endif
 
     !========================================================================
@@ -622,11 +613,6 @@ CONTAINS
     !$OMP PARALLEL DO                                                        &
     !$OMP DEFAULT( SHARED                                                   )&
     !$OMP PRIVATE( I, J, L, N                                               )&
-#ifdef MODEL_CLASSIC
-#ifndef NO_OMP
-    !$OMP PRIVATE( threadNum                                                )&
-#endif
-#endif
     !$OMP COLLAPSE( 3                                                       )&
     !$OMP SCHEDULE( DYNAMIC, 24                                             )
     DO L = 1, State_Grid%NZ
@@ -645,22 +631,6 @@ CONTAINS
        TEMP_OVER_K300 = TEMP / 300.0_dp           ! T/300 term for equations
        K300_OVER_TEMP = 300.0_dp / TEMP           ! 300/T term for equations
        SUNCOS         = State_Met%SUNCOSmid(I,J)  ! Cos(SZA) ) [1]
-#ifdef MODEL_CLASSIC
-#ifndef NO_OMP
-       threadNum      = OMP_GET_THREAD_NUM() + 1   ! OpenMP thread number
-#endif
-#endif
-
-       !=====================================================================
-       ! Start KPP main timer
-       !=====================================================================
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start(                                                  &
-               timerName = "  -> KPP",                                       &
-               inLoop    = .TRUE.,                                           &
-               threadNum = ThreadNum,                                        &
-               RC        = RC                                               )
-       ENDIF
 
        !=====================================================================
        ! Convert CO, CO2, CH4 to molec/cm3 for the KPP solver
@@ -684,24 +654,6 @@ CONTAINS
        ! Update reaction rates
        !===================================================================
 
-       ! Stop KPP timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End(                                                    &
-               timerName = "  -> KPP",                                       &
-               inLoop    = .TRUE.,                                           &
-               threadNum = ThreadNum,                                        &
-               RC        = RC                                               )
-       ENDIF
-
-       ! Start RCONST timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start(                                                  &
-               timerName = "     RCONST",                                    &
-               inLoop    = .TRUE.,                                           &
-               threadNum = ThreadNum,                                        &
-               RC        =  RC                                              )
-       ENDIF
-
        ! Compute the rate constants that will be used
        CALL carbon_ComputeRateConstants(                                     &
             I                = I,                                            &
@@ -724,27 +676,9 @@ CONTAINS
        ! Update the array of rate constants for the KPP solver
        CALL Update_RCONST()
 
-       ! Stop timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End(                                                    &
-               timerName = "     RCONST",                                    &
-               inLoop    = .TRUE.,                                           &
-               threadNum = threadNum,                                        &
-               RC        =  RC                                              )
-       ENDIF
-
        !=====================================================================
        ! Call the KPP integrator
        !=====================================================================
-
-       ! Start timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start(                                                  &
-               timerName = "     Integrate 1",                               &
-               inLoop    =  .TRUE.,                                          &
-               threadNum = threadNum,                                        &
-               RC        = RC                                               )
-       ENDIF
 
        ! Integrate the mechanism forward in time
        CALL Integrate(                                                       &
@@ -753,26 +687,8 @@ CONTAINS
             ICNTRL_U = ICNTRL,                                               &
             IERR_U   = IERR                                                 )
 
-       ! Stop timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End(                                                    &
-               timerName = "     Integrate 1",                               &
-               inLoop    = .TRUE.,                                           &
-               threadNum = ThreadNum,                                        &
-               RC        = RC                                               )
-       ENDIF
-
        ! Trap potential errors
        IF ( IERR /= 1 ) failed = .TRUE.
-
-       ! Start KPP timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End(                                                    &
-               timerName = "  -> KPP",                                       &
-               inLoop    = .TRUE.,                                           &
-               threadNum = ThreadNum,                                        &
-               RC        = RC                                               )
-       ENDIF
 
        !=====================================================================
        ! HISTORY: Archive KPP solver diagnostics
@@ -835,24 +751,6 @@ CONTAINS
             xnumol_CO2   = xnumol_CO2,                                       &
             State_Chm    = State_Chm,                                        &
             State_Met    = State_Met                                        )
-
-       IF ( Input_Opt%useTimers ) THEN
-
-          ! Stop main KPP timer
-          CALL Timer_End(                                                    &
-               timerName  = "  -> KPP",                                      &
-               inLoop     = .TRUE.,                                          &
-               threadNum  = threadNum,                                        &
-               RC         = RC                                              )
-
-          ! Start Prod/Loss timer
-          CALL Timer_Start(                                                  &
-               timerName = "  -> Prod/loss diags",                           &
-               inLoop    = .TRUE.,                                           &
-               threadNum = threadNum,                                        &
-               RC        = RC                                               )
-
-       ENDIF
 
 #ifdef ACTIVATE_TAGGED_SPECIES
        !@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@ -944,15 +842,6 @@ CONTAINS
           State_Diag%Loss(I,J,L,16) = ( COfrom_OH / STTCO / DTCHEM )
        ENDIF
 #endif
-
-       ! Stop Prod/Loss timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End(                                                    &
-               timerName =  "  -> Prod/loss diags",                          &
-               inLoop    = .TRUE.,                                           &
-               threadNum = threadNum,                                        &
-               RC        = RC                                               )
-       ENDIF
 
     ENDDO
     ENDDO

--- a/GeosCore/chemistry_mod.F90
+++ b/GeosCore/chemistry_mod.F90
@@ -409,7 +409,7 @@ CONTAINS
           ! Call gas-phase chemistry
           !------------------------------------------------------------------
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "=> FlexChem", RC )
+             CALL Timer_Start( "=> Gas-phase chem", RC )
           ENDIF
 
           ! Solve the KPP-generated mechanism
@@ -429,13 +429,13 @@ CONTAINS
 
           ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
-             ErrMsg = 'Error encountered in "Do_FlexChem"!'
+             ErrMsg = 'Error encountered in "Do_FullChem"!'
              CALL GC_Error( ErrMsg, RC, ThisLoc )
              RETURN
           ENDIF
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "=> FlexChem", RC )
+             CALL Timer_End( "=> Gas-phase chem", RC )
           ENDIF
 
           !------------------------------------------------------------------
@@ -989,9 +989,8 @@ CONTAINS
        !=====================================================================
        ELSE IF ( Input_Opt%ITS_A_CARBON_SIM ) THEN
 
-          ! Start "FlexChem" timer
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "=> FlexChem", RC )
+             CALL Timer_Start( "=> Gas-phase chem", RC )
           ENDIF
 
           ! Do carbon chemistry
@@ -1009,9 +1008,8 @@ CONTAINS
              RETURN
           ENDIF
 
-          ! Stop "FlexChem" timer
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "=> FlexChem", RC )
+             CALL Timer_End( "=> Gas-phase chem", RC )
           ENDIF
 
        !====================================================================
@@ -1019,9 +1017,8 @@ CONTAINS
        !=====================================================================
        ELSE IF ( Input_Opt%ITS_A_MERCURY_SIM ) THEN
 
-          ! Start "FlexChem" timer
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "=> FlexChem", RC )
+             CALL Timer_Start( "=> Gas-phase chem", RC )
           ENDIF
 
           ! Do Hg chemistry
@@ -1039,9 +1036,8 @@ CONTAINS
              RETURN
           ENDIF
 
-          ! Stop "FlexChem" timer
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "=> FlexChem", RC )
+             CALL Timer_End( "=> Gas-phase chem", RC )
           ENDIF
 
        !=====================================================================

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -375,7 +375,7 @@ CONTAINS
     ! Call photolysis routine to compute J-Values
     !========================================================================
     IF ( Input_Opt%useTimers ) THEN
-       CALL Timer_End  ( "=> FlexChem",   RC )
+       CALL Timer_End  ( "=> Gas-phase chem", RC )
        CALL Timer_Start( "=> Photolysis", RC )
     ENDIF
 
@@ -397,7 +397,7 @@ CONTAINS
 
     IF ( Input_Opt%useTimers ) THEN
        CALL Timer_End  ( "=> Photolysis", RC )
-       CALL Timer_Start( "=> FlexChem",           RC ) ! ended in Do_Chemistry
+       CALL Timer_Start( "=> Gas-phase chem", RC ) ! ended in Do_Chemistry
     ENDIF
 
 #if defined( MODEL_GEOS ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
@@ -479,10 +479,6 @@ CONTAINS
            '       computed Y upon return:            ', f11.4, /,          &
            'Hexit, last accepted step before exit:    ', f11.4, /,          &
            'Hnew, last predicted step (not yet taken):', f11.4 )
-
-    IF ( Input_Opt%useTimers ) THEN
-       CALL Timer_Start( "  -> FlexChem loop", RC )
-    ENDIF
 
     !------------------------------------------------------------------------
     ! Always consider halogens as "fast" species for auto-reduce
@@ -589,14 +585,6 @@ CONTAINS
        ! (update submitted by E. Fleming (NASA), 10/11/2018)
        !=====================================================================
        IF ( State_Met%SUNCOSmid(I,J) > -0.1391731e+0_fp ) THEN
-
-          ! Start timer
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( TimerName = "  -> Photolysis rates",          &
-                               InLoop    = .TRUE.,                           &
-                               ThreadNum = Thread,                           &
-                               RC        = RC                               )
-          ENDIF
 
           ! Only proceed if doing photolysis
           IF ( Input_Opt%Do_Photolysis ) THEN
@@ -720,13 +708,6 @@ CONTAINS
              ENDDO
           ENDIF
 
-          ! Stop timer
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( TimerName = "  -> Photolysis rates",            &
-                             InLoop    = .TRUE.,                             &
-                             ThreadNum = Thread,                             &
-                             RC        = RC                                 )
-          ENDIF
        ENDIF
 
 #if defined( MODEL_CESM )
@@ -801,16 +782,6 @@ CONTAINS
        ENDDO
 
        !=====================================================================
-       ! Start KPP main timer
-       !=====================================================================
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start( TimerName = "  -> KPP",                          &
-                            InLoop    = .TRUE.,                              &
-                            ThreadNum = Thread,                              &
-                            RC        = RC                                  )
-       ENDIF
-
-       !=====================================================================
        ! CHEMISTRY MECHANISM INITIALIZATION (#1)
        !
        ! Populate KPP global variables and arrays in gckpp_global.F90
@@ -823,14 +794,6 @@ CONTAINS
        !    -- Bob Yantosca (08 Mar 2022)
        !=====================================================================
 
-       ! Start timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start( TimerName = "  -> Init KPP",                     &
-                            InLoop    = .TRUE.,                              &
-                            ThreadNum = Thread,                              &
-                            RC        =  RC                                 )
-       ENDIF
-
        ! Copy values into the various KPP global variables
        CALL Set_Kpp_GridBox_Values( I          = I,                          &
                                     J          = J,                          &
@@ -840,14 +803,6 @@ CONTAINS
                                     State_Grid = State_Grid,                 &
                                     State_Met  = State_Met,                  &
                                     RC         = RC                         )
-
-       ! Stop timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End( TimerName =  "  -> Init KPP",                      &
-                          InLoop    = .TRUE.,                                &
-                          ThreadNum = Thread,                                &
-                          RC        =  RC                                   )
-       ENDIF
 
        !=====================================================================
        ! CHEMISTRY MECHANISM INITIALIZATION (#2)
@@ -862,14 +817,6 @@ CONTAINS
        !    -- Bob Yantosca (08 Mar 2022)
        !=====================================================================
 
-       ! Start timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start( TimerName = "     RCONST",                       &
-                            InLoop    = .TRUE.,                              &
-                            ThreadNum = Thread,                              &
-                            RC        = RC                                  )
-       ENDIF
-
        ! Compute sulfur chemistry reaction rates [1/s]
        ! If size_res = T, we'll call fullchem_HetDropChem below.
        CALL Set_Sulfur_Chem_Rates( I          = I,                           &
@@ -883,14 +830,6 @@ CONTAINS
                                    size_res   = size_res,                    &
                                    RC         = RC                          )
 
-       ! Stop timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End( TimerName = "     RCONST",                         &
-                          InLoop    = .TRUE.,                                &
-                          ThreadNum = Thread,                                &
-                          RC        = RC                                    )
-       ENDIF
-
        !=====================================================================
        ! CHEMISTRY MECHANISM INITIALIZATION (#3)
        !
@@ -902,14 +841,6 @@ CONTAINS
        ! See https://github.com/geoschem/geos-chem/issues/1157
        !    -- Bob Yantosca (08 Mar 2022)
        !=====================================================================
-
-       ! Start timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start( TimerName = "  -> Init KPP",                     &
-                            InLoop    = .TRUE.,                              &
-                            ThreadNum = Thread,                              &
-                            RC        =  RC                                 )
-       ENDIF
 
        ! Populate fields of the State_Het object
        CALL fullchem_SetStateHet( I         = I,                             &
@@ -924,14 +855,6 @@ CONTAINS
                                   State_Met = State_Met,                     &
                                   H         = State_Het,                     &
                                   RC        = RC                            )
-
-       ! Stop timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End( TimerName =  "  -> Init KPP",                      &
-                          InLoop    = .TRUE.,                                &
-                          ThreadNum = Thread,                                &
-                          RC        =  RC                                   )
-       ENDIF
 
        !=====================================================================
        ! CHEMISTRY MECHANISM INITIALIZATION (#5)
@@ -950,14 +873,6 @@ CONTAINS
        ! (5) Liquid water content is nonzero
        !=====================================================================
        IF ( State_Met%CLDF(I,J,L) > 1.0e-4_fp ) THEN
-
-          ! Start timer
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( TimerName = "     RCONST",                    &
-                               InLoop    = .TRUE.,                           &
-                               ThreadNum = Thread,                           &
-                               RC        =  RC                              )
-          ENDIF
 
           ! Liquid water content (same formula from the old sulfate_mod.F90)
           LWC = ( State_Met%QL(I,J,L) * State_Met%AIRDEN(I,J,L)              &
@@ -979,17 +894,10 @@ CONTAINS
                                         State_Chm = State_Chm               )
           ENDIF
 
-          ! Stop timer
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( TimerName = "     RCONST",                       &
-                             InLoop    = .TRUE.,                              &
-                             ThreadNum = Thread,                              &
-                             RC        =  RC                                 )
-          ENDIF
        ENDIF
 
        !=====================================================================
-       ! Start KPP main timer and prepare arrays
+       ! Prepare arrays
        !=====================================================================
 
        ! Zero out dummy species index in KPP
@@ -1002,24 +910,8 @@ CONTAINS
        ! Update reaction rates
        !=====================================================================
 
-       ! Start timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start( TimerName = "     RCONST",                       &
-                            InLoop    = .TRUE.,                              &
-                            ThreadNum = Thread,                              &
-                            RC        =  RC                                 )
-       ENDIF
-
        ! Update the array of rate constants
        CALL Update_RCONST( )
-
-       ! Stop timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End( TimerName = "     RCONST",                         &
-                          InLoop    = .TRUE.,                                &
-                          ThreadNum = Thread,                                &
-                          RC        =  RC                                   )
-       ENDIF
 
        !=====================================================================
        ! HISTORY (aka netCDF diagnostics)
@@ -1087,26 +979,10 @@ CONTAINS
        ! let us reset concentrations before calling "Integrate" a 2nd time.
        C_before_integrate = C
 
-       ! Start timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start( TimerName = "     Integrate 1",                  &
-                            InLoop    =  .TRUE.,                             &
-                            ThreadNum = Thread,                              &
-                            RC        = RC                                  )
-       ENDIF
-
        ! Call the Rosenbrock integrator
        ! (with optional auto-reduce functionality)
        CALL Integrate( TIN,    TOUT,    ICNTRL,                              &
                        RCNTRL, ISTATUS, RSTATE, IERR                        )
-
-       ! Stop timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End( TimerName = "     Integrate 1",                    &
-                          InLoop    = .TRUE.,                                &
-                          ThreadNum = Thread,                                &
-                          RC        = RC                                    )
-       ENDIF
 
        ! Print grid box indices to screen if integrate failed
        IF ( IERR < 0 ) THEN
@@ -1202,25 +1078,9 @@ CONTAINS
           ! Update rates again
           CALL Update_RCONST( )
 
-          ! Start timer
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( TimerName = "     Integrate 2",               &
-                               InLoop    =  .TRUE.,                          &
-                               ThreadNum = Thread,                           &
-                               RC        = RC                               )
-          ENDIF
-
           ! Call the Rosenbrock integrator (w/ auto-reduction disabled)
           CALL Integrate( TIN,    TOUT,    ICNTRL,                           &
                           RCNTRL, ISTATUS, RSTATE, IERR                     )
-
-          ! Stop timer
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( TimerName = "     Integrate 2",                 &
-                             InLoop    =  .TRUE.,                            &
-                             ThreadNum = Thread,                             &
-                             RC        = RC                                 )
-          ENDIF
 
           !==================================================================
           ! HISTORY: Archive KPP solver diagnostics
@@ -1382,21 +1242,6 @@ CONTAINS
           State_Chm%Species(SpcID)%Conc(I,J,L) = REAL( C(N), kind=fp )
 
        ENDDO
-
-       IF ( Input_Opt%useTimers ) THEN
-
-          ! Stop main KPP timer
-          CALL Timer_End( TimerName  = "  -> KPP",                           &
-                          InLoop     = .TRUE.,                               &
-                          ThreadNum  = Thread,                               &
-                          RC         = RC                                   )
-
-          ! Start Prod/Loss timer
-          CALL Timer_Start( TimerName = "  -> Prod/loss diags",              &
-                            InLoop    = .TRUE.,                              &
-                            ThreadNum = Thread,                              &
-                            RC        = RC                                  )
-       ENDIF
 
 #ifdef BPCH_DIAG
 #ifdef TOMAS
@@ -1579,14 +1424,6 @@ CONTAINS
 
        ENDIF
 
-       ! Stop Prod/Loss timer
-       IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End( TimerName =  "  -> Prod/loss diags",               &
-                          InLoop    = .TRUE.,                                &
-                          ThreadNum = Thread,                                &
-                          RC        = RC                                    )
-       ENDIF
-
        !====================================================================
        ! HISTORY (aka netCDF diagnostics)
        !
@@ -1597,14 +1434,6 @@ CONTAINS
        IF ( State_Diag%Archive_OHreactivity           .or.                   &
             State_Diag%Archive_SatDiagnOHreactivity ) THEN
 
-          ! Start timer
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( TimerName = "  -> OH reactivity diag",        &
-                               InLoop    = .TRUE.,                           &
-                               ThreadNum = Thread,                           &
-                               RC        = RC                               )
-          ENDIF
-
           ! Archive OH reactivity diagnostic
           CALL Get_OHreactivity ( C, RCONST, OHreact )
           IF ( State_Diag%Archive_OHreactivity ) THEN
@@ -1614,36 +1443,11 @@ CONTAINS
              State_Diag%SatDiagnOHreactivity(I,J,L) = OHreact
           ENDIF
 
-          ! Stop timer
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( TimerName = "  -> OH reactivity diag",          &
-                             InLoop    = .TRUE.,                             &
-                             ThreadNum = Thread,                             &
-                             RC        = RC                                 )
-          ENDIF
        ENDIF
     ENDDO
     ENDDO
     ENDDO
     !$OMP END PARALLEL DO
-
-    ! Stop timer
-    IF ( Input_Opt%useTimers ) THEN
-       CALL Timer_End( "  -> FlexChem loop", RC )
-    ENDIF
-
-    ! Compute sum of in-loop timers
-    IF ( Input_Opt%useTimers ) THEN
-       CALL Timer_Sum_Loop( "  -> Init KPP",            RC )
-       CALL Timer_Sum_Loop( "  -> Het chem rates",      RC )
-       CALL Timer_Sum_Loop( "  -> Photolysis rates",    RC )
-       CALL Timer_Sum_Loop( "  -> KPP",                 RC )
-       CALL Timer_Sum_Loop( "     RCONST",              RC )
-       CALL Timer_Sum_Loop( "     Integrate 1",         RC )
-       CALL Timer_Sum_Loop( "     Integrate 2",         RC )
-       CALL Timer_Sum_Loop( "  -> Prod/loss diags",     RC )
-       CALL Timer_Sum_Loop( "  -> OH reactivity diag",  RC )
-    ENDIF
 
     !=======================================================================
     ! Return gracefully if integration failed 2x anywhere

--- a/GeosCore/mercury_mod.F90
+++ b/GeosCore/mercury_mod.F90
@@ -634,7 +634,6 @@ CONTAINS
     USE GcKpp_Model
     USE Gckpp_Global
     USE GcKpp_Rates,        ONLY : UPDATE_RCONST, RCONST
-    USE Timers_Mod
     USE Photolysis_Mod,     ONLY : Do_Photolysis
     USE PhysConstants,      ONLY : AVO
     USE State_Chm_Mod,      ONLY : Ind_

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -218,8 +218,6 @@ CONTAINS
     USE State_Met_Mod,        ONLY : MetState
     USE TIME_MOD,             ONLY : GET_TS_DYN, GET_TS_CONV, GET_TS_CHEM
     USE UnitConv_Mod
-
-    use timers_mod
 #ifdef MODEL_CLASSIC
     use hco_utilities_gc_mod, only: TMP_MDL ! danger
 #endif

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -322,20 +322,9 @@ PROGRAM GEOS_Chem
 
      ! Add timers for various operations
      CALL Timer_Add( "GEOS-Chem",                    RC )
-     CALL Timer_Add( "Initialization",               RC )
      CALL Timer_Add( "HEMCO",                        RC )
      CALL Timer_Add( "All chemistry",                RC )
-     CALL Timer_Add( "=> FlexChem",                  RC )
-     CALL Timer_Add( "  -> FlexChem loop",           RC )
-     CALL Timer_Add( "  -> Init KPP",                RC )
-     CALL Timer_Add( "  -> Het chem rates",          RC )
-     CALL Timer_Add( "  -> Photolysis rates",        RC )
-     CALL Timer_Add( "  -> KPP",                     RC )
-     CALL Timer_Add( "     RCONST",                  RC )
-     CALL Timer_Add( "     Integrate 1",             RC )
-     CALL Timer_Add( "     Integrate 2",             RC )
-     CALL Timer_Add( "  -> Prod/loss diags",         RC )
-     CALL Timer_Add( "  -> OH reactivity diag",      RC )
+     CALL Timer_Add( "=> Gas-phase chem",            RC )
      CALL Timer_Add( "=> Photolysis",                RC )
      CALL Timer_Add( "=> Aerosol chem",              RC )
      CALL Timer_Add( "=> Linearized chem",           RC )
@@ -347,21 +336,11 @@ PROGRAM GEOS_Chem
 #ifdef RRTMG
      CALL Timer_Add( "RRTMG",                        RC )
 #endif
-     CALL Timer_Add( "All diagnostics",              RC )
-     CALL Timer_Add( "=> HEMCO diagnostics",         RC )
-#ifdef BPCH_DIAG
-     CALL Timer_Add( "=> Binary punch diagnostics",  RC )
-#endif
-     CALL Timer_Add( "=> ObsPack diagnostics",       RC )
-     CALL Timer_Add( "=> History (netCDF diags)",    RC )
+     CALL Timer_Add( "Diagnostics",                  RC )
      CALL Timer_Add( "Unit conversions",             RC )
-     CALL Timer_Add( "Input",                        RC )
-     CALL Timer_Add( "Output",                       RC )
-     CALL Timer_Add( "Finalization",                 RC )
 
      ! Start running the main and initialization timer
      CALL Timer_Start( "GEOS-Chem",                  RC )
-     CALL Timer_Start( "Initialization",             RC )
   ENDIF
 
   !--------------------------------------------------------------------------
@@ -446,8 +425,7 @@ PROGRAM GEOS_Chem
   !--------------------------------------------------------------------------
   IF ( notDryRun ) THEN
      IF ( Input_Opt%useTimers ) THEN
-        CALL Timer_Start( "All diagnostics",           RC )
-        CALL Timer_Start( "=> History (netCDF diags)", RC )
+        CALL Timer_Start( "Diagnostics", RC )
      ENDIF
 
      ! Initialize the Diag_List (list of all diagnostics)
@@ -472,8 +450,7 @@ PROGRAM GEOS_Chem
      ENDIF
 
      IF ( Input_Opt%useTimers ) THEN
-        CALL Timer_End( "All diagnostics",           RC )
-        CALL Timer_End( "=> History (netCDF diags)", RC )
+        CALL Timer_End( "Diagnostics", RC )
      ENDIF
   ENDIF
 
@@ -649,8 +626,7 @@ PROGRAM GEOS_Chem
   !         ***** H I S T O R Y   I N I T I A L I Z A T I O N *****
   !--------------------------------------------------------------------------
   IF ( Input_Opt%useTimers .and. notDryRun ) THEN
-     CALL Timer_Start( "All diagnostics",           RC )
-     CALL Timer_Start( "=> History (netCDF diags)", RC )
+     CALL Timer_Start( "Diagnostics", RC )
   ENDIF
 
   ! For now, just hardwire the input file for the History component
@@ -668,8 +644,7 @@ PROGRAM GEOS_Chem
   ENDIF
 
   IF ( Input_Opt%useTimers .and. notDryRun ) THEN
-     CALL Timer_End( "All diagnostics",           RC )
-     CALL Timer_End( "=> History (netCDF diags)", RC )
+     CALL Timer_End( "Diagnostics", RC )
   ENDIF
 
   !--------------------------------------------------------------------------
@@ -806,10 +781,6 @@ PROGRAM GEOS_Chem
 #endif
 !-----------------------------------------------------------------------------
 
-  IF ( Input_Opt%useTimers ) THEN
-     CALL Timer_End( "Initialization", RC )
-  ENDIF
-
   !===========================================================================
   !             ***** O U T E R   T I M E S T E P   L O O P  *****
   !===========================================================================
@@ -854,8 +825,7 @@ PROGRAM GEOS_Chem
     !---------------------------------------------------------------------
     IF ( notDryRun ) THEN
        IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start( "All diagnostics",           RC )
-          CALL Timer_Start( "=> History (netCDF diags)", RC )
+          CALL Timer_Start( "Diagnostics", RC )
        ENDIF
 
        ! Write collections (such as BoundaryConditions) that need
@@ -869,8 +839,7 @@ PROGRAM GEOS_Chem
        ENDIF
 
        IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End( "All diagnostics",           RC )
-          CALL Timer_End( "=> History (netCDF diags)", RC )
+          CALL Timer_End( "Diagnostics", RC )
        ENDIF
     ENDIF
 
@@ -910,8 +879,7 @@ PROGRAM GEOS_Chem
        !---------------------------------------------------------------------
        IF ( notDryRun ) THEN
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "All diagnostics",           RC )
-             CALL Timer_Start( "=> History (netCDF diags)", RC )
+             CALL Timer_Start( "Diagnostics", RC )
           ENDIF
 
           CALL Zero_Diagnostics_StartOfTimestep( Input_Opt, State_Diag, RC )
@@ -921,8 +889,7 @@ PROGRAM GEOS_Chem
           ENDIF
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "All diagnostics",           RC )
-             CALL Timer_End( "=> History (netCDF diags)", RC )
+             CALL Timer_End( "Diagnostics", RC )
           ENDIF
        ENDIF
 
@@ -937,7 +904,6 @@ PROGRAM GEOS_Chem
        !=====================================================================
        IF ( Input_Opt%useTimers ) THEN
           CALL Timer_Start( "HEMCO", RC )
-          CALL Timer_Start( "Input", RC )
        ENDIF
 
        ! Is it time for emissions?
@@ -955,7 +921,6 @@ PROGRAM GEOS_Chem
 
        IF ( Input_Opt%useTimers ) THEN
           CALL Timer_End( "HEMCO", RC )
-          CALL Timer_End( "Input", RC )
        ENDIF
 
        IF ( VerboseAndRoot ) THEN
@@ -967,9 +932,7 @@ PROGRAM GEOS_Chem
        !=====================================================================
        IF ( notDryRun ) THEN
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "All diagnostics",       RC )
-             CALL Timer_Start( "=> HEMCO diagnostics",  RC )
-             CALL Timer_Start( "Output",                RC )
+             CALL Timer_Start( "Diagnostics", RC )
           ENDIF
 
           ! Do not do actual output for dry-run
@@ -984,9 +947,7 @@ PROGRAM GEOS_Chem
           ENDIF
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "All diagnostics",      RC )
-             CALL Timer_End( "=> HEMCO diagnostics", RC )
-             CALL Timer_End( "Output",               RC )
+             CALL Timer_End( "Diagnostics", RC )
           ENDIF
        ENDIF
 
@@ -997,8 +958,7 @@ PROGRAM GEOS_Chem
           ( ELAPSED_TODAY == 0 ) .and. notDryRun ) THEN
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "All diagnostics",         RC )
-             CALL Timer_Start( "=> ObsPack diagnostics",  RC )
+             CALL Timer_Start( "Diagnostics", RC )
           ENDIF
 
           ! Initialize Obspack for the new day
@@ -1011,8 +971,7 @@ PROGRAM GEOS_Chem
           ENDIF
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "All diagnostics",         RC )
-             CALL Timer_End( "=> ObsPack diagnostics",  RC )
+             CALL Timer_End( "Diagnostics", RC )
           ENDIF
        ENDIF
 
@@ -1023,9 +982,7 @@ PROGRAM GEOS_Chem
        IF ( ITS_TIME_FOR_BPCH( Input_Opt ) .and. notDryRun ) THEN
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "All diagnostics",              RC )
-             CALL Timer_Start( "=> Binary punch diagnostics",  RC )
-             CALL Timer_Start( "Output",                       RC )
+             CALL Timer_Start( "Diagnostics", RC )
           ENDIF
 
           ! Set time at end of diagnostic timestep
@@ -1050,9 +1007,7 @@ PROGRAM GEOS_Chem
           CALL INITIALIZE( Input_Opt, State_Grid, 3, RC )
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "All diagnostics",              RC )
-             CALL Timer_End( "=> Binary punch diagnostics",  RC )
-             CALL Timer_End( "Output",                       RC )
+             CALL Timer_End( "Diagnostics", RC )
           ENDIF
        ENDIF
 #endif
@@ -1813,9 +1768,7 @@ PROGRAM GEOS_Chem
           !            ***** H I S T O R Y   U P D A T E  *****
           !------------------------------------------------------------------
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "All diagnostics",           RC )
-             CALL Timer_Start( "Output",                    RC )
-             CALL Timer_Start( "=> History (netCDF diags)", RC )
+             CALL Timer_Start( "Diagnostics", RC )
           ENDIF
 
           ! Set State_Diag arrays that rely on state at end of timestep
@@ -1866,9 +1819,7 @@ PROGRAM GEOS_Chem
           ENDIF
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "All diagnostics",           RC )
-             CALL Timer_End( "Output",                    RC )
-             CALL Timer_End( "=> History (netCDF diags)", RC )
+             CALL Timer_End( "Diagnostics", RC )
           ENDIF
 
           !------------------------------------------------------------------
@@ -1877,8 +1828,7 @@ PROGRAM GEOS_Chem
           IF ( Input_Opt%Do_ObsPack ) THEN
 
              IF ( Input_Opt%useTimers ) THEN
-                CALL Timer_Start( "All diagnostics",        RC )
-                CALL Timer_Start( "=> ObsPack diagnostics", RC )
+                CALL Timer_Start( "Diagnostics", RC )
              ENDIF
 
              ! Sample the observations in today's ObsPack file
@@ -1886,8 +1836,7 @@ PROGRAM GEOS_Chem
                                   State_Diag, State_Grid, State_Met, RC )
 
              IF ( Input_Opt%useTimers ) THEN
-                CALL Timer_End( "All diagnostics",        RC )
-                CALL Timer_End( "=> ObsPack diagnostics", RC )
+                CALL Timer_End( "Diagnostics", RC )
              ENDIF
 
           ENDIF
@@ -1898,9 +1847,7 @@ PROGRAM GEOS_Chem
           IF ( Input_Opt%Do_Planeflight .and. ITS_A_NEW_DAY() ) THEN
 
              IF ( Input_Opt%useTimers ) THEN
-                CALL Timer_Start( "All diagnostics",             RC)
-                CALL Timer_Start( "Output",                      RC)
-                CALL Timer_Start( "=> Binary punch diagnostics", RC)
+                CALL Timer_Start( "Diagnostics", RC)
              ENDIF
 
              ! Initialize planeflight diagnostic
@@ -1914,9 +1861,7 @@ PROGRAM GEOS_Chem
              ENDIF
 
              IF ( Input_Opt%useTimers ) THEN
-                CALL Timer_End( "All diagnostics",             RC )
-                CALL Timer_End( "Output",                      RC )
-                CALL Timer_End( "=> Binary punch diagnostics", RC )
+                CALL Timer_End( "Diagnostics", RC )
              ENDIF
 
           ENDIF
@@ -1970,8 +1915,7 @@ PROGRAM GEOS_Chem
           !                 ***** C O N T I N U E D *****
           !==================================================================
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "All diagnostics",              RC )
-             CALL Timer_Start( "Output",                       RC )
+             CALL Timer_Start( "Diagnostics", RC )
           ENDIF
 
           !------------------------------------------------------------------
@@ -1991,8 +1935,7 @@ PROGRAM GEOS_Chem
           IF ( VerboseAndRoot ) CALL Debug_Msg( '### MAIN: after Planeflight' )
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "All diagnostics",              RC )
-             CALL Timer_End( "Output",                       RC )
+             CALL Timer_End( "Diagnostics", RC )
           ENDIF
        ENDIF
 
@@ -2017,9 +1960,7 @@ PROGRAM GEOS_Chem
        !---------------------------------------------------------------------
        IF ( notDryRun ) THEN
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "All diagnostics",           RC )
-             CALL Timer_Start( "Output",                    RC )
-             CALL Timer_Start( "=> History (netCDF diags)", RC )
+             CALL Timer_Start( "Diagnostics", RC )
           ENDIF
 
           ! Write HISTORY ITEMS in each diagnostic collection to disk
@@ -2033,9 +1974,7 @@ PROGRAM GEOS_Chem
           ENDIF
 
           IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "All diagnostics",           RC )
-             CALL Timer_End( "Output",                    RC )
-             CALL Timer_End( "=> History (netCDF diags)", RC )
+             CALL Timer_End( "Diagnostics", RC )
           ENDIF
        ENDIF
 
@@ -2062,7 +2001,6 @@ PROGRAM GEOS_Chem
     !------------------------------------------------------------------------
      IF ( Input_Opt%useTimers ) THEN
         CALL Timer_Start( "HEMCO",  RC )
-        CALL Timer_Start( "Output", RC )
      ENDIF
 
     ! Force the output of a HEMCO restart file (ckeller, 4/1/15)
@@ -2076,7 +2014,6 @@ PROGRAM GEOS_Chem
 
     IF ( Input_Opt%useTimers ) THEN
        CALL Timer_End( "HEMCO",  RC )
-       CALL Timer_End( "Output", RC )
     ENDIF
 
     !------------------------------------------------------------------------
@@ -2087,8 +2024,7 @@ PROGRAM GEOS_Chem
     IF ( Input_Opt%Do_ObsPack ) THEN
 
        IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_Start( "All diagnostics",        RC )
-          CALL Timer_Start( "=> ObsPack diagnostics", RC )
+          CALL Timer_Start( "Diagnostics", RC )
        ENDIF
 
        ! Write any remaining ObsPack data to disk, and immediately
@@ -2109,8 +2045,7 @@ PROGRAM GEOS_Chem
        ENDIF
 
        IF ( Input_Opt%useTimers ) THEN
-          CALL Timer_End( "All diagnostics",        RC )
-          CALL Timer_End( "=> ObsPack diagnostics", RC )
+          CALL Timer_End( "Diagnostics", RC )
        ENDIF
     ENDIF
   ENDIF
@@ -2118,9 +2053,6 @@ PROGRAM GEOS_Chem
   !--------------------------------------------------------------------------
   ! Finalize GEOS-Chem
   !--------------------------------------------------------------------------
-  IF ( Input_Opt%useTimers ) THEN
-     CALL Timer_Start( "Finalization", RC )
-  ENDIF
 
   ! Cleanup the dry-run simulation (if necessary)
   CALL Cleanup_Dry_Run( Input_Opt, RC )
@@ -2230,7 +2162,6 @@ PROGRAM GEOS_Chem
 
   IF ( Input_Opt%useTimers ) THEN
      ! Stop remaining timers
-     CALL Timer_End( "Finalization", RC )
      CALL Timer_End( "GEOS-Chem",    RC )
 
      ! Print timer output (skip if a dry-run)


### PR DESCRIPTION

### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update

The timers used in benchmarking to track model performance and generate this chart https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_1-month_benchmark_timing_results include:

  - GEOS-Chem
  - HEMCO
  - All chemistry
  - Gas-phase chem
  - Photolysis
  - Aerosol chem
  - Linearized chem
  - Transport
  - Convection
  - Boundary layer mixing
  - Dry deposition
  - Wet deposition
  - Diagnostics
  - Unit conversion

The remaining timers are superfluous. They are removed here to clean up output and reduce unnecessary time spent computing those timers.

### Expected changes

This is a zero difference update with respect to diagnostic output. It will change the output in the log file when timers are turned on. Timers are only on by default in benchmark simulations. Log output will change from

```
===============================================================================
G E O S - C H E M   T I M E R S
 
  Timer name                       DD-hh:mm:ss.SSS     Total Seconds
-------------------------------------------------------------------------------
  GEOS-Chem                     :  00-00:19:12.000          1152.000
  Initialization                :  00-00:16:05.500           965.500
  HEMCO                         :  00-00:15:15.625           915.625
  All chemistry                 :  00-00:01:04.250            64.250
  => FlexChem                   :  00-00:00:37.625            37.625
    -> FlexChem loop            :  00-00:00:35.125            35.125
    -> Init KPP                 :  00-00:00:00.286             0.286
    -> Het chem rates           :  >>>>> THE TIMER DID NOT RUN <<<<<
    -> Photolysis rates         :  00-00:00:00.505             0.505
    -> KPP                      :  00-00:00:33.817            33.818
       RCONST                   :  00-00:00:01.500             1.500
       Integrate 1              :  00-00:00:31.015            31.016
       Integrate 2              :  >>>>> THE TIMER DID NOT RUN <<<<<
    -> Prod/loss diags          :  00-00:00:00.083             0.083
    -> OH reactivity diag       :  >>>>> THE TIMER DID NOT RUN <<<<<
  => Photolysis                 :  00-00:00:06.000             6.000
  => Aerosol chem               :  00-00:00:16.625            16.625
  => Linearized chem            :  00-00:00:00.500             0.500
  Transport                     :  00-00:00:21.500            21.500
  Convection                    :  00-00:00:04.250             4.250
  Boundary layer mixing         :  00-00:00:37.500            37.500
  Dry deposition                :  00-00:00:00.375             0.375
  Wet deposition                :  00-00:00:08.250             8.250
  All diagnostics               :  00-00:00:14.875            14.875
  => HEMCO diagnostics          :  00-00:00:01.375             1.375
  => ObsPack diagnostics        :  >>>>> THE TIMER DID NOT RUN <<<<<
  => History (netCDF diags)     :  00-00:00:13.500            13.500
  Unit conversions              :  00-00:00:29.500            29.500
  Input                         :  00-00:00:00.125             0.125
  Output                        :  00-00:00:13.875            13.875
  Finalization                  :  00-00:00:06.875             6.875
```

to: 

```
===============================================================================
G E O S - C H E M   T I M E R S
 
  Timer name                       DD-hh:mm:ss.SSS     Total Seconds
-------------------------------------------------------------------------------
  GEOS-Chem                     :  00-00:02:57.375           177.375
  HEMCO                         :  00-00:00:23.250            23.250
  All chemistry                 :  00-00:00:39.000            39.000
  => Gas-phase chem             :  00-00:00:22.875            22.875
  => Photolysis                 :  00-00:00:04.625             4.625
  => Aerosol chem               :  00-00:00:08.875             8.875
  => Linearized chem            :  00-00:00:00.250             0.250
  Transport                     :  00-00:00:10.625            10.625
  Convection                    :  00-00:00:03.250             3.250
  Boundary layer mixing         :  00-00:00:14.875            14.875
  Dry deposition                :  00-00:00:00.250             0.250
  Wet deposition                :  00-00:00:05.500             5.500
  Diagnostics                   :  00-00:00:13.250            13.250
  Unit conversions              :  00-00:00:18.125            18.125
```

