### PR TITLE
Fix bugs in PDER, OCPISOA and TotalOC in complexSOA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+- Simplified SOA representations and fixed related AOD and TotalOA/OC calculations in benchmark.
+
 ## [14.4.1] - 2024-06-28
 ### Added
 - Added initialization of PHOTDELTA in `ucx_h2so4phot` to avoid run-time error in CESM

--- a/GeosCore/aerosol_mod.F90
+++ b/GeosCore/aerosol_mod.F90
@@ -876,19 +876,16 @@ CONTAINS
       ! Parameterized dry effective radius for SNA and OM
       !===========================================================
       IF ( State_Chm%AerMass%SO4_NH4_NIT(I,J,L) > 0e+0_fp ) THEN
-         IF ( Is_SimpleSOA ) THEN
-            ! dry SNA and OM mass, in unit of ug/m3
-            State_Chm%AerMass%SNAOM(I,J,L) = ( State_Chm%AerMass%SO4_NH4_NIT(I,J,L) + State_Chm%AerMass%OCPO(I,J,L) + State_Chm%AerMass%OCPI(I,J,L) + State_Chm%AerMass%SOAS(I,J,L) )*1.0e+9_fp
-            ! ratio between OM and SNA, unitless
-            State_Chm%AerMass%R_OMSNA(I,J,L) = (State_Chm%AerMass%OCPO(I,J,L) + State_Chm%AerMass%OCPI(I,J,L) + State_Chm%AerMass%SOAS(I,J,L)) / State_Chm%AerMass%SO4_NH4_NIT(I,J,L)  
+         ! dry SNA and OM mass, in unit of ug/m3
+         State_Chm%AerMass%SNAOM(I,J,L) = ( State_Chm%AerMass%SO4_NH4_NIT(I,J,L) + &
+                                            State_Chm%AerMass%OCPO(I,J,L) + &
+                                            State_Chm%AerMass%OCPISOA(I,J,L) ) * 1.0e+9_fp
 
-         ELSE IF ( Is_ComplexSOA ) THEN
-            ! dry SNA and OM mass, in unit of ug/m3
-            State_Chm%AerMass%SNAOM(I,J,L) = ( State_Chm%AerMass%SO4_NH4_NIT(I,J,L) + State_Chm%AerMass%OCPO(I,J,L) + State_Chm%AerMass%OCPI(I,J,L) + State_Chm%AerMass%TSOA(I,J,L) + State_Chm%AerMass%ASOA(I,J,L) + State_Chm%AerMass%ISOAAQ(I,J,L)  ) * 1.0e+9_fp
-            ! ratio between OM and SNA, unitless
-            State_Chm%AerMass%R_OMSNA(I,J,L) = (State_Chm%AerMass%OCPO(I,J,L) + State_Chm%AerMass%OCPI(I,J,L) + State_Chm%AerMass%TSOA(I,J,L) + State_Chm%AerMass%ASOA(I,J,L) + State_Chm%AerMass%ISOAAQ(I,J,L) )/ State_Chm%AerMass%SO4_NH4_NIT(I,J,L) 
-                     
-         ENDIF
+         ! ratio between OM and SNA, unitless
+         State_Chm%AerMass%R_OMSNA(I,J,L) = ( State_Chm%AerMass%OCPO(I,J,L) + &
+                                              State_Chm%AerMass%OCPISOA(I,J,L) ) / &
+                                              State_Chm%AerMass%SO4_NH4_NIT(I,J,L)
+
          ! Parameterized dry effective radius, in unit of um
          State_Chm%AerMass%PDER(I,J,L) = (exp( 4.36_fp + 0.20_fp*log(State_Chm%AerMass%SNAOM(I,J,L)) + 0.065_fp*log(State_Chm%AerMass%R_OMSNA(I,J,L)) ) *0.001_fp )/0.9_fp ;  
          

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1768,7 +1768,8 @@ CONTAINS
 !
 ! !USES:
 !
-    USE Aerosol_Mod,    ONLY : IS_POA, IS_OPOA
+    USE Aerosol_Mod,    ONLY : Is_POA, Is_OPOA, Is_OCPO, Is_OCPI
+    USE Aerosol_Mod,    ONLY : Is_ComplexSOA, Is_SimpleSOA
     USE ErrCode_Mod
     USE Input_Opt_Mod,  ONLY : OptInput
     USE Species_Mod,    ONLY : Species, SpcConc
@@ -2087,7 +2088,7 @@ CONTAINS
        IF ( State_Diag%Archive_AerMassPOA ) THEN
           IF ( Is_POA ) THEN
              State_Diag%AerMassPOA(I,J,L) = OCPO(I,J,L) * kgm3_to_ugm3
-          ELSE
+          ELSEIF ( Is_OCPO ) THEN
              State_Diag%AerMassPOA(I,J,L) = ( OCPI(I,J,L) + OCPO(I,J,L) ) * &
                                               kgm3_to_ugm3
           ENDIF
@@ -2158,12 +2159,13 @@ CONTAINS
        ! PDER [nm]
        !--------------------------------------
        IF ( State_Diag%Archive_PDER ) THEN
-          State_Diag%PDER(I,J,L) = PDER(I,J,L) 
+          State_Diag%PDER(I,J,L) = PDER(I,J,L)
        ENDIF
 
        !--------------------------------------
        ! Sum of all biogenic organic aerosol
        !--------------------------------------
+       ! ComplexSOA only
        IF ( State_Diag%Archive_TotalBiogenicOA ) THEN
           State_Diag%TotalBiogenicOA(I,J,L) = ( TSOA(I,J,L) + ISOAAQ(I,J,L) ) &
                                                 * kgm3_to_ugm3
@@ -2172,34 +2174,47 @@ CONTAINS
        !--------------------------------------
        ! Sum of all organic aerosol [ug/m3]
        !--------------------------------------
+       ! Now TotalOA also works for simpleSOA
        IF ( State_Diag%Archive_TotalOA ) THEN
-          State_Diag%TotalOA(I,J,L) = ( TSOA(I,J,L) + &
-                                        ASOA(I,J,L) + &
-                                        OCPO(I,J,L) + &
-                                        OCPI(I,J,L) + &
-                                        OPOA(I,J,L) + &
-                                        ISOAAQ(I,J,L) ) * kgm3_to_ugm3
+          State_Diag%TotalOA(I,J,L) = ( OCPO(I,J,L) + &
+                                        OCPISOA(I,J,L) ) * kgm3_to_ugm3
        ENDIF
 
        !--------------------------------------
        ! Sum of all organic carbon [ug/m3]
        !--------------------------------------
+       ! ComplexSOA only
+       ! since OM/OC ratio is not available for SOAS
+       ! consistent with aerosol_mod.F90
        IF ( State_Diag%Archive_TotalOC ) THEN
 
+         ! Hydrophobic OC
           IF ( Is_POA ) THEN
              State_Diag%TotalOC(I,J,L) = &
-                  ( ( TSOA(I,J,L) + ASOA(I,J,L) &
-                    + OCPI(I,J,L) + OPOA(I,J,L) ) / OCFOPOA(I,J) &
+                  ( ( TSOA(I,J,L) + ASOA(I,J,L) ) / OCFOPOA(I,J) &
                     + OCPO(I,J,L) / OCFPOA(I,J) ) * kgm3_to_ugm3
-
-          ELSE IF ( Is_OPOA ) THEN
+          ELSE IF ( Is_OCPO ) THEN
              State_Diag%TotalOC(I,J,L) = &
                   ( ( TSOA(I,J,L) + ASOA(I,J,L) &
-                    + OCPO(I,J,L) + OCPI(I,J,L) + OPOA(I,J,L) ) &
-                    / OCFOPOA(I,J) ) * kgm3_to_ugm3
+                    + OCPO(I,J,L) ) / OCFOPOA(I,J) ) * kgm3_to_ugm3
           ENDIF
 
-          IF ( Input_Opt%LSOA ) THEN
+          ! Hydrophilic OC
+          IF (Is_OCPI) THEN
+             State_Diag%TotalOC(I,J,L) = State_Diag%TotalOC(I,J,L) + &
+                                         ( OCPI(I,J,L) / OCFOPOA(I,J) * &
+                                         kgm3_to_ugm3 )
+          ENDIF
+
+          ! OPOA OC
+          IF (Is_OPOA) THEN
+            State_Diag%TotalOC(I,J,L) = State_Diag%TotalOC(I,J,L) + &
+                                        ( OPOA(I,J,L) / OCFOPOA(I,J) * &
+                                        kgm3_to_ugm3 )
+          ENDIF
+
+          ! Isoprene SOA OC
+          IF ( Is_ComplexSOA ) THEN
              State_Diag%TotalOC(I,J,L) =  State_Diag%TotalOC(I,J,L) + &
                   ( ( Spc(id_SOAIE )%Conc(I,J,L) * Fac_SOAIE  ) + &
                     ( Spc(id_INDIOL)%Conc(I,J,L) * Fac_INDIOL ) + &


### PR DESCRIPTION
### Name and Institution (Required)

Name: Yuanjian Zhang
Institution: WashU

### Describe the update

```console
SimpleSOA:           OCPISOA = OCPI*OCFOPOA + SOAS 
ComplexSOA_nonSVPOA: OCPISOA = OCPI*OCFOPOA + TSOA + ASOA + ISOAAQ
ComplexSOA_SVPOA:    OCPISOA = OPOA + TSOA + ASOA + ISOAAQ
```
- Simplify verbose calculations.
- Use OCPISOA+OCPO in dry effective radius calculation instead of summing up each species.
- Use OCPISOA+OCPO for TotalOA, enabling TotalOA diagnostic for SimpleSOA.
- Match TotalOC calculation consistent with aerosol_mod.F90.

### Expected changes

- Parameterized dry effective radius for SNA and OM will correctly handle SVPOA scenario (OCPI replaced by OPOA).
- ~This update should be no-diff-to-benchmark since SVPOA is not activated in benchmark simulation.~
- OCPISOA in benchmark(both simpleSOA and complexSOA are activated) will no longer double count ISOAAQ as was in PM2.5 before.
- TotalOC will no longer omit TSOA, ASOA, OCPI and OCPO in complexSOA_nonSVPOA (benchmark falls into this).

### Reference(s)

Tagging @Haihui-Zhu for confirmation about the PDER update.

### Related Github Issue
#2314
#2321 
