### PR TITLE
Update run directory scripts to get certain restarts from 14.3.0 1-year benchmark output and boundary condition output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed CO2 concentration used in RRTMG to be modifiable in geoschem_config.yml
 - Changed water vapor used in RRTMG to match to tracer field at all altitudes
 - Look for fullchem and TransportTracers restarts in the `GEOSCHEM_RESTARTS/GC_4.3.0` folder
+- Look for fullchem/aerosol boundary conditions in the `HEMCO/SAMPLE_BCs/GC_14.3.0/fullchem` folder
 
 ### Fixed
 - Fixed bug in stratospheric aerosols optical depths passed to Fast-JX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increse requested time limits in GCHP integration tests (compile 2h30m, run 5h)
 - Changed CO2 concentration used in RRTMG to be modifiable in geoschem_config.yml
 - Changed water vapor used in RRTMG to match to tracer field at all altitudes
+- Look for fullchem and TransportTracers restarts in the `GEOSCHEM_RESTARTS/GC_4.3.0` folder
 
 ### Fixed
 - Fixed bug in stratospheric aerosols optical depths passed to Fast-JX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increse requested time limits in GCHP integration tests (compile 2h30m, run 5h)
 - Changed CO2 concentration used in RRTMG to be modifiable in geoschem_config.yml
 - Changed water vapor used in RRTMG to match to tracer field at all altitudes
-- Look for fullchem and TransportTracers restarts in the `GEOSCHEM_RESTARTS/GC_4.3.0` folder
+- Look for fullchem and TransportTracers restarts in the `GEOSCHEM_RESTARTS/GC_14.3.0` folder
 - Look for fullchem/aerosol boundary conditions in the `HEMCO/SAMPLE_BCs/GC_14.3.0/fullchem` folder
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increse requested time limits in GCHP integration tests (compile 2h30m, run 5h)
 - Changed CO2 concentration used in RRTMG to be modifiable in geoschem_config.yml
 - Changed water vapor used in RRTMG to match to tracer field at all altitudes
-- Look for fullchem and TransportTracers restarts in the `GEOSCHEM_RESTARTS/GC_14.3.0` folder
+- Look for fullchem restarts in the `GEOSCHEM_RESTARTS/GC_14.3.0` folder
 - Look for fullchem/aerosol boundary conditions in the `HEMCO/SAMPLE_BCs/GC_14.3.0/fullchem` folder
 
 ### Fixed

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -1966,7 +1966,7 @@ VerboseOnCores:              root       # Accepted values: root all
 # --- GEOS-Chem boundary condition file ---
 #==============================================================================
 (((GC_BCs
-* BC_  $ROOT/SAMPLE_BCs/v2021-09/fullchem/GEOSChem.BoundaryConditions.$YYYY$MM$DD_$HH$MNz.nc4 SpeciesBC_?ADV?  1980-2021/1-12/1-31/* EFY xyz 1 * - 1 1
+* BC_  $ROOT/SAMPLE_BCs/GC_14.3.0/fullchem/GEOSChem.BoundaryConditions.$YYYY$MM$DD_$HH$MNz.nc4 SpeciesBC_?ADV?  1980-2021/1-12/1-31/* EFY xyz 1 * - 1 1
 )))GC_BCs
 
 (((CHEMISTRY_INPUT

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3458,7 +3458,7 @@ VerboseOnCores:              root       # Accepted values: root all
 # --- GEOS-Chem boundary condition file ---
 #==============================================================================
 (((GC_BCs
-* BC_  $ROOT/SAMPLE_BCs/v2021-09/fullchem/GEOSChem.BoundaryConditions.$YYYY$MM$DD_$HH$MNz.nc4 SpeciesBC_?ADV?  1980-2021/1-12/1-31/* EFY xyz 1 * - 1 1
+* BC_  $ROOT/SAMPLE_BCs/GC_14.3.0/fullchem/GEOSChem.BoundaryConditions.$YYYY$MM$DD_$HH$MNz.nc4 SpeciesBC_?ADV?  1980-2021/1-12/1-31/* EFY xyz 1 * - 1 1
 )))GC_BCs
 
 (((CHEMISTRY_INPUT

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -652,16 +652,16 @@ ln -s ${wrapperdir}/run/runScriptSamples ${rundir}/runScriptSamples
 restarts=${GC_DATA_ROOT}/GEOSCHEM_RESTARTS
 if [[ "x${sim_name}" == "xfullchem" ]]; then
     start_date='20190701'
-    restart_dir='GC_14.2.0'
+    restart_dir='GC_14.3.0'
     restart_name="${sim_name}"
 elif [[ "x${sim_name}" == "xtagO3" ]]; then
     # NOTE: we use the fullchem restart file for tagO3
     start_date='20190701'
-    restart_dir='GC_14.2.0'
+    restart_dir='GC_14.3.0'
     restart_name="fullchem"
 elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
     start_date='20190101'
-    restart_dir='GC_14.2.0'
+    restart_dir='GC_14.3.0'
     restart_name="${sim_name}"
 elif [[ ${sim_name} = "carbon" ]]; then
     start_date='20190101'

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -661,7 +661,7 @@ elif [[ "x${sim_name}" == "xtagO3" ]]; then
     restart_name="fullchem"
 elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
     start_date='20190101'
-    restart_dir='GC_14.3.0'
+    restart_dir='GC_14.2.0'
     restart_name="${sim_name}"
 elif [[ ${sim_name} = "carbon" ]]; then
     start_date='20190101'

--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -27,7 +27,7 @@ mirrors:
 restarts:
   root: GEOSCHEM_RESTARTS
   aerosol:
-    remote: GC_14.2.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
+    remote: GC_14.3.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   carbon:
     remote: v2023-01/GEOSChem.Restart.carbon.20190101_0000z.nc4
@@ -39,7 +39,7 @@ restarts:
     remote: v2020-02/GEOSChem.Restart.CO2.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   fullchem:
-    remote: GC_14.2.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
+    remote: GC_14.3.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   metals:
     remote: v2021-06/GEOSChem.Restart.metals.20110101_0000z.nc4
@@ -57,7 +57,7 @@ restarts:
     remote: v2020-02/GEOSChem.Restart.tagCO.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4 
   tago3:
-    remote: GC_14.2.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
+    remote: GC_14.3.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   tomas15:
     remote: v2021-12/GEOSChem.Restart.TOMAS15.20190701_0000z.nc4
@@ -66,6 +66,6 @@ restarts:
     remote: v2021-12/GEOSChem.Restart.TOMAS40.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   transporttracers:
-    remote: GC_14.2.0/GEOSChem.Restart.TransportTracers.20190101_0000z.nc4
+    remote: GC_14.3.0/GEOSChem.Restart.TransportTracers.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   

--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -66,6 +66,6 @@ restarts:
     remote: v2021-12/GEOSChem.Restart.TOMAS40.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   transporttracers:
-    remote: GC_14.3.0/GEOSChem.Restart.TransportTracers.20190101_0000z.nc4
+    remote: GC_14.2.0/GEOSChem.Restart.TransportTracers.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

**NOTE: This PR should only be merged just before the 14.3.0 release!**

This PR updates the `run/shared/download_data.yml` config file and `run/GCHP/createRunDir.sh` script so that the fullchem and TransportTracers restart files will be copied from the `ExtData/GEOSCHEM_RESTARTS/GC_14.3.0` folder.  This folder contains restarts from the 1-year fullchem and TransportTracers benchmarks.

### Expected changes
This is necessary structural update that will prevent GEOS-Chem simulations from failing "out-of-the-box" due to missing species in the restart files.  This modification is also necessary to pass no-bootstrap integration tests.

### Reference(s)
N/A

### Related Github Issue(s)
N/A