### PR TITLE
Add fix to cldj_interface_mod.F90 to avoid floating-point exception in GCHP integration tests

### DIFF
--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -483,9 +483,11 @@ CONTAINS
        CLDF(1:State_Grid%NZ) = State_Met%CLDF(I,J,1:State_Grid%NZ)
        CLDF(State_Grid%NZ+1) = CLDF(State_Grid%NZ)
 
-       ! Set humidity from input meteorology field
-       ! Convert relative humidity [unitless] from percent to fraction
+       ! Set relative humidity from input meteorology field and convert
+       ! from percent to fraction
        RRR(1:State_Grid%NZ) = State_Met%RH(I,J,1:State_Grid%NZ) / 100.d0
+
+       ! Set top of atmosphere relative humidity to 10% of layer below
        RRR(State_Grid%NZ+1) = RRR(State_Grid%NZ) * 1.d-1
 
        ! Loop over # layers in cloud-j (layers with clouds)

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -483,6 +483,11 @@ CONTAINS
        CLDF(1:State_Grid%NZ) = State_Met%CLDF(I,J,1:State_Grid%NZ)
        CLDF(State_Grid%NZ+1) = CLDF(State_Grid%NZ)
 
+       ! Set humidity from input meteorology field
+       ! Convert relative humidity [unitless] from percent to fraction
+       RRR(1:State_Grid%NZ) = State_Met%RH(I,J,1:State_Grid%NZ) / 100.d0
+       RRR(State_Grid%NZ+1) = RRR(State_Grid%NZ) * 1.d-1
+
        ! Loop over # layers in cloud-j (layers with clouds)
        DO L = 1, LWEPAR
 
@@ -522,13 +527,7 @@ CONTAINS
              REFFI(L) = IWP(L) * 0.75d0 * 2.06d0 / ( State_Met%TAUCLI(I,J,L) * 0.917d0 )
           ENDIF
 
-          ! Convert relative humidity [unitless] from percent to fraction
-          RRR(L) = State_Met%RH(I,J,L) / 100.d0
-
        ENDDO
-
-       ! Set top of atmosphere relative humidity to 10% of layer below
-       RRR(State_Grid%NZ+1) = RRR(State_Grid%NZ) * 1.d-1
 
        !-----------------------------------------------------------------
        ! Compute concentrations per aerosol [g/m2]


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard/GCST

### Describe the update

The following line in GeosCore/cldj_interface_mod.F90 was causing a floating- point exception error in GCHP integration tests:

```
    ! Set top of atmosphere relative humidity to 10% of layer below
    RRR(State_Grid%NZ+1) = RRR(State_Grid%NZ) * 1.d-1
```

This is resolved by moving the lines for setting RRR to before the loop over the number of layers with clouds.

Please provide a clear and concise overview of the update.

### Expected changes

@lizziel wrote:
>This fix may cause small differences in the results due to a change in relative humidity above level 34 used for retrieving aerosol optical properties. RRR is the relative humidity, which is used only for aerosols in Cloud-J. The way it was before, relative humidity was only assigned up to level 34 which is defined as where there are clouds. In this fix the relative humidity is set for the full column.


### Related Github Issue(s)

- https://github.com/geoschem/geos-chem/issues/2110
