### PR TITLE
Fix bug for SLP and TROPP scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed GEOS-IT native lat-lon filenames used for clusters other than discover
 - Fixed offline emission paths set when using GEOS-IT meteorology
 - Fixed format issue in input_mod RRTMG print statement caught by some compilers
+- Fixed GEOS-IT SLP and TROPP scaling in pre-processed files used in GCHP
 
 ### Removed
 - Removed MPI broadcasts in CESM-only photolysis code; will read on all cores

--- a/run/shared/settings/geosfp/geosfp.preprocessed_ll.txt
+++ b/run/shared/settings/geosfp/geosfp.preprocessed_ll.txt
@@ -57,7 +57,7 @@ SEAICE70 1 N Y F0;003000 none none SEAICE70 ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1
 SEAICE80 1 N Y F0;003000 none none SEAICE80 ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
 SEAICE90 1 N Y F0;003000 none none SEAICE90 ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
 
-SLP hPa N Y F0;003000 none 1.0 SLP ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
+SLP hPa N Y F0;003000 none none SLP ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
 
 SNODP  1 N Y F0;003000 none none SNODP  ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
 SNOMAS 1 N Y F0;003000 none none SNOMAS ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
@@ -65,7 +65,7 @@ RADSWG 1 N Y F0;003000 none none SWGDN  ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025
 
 TO3 dobson N Y F0;003000 none none TO3 ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
 
-TROPP hPa N Y F0;003000 none 1.0 TROPPT ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
+TROPP hPa N Y F0;003000 none none TROPPT ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
 
 TSKIN 1 N Y F0;003000 none none TS    ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
 TS    1 N Y F0;003000 none none T2M   ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
@@ -77,8 +77,8 @@ V10M m_s-1 N Y F0;003000 none none V10M ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025
 Z0 1 N Y F0;003000 none none Z0M ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1.025x03125.nc
 
 # --- Surface pressure, 3-hr instantaneous ---
-PS1 hPa N Y 0        none 1.0 PS ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.I3.025x03125.nc
-PS2 hPa N Y 0;001000 none 1.0 PS ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.I3.025x03125.nc
+PS1 hPa N Y 0        none none PS ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.I3.025x03125.nc
+PS2 hPa N Y 0;001000 none none PS ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.I3.025x03125.nc
 
 # --- 3D variables, 3-hr instantaneous ---
 SPHU1 kg_kg-1 N Y 0        none none QV ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.I3.025x03125.nc

--- a/run/shared/settings/geosit/geosit.preprocessed_ll.txt
+++ b/run/shared/settings/geosit/geosit.preprocessed_ll.txt
@@ -70,9 +70,9 @@ SEAICE70 1  N Y F0;003000 none none SEAICE70 ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A
 SEAICE80 1  N Y F0;003000 none none SEAICE80 ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 SEAICE90 1  N Y F0;003000 none none SEAICE90 ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 SLP    hPa  N Y F0;003000 none none SLP      ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
-SNODP    1 N Y F0;003000 none none SNODP    ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
-SNOMAS   1 N Y F0;003000 none none SNOMAS   ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
-RADSWG   1 N Y F0;003000 none none SWGDN    ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
+SNODP    1  N Y F0;003000 none none SNODP    ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
+SNOMAS   1  N Y F0;003000 none none SNOMAS   ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
+RADSWG   1  N Y F0;003000 none none SWGDN    ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 TO3 dobson  N Y F0;003000 none none TO3      ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 TROPP  hPa  N Y F0;003000 none none TROPPT   ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 TSKIN    1  N Y F0;003000 none none TS       ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc

--- a/run/shared/settings/geosit/geosit.preprocessed_ll.txt
+++ b/run/shared/settings/geosit/geosit.preprocessed_ll.txt
@@ -69,12 +69,12 @@ SEAICE60 1  N Y F0;003000 none none SEAICE60 ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A
 SEAICE70 1  N Y F0;003000 none none SEAICE70 ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 SEAICE80 1  N Y F0;003000 none none SEAICE80 ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 SEAICE90 1  N Y F0;003000 none none SEAICE90 ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
-SLP     Pa  N Y F0;003000 none 0.01 SLP      ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
+SLP    hPa  N Y F0;003000 none none SLP      ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 SNODP    1 N Y F0;003000 none none SNODP    ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 SNOMAS   1 N Y F0;003000 none none SNOMAS   ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 RADSWG   1 N Y F0;003000 none none SWGDN    ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 TO3 dobson  N Y F0;003000 none none TO3      ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
-TROPP   Pa  N Y F0;003000 none 0.01 TROPPT   ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
+TROPP  hPa  N Y F0;003000 none none TROPPT   ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 TSKIN    1  N Y F0;003000 none none TS       ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 TS       1  N Y F0;003000 none none T2M      ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc
 USTAR    1  N Y F0;003000 none none USTAR    ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A1.05x0625.nc


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren on behalf of Yuanjian Zhang
Institution: Harvard University and WashU

### Describe the update

This PR corrects a bug in the ExtData.rc template file for GEOS-IT pre-processed file fields `SLP` and `TROPP`. Both were erroneously scaled by 0.01 to convert from Pa to hPa. In the pre-processed files, however, they are already in hPa.

This PR also includes a zero diff update to change `1.0` scaling in GEOS-FP `ExtData.rc` template to `none`.

### Expected changes

This updates only impacts GCHP runs that use GEOS-IT processed data. GC-Classic is not affected. For GEOS-IT run that use pre-processed data there will be differences in transport tracers, chemistry, and satellite diagnostics.

### Reference(s)

None

### Related Github Issue(s)

closes https://github.com/geoschem/GCHP/issues/398
