### PR TITLE
Fix bug in transport tracer pressure mask criteria affecting tracer st80_25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed GEOS-IT SLP and TROPP scaling in pre-processed files used in GCHP
 - Fixed reading of NEI emissions through HEMCO
 - Fixed incorrect units metadata for `State_Met%PHIS`
+- Fixed bug in transport tracer ST80 mask criteria which prevented mask from ever being zero
 
 ### Removed
 - Removed MPI broadcasts in CESM-only photolysis code; will read on all cores

--- a/GeosCore/tracer_mod.F90
+++ b/GeosCore/tracer_mod.F90
@@ -268,8 +268,8 @@ CONTAINS
           DO I = 1, State_Grid%NX
 
              ! Set mask to zero outside of pressure levels
-             IF ( State_Met%PEDGE(I,J,L+1) < SpcInfo%Src_PresMin   .and. &
-                  State_Met%PEDGE(I,J,L)   > SpcInfo%Src_PresMax ) THEN
+             IF ( .not. ( State_Met%PMID(I,J,L) >= SpcInfo%Src_PresMin   .and. &
+                          State_Met%PMID(I,J,L) <= SpcInfo%Src_PresMax ) ) THEN
                 Mask(I,J,L) = 0.0_fp
              ENDIF
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR changes the pressure mask criteria used to mask sources for transport tracer `st80_25`. The criteria to mask the source was previously that the grid cell's upper bound was above the target region and the lower bound was below the target region. This effectively prevented the mask from ever being set since no grid cells span the entire target vertical region of 0 to 80 hPa.

The fix changes the criteria to match what is done in GMAO's TR tracer package, checking only that the current grid cell's mid-point pressure is not within the target bounds.

### Expected changes

We expect more heterogeneity in the tr80_25 tracer in transport tracer simulations, particularly outside of the source region of 0 to 80 hPa. Outside of that region the source will now be masked.

### Reference(s)

None

### Related Github Issue(s)

closes https://github.com/geoschem/geos-chem/issues/2033
