### PR TITLE
ObsPack bug fixes: (1) Use netCDF-F90 library routines (2) Read `obspack_id` variable into a character array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added operational run scripts for the Imperial College London (ICL) cluster
 - Added new vertical region option to budget diagnostic for fixed bottom and top levels
 - Added GEOS-IT processed lat-lon fields as a valid option when creating GCHP run directories
+- Functions `charArr2str` and `str2CharArr` in `Headers/charpak_mod.F90`
+- Field `State_Diag%Obspack_CharArray` as a 2-D character array
 
 ### Changed
 - Updated Harvard Cannon operational run scripts to use `huce_cascade` instead of `huce_intel`; also added `sapphire`
 - Changed exponent 'e' to 'd' for one entry in KPP to prevent precision error in external models
 - Changed GCHP sample run scripts to not print script execution commands to log
 - Changed offline emissions grid resolution templates in config files to be more descriptive
+- Read `obspack_id` from netCDF files into a character array, then convert to string
 
 ### Fixed
 - Fixed unit conversions in GEOS-only code

--- a/Headers/charpak_mod.F90
+++ b/Headers/charpak_mod.F90
@@ -35,9 +35,8 @@ MODULE Charpak_Mod
   PUBLIC  :: Txtext
   PUBLIC  :: WordWrapPrint
   PUBLIC  :: Unique
-!
-! !PRIVATE MEMBER FUNCTIONS
-!
+  PUBLIC  :: charArr2Str
+  PUBLIC  :: str2CharArr
 !
 ! !REMARKS:
 !  CHARPAK routines by Robert D. Stewart, 1992.  Subsequent modifications
@@ -1022,6 +1021,10 @@ CONTAINS
 
     mask = .false.
 
+    !=======================================================================
+    ! Unique begins here!
+    !=======================================================================
+
     ! Loop over all elements
     do i = 1, SIZE( vec )
 
@@ -1053,5 +1056,108 @@ CONTAINS
     !call ISORT (vec_unique, [0], size(vec_unique), 1)
 
   END SUBROUTINE Unique
+!
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: charArr2Str
+!
+! !DESCRIPTION: Converts a character array of dimension N to a string of
+!  length N.  Useful for writing character strings to netCDF files.
+!\\
+!\\
+! !INTERFACE:
+!
+  FUNCTION charArr2Str( charArray, N ) RESULT( string )
+!
+! !INPUT PARAMETERS: 
+!
+    INTEGER,          INTENT(IN) :: N              ! Dimension of charArray
+    CHARACTER(LEN=1), INTENT(IN) :: charArray(N)   ! Character array
+!
+! !RETURN VALUE:
+!
+    CHARACTER(LEN=N)             :: string         ! Output string
+!
+! !REVISION HISTORY:
+!  05 Mar 2024 - R. Yantosca - Initial version
+!  See the subsequent Git history with the gitk browser!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    INTEGER :: C
+    
+    !=======================================================================
+    ! charArray2str begins here!
+    !=======================================================================
+
+    ! Initialize the string
+    string = ""
+
+
+    ! Copy as much of the charArray to the string, until we hit the 
+    ! null byte (ASCII character 0), which denotes the end of characters
+    DO C = 1, N
+       IF ( chararray(C) == ACHAR(0) ) EXIT
+       string(C:C) = chararray(C)
+    ENDDO
+
+  END FUNCTION charArr2Str
+!EOC
+!
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: str2CharArr
+!
+! !DESCRIPTION: Converts a string of length N to a character array of 
+!  dimension N.  Useful for writing character strings to netCDF files.
+
+! !DESCRIPTION: 
+!\\
+!\\
+! !INTERFACE:
+!
+  FUNCTION str2CharArr( string, N ) RESULT( charArray )
+!
+! !INPUT PARAMETERS: 
+!
+    INTEGER,          INTENT(IN) :: N              ! Length of string
+    CHARACTER(LEN=N), INTENT(IN) :: string         ! Input string
+!
+! !RETURN VALUE:
+!
+    CHARACTER(LEN=1)             :: charArray(N)   ! Output character array
+!
+! !REVISION HISTORY:
+!  05 Mar 2024 - R. Yantosca - Initial version
+!  See the subsequent Git history with the gitk browser!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+   INTEGER :: C,  L
+
+   ! Length of the string without trailing whitespace
+   L = LEN_TRIM( string )
+   
+   ! Copy the non-whitespace characters to chararray
+   DO C = 1, L
+      chararray(C) = string(C:C)
+   ENDDO
+   
+   ! Pad the remaining elements with the null byte
+   charArray(L+1:) = ACHAR(0)
+
+ END FUNCTION str2CharArr
 !EOC
 END MODULE CharPak_Mod

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -1309,6 +1309,7 @@ MODULE State_Diag_Mod
 
      ! ObsPack Inputs
      INTEGER                     :: ObsPack_nObs
+     CHARACTER(LEN=1),   POINTER :: ObsPack_CharArray    (:,:)
      CHARACTER(LEN=200), POINTER :: ObsPack_Id           (:  )
      INTEGER,            POINTER :: ObsPack_nSamples     (:  )
      INTEGER,            POINTER :: ObsPack_Strategy     (:  )


### PR DESCRIPTION
### Name and Institution (Required):

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This PR fixes the issues first raised by @alli-moon in #2170.  The fixes are as follows:

1. Replace references to `#include netcdf.inc` with `USE netCDF`.  This will make sure we are using the netCDF-F90 interface, which is now the default in GEOS-Chem.
2. Replace calls to `NF_*` functions with the equivalent `NF90_*` functions.
3. Read the Obspack `obspack_id` variable into a character array (stored in the field `State_Diag%Obspack_CharArray`.  The character array is of dimension # characters x # observations.  Then convert to a string and store in `State_Diag%ObsPack_Id`.

### Expected changes

This will prevent the `NetCDF: Start+count exceeds dimension bound` error as described in #2170.

### Related Github Issue(s)

- Closes #2170
