### PR TITLE
Remove `BudgetWetDep*` entries from HISTORY.rc files for simulations where wetdep is turned off

### DIFF
--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
@@ -136,10 +136,6 @@ COLLECTIONS: 'Restart',
                        'BudgetConvectionTrop_?ADV?           ',
                        'BudgetConvectionPBL_?ADV?            ',
                        'BudgetConvectionLevs1to35_?ADV?      ',
-                       'BudgetWetDepFull_?WET?               ',
-                       'BudgetWetDepTrop_?WET?               ',
-                       'BudgetWetDepPBL_?WET?                ',
-                       'BudgetWetDepLevs1to35_?WET?          ',
 ::
 #==============================================================================
 # %%%%% THE CH4 COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -111,10 +111,6 @@ COLLECTIONS: 'Restart',
                        'BudgetConvectionTrop_?ADV?           ',
                        'BudgetConvectionPBL_?ADV?            ',
                        'BudgetConvectionLevs1to35_?ADV?      ',
-                       'BudgetWetDepFull_?WET?               ',
-                       'BudgetWetDepTrop_?WET?               ',
-                       'BudgetWetDepPBL_?WET?                ',
-                       'BudgetWetDepLevs1to35_?WET?          ',
 ::
 #==============================================================================
 # %%%%% THE CO2 COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -136,10 +136,6 @@ COLLECTIONS: 'Restart',
                               'BudgetConvectionTrop_?ADV?           ',
                               'BudgetConvectionPBL_?ADV?            ',
                               'BudgetConvectionLevs1to35_?ADV?      ',
-                              'BudgetWetDepFull_?WET?               ',
-                              'BudgetWetDepTrop_?WET?               ',
-                              'BudgetWetDepPBL_?WET?                ',
-                              'BudgetWetDepLevs1to35_?WET?          ',
 ::
 #==============================================================================
 # %%%%% THE Carbon COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
@@ -112,10 +112,6 @@ COLLECTIONS: 'Restart',
                        'BudgetConvectionTrop_?ADV?           ',
                        'BudgetConvectionPBL_?ADV?            ',
                        'BudgetConvectionLevs1to35_?ADV?      ',
-                       'BudgetWetDepFull_?WET?               ',
-                       'BudgetWetDepTrop_?WET?               ',
-                       'BudgetWetDepPBL_?WET?                ',
-                       'BudgetWetDepLevs1to35_?WET?          ',
 ::
 #==============================================================================
 # %%%%% THE CloudConvFlux COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
@@ -113,10 +113,6 @@ COLLECTIONS: 'Restart',
                        'BudgetConvectionTrop_?ADV?           ',
                        'BudgetConvectionPBL_?ADV?            ',
                        'BudgetConvectionLevs1to35_?ADV?      ',
-                       'BudgetWetDepFull_?WET?               ',
-                       'BudgetWetDepTrop_?WET?               ',
-                       'BudgetWetDepPBL_?WET?                ',
-                       'BudgetWetDepLevs1to35_?WET?          ',
 ::
 #==============================================================================
 # %%%%% THE CloudConvFlux COLLECTION %%%%%


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #2305.  In that issue it was reported that the `BudgetWetDep*` diagnostics were causing a CO2 simulation to crash.  This is because the CO2 simulation does not have wet deposition turned on (as CO2 is not a soluble species). 

To fix this issue we have now removed the `BudgetWetDep*` entries from the carbon, CH4, CO2, tagCO, and tagO3 `HISTORY.rc.template` files.  

### Expected changes
The carbon, CH4, CO2, tagCO, and tagO3 simulations should now no longer fail when the `Budget` collection is turned on.

### Reference(s)
N/A

### Related Github Issue
- Closes #2305 