### PR TITLE
Implement updated timezones file for HEMCO, that better accounts for daylight savings time worldwide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Diel and day-of-week scale factors for CEDS global base emissions
 
+### Changed
+- Now use updated timezones for HEMCO, which treat daylight savings time more accurately
+
 ### Fixed
 - Use rate-law function `GCARR_ac` for rxns that have Arrhenius `B` parameters that are zero
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Diel and day-of-week scale factors for CEDS global base emissions
 
 ### Changed
-- Now use updated timezones for HEMCO, which treat daylight savings time more accurately
+- Switch from fixed to monthly timezones, which account for daylight savings time more accurately when computing emissions
 
 ### Fixed
 - Use rate-law function `GCARR_ac` for rxns that have Arrhenius `B` parameters that are zero

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
@@ -621,7 +621,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CO2
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CO2
@@ -341,7 +341,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.Hg
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.Hg
@@ -470,7 +470,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.POPs
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.POPs
@@ -106,7 +106,7 @@ ${RUNDIR_GLOBAL_BC}
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.TransportTracers
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.TransportTracers
@@ -174,7 +174,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -1937,7 +1937,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -1058,7 +1058,7 @@ Mask fractions:              false
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3425,7 +3425,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.metals
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.metals
@@ -254,7 +254,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCH4
@@ -832,7 +832,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCO
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagCO
@@ -853,7 +853,7 @@ Mask fractions:              false
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagO3
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagO3
@@ -90,7 +90,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.CO2
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.CO2
@@ -152,7 +152,7 @@ CMSF_CO2_BN     kgC/km2/s N Y F%y4-%m2-01T00:00:00   none   1e-6 CO2_Flux /nobac
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-TIMEZONES count Y Y 2017-%m2-01T00:00:00 none none UTC_OFFSET ./HcoDir/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc
+TIMEZONES count Y V 2017-%m2-01T00:00:00 none none UTC_OFFSET ./HcoDir/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc
 #
 ###############################################################################
 ###

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.CO2
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.CO2
@@ -152,7 +152,7 @@ CMSF_CO2_BN     kgC/km2/s N Y F%y4-%m2-01T00:00:00   none   1e-6 CO2_Flux /nobac
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-TIMEZONES count N V - none none UTC_OFFSET ./HcoDir/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc
+TIMEZONES count Y Y 2017-%m2-01T00:00:00 none none UTC_OFFSET ./HcoDir/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc
 #
 ###############################################################################
 ###

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.TransportTracers
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.TransportTracers
@@ -182,7 +182,7 @@ ZHANG_Rn222_EMIS  kg/m2/s N Y F%y4-%m2-01T00:00:00 none none rnemis   ./HcoDir/Z
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-TIMEZONES count N V - none none UTC_OFFSET ./HcoDir/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc
+TIMEZONES count Y V 2017-%m2-01T00:00:00 none none UTC_OFFSET ./HcoDir/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc
 #
 ###############################################################################
 ###

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -464,7 +464,7 @@ GFED_FRAC_DAY 1 N Y %y4-%m2-%d2T00:00:00 none none GFED_FRACDAY ./HcoDir/GFED4/v
 ###############################################################################
 
 # --- Time zones (offset to UTC) ---
-TIMEZONES count N V - none none UTC_OFFSET ./HcoDir/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc
+TIMEZONES count Y V 2017-%m2-01T00:00:00 none none UTC_OFFSET ./HcoDir/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc
 
 # --- OH from the latest 10-year benchmark ---
 #GLOBAL_OH kg/m3 N N %y4-%m2-01T00:00:00       none none SpeciesConc_OH ./HcoDir/GCClassic_Output/14.0.0/%y4/GEOSChem.SpeciesConc.%y4%m2%d2_0000z.nc4

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -1781,7 +1781,7 @@ GFED_FRAC_3HOUR 1 N Y %y4-%m2-01T%h2:00:00 none none GFED_FRAC3HR ./HcoDir/GFED4
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-TIMEZONES count N V - none none UTC_OFFSET ./HcoDir/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc
+TIMEZONES count Y V 2017-%m2-01T00:00:00 none none UTC_OFFSET ./HcoDir/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc
 #
 #==============================================================================
 # --- UV albedo (UVALBEDO) ---

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.tagO3
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.tagO3
@@ -211,7 +211,7 @@ XLAIMULTI cm2_cm-2 N Y %y4-%m2-%d2T00:00:00 none none XLAIMULTI ./HcoDir/Yuan_XL
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-TIMEZONES count N V - none none UTC_OFFSET ./HcoDir/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc
+TIMEZONES count Y V 2017-%m2-01T00:00:00 none none UTC_OFFSET ./HcoDir/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc
 #
 #==============================================================================
 #--- Prod/Loss rates from the fullchem simulation ---

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.CO2
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.CO2
@@ -315,7 +315,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- GEOS-Chem restart file ---

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.TransportTracers
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.TransportTracers
@@ -172,7 +172,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- GEOS-Chem restart file ---

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -1058,7 +1058,7 @@ Mask fractions:              false
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- Meteorology fields ---

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3424,7 +3424,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- GEOS-Chem restart file ---

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagO3
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagO3
@@ -88,7 +88,7 @@ Warnings:                    1
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 #==============================================================================
 # --- GEOS-Chem restart file ---


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca 
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This PR is the companion to #1928.  It implements a new timezones file containing offsets from UTC in minutes.  This should better represent e.g. daylight savings time, which shift when emissions occur.

A new timezones file (`HEMCO/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc`) has been submitted by Karn Vorha (@karnvoh), who is working with Eloise Marais (@eamarais) at UCL.

### Expected changes

Karn Vohra (@karhnvoh) writes:

>This is with respect to the updated 0.1x0.1 degree timezone file including daylight savings time which I had developed for 2017 ([GitHub issue #1928](https://github.com/geoschem/geos-chem/issues/1928)). 
>
>The updated file is available [here](https://liveuclac-my.sharepoint.com/:u:/g/personal/ucfakvo_ucl_ac_uk/EbH3NUlgA4JGjSwYlMxiln8BBqZcKBAEeJqoN3OnHHB3Dw?e=BZ3wiZ). It has higher resolution data for 12 months and so is much larger than the current file. I had also conducted a benchmark simulation for version 13 and the [results are in the attached slides](https://github.com/geoschem/geos-chem/files/14168607/timezone-slides-19Sept2023.pdf).  The recommendation is to use it over land mass as there was a small change in shipping NO emissions from the two timezone files (slide 5 of the attached). We also find that there is a small change in soil NO emissions at the grid cell level from the two timezone files (slide 6 of the attached) and it could be that the soil NOx inventory is using a timezone file rather than environmental time.

### Related Github Issue(s)

- Closes #1928