### PR TITLE
Fix geopotential height units in netCDF file

### DIFF
--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -4709,7 +4709,7 @@ CONTAINS
 
        CASE ( 'PHIS' )
           IF ( isDesc  ) Desc  = 'Surface geopotential height'
-          IF ( isUnits ) Units = 'm2 s-1'
+          IF ( isUnits ) Units = 'm'
           IF ( isRank  ) Rank  = 2
 
        CASE ( 'PRECANV' )


### PR DESCRIPTION
Name: Christopher Holmes
Institution: Florida State University

The units of geopotential height are 'm', as updated here.
StateMet netCDF output previously said units were 'm2/s'. 


