### PR TITLE
Remove large declared array not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - GitHub config files `.github/stale.yml` and `.github/no-response.yml`
 - Unused CO2 and carbon simulation options from `geoschem_config.yml` (and from related code in co2_mod.F90).
 - Removed ISORROPIA
+- Removed Begin array in do_fullchem (declared but not used)
 
 ## [14.3.1] - 2024-04-02
 ### Added

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -200,8 +200,6 @@ CONTAINS
     REAL(dp)               :: RCNTRL (20)
     REAL(dp)               :: RSTATE (20)
     REAL(dp)               :: C_before_integrate(NSPEC)
-    REAL(fp)               :: Before(State_Grid%NX, State_Grid%NY,           &
-                                     State_Grid%NZ, State_Chm%nAdvect       )
 
     ! For tagged CO saving
     REAL(fp)               :: LCH4, PCO_TOT, PCO_CH4, PCO_NMVOC


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

Obim Sturm (GMAO) reported a large 4D array in `Do_FullChem` that is declared but never used. I looked into the history and the usage of the array was removed in 13.4.0. This PR removes the declaration.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue(s)

https://github.com/GEOS-ESM/geos-chem/issues/17