### PR TITLE
Increase time limits for GCHP integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Changed
 - Now read the Hg restart file from `ExtData/GEOSCHEM_RESTARTS/v2023-12`
+- Increse requested time limits in GCHP integration tests (compile 2h30m, run 5h)
 
 ### Fixed
 - Added missing units in comments of `KPP/fullchem/commonIncludeVars.H` 

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -213,7 +213,7 @@ if [[ "x${scheduler}" == "xSLURM" ]]; then
     # Remove LSF #BSUB tags
     sed_ie '/#BSUB -q REQUESTED_PARTITION/d' "${scriptsDir}/integrationTestCompile.sh"
     sed_ie '/#BSUB -n 8/d'                   "${scriptsDir}/integrationTestCompile.sh"
-    sed_ie '/#BSUB -W 1:30/d'                "${scriptsDir}/integrationTestCompile.sh"
+    sed_ie '/#BSUB -W 2:30/d'                "${scriptsDir}/integrationTestCompile.sh"
     sed_ie '/#BSUB -o lsf-%J.txt/d'          "${scriptsDir}/integrationTestCompile.sh"
     sed_ie \
 	'/#BSUB -R "rusage\[mem=8GB\] span\[ptile=1\] select\[mem < 1TB\]"/d' \
@@ -223,7 +223,7 @@ if [[ "x${scheduler}" == "xSLURM" ]]; then
 	"${scriptsDir}/integrationTestCompile.sh"
     sed_ie '/#BSUB -q REQUESTED_PARTITION/d' "${scriptsDir}/integrationTestExecute.sh"
     sed_ie '/#BSUB -n 24/d'                  "${scriptsDir}/integrationTestExecute.sh"
-    sed_ie '/#BSUB -W 3:30/d'                "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie '/#BSUB -W 5:00/d'                "${scriptsDir}/integrationTestExecute.sh"
     sed_ie '/#BSUB -o lsf-%J.txt/d'          "${scriptsDir}/integrationTestExecute.sh"
     sed_ie \
 	'/#BSUB -R "rusage\[mem=90GB\] span\[ptile=1\] select\[mem < 2TB\]"/d' \
@@ -259,14 +259,14 @@ elif [[ "x${scheduler}" == "xLSF" ]]; then
     # Remove SLURM #SBATCH tags
     sed_ie '/#SBATCH -c 8/d'                   "${scriptsDir}/integrationTestCompile.sh"
     sed_ie '/#SBATCH -N 1/d'                   "${scriptsDir}/integrationTestCompile.sh"
-    sed_ie '/#SBATCH -t 0-1:30/d'              "${scriptsDir}/integrationTestCompile.sh"
+    sed_ie '/#SBATCH -t 0-2:30/d'              "${scriptsDir}/integrationTestCompile.sh"
     sed_ie '/#SBATCH -p REQUESTED_PARTITION/d' "${scriptsDir}/integrationTestCompile.sh"
     sed_ie '/#SBATCH --mem=8000/d'             "${scriptsDir}/integrationTestCompile.sh"
     sed_ie '/#SBATCH -p REQUESTED_PARTITION/d' "${scriptsDir}/integrationTestCompile.sh"
     sed_ie '/#SBATCH --mail-type=END/d'        "${scriptsDir}/integrationTestCompile.sh"
     sed_ie '/#SBATCH -c 24/d'                  "${scriptsDir}/integrationTestExecute.sh"
     sed_ie '/#SBATCH -N 1/d'                   "${scriptsDir}/integrationTestExecute.sh"
-    sed_ie '/#SBATCH -t 0-3:30/d'              "${scriptsDir}/integrationTestExecute.sh"
+    sed_ie '/#SBATCH -t 0-5:00/d'              "${scriptsDir}/integrationTestExecute.sh"
     sed_ie '/#SBATCH -p REQUESTED_PARTITION/d' "${scriptsDir}/integrationTestExecute.sh"
     sed_ie '/#SBATCH --mem=90000/d'            "${scriptsDir}/integrationTestExecute.sh"
     sed_ie '/#SBATCH --mail-type=END/d'        "${scriptsDir}/integrationTestExecute.sh"

--- a/test/integration/GCHP/integrationTestCompile.sh
+++ b/test/integration/GCHP/integrationTestCompile.sh
@@ -2,13 +2,13 @@
 
 #SBATCH -c 8
 #SBATCH -N 1
-#SBATCH -t 0-1:30
+#SBATCH -t 0-2:30
 #SBATCH -p REQUESTED_PARTITION
 #SBATCH --mem=6000
 #SBATCH --mail-type=END
 #BSUB -q REQUESTED_PARTITION
 #BSUB -n 8
-#BSUB -W 1:30
+#BSUB -W 2:30
 #BSUB -R "rusage[mem=8GB] span[ptile=1] select[mem < 1TB]"
 #BSUB -a 'docker(registry.gsc.wustl.edu/sleong/esm:intel-2021.1.2)'
 #BSUB -o lsf-%J.txt

--- a/test/integration/GCHP/integrationTestExecute.sh
+++ b/test/integration/GCHP/integrationTestExecute.sh
@@ -2,13 +2,13 @@
 
 #SBATCH -n 24
 #SBATCH -N 1
-#SBATCH -t 0-3:30
+#SBATCH -t 0-5:00
 #SBATCH -p REQUESTED_PARTITION
 #SBATCH --mem=90000
 #SBATCH --mail-type=END
 #BSUB -q REQUESTED_PARTITION
 #BSUB -n 24
-#BSUB -W 3:30
+#BSUB -W 5:00
 #BSUB -R "rusage[mem=90GB] span[ptile=1] select[mem < 2TB]"
 #BSUB -a 'docker(registry.gsc.wustl.edu/sleong/esm:intel-2021.1.2)'
 #BSUB -o lsf-%J.txt


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This PR updates the requested time for GCHP integration tests.  This is necessary due to the addition of the TOMAS integration test for GCHP.  Also this will give the GCHP integration tests a little cushion if the scratch disk is slow.

The compilation phase now requests 2h 30m (instead of 1h 30m) and the run phase now requests 5h (instead of 3h 30m).

### Expected changes

This is a no-diff-to-benchmark update.  It should prevent abnormal exits of GCHP integration tests due to exceeding the requested time.

### Reference(s)
N/A

### Related Github Issue(s)
N/A