### PR TITLE
Removing unused carbon simulation options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `IU_BPCH` logical file unit (in `GeosUtil/file_mod.F90`)
 - Removed tagged CH4 and CO species handling from `carbon_gases_mod.F90`
 - GitHub config files `.github/stale.yml` and `.github/no-response.yml`
+- Unused CO2 and carbon simulation options from `geoschem_config.yml` (and from related code in co2_mod.F90).
 
 ## [14.3.1] - 2024-04-02
 ### Added

--- a/GeosCore/co2_mod.F90
+++ b/GeosCore/co2_mod.F90
@@ -959,16 +959,8 @@ CONTAINS
     INTEGER          :: AS
 
     ! For values from Input_Opt
-    LOGICAL          :: LFOSSIL
     LOGICAL          :: LCHEMCO2
-    LOGICAL          :: LBIODIURNAL
-    LOGICAL          :: LBIONETCLIM
-    LOGICAL          :: LOCEAN
-    LOGICAL          :: LSHIP
-    LOGICAL          :: LPLANE
-    LOGICAL          :: LFFBKGRD
-    LOGICAL          :: LBIOSPHTAG,  LFOSSILTAG,  LSHIPTAG
-    LOGICAL          :: LPLANETAG
+    LOGICAL          :: LBIOSPHTAG,  LFOSSILTAG
 
     !=================================================================
     ! INIT_CO2 begins here!
@@ -982,18 +974,9 @@ CONTAINS
     IF ( IS_INIT .or. Input_Opt%DryRun ) RETURN
 
     ! Copy values from Input_Opt
-    LFOSSIL     = Input_Opt%LFOSSIL
     LCHEMCO2    = Input_Opt%LCHEMCO2
-    LBIODIURNAL = Input_Opt%LBIODIURNAL
-    LBIONETCLIM = Input_Opt%LBIONETCLIM
-    LOCEAN      = Input_Opt%LOCEAN
-    LSHIP       = Input_Opt%LSHIP
-    LPLANE      = Input_Opt%LPLANE
-    LFFBKGRD    = Input_Opt%LFFBKGRD
     LBIOSPHTAG  = Input_Opt%LBIOSPHTAG
     LFOSSILTAG  = Input_Opt%LFOSSILTAG
-    LSHIPTAG    = Input_Opt%LSHIPTAG
-    LPLANETAG   = Input_Opt%LPLANETAG
 
     ! Array for Fossil Fuel regions
     ALLOCATE( FOSSIL_REGION( State_Grid%NX, State_Grid%NY ), STAT=AS )

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -2103,84 +2103,6 @@ CONTAINS
     thisLoc = ' -> at Config_CO2 (in module GeosCore/input_mod.F90)'
 
     !------------------------------------------------------------------------
-    ! Use Fossil Fuel emissions?
-    !------------------------------------------------------------------------
-    key    = "CO2_simulation_options%sources%fossil_fuel_emissions"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%LFOSSIL = v_bool
-
-    !------------------------------------------------------------------------
-    ! Use Ocean Exchange?
-    !------------------------------------------------------------------------
-    key    = "CO2_simulation_options%sources%ocean_exchange"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%LOCEAN = v_bool
-
-    !------------------------------------------------------------------------
-    ! Turn on (balanced) biosphere with diurnal cycle?
-    !------------------------------------------------------------------------
-    key    = "CO2_simulation_options%sources%balanced_biosphere_exchange"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%LBIODIURNAL = v_bool
-
-    !------------------------------------------------------------------------
-    ! Use Net Terrestrial Exchange Climatology?
-    !------------------------------------------------------------------------
-    key    = "CO2_simulation_options%sources%net_terrestrial_exchange"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%LBIONETCLIM = v_bool
-
-    !------------------------------------------------------------------------
-    ! Turn on Ship emissions?
-    !------------------------------------------------------------------------
-    key    = "CO2_simulation_options%sources%ship_emissions"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%LSHIP = v_bool
-
-    !------------------------------------------------------------------------
-    ! Turn on Aviation emissions?
-    !------------------------------------------------------------------------
-    key    = "CO2_simulation_options%sources%aviation_emissions"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%LPLANE = v_bool
-
-    !------------------------------------------------------------------------
     ! Turn on CO2 3D chemical source and surface correction?
     !------------------------------------------------------------------------
     key    = "CO2_simulation_options%sources%3D_chemical_oxidation_source"
@@ -2192,19 +2114,6 @@ CONTAINS
        RETURN
     ENDIF
     Input_Opt%LCHEMCO2 = v_bool
-
-    !------------------------------------------------------------------------
-    ! Background CO2 (no emissions or exchange) for Tagged-CO2 runs
-    !------------------------------------------------------------------------
-    key = "CO2_simulation_options%tagged_species%save_fossil_fuel_in_background"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%LFFBKGRD = v_bool
 
     !------------------------------------------------------------------------
     ! Turn on biosphere and ocean exchange region tagged species?
@@ -2232,32 +2141,6 @@ CONTAINS
     ENDIF
     Input_Opt%LFOSSILTAG = v_bool
 
-    !------------------------------------------------------------------------
-    ! Turn on global ship emissions tagged species?
-    !------------------------------------------------------------------------
-    key    = "CO2_simulation_options%tagged_species%tag_global_ship_CO2"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%LSHIPTAG = v_bool
-
-    !------------------------------------------------------------------------
-    ! Turn on global aircraft emissions tagged species?
-    !------------------------------------------------------------------------
-    key    = "CO2_simulation_options%tagged_species%tag_global_aircraft_CO2"
-    v_bool = MISSING_BOOL
-    CALL QFYAML_Add_Get( Config, key, v_bool, "", RC )
-    IF ( RC /= GC_SUCCESS ) THEN
-       errMsg = 'Error parsing ' // TRIM( key ) // '!'
-       CALL GC_Error( errMsg, RC, thisLoc )
-       RETURN
-    ENDIF
-    Input_Opt%LPLANETAG = v_bool
-
     !=================================================================
     ! Print to screen
     !=================================================================
@@ -2265,19 +2148,10 @@ CONTAINS
        WRITE( 6,90  ) 'CO2 SIMULATION SETTINGS'
        WRITE( 6,95  ) '(overwrites any other settings related to CO2)'
        WRITE( 6,95  ) '----------------------------------------------'
-       WRITE( 6,100 ) 'National Fossil Fuel Emission :', Input_Opt%LFOSSIL
-       WRITE( 6,100 ) 'Ocean CO2 Uptake/Emission     :', Input_Opt%LOCEAN
-       WRITE( 6,100 ) 'Biosphere seas/diurnal cycle  :', Input_Opt%LBIODIURNAL
-       WRITE( 6,100 ) 'Net Terr Exch - Climatology   :', Input_Opt%LBIONETCLIM
-       WRITE( 6,100 ) 'Intl/Domestic Ship emissions  :', Input_Opt%LSHIP
-       WRITE( 6,100 ) 'Intl/Domestic Aviation emiss  :', Input_Opt%LPLANE
        WRITE( 6,100 ) 'CO2 from oxidation (CO,CH4,..):', Input_Opt%LCHEMCO2
        WRITE( 6, 95 ) 'Tagged CO2 settings'
-       WRITE( 6,100 ) '  Save Fossil CO2 in Bckgrnd  :', Input_Opt%LFFBKGRD
        WRITE( 6,100 ) '  Tag Biosphere/Ocean CO2     :', Input_Opt%LBIOSPHTAG
        WRITE( 6,100 ) '  Tag Fossil Fuel CO2         :', Input_Opt%LFOSSILTAG
-       WRITE( 6,100 ) '  Tag Global Ship CO2         :', Input_Opt%LSHIPTAG
-       WRITE( 6,100 ) '  Tag Global Aviation CO2     :', Input_Opt%LPLANETAG
     ENDIF
 
     ! FORMAT statements

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -157,18 +157,9 @@ MODULE Input_Opt_Mod
      !----------------------------------------
      ! CO2 MENU fields
      !----------------------------------------
-     LOGICAL                     :: LFOSSIL
      LOGICAL                     :: LCHEMCO2
-     LOGICAL                     :: LBIODIURNAL
-     LOGICAL                     :: LBIONETCLIM
-     LOGICAL                     :: LOCEAN
-     LOGICAL                     :: LSHIP
-     LOGICAL                     :: LPLANE
-     LOGICAL                     :: LFFBKGRD
      LOGICAL                     :: LBIOSPHTAG
      LOGICAL                     :: LFOSSILTAG
-     LOGICAL                     :: LSHIPTAG
-     LOGICAL                     :: LPLANETAG
 
      !----------------------------------------
      ! CHEMISTRY MENU fields
@@ -653,19 +644,9 @@ CONTAINS
     !----------------------------------------
     ! CO2 MENU fields
     !----------------------------------------
-    Input_Opt%LFOSSIL                = .FALSE.
     Input_Opt%LCHEMCO2               = .FALSE.
-    Input_Opt%LBIOFUEL               = .FALSE.
-    Input_Opt%LBIODIURNAL            = .FALSE.
-    Input_Opt%LBIONETCLIM            = .FALSE.
-    Input_Opt%LOCEAN                 = .FALSE.
-    Input_Opt%LSHIP                  = .FALSE.
-    Input_Opt%LPLANE                 = .FALSE.
-    Input_Opt%LFFBKGRD               = .FALSE.
     Input_Opt%LBIOSPHTAG             = .FALSE.
     Input_Opt%LFOSSILTAG             = .FALSE.
-    Input_Opt%LSHIPTAG               = .FALSE.
-    Input_Opt%LPLANETAG              = .FALSE.
 
     !----------------------------------------
     ! CHEMISTRY MENU fields

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CO2
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.CO2
@@ -73,20 +73,11 @@ operations:
 CO2_simulation_options:
 
   sources:
-    fossil_fuel_emissions: true
-    ocean_exchange: true
-    balanced_biosphere_exchange: true
-    net_terrestrial_exchange: true
-    ship_emissions: true
-    aviation_emissions: true
     3D_chemical_oxidation_source: true
 
   tagged_species:
-    save_fossil_fuel_in_background: false
     tag_bio_and_ocean_CO2: false
-    tag_land_fossil_fuel_CO2: 
-    tag_global_ship_CO2: false
-    tag_global_aircraft_CO2: false
+    tag_land_fossil_fuel_CO2: false
     
 #============================================================================
 # Settings for diagnostics (other than HISTORY and HEMCO)

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
@@ -96,20 +96,11 @@ CO_simulation_options:
 CO2_simulation_options:
 
   sources:
-    fossil_fuel_emissions: true
-    ocean_exchange: true
-    balanced_biosphere_exchange: true
-    net_terrestrial_exchange: true
-    ship_emissions: true
-    aviation_emissions: true
     3D_chemical_oxidation_source: true
 
   tagged_species:
-    save_fossil_fuel_in_background: false
     tag_bio_and_ocean_CO2: false
-    tag_land_fossil_fuel_CO2: 
-    tag_global_ship_CO2: false
-    tag_global_aircraft_CO2: false
+    tag_land_fossil_fuel_CO2: false
 
 #============================================================================
 # Settings for diagnostics (other than HISTORY and HEMCO)

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.carbon
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.carbon
@@ -71,20 +71,11 @@ CO_simulation_options:
 CO2_simulation_options:
 
   sources:
-    fossil_fuel_emissions: true
-    ocean_exchange: true
-    balanced_biosphere_exchange: true
-    net_terrestrial_exchange: true
-    ship_emissions: true
-    aviation_emissions: true
     3D_chemical_oxidation_source: true
 
   tagged_species:
-    save_fossil_fuel_in_background: false
     tag_bio_and_ocean_CO2: false
-    tag_land_fossil_fuel_CO2: 
-    tag_global_ship_CO2: false
-    tag_global_aircraft_CO2: false
+    tag_land_fossil_fuel_CO2: false
 
 #============================================================================
 # Settings for diagnostics (other than HISTORY and HEMCO)

--- a/run/WRF/co2/geoschem_config.yml
+++ b/run/WRF/co2/geoschem_config.yml
@@ -52,20 +52,11 @@ operations:
 CO2_simulation_options:
 
   sources:
-    fossil_fuel_emissions: true
-    ocean_exchange: true
-    balanced_biosphere_exchange: true
-    net_terrestrial_exchange: true
-    ship_emissions: true
-    aviation_emissions: true
     3D_chemical_oxidation_source: true
 
   tagged_species:
-    save_fossil_fuel_in_background: false
     tag_bio_and_ocean_CO2: false
     tag_land_fossil_fuel_CO2: 
-    tag_global_ship_CO2: false
-    tag_global_aircraft_CO2: false
     
 #============================================================================
 # Settings for diagnostics (other than HISTORY and HEMCO)

--- a/run/shared/singleCarbonSpecies.sh
+++ b/run/shared/singleCarbonSpecies.sh
@@ -116,18 +116,9 @@ function updateGeosChemConfig() {
     # If CO2 is in the exclude list, turn off CO2 options
     isItemInList "CO2" "${1}"
     if [[ $? == 0 ]]; then
-        keys=("fossil_fuel_emissions"          \
-              "ocean_exchange"                 \
-              "balanced_biosphere_exchange"    \
-              "net_terrestrial_exchange"       \
-              "ship_emissions"                 \
-              "aviation_emissions"             \
-              "3D_chemical_oxidation_source"   \
-              "save_fossil_fuel_in_background" \
+        keys=("3D_chemical_oxidation_source"   \
               "tag_bio_and_ocean_CO2"          \
-              "tag_land_fossil_fuel_CO2"       \
-              "tag_global_ship_CO2"            \
-              "tag_global_aircraft_CO2"       )
+              "tag_land_fossil_fuel_CO2"      )
         for key in ${keys[@]}; do
             keyValueUpdate "${key}" "true" "false" "${file}"
         done


### PR DESCRIPTION
### Name and Institution (Required)

Name: Hannah Nesser
Institution: JPL

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

I have removed the following options from the CO2 simulation (including from the carbon single tracer simulation) because they were unused: LFOSSIL, LBIODIURNAL, LBIONETCLIM, LOCEAN, LSHIP, LPLANE, LFFBKGRD, LSHIPTAG,  LPLANETAG

I also added a default value for tag_land_fossil_fuel_CO2: false, which was previously missing.

### Expected changes

This should not change any model operations since all removed options were unused.

### Reference(s)

None

### Related Github Issue(s)

None
