### PR TITLE
Fix additional memory leaks in GEOS-Chem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed bug in stratospheric aerosols optical depths passed to Fast-JX
 - Restored consideration of both isSnow and isIce in dry deposition
-- Fixed calculation of FRLAND_NOSNO_NOICE in `calc_met_mod.F90`
+- Fixed calculation of `FRLAND_NOSNO_NOICE` in `calc_met_mod.F90`
+- Fixed memory leaks in `State_Chm%AerMass` and `State_Chm%Phot` containers
 
 ### Added
 - Added interface to Cloud-J package for computing photolysis rates

--- a/Headers/phot_container_mod.F90
+++ b/Headers/phot_container_mod.F90
@@ -758,6 +758,7 @@ CONTAINS
        IF (ALLOCATED(Phot%RTASYMAER     )) DEALLOCATE(Phot%RTASYMAER )
 #endif
 
+       DEALLOCATE( Phot )
        Phot => NULL()
     ENDIF
 

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -1020,7 +1020,7 @@ CONTAINS
        ! Save nAerosol to State_Chm
        State_Chm%nAeroType = nAerosol
 
-        !---------------------------------------------------------------------
+       !---------------------------------------------------------------------
        ! Aerosol object
        ! NOTE: content is currently not registered
        !---------------------------------------------------------------------
@@ -3063,8 +3063,8 @@ CONTAINS
     !=======================================================================
     ! Deallocate and nullify pointer fields of State_Chm
     !=======================================================================
-    IF ( ASSOCIATED ( State_Chm%Phot ) ) THEN
-       CALL Cleanup_Phot_Container(State_Chm%Phot, RC )
+    IF ( ASSOCIATED( State_Chm%Phot ) ) THEN
+       CALL Cleanup_Phot_Container( State_Chm%Phot, RC )
        State_Chm%Phot => NULL()
     ENDIF
 
@@ -3212,6 +3212,7 @@ CONTAINS
 
     IF ( ASSOCIATED( State_Chm%AerMass ) ) THEN
        CALL Cleanup_AerMass_Container(State_Chm%AerMass, RC )
+       DEALLOCATE( State_Chm%AerMass )
        State_Chm%AerMass => NULL()
     ENDIF
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update
**This is a placeholder PR and should not yet be merged.  I have made the base branch `main` but will change it later.**

This is a companion PR to #2102.  Configuring GEOS-Chem with `-DSANITIZE=y` has revealed the following memory leaks in GEOS-Chem and HEMCO:
```console
=================================================================
==1495473==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 107464 byte(s) in 133 object(s) allocated from:
    #0 0x14815712993f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x1bd566d in __hco_filedata_mod_MOD_filedata_init /n/holyscratch01/jacob_lab/ryantosca/tests/cloudj/test_memory/CodeDir/src/HEMCO/src/Core/hco_filedata_mod.F90:174
    #2 0x202020202020201f  (<unknown module>)

Direct leak of 29248 byte(s) in 8 object(s) allocated from:
    #0 0x14815712993f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x10c438e in __histcontainer_mod_MOD_histcontainer_create /n/holyscratch01/jacob_lab/ryantosca/tests/cloudj/test_memory/CodeDir/src/GEOS-Chem/History/histcontainer_mod.F90:319
    #2 0x202020202020201f  (<unknown module>)

Direct leak of 3720 byte(s) in 1 object(s) allocated from:
    #0 0x14815712993f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x18f6ae1 in __state_chm_mod_MOD_init_state_chm /n/holyscratch01/jacob_lab/ryantosca/tests/cloudj/test_memory/CodeDir/src/GEOS-Chem/Headers/state_chm_mod.F90:803

Direct leak of 3160 byte(s) in 1 object(s) allocated from:
    #0 0x14815712993f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x18fe162 in __state_chm_mod_MOD_init_state_chm /n/holyscratch01/jacob_lab/ryantosca/tests/cloudj/test_memory/CodeDir/src/GEOS-Chem/Headers/state_chm_mod.F90:1027

SUMMARY: AddressSanitizer: 143592 byte(s) leaked in 143 allocation(s).
```

Leak 1 is in HEMCO and will be addressed by a separate PR at https://github.com/geoschem/hemco.  We are still investigating.

Leak 2 is in the GEOS-Chem Classic History code.  We are still investigating.

Leaks 3 and 4 were resolved by adding DEALLOCATE statements (see commit 78fc20489ca3d1347c642ae0a65db49934d1c02f).  

Tagging @msulprizio @lizziel

### Expected changes
This will be a zero-diff update that will remove memory leaks.  It will not change results.

### Reference(s)
N/A

### Related Github Issue(s)

- See https://github.com/geoschem/HEMCO/pull/255
- Closes #2102