### PR TITLE
Fix PBL level calculations

### DIFF
--- a/GeosCore/pbl_mix_mod.F90
+++ b/GeosCore/pbl_mix_mod.F90
@@ -281,7 +281,7 @@ CONTAINS
     ! Scalars
     LOGICAL  :: Bad_Sum
     INTEGER  :: I,      J,      L,    LTOP
-    REAL(fp) :: BLTOP,  BLTHIK, DELP, Lower_Edge_Height
+    REAL(fp) :: Lower_Edge_Height
 
     ! Arrays
     REAL(fp) :: P(0:State_Grid%NZ)
@@ -297,8 +297,7 @@ CONTAINS
 
     !$OMP PARALLEL DO                                      &
     !$OMP DEFAULT( SHARED                                ) &
-    !$OMP PRIVATE( I, J, L, P, BLTOP, BLTHIK, LTOP, DELP ) &
-    !$OMP PRIVATE( Lower_Edge_Height )
+    !$OMP PRIVATE( I, J, L, P, LTOP, Lower_Edge_Height   )
     DO J = 1, State_Grid%NY
     DO I = 1, State_Grid%NX
 
@@ -306,7 +305,7 @@ CONTAINS
        State_Met%PBL_Top_m(I,J) = State_Met%PBLH(I,J)
 
        ! Height of lower edge above surface, m
-       Lower_Edge_Height = 0d0
+       Lower_Edge_Height = 0.0_fp
 
        ! Find PBL top level (L) and pressure (hPa)
        Do L=1, State_Grid%NZ
@@ -346,7 +345,7 @@ CONTAINS
             State_Met%inPBL(I,J,L) = .True.
 
             ! Fraction of the grid cell mass under PBL top
-            State_Met%F_Under_PBLTop(I,J,L) = 1.0d0
+            State_Met%F_Under_PBLTop(I,J,L) = 1.0_fp
 
             ! Fraction of PBL mass in layer L, will be normalized below
             State_Met%F_of_PBL(I,J,L) = State_Met%PEdge(I,J,L) - State_Met%PEdge(I,J,L+1)
@@ -450,15 +449,15 @@ CONTAINS
     REAL(fp)           :: AA,   CC, CC_AA, DTCONV
 
     ! Arrays
-    REAL(fp)           :: A(State_Grid%NX,State_Grid%NY)
     REAL(fp)           :: DTC
+    REAL(fp)           :: A(State_Grid%NX,State_Grid%NY)
+    REAL(fp)           :: FPBL(State_Grid%NX,State_Grid%NY)
+    INTEGER            :: IMIX(State_Grid%NX,State_Grid%NY)
 
     ! Strings
     CHARACTER(LEN=255) :: ErrMsg, ThisLoc
 
     ! Pointers
-    INTEGER,       POINTER  :: IMIX(:,:    )
-    REAL(fp),      POINTER  :: FPBL(:,:    )
     REAL(fp),      POINTER  :: AD  (:,:,:  )
     TYPE(SpcConc), POINTER  :: TC  (:      )
 

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -272,8 +272,6 @@ MODULE State_Met_Mod
      !----------------------------------------------------------------------
      ! Fields for boundary layer mixing
      !----------------------------------------------------------------------
-     INTEGER,  POINTER :: IMIX          (:,:  ) ! Integer and fractional level
-     REAL(fp), POINTER :: FPBL          (:,:  ) !  where PBL top occurs
      INTEGER           :: PBL_MAX_L             ! Max level where PBL top occurs
 
      !----------------------------------------------------------------------
@@ -494,8 +492,6 @@ CONTAINS
     State_Met%PDOWN          => NULL()
     State_Met%QQ             => NULL()
     State_Met%REEVAP         => NULL()
-    State_Met%IMIX           => NULL()
-    State_Met%FPBL           => NULL()
     State_Met%REEVAP         => NULL()
     State_Met%PBL_MAX_L      = 0
 
@@ -741,25 +737,6 @@ CONTAINS
     ENDIF
 
     !------------------------------------------------------------------------
-    ! FPBL [1] : Local variable for PBL mixing -- do not register this
-    !------------------------------------------------------------------------
-    metId = 'FPBL'
-    CALL Init_and_Register(                                                  &
-         Input_Opt  = Input_Opt,                                             &
-         State_Met  = State_Met,                                             &
-         State_Grid = State_Grid,                                            &
-         metId      = metId,                                                 &
-         Ptr2Data   = State_Met%FPBL,                                        &
-         noRegister = .TRUE.,                                                &
-         RC         = RC                                                    )
-
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = TRIM( errMsg_ir ) // TRIM( metId )
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-
-    !------------------------------------------------------------------------
     ! FRCLND [1]
     !------------------------------------------------------------------------
     metId = 'FRCLND'
@@ -931,25 +908,6 @@ CONTAINS
          State_Grid = State_Grid,                                            &
          metId      = metId,                                                 &
          Ptr2Data   = State_Met%HFLUX,                                       &
-         RC         = RC                                                    )
-
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = TRIM( errMsg_ir ) // TRIM( metId )
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-
-    !------------------------------------------------------------------------
-    ! IMIX [1]: Local variable for PBL mixing -- Do not register this
-    !------------------------------------------------------------------------
-    metId = 'IMIX'
-    CALL Init_and_Register(                                                  &
-         Input_Opt  = Input_Opt,                                             &
-         State_Met  = State_Met,                                             &
-         State_Grid = State_Grid,                                            &
-         metId      = metId,                                                 &
-         Ptr2Data   = State_Met%IMIX,                                        &
-         noRegister = .TRUE.,                                                &
          RC         = RC                                                    )
 
     IF ( RC /= GC_SUCCESS ) THEN
@@ -3768,20 +3726,6 @@ CONTAINS
        CALL GC_CheckVar( 'State_Met%IREG', 2, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
        State_Met%IREG => NULL()
-    ENDIF
-
-    IF ( ASSOCIATED( State_Met%IMIX) ) THEN
-       DEALLOCATE( State_Met%IMIX, STAT=RC  )
-       CALL GC_CheckVar( 'State_Met%IMIX', 2, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       State_Met%IMIX => NULL()
-    ENDIF
-
-    IF ( ASSOCIATED( State_Met%FPBL ) ) THEN
-       DEALLOCATE( State_Met%FPBL, STAT=RC  )
-       CALL GC_CheckVar( 'State_Met%FPBL', 2, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       State_Met%FPBL => NULL()
     ENDIF
 
     !========================================================================


### PR DESCRIPTION
@lizziel, This is a PR for the PBL level fix only, as you requested.

Use local scale height and level thickness to determine PBL top level and pressure thickness. The code previously used a fixed global value for scale height, which is too large near poles and too small in tropics. This update lowers the PBL top level in the tropics and raises it near the poles. The change is typically 1 model level or less.

### Name and Institution (Required)

Name: Chris Holmes
Institution: FSU

### Related Github Issue(s)

See #2002 for the expected impact of this change on PBL heights: typically no more than 1 model level up or down.