### PR TITLE
Capture all trop pbl ht changes in budget diags

### DIFF
--- a/GeosCore/calc_met_mod.F90
+++ b/GeosCore/calc_met_mod.F90
@@ -300,7 +300,7 @@ CONTAINS
             diagFull    = NULL(),                                            &
             mapDataFull = NULL(),                                            &
             isTrop      = .TRUE.,                                            &
-            diagTrop    = State_Diag%BudgetTransportTropHeight,              &
+            diagTrop    = State_Diag%BudgetTransportTrop,                    &
             mapDataTrop = State_Diag%Map_BudgetTransportTrop,                &
             isPBL       = .FALSE.,                                           &
             diagPBL     = NULL(),                                            &
@@ -765,14 +765,13 @@ CONTAINS
             diagFull    = NULL(),                                            &
             mapDataFull = NULL(),                                            &
             isTrop      = .TRUE.,                                            &
-            diagTrop    = State_Diag%BudgetTransportTropHeight,              &
+            diagTrop    = State_Diag%BudgetTransportTrop,                    &
             mapDataTrop = State_Diag%Map_BudgetTransportTrop,                &
             isPBL       = .FALSE.,                                           &
             diagPBL     = NULL(),                                            &
             mapDataPBL  = NULL(),                                            &
             colMass     = State_Diag%BudgetColumnMass,                       &
             timeStep    = DT_Dyn,                                            &
-            accum       = .TRUE.,                                            &
             RC          = RC                                                )
 
        ! Trap potential errors

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -226,24 +226,6 @@ CONTAINS
     ENDIF
 
     !------------------------------------------------------------------------
-    ! Budget diagnostic adjustment for changes in PBL heigh†
-    ! (mixing budget in PBL only)
-    !------------------------------------------------------------------------
-    IF ( State_Diag%Archive_BudgetMixingPBL ) THEN
-       State_Diag%BudgetMixingPBL = State_Diag%BudgetMixingPBL              &
-            + State_Diag%BudgetMixingPBLHeight
-    ENDIF
-
-    !------------------------------------------------------------------------
-    ! Budget diagnostic adjustment for changes in tropopause height
-    ! (transport budget in trop only)
-    !------------------------------------------------------------------------
-    IF ( State_Diag%Archive_BudgetTransportTrop ) THEN
-       State_Diag%BudgetTransportTrop = State_Diag%BudgetTransportTrop      &
-            + State_Diag%BudgetTransportTropHeight
-    ENDIF
-
-    !------------------------------------------------------------------------
     ! Diagnostics for the mercury and tagged mercury simulations
     !------------------------------------------------------------------------
     IF ( Input_Opt%ITS_A_MERCURY_SIM ) THEN
@@ -405,11 +387,48 @@ CONTAINS
        ENDIF
     ENDIF
 
-    ! Budget diagnostic adjustment for changes in tropopause height
-    ! (transport budget in trop only)
-    IF ( State_Diag%Archive_BudgetTransportTrop ) THEN
-       State_Diag%BudgetTransportTropHeight = 0.0_f8
-    ENDIF
+    ! Budget Diagnostics
+    IF ( State_Diag%Archive_BudgetTransportFull ) &
+         State_Diag%BudgetTransportFull = 0.0_f8
+    IF ( State_Diag%Archive_BudgetTransportTrop ) &
+         State_Diag%BudgetTransportTrop = 0.0_f8
+    IF ( State_Diag%Archive_BudgetTransportPBL ) &
+         State_Diag%BudgetTransportPBL = 0.0_f8
+
+    IF ( State_Diag%Archive_BudgetMixingFull ) &
+         State_Diag%BudgetMixingFull = 0.0_f8
+    IF ( State_Diag%Archive_BudgetMixingTrop ) &
+         State_Diag%BudgetMixingTrop = 0.0_f8
+    IF ( State_Diag%Archive_BudgetMixingPBL ) &
+         State_Diag%BudgetMixingPBL = 0.0_f8
+
+    IF ( State_Diag%Archive_BudgetConvectionFull ) &
+         State_Diag%BudgetConvectionFull = 0.0_f8
+    IF ( State_Diag%Archive_BudgetConvectionTrop ) &
+         State_Diag%BudgetConvectionTrop = 0.0_f8
+    IF ( State_Diag%Archive_BudgetConvectionPBL ) &
+         State_Diag%BudgetConvectionPBL = 0.0_f8
+
+    IF ( State_Diag%Archive_BudgetChemistryFull ) &
+         State_Diag%BudgetChemistryFull = 0.0_f8
+    IF ( State_Diag%Archive_BudgetChemistryTrop ) &
+         State_Diag%BudgetChemistryTrop = 0.0_f8
+    IF ( State_Diag%Archive_BudgetChemistryPBL ) &
+         State_Diag%BudgetChemistryPBL = 0.0_f8
+
+    IF ( State_Diag%Archive_BudgetEmisDryDepFull ) &
+         State_Diag%BudgetEmisDryDepFull = 0.0_f8
+    IF ( State_Diag%Archive_BudgetEmisDryDepTrop ) &
+         State_Diag%BudgetEmisDryDepTrop = 0.0_f8
+    IF ( State_Diag%Archive_BudgetEmisDryDepPBL ) &
+         State_Diag%BudgetEmisDryDepPBL = 0.0_f8
+
+    IF ( State_Diag%Archive_BudgetWetDepFull ) &
+         State_Diag%BudgetWetDepFull = 0.0_f8
+    IF ( State_Diag%Archive_BudgetWetDepTrop ) &
+         State_Diag%BudgetWetDepTrop = 0.0_f8
+    IF ( State_Diag%Archive_BudgetWetDepPBL ) &
+         State_Diag%BudgetWetDepPBL = 0.0_f8
 
   END SUBROUTINE Zero_Diagnostics_StartofTimestep
 !EOC
@@ -955,9 +974,7 @@ CONTAINS
                                          mapDataFull, isTrop,    diagTrop,   &
                                          mapDataTrop, isPBL,     diagPBL,    &
                                          mapDataPBL,  colMass,   RC,         &
-                                         timeStep,    isWetDep,  before_op,  &
-                                         accum                              )
-
+                                         timeStep,    isWetDep,  before_op   )
 !
 ! !USES:
 !
@@ -983,7 +1000,6 @@ CONTAINS
     LOGICAL,        OPTIONAL      :: isWetDep         ! T = wetdep budgets
     LOGICAL,        OPTIONAL      :: before_op        ! T = before operation; F = after
     REAL(f8),       OPTIONAL      :: timestep         ! Timestep of the operation
-    LOGICAL,        OPTIONAL      :: accum            ! Accumulate diagnostic?
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -1009,7 +1025,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    LOGICAL            :: after,  before, wetDep, accumulate_array
+    LOGICAL            :: after,  before, wetDep
     INTEGER            :: I,      J,      L,       N
     INTEGER            :: numSpc, region, topLev,  S
     REAL(f8)           :: colSum, dt
@@ -1019,6 +1035,11 @@ CONTAINS
 
     ! Strings
     CHARACTER(LEN=255) :: errMsg, thisLoc
+
+    ! cdholmes, devel
+    real(f8) :: finalMass(300,3)
+    real(f8) :: finalDiff(300,3)
+    real(f8) :: finalMass4(72,46,100,3)
 
     !====================================================================
     ! Compute_Budget_Diagnostics begins here!
@@ -1030,6 +1051,9 @@ CONTAINS
     ThisLoc = ' -> at Compute_Budget_Diagnostics (in GeosCore/diagnostics_mod.F90)'
     colSum  = 0.0_f8
     spcMass = 0.0_f8
+    finalMass = 0.0_f8
+    finalDiff = 0.0_f8
+    finalMass4 = 0.0_f8
 
     ! Exit if concentrations are not in [kg/kg dry]
     IF ( State_Chm%Spc_Units /= KG_SPECIES_PER_KG_DRY_AIR ) THEN
@@ -1111,14 +1135,6 @@ CONTAINS
        RETURN
     ENDIF
 
-    ! Determine if diagnostics will be accumulated or reset. Default
-    ! is to overwrite arrays (ac
-    IF ( PRESENT( accum ) ) THEN
-       accumulate_array = accum
-    ELSE
-       accumulate_array = .FALSE.
-    ENDIF
-
     !====================================================================
     ! Before operation: Compute column masses (full, trop, PBL)
     !
@@ -1128,16 +1144,8 @@ CONTAINS
 
     ! Zero out the column mass array if we are calling this routine
     ! before the desired operation.  This will let us compute initial mass.
-    ! If calling this routine after the desired operation then zero out
-    ! the diagnostic arrays if not accumulating.
     IF ( before ) THEN
        colMass = 0.0_f8
-    ELSE
-       IF ( .NOT. accumulate_array ) THEN
-          IF ( isFull ) diagFull(:,:,:) = 0.0_f8
-          IF ( isTrop ) diagTrop(:,:,:) = 0.0_f8
-          IF ( isPBL  ) diagPBL(:,:,:)  = 0.0_f8
-       ENDIF
     ENDIF
 
     ! Loop over NX and NY dimensions
@@ -1187,6 +1195,9 @@ CONTAINS
              IF ( before ) THEN
                 colMass(I,J,N,1) = colSum
              ELSE
+                finalMass4(I,J,N,1) = colSum
+                finalMass(N,1) = finalMass(N,1) + colSum
+                finalDiff(N,1) = finalDiff(N,1) + (colSum - colMass(I,J,N,1)) / timeStep
 #ifdef MODEL_GEOS
                 diagFull(I,J,S) = diagFull(I,J,S) + ( ( colSum - colMass(I,J,N,1) ) &
                                   / timeStep / State_Grid%AREA_M2(I,J) )
@@ -1237,6 +1248,9 @@ CONTAINS
              IF ( before ) THEN
                 colMass(I,J,N,2) = colSum
              ELSE
+               finalMass4(I,J,N,2) = colSum
+               finalMass(N,2) = finalMass(N,2) + colSum
+               finalDiff(N,2) = finalDiff(N,2) + (colSum - colMass(I,J,N,2)) / timeStep
 #ifdef MODEL_GEOS
                 diagTrop(I,J,S) = diagTrop(I,J,S) + ( ( colSum - colMass(I,J,N,2) ) &
                                   / timeStep / State_Grid%AREA_M2(I,J) )
@@ -1286,6 +1300,9 @@ CONTAINS
              IF ( before ) THEN
                 colMass(I,J,N,3) = colSum
              ELSE
+               finalMass4(I,J,N,3) = colSum
+               finalMass(N,3) = finalMass(N,3) + colSum
+               finalDiff(N,3) = finalDiff(N,3) + (colSum - colMass(I,J,N,3)) / timeStep              
 #ifdef MODEL_GEOS
                 diagPBL(I,J,S) = diagPBL(I,J,S) + ( ( colSum - colMass(I,J,N,3) ) &
                                  / timeStep / State_Grid%AREA_M2(I,J) )
@@ -1300,6 +1317,27 @@ CONTAINS
     ENDDO
     ENDDO
     !$OMP END PARALLEL DO
+
+    if (after .and. isTrop) then
+      ! Print initial, final, and change of mass for tracer N
+      ! For development only (cdholmes)
+      N=2; S=1
+      ! print*,shape(diagTrop),',',shape(State_Grid%Area_M2)
+      ! print'(A10,4(F20.6),L4)','**BUDGET',&
+      !    sum(colMass(:,:,N,2)), &
+      !    finalMass(N,2), &
+      !    finalMass(N,2) - sum(colMass(:,:,N,2)), &
+      !    sum(diagTrop(:,:,N)*State_Grid%AREA_M2(:,:))*timeStep,&
+      !    WetDep
+      print'(A10,5(F20.6))','**BUDGET',&
+         sum(colMass(:,:,N,2)), &
+         sum(finalMass4(:,:,N,2)), &
+         sum(finalMass4(:,:,N,2)) - sum(colMass(:,:,N,2)), &
+         sum(diagTrop(:,:,S))*timeStep, &
+         finalDiff(N,2)*timeStep
+      ! ** To Be Determined ** Should we be concerned that finalDiff differs from sum(diagTrop)?
+      ! print*,finalDiff(N,2)
+    endif
 
   END SUBROUTINE Compute_Budget_Diagnostics
 !EOC

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1036,11 +1036,6 @@ CONTAINS
     ! Strings
     CHARACTER(LEN=255) :: errMsg, thisLoc
 
-    ! cdholmes, devel
-    real(f8) :: finalMass(300,3)
-    real(f8) :: finalDiff(300,3)
-    real(f8) :: finalMass4(72,46,100,3)
-
     !====================================================================
     ! Compute_Budget_Diagnostics begins here!
     !====================================================================
@@ -1051,9 +1046,6 @@ CONTAINS
     ThisLoc = ' -> at Compute_Budget_Diagnostics (in GeosCore/diagnostics_mod.F90)'
     colSum  = 0.0_f8
     spcMass = 0.0_f8
-    finalMass = 0.0_f8
-    finalDiff = 0.0_f8
-    finalMass4 = 0.0_f8
 
     ! Exit if concentrations are not in [kg/kg dry]
     IF ( State_Chm%Spc_Units /= KG_SPECIES_PER_KG_DRY_AIR ) THEN
@@ -1195,9 +1187,6 @@ CONTAINS
              IF ( before ) THEN
                 colMass(I,J,N,1) = colSum
              ELSE
-                finalMass4(I,J,N,1) = colSum
-                finalMass(N,1) = finalMass(N,1) + colSum
-                finalDiff(N,1) = finalDiff(N,1) + (colSum - colMass(I,J,N,1)) / timeStep
 #ifdef MODEL_GEOS
                 diagFull(I,J,S) = diagFull(I,J,S) + ( ( colSum - colMass(I,J,N,1) ) &
                                   / timeStep / State_Grid%AREA_M2(I,J) )
@@ -1248,9 +1237,6 @@ CONTAINS
              IF ( before ) THEN
                 colMass(I,J,N,2) = colSum
              ELSE
-               finalMass4(I,J,N,2) = colSum
-               finalMass(N,2) = finalMass(N,2) + colSum
-               finalDiff(N,2) = finalDiff(N,2) + (colSum - colMass(I,J,N,2)) / timeStep
 #ifdef MODEL_GEOS
                 diagTrop(I,J,S) = diagTrop(I,J,S) + ( ( colSum - colMass(I,J,N,2) ) &
                                   / timeStep / State_Grid%AREA_M2(I,J) )
@@ -1299,10 +1285,7 @@ CONTAINS
              ! convert to [kg/s], and store in the diagPBL array.
              IF ( before ) THEN
                 colMass(I,J,N,3) = colSum
-             ELSE
-               finalMass4(I,J,N,3) = colSum
-               finalMass(N,3) = finalMass(N,3) + colSum
-               finalDiff(N,3) = finalDiff(N,3) + (colSum - colMass(I,J,N,3)) / timeStep              
+             ELSE     
 #ifdef MODEL_GEOS
                 diagPBL(I,J,S) = diagPBL(I,J,S) + ( ( colSum - colMass(I,J,N,3) ) &
                                  / timeStep / State_Grid%AREA_M2(I,J) )
@@ -1317,27 +1300,6 @@ CONTAINS
     ENDDO
     ENDDO
     !$OMP END PARALLEL DO
-
-    if (after .and. isTrop) then
-      ! Print initial, final, and change of mass for tracer N
-      ! For development only (cdholmes)
-      N=2; S=1
-      ! print*,shape(diagTrop),',',shape(State_Grid%Area_M2)
-      ! print'(A10,4(F20.6),L4)','**BUDGET',&
-      !    sum(colMass(:,:,N,2)), &
-      !    finalMass(N,2), &
-      !    finalMass(N,2) - sum(colMass(:,:,N,2)), &
-      !    sum(diagTrop(:,:,N)*State_Grid%AREA_M2(:,:))*timeStep,&
-      !    WetDep
-      print'(A10,5(F20.6))','**BUDGET',&
-         sum(colMass(:,:,N,2)), &
-         sum(finalMass4(:,:,N,2)), &
-         sum(finalMass4(:,:,N,2)) - sum(colMass(:,:,N,2)), &
-         sum(diagTrop(:,:,S))*timeStep, &
-         finalDiff(N,2)*timeStep
-      ! ** To Be Determined ** Should we be concerned that finalDiff differs from sum(diagTrop)?
-      ! print*,finalDiff(N,2)
-    endif
 
   END SUBROUTINE Compute_Budget_Diagnostics
 !EOC

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1028,10 +1028,11 @@ CONTAINS
     LOGICAL            :: after,  before, wetDep
     INTEGER            :: I,      J,      L,       N
     INTEGER            :: numSpc, region, topLev,  S
-    REAL(f8)           :: colSum, dt
+    REAL(f8)           :: colSum, dt,     rtol
 
     ! Arrays
     REAL(f8)           :: spcMass(State_Grid%NZ)
+    REAL(f8)           :: rerr(3),  PriorGlobalMass(3)
 
     ! Strings
     CHARACTER(LEN=255) :: errMsg, thisLoc
@@ -1134,10 +1135,13 @@ CONTAINS
     !                   and then update diagnostic arrays
     !====================================================================
 
-    ! Zero out the column mass array if we are calling this routine
-    ! before the desired operation.  This will let us compute initial mass.
     IF ( before ) THEN
-       colMass = 0.0_f8
+       ! Prior global tracer mass, summed over all tracers
+       ! This isn't physically meaningful, 
+       ! but can be used to check if the budget diagnostic is working correctly
+       PriorGlobalMass(1) = sum( colMass(:,:,:,1) )
+       PriorGlobalMass(2) = sum( colMass(:,:,:,2) )
+       PriorGlobalMass(3) = sum( colMass(:,:,:,3) )
     ENDIF
 
     ! Loop over NX and NY dimensions
@@ -1194,6 +1198,8 @@ CONTAINS
                 diagFull(I,J,S) = diagFull(I,J,S) + ( ( colSum - colMass(I,J,N,1) ) &
                                   / timeStep )
 #endif
+                ! Save to enable budget consistency check
+                colMass(I,J,N,1) = colSum
              ENDIF
           ENDDO
 
@@ -1244,6 +1250,8 @@ CONTAINS
                 diagTrop(I,J,S) = diagTrop(I,J,S) + ( ( colSum - colMass(I,J,N,2) ) &
                                   / timeStep )
 #endif
+                ! Save to enable budget consistency check
+                colMass(I,J,N,2) = colSum
              ENDIF
           ENDDO
        ENDIF
@@ -1293,6 +1301,8 @@ CONTAINS
                 diagPBL(I,J,S) = diagPBL(I,J,S) + ( ( colSum - colMass(I,J,N,3) ) &
                                  / timeStep )
 #endif
+                ! Save to enable budget consistency check
+                colMass(I,J,N,3) = colSum
              ENDIF
           ENDDO
        ENDIF
@@ -1300,6 +1310,37 @@ CONTAINS
     ENDDO
     ENDDO
     !$OMP END PARALLEL DO
+
+    ! Budget consistency check
+    ! The global total tracer mass should *not* change between an "after" call and the next "before" call
+    if ( before .and. (.not. any( PriorGlobalMass == 0. )) ) then
+       
+       ! Relative error, change since prior "after" call
+       rerr(1) = abs( sum( colMass(:,:,:,1) ) / PriorGlobalMass(1) - 1 )
+       rerr(2) = abs( sum( colMass(:,:,:,2) ) / PriorGlobalMass(2) - 1 )
+       rerr(3) = abs( sum( colMass(:,:,:,3) ) / PriorGlobalMass(3) - 1 )
+       
+       ! Relative error tolarance, errors larger than this will halt the model
+       rtol = 0.001
+
+       IF ( rerr(1) > rtol ) THEN
+         print*,'Budget Diagnostic Error: FULL-column tracer mass changed unexpectedly, rerr=',rerr(1)
+       ENDIF
+       IF ( rerr(2) > rtol ) THEN
+         print*,'Budget Diagnostic Error: TROP-column tracer mass changed unexpectedly, rerr=', rerr(2)
+       ENDIF
+       IF ( rerr(3) > rtol ) THEN
+         print*,'Budget Diagnostic Error: PBL-column tracer mass changed unexpectedly, rerr=', rerr(3)
+       ENDIF
+
+       IF ( any( rerr > rtol ) ) THEN
+         print*,'If H2O or CLOCK are included, Budget Diagnostic Errors are expected for these species'
+         ! errMsg = 'Tracer mass changed outside locations expected by Compute_Budget_Diagnostics!!! ' &
+         !    //'This could indicate a bug or additional calls to Compute_Budget_Diagnostics are needed.'
+         ! CALL GC_Error( errMsg, RC, thisLoc )
+         ! RETURN
+       ENDIF
+    endif
 
   END SUBROUTINE Compute_Budget_Diagnostics
 !EOC

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1324,22 +1324,22 @@ CONTAINS
        rtol = 0.001
 
        IF ( rerr(1) > rtol ) THEN
-         print*,'Budget Diagnostic Error: FULL-column tracer mass changed unexpectedly, rerr=',rerr(1)
+         print*,'Budget Diagnostic Warning: FULL-column tracer mass changed unexpectedly, rerr=',rerr(1)
        ENDIF
        IF ( rerr(2) > rtol ) THEN
-         print*,'Budget Diagnostic Error: TROP-column tracer mass changed unexpectedly, rerr=', rerr(2)
+         print*,'Budget Diagnostic Warning: TROP-column tracer mass changed unexpectedly, rerr=', rerr(2)
        ENDIF
        IF ( rerr(3) > rtol ) THEN
-         print*,'Budget Diagnostic Error: PBL-column tracer mass changed unexpectedly, rerr=', rerr(3)
+         print*,'Budget Diagnostic Warning: PBL-column tracer mass changed unexpectedly, rerr=', rerr(3)
        ENDIF
 
        IF ( any( rerr > rtol ) ) THEN
-         print*,'If H2O or CLOCK are included, Budget Diagnostic Errors are expected for these species'
-         ! errMsg = 'Tracer mass changed outside locations expected by Compute_Budget_Diagnostics!!! ' &
-         !    //'This could indicate a bug or additional calls to Compute_Budget_Diagnostics are needed.'
+         errMsg = 'Tracer mass changed outside code sections monitored by Compute_Budget_Diagnostics!!! ' &
+            //'This could indicate a bug or additional calls to Compute_Budget_Diagnostics are needed.'
+         print*,errMsg
+         print*,'Budget Diagnostic Warnings are expected in simulations with H2O or CLOCK'
          ! CALL GC_Error( errMsg, RC, thisLoc )
          ! RETURN
-       ENDIF
     endif
 
   END SUBROUTINE Compute_Budget_Diagnostics

--- a/GeosCore/pbl_mix_mod.F90
+++ b/GeosCore/pbl_mix_mod.F90
@@ -334,7 +334,7 @@ CONTAINS
             diagTrop    = NULL(),                                            &
             mapDataTrop = NULL(),                                            &
             isPBL       = .TRUE.,                                            &
-            diagPBL     = State_Diag%BudgetMixingPBLHeight,                  &
+            diagPBL     = State_Diag%BudgetMixingPBL,                        &
             mapDataPBL  = State_Diag%Map_BudgetMixingPBL,                    &
             colMass     = State_Diag%BudgetColumnMass,                       &
             before_op   = .TRUE.,                                            &
@@ -545,7 +545,7 @@ CONTAINS
             diagTrop    = NULL(),                                            &
             mapDataTrop = NULL(),                                            &
             isPBL       = .TRUE.,                                            &
-            diagPBL     = State_Diag%BudgetMixingPBLHeight,                  &
+            diagPBL     = State_Diag%BudgetMixingPBL,                        &
             mapDataPBL  = State_Diag%Map_BudgetMixingPBL,                    &
             colMass     = State_Diag%BudgetColumnMass,                       &
             timeStep    = DT_Dyn,                                            &

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -156,7 +156,6 @@ MODULE State_Diag_Mod
      LOGICAL                     :: Archive_BudgetTransportFull
 
      REAL(f8),           POINTER :: BudgetTransportTrop(:,:,:)
-     REAL(f8),           POINTER :: BudgetTransportTropHeight(:,:,:)
      TYPE(DgnMap),       POINTER :: Map_BudgetTransportTrop
      LOGICAL                     :: Archive_BudgetTransportTrop
 
@@ -173,7 +172,6 @@ MODULE State_Diag_Mod
      LOGICAL                     :: Archive_BudgetMixingTrop
 
      REAL(f8),           POINTER :: BudgetMixingPBL(:,:,:)
-     REAL(f8),           POINTER :: BudgetMixingPBLHeight(:,:,:)
      TYPE(DgnMap),       POINTER :: Map_BudgetMixingPBL
      LOGICAL                     :: Archive_BudgetMixingPBL
 
@@ -1395,7 +1393,6 @@ CONTAINS
     State_Diag%Archive_BudgetTransport             = .FALSE.
 
     State_Diag%BudgetTransportTrop                 => NULL()
-    State_Diag%BudgetTransportTropHeight           => NULL()
     State_Diag%Map_BudgetTransportTrop             => NULL()
     State_Diag%Archive_BudgetTransportTrop         = .FALSE.
 
@@ -1413,7 +1410,6 @@ CONTAINS
     State_Diag%Archive_BudgetMixingTrop            = .FALSE.
 
     State_Diag%BudgetMixingPBL                     => NULL()
-    State_Diag%BudgetMixingPBLHeight               => NULL()
     State_Diag%Map_BudgetMixingPBL                 => NULL()
     State_Diag%Archive_BudgetMixingPBL             = .FALSE.
 
@@ -2832,17 +2828,6 @@ CONTAINS
        RETURN
     ENDIF
 
-    ! Mass change due to change in tropopause height, for transport in trop only
-    IF ( State_Diag%Archive_BudgetTransportTrop ) THEN
-       diagID  = 'BudgetTransportTropHeight'
-       ALLOCATE( State_Diag%BudgetTransportTropHeight(                       &
-            State_Grid%NX, State_Grid%NY,                                    &
-            SIZE(State_Diag%BudgetTransportTrop,3)), STAT=RC                )
-       CALL GC_CheckVar( diagID, 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       State_diag%BudgetTransportTropHeight = 0.0_f8
-    ENDIF
-
     ! PBL-only transport
     diagID  = 'BudgetTransportPBL'
     CALL Init_and_Register(                                                  &
@@ -2938,17 +2923,6 @@ CONTAINS
        errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
        CALL GC_Error( errMsg, RC, thisLoc )
        RETURN
-    ENDIF
-
-    ! Mass change due to change in PBL top level, for PBL mixing only
-    IF ( State_Diag%Archive_BudgetMixingPBL ) THEN
-       diagID  = 'BudgetMixingPBLHeight'
-       ALLOCATE( State_Diag%BudgetMixingPBLHeight(                           &
-            State_Grid%NX, State_Grid%NY,                                    &
-            SIZE(State_Diag%BudgetMixingPBL,3)), STAT=RC                    )
-       CALL GC_CheckVar( diagID, 0, RC )
-       IF ( RC /= GC_SUCCESS ) RETURN
-       State_diag%BudgetMixingPBLHeight = 0.0_f8
     ENDIF
 
     ! High-level logical for mixing budget
@@ -10662,11 +10636,6 @@ CONTAINS
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
-    CALL Finalize( diagId   = 'BudgetTransportTropHeight',                   &
-                   Ptr2Data = State_Diag%BudgetTransportTropHeight,          &
-                   RC       = RC                                            )
-    IF ( RC /= GC_SUCCESS ) RETURN
-
     CALL Finalize( diagId   = 'BudgetTransportPBL',                          &
                    Ptr2Data = State_Diag%BudgetTransportPBL,                 &
                    mapData  = State_Diag%Map_BudgetTransportPBL,             &
@@ -10688,11 +10657,6 @@ CONTAINS
     CALL Finalize( diagId   = 'BudgetMixingPBL',                             &
                    Ptr2Data = State_Diag%BudgetMixingPBL,                    &
                    mapData  = State_Diag%Map_BudgetMixingPBL,                &
-                   RC       = RC                                            )
-    IF ( RC /= GC_SUCCESS ) RETURN
-
-    CALL Finalize( diagId   = 'BudgetMixingPBLHeight',                       &
-                   Ptr2Data = State_Diag%BudgetMixingPBLHeight,              &
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
@@ -12357,10 +12321,6 @@ CONTAINS
           IF ( isDesc    ) Desc  = 'Troposphere-only total mass rate of ' // &
                                    'change in column for transport'
 
-       ELSE IF ( TRIM( Name_AllCaps ) == 'BUDGETTRANSPORTTROPHEIGHT' ) THEN
-          IF ( isDesc    ) Desc  = 'Troposphere-only mass change due to ' // &
-                                   'change in tropopause level'
-
        ELSE IF ( TRIM( Name_AllCaps ) == 'BUDGETTRANSPORTPBL' ) THEN
           IF ( isDesc    ) Desc  = 'PBL-only total mass rate of change ' // &
                                    ' in column for transport'
@@ -12388,10 +12348,6 @@ CONTAINS
        ELSE IF ( TRIM( Name_AllCaps ) == 'BUDGETMIXINGPBL' ) THEN
           IF ( isDesc    ) Desc  = 'PBL-only total mass rate of change ' // &
                                    'in column for mixing'
-
-       ELSE IF ( TRIM( Name_AllCaps ) == 'BUDGETMIXINGPBLHEIGHT' ) THEN
-          IF ( isDesc    ) Desc  = 'PBL-only mass change due to ' // &
-                                   'change in PBL top level'
 
        ELSE IF ( TRIM( Name_AllCaps ) == 'BUDGETCONVECTIONFULL' ) THEN
           IF ( isDesc    ) Desc  = 'Total mass rate of change in column ' // &


### PR DESCRIPTION
This PR simplifies the updated budget diagnostics developed in PR #2103, removing the distinction that some accumulated while others didn't. 

With this update, all of the budget diagnostics accumulate over the dynamic time step, giving more consistency in how the code looks and works. The extra arrays for tropopause height and PBL height budgets were then eliminated. 

I verified that the diagnostics are capturing all changes in tracer mass, with the exception of H2O, CLOCK and perhaps some other specialty simulation tracers. d

I added a budget consistency check. This prints a message global total tracer mass changes in code that is not between the "before" and "after" calls to Compute_Budget_Diagnostic. This could indicate a bug or, perhaps, that a some future feature requires updating the budget diagnostic. I think that this could be useful for unit testing. However, simulations that include H2O or CLOCK will trigger these messages, even when they run correctly. This could be fixed by moving the CLOCK updates inside chemistry or excluding H2O from the consistency check. For that reason, it could make sense to run the budget consistency check only in DEBUG simulations.