### PR TITLE
Limit Cloud-J initialization prints to single core

### DIFF
--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -131,7 +131,8 @@ CONTAINS
     ! Initialize Cloud-J. Includes reading input data files
     ! FJX_spec.dat (RD_XXX), FJX_scat-aer.dat (RD_MIE), and 
     ! FJX_j2j.dat (RD_JS_JX)
-    CALL Init_CldJ(Input_Opt%CloudJ_Dir, State_Grid%NZ, TITLEJXX, JVN_, NJXX)
+    CALL Init_CldJ(Input_Opt%amIRoot, Input_Opt%CloudJ_Dir, &
+                   State_Grid%NZ, TITLEJXX, JVN_, NJXX)
 
     ! Store # of photolysis reactions in State_Chm object
     State_Chm%Phot%nPhotRxns = NRatJ


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR passes Input_Opt%amIRoot to Cloud-J initialization. It goes with Cloud-J PR https://github.com/geoschem/Cloud-J/pull/5 to limit Cloud-J informational prints to a single core only.

### Expected changes

This is a no diff update. The log file in GCHP and other MPI models will no longer print Cloud-J initialization messages from every core.

### Reference(s)

None

### Related Github Issue(s)

This PR must be merged with the following Cloud-J PR:
https://github.com/geoschem/Cloud-J/pull/5
