### PR TITLE
UCX bug fixes : (1) Use proper 4th index for WERADIUS array; (2) Get density of black carbon from the species database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Use rate-law function `GCARR_ac` for rxns that have Arrhenius `B` parameters that are zero
+- Now use correct index `WEAEROSOL(I,J,L,2+NDUST)` in routine `Settle_Strat_Aer` of `GeosCore/ucx_mod.F90`
+- Now get density of BCPI species from the species database in `ucx_mod.F90`
 
 ### Removed
 - Legacy binary punch diagnostic code contained within `#ifdef BPCH_DIAG` blocks

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -809,9 +809,6 @@ CONTAINS
     ! Used for old Seinfeld & Pandis slip factor calc
     REAL(fp)               :: sp_Lambda, sp_Num
 
-    ! Parameters
-    REAL(fp), PARAMETER    :: BCDEN = 1000.e+0_fp ! density (kg/m3)
-
     ! Indexing
     INTEGER, PARAMETER     :: IBC  = 1
     INTEGER, PARAMETER     :: ILIQ = 2
@@ -924,7 +921,9 @@ CONTAINS
           IF (RUNCALC) THEN
              ! Need to translate for BC radii
              IF ( State_Met%InChemGrid(I,J,L) ) THEN
-                RWET(IBC) = WERADIUS(I,J,L,2)*1.e-2_fp
+                ! NOTE: Replace 2 with 2+NDUST
+                ! See: https://github.com/geoschem/geos-chem/issues/2169
+                RWET(IBC) = WERADIUS(I,J,L,2+NDUST)*1.e-2_fp
              ELSE
                 ! Use defaults, assume dry (!)
 #ifdef FASTJX
@@ -934,8 +933,9 @@ CONTAINS
 #endif
              ENDIF
 
-             ! Taken from aerosol_mod (MSDENS(2))
-             RHO(IBC) = BCDEN
+             ! Now use the density of BCPI from the species database.
+             ! See: https://github.com/geoschem/geos-chem/issues/2169
+             RHO(IBC) = State_Chm%SpcData(id_BCPI)%Info%Density
 
              ! Get aerosol properties
              RWET(ILIQ) = State_Chm%RAD_AER(I,J,L,I_SLA)*1.e-2_fp

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -761,6 +761,7 @@ CONTAINS
 #else
     USE Cldj_Cmn_Mod,    ONLY : RAA
 #endif
+    USE CMN_SIZE_Mod,    ONLY : NDUST
     USE ErrCode_Mod
     USE ERROR_MOD,       ONLY : IT_IS_NAN,ERROR_STOP
     USE Input_Opt_Mod,   ONLY : OptInput

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -921,8 +921,6 @@ CONTAINS
           IF (RUNCALC) THEN
              ! Need to translate for BC radii
              IF ( State_Met%InChemGrid(I,J,L) ) THEN
-                ! NOTE: Replace 2 with 2+NDUST
-                ! See: https://github.com/geoschem/geos-chem/issues/2169
                 RWET(IBC) = WERADIUS(I,J,L,2+NDUST)*1.e-2_fp
              ELSE
                 ! Use defaults, assume dry (!)
@@ -933,8 +931,6 @@ CONTAINS
 #endif
              ENDIF
 
-             ! Now use the density of BCPI from the species database.
-             ! See: https://github.com/geoschem/geos-chem/issues/2169
              RHO(IBC) = State_Chm%SpcData(id_BCPI)%Info%Density
 
              ! Get aerosol properties


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to issue #2162, raised by @cbarker211.  It does the following:

1. Now use `WERADIUS(I,J,L,2+NDUST)` instead of `WERADIUS(I,J,L,2)`.
2. Now gets the density of black carbon from the species database instead of setting it to 1000 kg/m3.

Integration tests are running.

### Expected changes

Please provide details on how this update will impact model output and include plots or tables as needed.

### Reference(s)

N/A

### Related Github Issue(s)
- Closes #2169 
