### PR TITLE
Remove requirement for photolysis data directories to end with slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Field `State_Diag%Obspack_CharArray` as a 2-D character array
 - Added util folder in run/CESM to include .cdl file used to generate CESM NetCDF input file for deposition
 - Add GCClassic operational example environment files for Harvard Cannon
+- Added slash in front of names of LUT files read into photolysis_mod to avoid needing it in path
 
 ### Changed
 - Updated Harvard Cannon operational run scripts to use `huce_cascade` instead of `huce_intel`; also added `sapphire`

--- a/GeosCore/photolysis_mod.F90
+++ b/GeosCore/photolysis_mod.F90
@@ -938,7 +938,7 @@ CONTAINS
 
        ! Choose different set of input files for standard (trop+strat chenm)
        ! and tropchem (trop-only chem) simulations
-       THISFILE = TRIM( DATA_DIR ) // TRIM( SPECFIL(k) )
+       THISFILE = TRIM( DATA_DIR ) // '/' // TRIM( SPECFIL(k) )
 
        !--------------------------------------------------------------
        ! In dry-run mode, print file path to dryrun log and cycle.
@@ -1572,7 +1572,7 @@ CONTAINS
     TREF => State_Chm%Phot%TREF
 
     ! Directory and file names
-    nc_dir  = TRIM( Input_Opt%CHEM_INPUTS_DIR ) // 'FastJ_201204/'
+    nc_dir  = TRIM( Input_Opt%CHEM_INPUTS_DIR ) // '/' // 'FastJ_201204' // '/'
     nc_file = 'fastj.jv_atms_dat.nc'
     nc_path = TRIM( nc_dir ) // TRIM( nc_file )
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR removes the expectation that data directories used for lookup tables read in photolysis_mod.F90 gave a trailing slash. This gives greater flexibility with defining these paths externally to the model.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue(s)

None
