### PR TITLE
Use rundir (not absolute path) to select the executable file for integration and parallel tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Added missing units in comments of `KPP/fullchem/commonIncludeVars.H` 
+- Use run directory (not absolute path) to determine the executable file name in integration & parallel tests.
 
 ### Removed
 - Reduced timers saved out to essential list used for benchmarking model performance

--- a/test/integration/GCClassic/integrationTestExecute.sh
+++ b/test/integration/GCClassic/integrationTestExecute.sh
@@ -170,7 +170,7 @@ for runDir in *; do
         failMsg="$runDir${FILL:${#runDir}}.....${EXE_FAIL_STR}"
 
         # Get the executable file corresponding to this run directory
-        exeFile=$(exe_name "gcclassic" "${runAbsPath}")
+        exeFile=$(exe_name "gcclassic" "${runDir}")
 
         # Test if the executable exists
         if [[ -f "${binDir}/${exeFile}" ]]; then

--- a/test/integration/GCHP/integrationTestExecute.sh
+++ b/test/integration/GCHP/integrationTestExecute.sh
@@ -174,7 +174,7 @@ for runDir in *; do
         failMsg="$runDir${FILL:${#runDir}}.....${EXE_FAIL_STR}"
 
         # Get the executable file corresponding to this run directory
-        exeFile=$(exe_name "gchp" "${runAbsPath}")
+        exeFile=$(exe_name "gchp" "${runDir}")
 
         # Test if the executable exists
         if [[ -f "${binDir}/${exeFile}" ]]; then

--- a/test/parallel/GCClassic/parallelTestExecute.sh
+++ b/test/parallel/GCClassic/parallelTestExecute.sh
@@ -166,7 +166,7 @@ for runDir in *; do
         failMsg="$runDir${FILL:${#runDir}}.....${EXE_FAIL_STR}"
 
         # Get the executable file corresponding to this run directory
-        exeFile=$(exe_name "gcclassic" "${runAbsPath}")
+        exeFile=$(exe_name "gcclassic" "${runDir}")
 
         # Test if the executable exists
         if [[ -f "${binDir}/${exeFile}" ]]; then


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update
This is the companion PR to issue #2083.  We have now updated the integration and parallel test execution scripts so that the the run directory (and not the absolute path) is passed to the function that determines the executable file name that gets copied to each run directory.

### Expected changes
Previously, if the root path of the integration or parallel test had e.g. "rrtmg", then the "rrtmg" executable would be used for all integration or parallel tests.  This update now prevents this from happeing.

This is a zero-diff update w/r/t the GEOS-Chem benchmarks.

### Reference(s)

N/A

### Related Github Issue(s)

- Closes #2083 
