### PR TITLE
Update integration tests to pass quick option to compile scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Copy utility scripts that allow you to resubmit failed to integration and parallel test root directories
 - Update GCHP operational example environment files for Harvard Cannon
 - Do not run GCClassic integration test compile jobs in the background
+- Updated integration tests to pass quick option to compile scripts
 
 ### Fixed
 - Fixed unit conversions in GEOS-only code

--- a/test/integration/GCClassic/integrationTest.sh
+++ b/test/integration/GCClassic/integrationTest.sh
@@ -203,7 +203,7 @@ if [[ "X${testsToRun}" == "XCOMPILE" ]]; then
     #-------------------------------------------------------------------------
     echo ""
     echo "Compiliation tests are running..."
-    ${scriptsDir}/integrationTestCompile.sh
+    ${scriptsDir}/integrationTestCompile.sh "${quick}"
 
 elif [[ "X${testsToRun}" == "XALL" && "X${site}" == "XCANNON" ]]; then
 
@@ -238,7 +238,7 @@ elif [[ "X${testsToRun}" == "XALL" && "X${site}" == "XCANNON" ]]; then
     sed_ie "${sedPartitionCmd}" "${scriptsDir}/integrationTestExecute.sh"
 
     # Submit compilation tests script
-    output=$(sbatch ${scriptsDir}/integrationTestCompile.sh)
+    output=$(sbatch ${scriptsDir}/integrationTestCompile.sh "${quick}")
     output=($output)
     cmpId=${output[3]}
 
@@ -278,7 +278,7 @@ elif [[ "X${testsToRun}" == "XALL" && "X${site}" == "XCOMPUTE1" ]]; then
     sed_ie "${sedPartitionCmd}" "${scriptsDir}/integrationTestExecute.sh"
 
     # Submit compilation tests script
-    output=$(bsub ${scriptsDir}/integrationTestCompile.sh)
+    output=$(bsub ${scriptsDir}/integrationTestCompile.sh "${quick}")
     output=($output)
     cmpId=${output[1]}
     cmpId=${cmpId/<}

--- a/test/integration/GCClassic/integrationTestCompile.sh
+++ b/test/integration/GCClassic/integrationTestCompile.sh
@@ -112,7 +112,7 @@ fi
 [[ "X${OMP_STACKSIZE}" == "X" ]] && export OMP_STACKSIZE=500m
 
 # Only create necessary executables if $quick is "yes"
-if [[ "x${quick}" == "xyes" ]]; then
+if [[ "X${quick}" == "XYES" ]]; then
     EXE_LIST=("default" "carbon")
 else
     EXE_LIST=$EXE_GCC_BUILD_LIST

--- a/test/integration/GCClassic/integrationTestCompile.sh
+++ b/test/integration/GCClassic/integrationTestCompile.sh
@@ -115,7 +115,7 @@ fi
 if [[ "X${quick}" == "XYES" ]]; then
     EXE_LIST=("default" "carbon")
 else
-    EXE_LIST=$EXE_GCC_BUILD_LIST
+    EXE_LIST=("${EXE_GCC_BUILD_LIST[@]}")
 fi
 
 # Count the number of tests to be done

--- a/test/integration/GCClassic/integrationTestCompile.sh
+++ b/test/integration/GCClassic/integrationTestCompile.sh
@@ -32,6 +32,13 @@
 #------------------------------------------------------------------------------
 #BOC
 
+#=============================================================================
+# Arguments
+#=============================================================================
+
+# Run a short integration test?
+quick="${1}"
+
 #============================================================================
 # Global variable and function definitions
 #============================================================================
@@ -104,8 +111,15 @@ fi
 # Sanity check: Max out the OMP_STACKSIZE if it is not set
 [[ "X${OMP_STACKSIZE}" == "X" ]] && export OMP_STACKSIZE=500m
 
+# Only create necessary executables if $quick is "yes"
+if [[ "x${quick}" == "xyes" ]]; then
+    EXE_LIST=("default" "carbon")
+else
+    EXE_LIST=$EXE_GCC_BUILD_LIST
+fi
+
 # Count the number of tests to be done
-numTests=${#EXE_GCC_BUILD_LIST[@]}
+numTests=${#EXE_LIST[@]}
 
 #============================================================================
 # Initialize results logfile
@@ -151,7 +165,7 @@ let failed=0
 let remain=${numTests}
 
 # Loop over build directories
-for dir in ${EXE_GCC_BUILD_LIST[@]}; do
+for dir in ${EXE_LIST[@]}; do
 
     # Define build directory
     thisBuildDir="${buildDir}/${dir}"

--- a/test/integration/GCClassic/integrationTestCreate.sh
+++ b/test/integration/GCClassic/integrationTestCreate.sh
@@ -215,7 +215,7 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     # 4x5 merra2 fullchem
     create_rundir "1\n1\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
 
-    # DEBUG: Exit after creating a couple of rundirsDirs if $quick is "yes"
+    # Exit after creating a couple of rundirsDirs if $quick is "yes"
     if [[ "X${quick}" == "XYES" ]]; then
         cd ${thisDir}
         exit 0

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -236,7 +236,7 @@ elif [[ "x${testsToRun}" == "xALL" && "x${site}" == "xCANNON" ]]; then
     sed_ie "${sedPartitionCmd}" "${scriptsDir}/integrationTestExecute.sh"
 
     # Submit compilation tests script
-    output=$(sbatch ${scriptsDir}/integrationTestCompile.sh)
+    output=$(sbatch ${scriptsDir}/integrationTestCompile.sh ${quick})
     output=($output)
     cmpId=${output[3]}
     

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -201,7 +201,7 @@ if [[ "x${testsToRun}" == "xCOMPILE" ]]; then
     #-------------------------------------------------------------------------
     echo ""
     echo "Compiliation tests are running..."
-    ${scriptsDir}/integrationTestCompile.sh &
+    ${scriptsDir}/integrationTestCompile.sh "${quick}"
     
 elif [[ "x${testsToRun}" == "xALL" && "x${site}" == "xCANNON" ]]; then
 
@@ -236,7 +236,7 @@ elif [[ "x${testsToRun}" == "xALL" && "x${site}" == "xCANNON" ]]; then
     sed_ie "${sedPartitionCmd}" "${scriptsDir}/integrationTestExecute.sh"
 
     # Submit compilation tests script
-    output=$(sbatch ${scriptsDir}/integrationTestCompile.sh ${quick})
+    output=$(sbatch ${scriptsDir}/integrationTestCompile.sh "${quick}")
     output=($output)
     cmpId=${output[3]}
     
@@ -276,7 +276,7 @@ elif [[ "x${testsToRun}" == "xALL" && "x${site}" == "xCOMPUTE1" ]]; then
     sed_ie "${sedPartitionCmd}" "${scriptsDir}/integrationTestExecute.sh"
 
     # Submit compilation tests script
-    output=$(bsub ${scriptsDir}/integrationTestCompile.sh)
+    output=$(bsub ${scriptsDir}/integrationTestCompile.sh "${quick}")
     output=($output)
     cmpId=${output[1]}
     cmpId=${cmpId/<}

--- a/test/integration/GCHP/integrationTestCompile.sh
+++ b/test/integration/GCHP/integrationTestCompile.sh
@@ -114,7 +114,7 @@ fi
 [[ "x${OMP_STACKSIZE}" == "x" ]] && export OMP_STACKSIZE=500m
 
 # Only create necessary executables if $quick is "yes"
-if [[ "x${quick}" == "xyes" ]]; then
+if [[ "X${quick}" == "XYES" ]]; then
     EXE_LIST=("default" "carbon")
 else
     EXE_LIST=$EXE_GCHP_BUILD_LIST

--- a/test/integration/GCHP/integrationTestCompile.sh
+++ b/test/integration/GCHP/integrationTestCompile.sh
@@ -32,6 +32,13 @@
 #------------------------------------------------------------------------------
 #BOC
 
+#=============================================================================
+# Arguments
+#=============================================================================
+
+# Run a short integration test?
+quick="${1}"
+
 #============================================================================
 # Global variable and function definitions
 #============================================================================
@@ -106,8 +113,15 @@ fi
 # Sanity check: Max out the OMP_STACKSIZE if it is not set
 [[ "x${OMP_STACKSIZE}" == "x" ]] && export OMP_STACKSIZE=500m
 
+# Only create necessary executables if $quick is "yes"
+if [[ "x${quick}" == "xyes" ]]; then
+    EXE_LIST=("default" "carbon")
+else
+    EXE_LIST=$EXE_GCHP_BUILD_LIST
+fi
+
 # Count the number of tests to be done
-numTests=${#EXE_GCHP_BUILD_LIST[@]}
+numTests=${#EXE_LIST[@]}
 
 #============================================================================
 # Initialize results logfile
@@ -151,8 +165,10 @@ let passed=0
 let failed=0
 let remain=${numTests}
 
+
+
 # Loop over build directories
-for dir in ${EXE_GCHP_BUILD_LIST[@]}; do
+for dir in ${EXE_LIST[@]}; do
 
     # Define build directory
     thisBuildDir="${buildDir}/${dir}"

--- a/test/integration/GCHP/integrationTestCompile.sh
+++ b/test/integration/GCHP/integrationTestCompile.sh
@@ -117,7 +117,7 @@ fi
 if [[ "X${quick}" == "XYES" ]]; then
     EXE_LIST=("default" "carbon")
 else
-    EXE_LIST=$EXE_GCHP_BUILD_LIST
+    EXE_LIST=("${EXE_GCHP_BUILD_LIST[@]}")
 fi
 
 # Count the number of tests to be done

--- a/test/integration/GCHP/integrationTestCreate.sh
+++ b/test/integration/GCHP/integrationTestCreate.sh
@@ -206,7 +206,7 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     # c24 merra2 carbon
     #create_rundir "12\n1\n${rundirsDir}\n\nn\n" "${log}"
 
-    # DEBUG: Exit after creating a couple of rundirs if $quick is "yes"
+    # Exit after creating a couple of rundirs if $quick is "yes"
     if [[ "X${quick}" == "XYES" ]]; then
         cd ${thisDir}
         exit 0


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The quick option included in the integration tests generates and runs a subset of simulations. However, with this option activated, executables were still being created for all possible compile options. We now pass the quick argument to integrationTestCompile.sh so that only the necessary executables are built. This will further speed up the quick integration tests.

### Expected changes

This is a zero difference update. It only impacts the build stage of integration tests when the quick option is activated.
