### PR TITLE
Remove --request-payer requester from download_data.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Unused CO2 and carbon simulation options from `geoschem_config.yml` (and from related code in co2_mod.F90).
 - Removed ISORROPIA
 - Removed tagCH4 simulation as option
+- Removed `--request-payer requester` from `run/shared/download_data.py`; the `s3://gcgrid` data is open-source
 
 ## [14.3.1] - 2024-04-02
 ### Added

--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -9,7 +9,7 @@ mirrors:
     short_name: aws
     s3_bucket: True
     remote: s3://gcgrid
-    command: 'aws s3 cp --request-payer requester '
+    command: 'aws s3 cp '
     quote: ""
   rochester:
     short_name: ur


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This update removes the `--request-payer requester` option from the command in `download_data.yml` to download data from the `s3://gcgrid` bucket.  This data is now covered under the AWS Open Data Policy and no longer incurs an egress fee.

### Expected changes
This is a zero-diff update.

### Related Github Issue(s)
N/A