### PR TITLE
Chemistry for RCOOH, monoterpenes, new PNs and ANs from Travis et al. (2024)

### DIFF
--- a/KPP/fullchem/CHANGELOG_fullchem.md
+++ b/KPP/fullchem/CHANGELOG_fullchem.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Mechanism history
 
+### Added
+- Added new monoterpene mechanism, RCOOH oxidation, chemistry for new PNs (PHAN, AROMPN, MEKPN, APAN, LIMPAN, PINPAN) and aromatic AN (RNO3) per Travis et al., 2024
+
 ## [14.3.0] - 2024-02-07
 ### Added
 - Added PH2SO2 and PSO4AQ to track production of SO4 for use in TOMAS

--- a/KPP/fullchem/fullchem.eqn
+++ b/KPP/fullchem/fullchem.eqn
@@ -116,15 +116,23 @@ Comment format is
 #DEFVAR
 
 A3O2       = IGNORE; {CH3CH2CH2OO; Primary RO2 from C3H8}
+ACR        = IGNORE; {C3H4O, Acrolein}
+ACRO2      = IGNORE; {C3H5O4}
+ACO3       = IGNORE; {C3H3O3}
 ACET       = IGNORE; {CH3C(O)CH3; Acetone}
 ACTA       = IGNORE; {CH3C(O)OH; Acetic acid}
 AERI       = IGNORE; {I; Dissolved iodine}
 ALD2       = IGNORE; {CH3CHO; Acetaldehyde}
-ALK4       = IGNORE; {>= C4 alkanes}
+ALK4       = IGNORE; {C4+C5 alkanes}
+ALK7       = IGNORE; {>= C6 alkanes}
 AONITA     = IGNORE; {Aerosol-phase organic nitrate from aromatic precursors}
+APAN       = IGNORE; {C3H3NO5; Acryloyl peroxynitrate}
+AROMCHO    = IGNORE; {C5H6O4}
 AROMRO2    = IGNORE; {generic peroxy radical from aromatic oxidation}
 AROMP4     = IGNORE; {Generic C4 product from aromatic oxidation}
 AROMP5     = IGNORE; {Generic C5 product from aromatic oxidation}
+AROMPN     = IGNORE; {Lumped aromatic PN}
+AROMCO3    = IGNORE; {Lumped aromatic acyl peroxy radical}
 ATO2       = IGNORE; {CH3C(O)CH2O2; RO2 from acetone}
 ATOOH      = IGNORE; {CH3C(O)CH2OOH; ATO2 peroxide}
 B3O2       = IGNORE; {CH3CH(OO)CH3; Secondary RO2 from C3H8}
@@ -143,6 +151,8 @@ BRO2       = IGNORE; {C6H5O2 ; Peroxy radical from BENZ oxidation}
 BrSALA     = IGNORE; {Br; Fine sea salt bromine}
 BrSALC     = IGNORE; {Br; Course sea salt bromine}
 BUTDI      = IGNORE; {Butenedial}
+BUTN       = IGNORE; {BUTN; alkyl nitrate from C4H6}
+BUTO2      = IGNORE; {C4H7O3}
 BZCO3      = IGNORE; {benzoylperoxy radical}
 BZCO3H     = IGNORE; {perbenzoic acid}
 BZPAN      = IGNORE; {peroxybenzoyl nitrate}
@@ -150,6 +160,7 @@ C2H2       = IGNORE; {C2H2; Ethyne}
 C2H4       = IGNORE; {Ethylene}
 C2H6       = IGNORE; {C2H6; Ethane}
 C3H8       = IGNORE; {C3H8; Propane}
+C4H6       = IGNORE; {C4H6; 1,4 butadiene}
 C4HVP1     = IGNORE; {C4 hydroxy-vinyl-peroxy radicals from HPALDs}
 C4HVP2     = IGNORE; {C4 hydroxy-vinyl-peroxy radicals from HPALDs}
 CCl4       = IGNORE; {CCl4; Carbon tetrachloride}
@@ -184,6 +195,7 @@ CO         = IGNORE; {CO; Carbon monoxide}
 CO2        = IGNORE; {CO2; Carbon dioxide}
 CSL        = IGNORE; {cresols and xylols}
 DMS        = IGNORE; {(CH3)2S; Dimethylsulfide}
+EBZ        = IGNORE; {C6H5CH2CH3; Ethylbenzene}
 EOH        = IGNORE; {C2H5OH; Ethanol}
 ETHLN      = IGNORE; {CHOCH2ONO2; Ethanal nitrate}
 ETHN       = IGNORE; {stable hydroxy-nitrooxy-ethane}
@@ -194,6 +206,7 @@ ETOO       = IGNORE; {hydroxy-peroxy-ethane radical, formed from ethene + OH}
 ETO2       = IGNORE; {CH3CH2OO; Ethylperoxy radical}
 ETP        = IGNORE; {CH3CH2OOH; Ethylhydroperoxide}
 FURA       = IGNORE; {FURAN conglomerate}
+GCO3       = IGNORE; {HOCH2CO3: PHAN peroxyacetyl radical}
 GLYC       = IGNORE; {HOCH2CHO; Glycoaldehyde}
 GLYX       = IGNORE; {CHOCHO; Glyoxal}
 H          = IGNORE; {H; Atomic hydrogen}
@@ -203,6 +216,7 @@ H2402      = IGNORE; {C2Br2F4; H-2402}
 H2O        = IGNORE; {H2O; Water vapor}
 H2O2       = IGNORE; {H2O2; Hydrogen peroxide}
 HAC        = IGNORE; {HOCH2C(O)CH3; Hydroxyacetone}
+HACTA      = IGNORE; {HOCH2CO2H; hydroxyacetic acid}
 HBr        = IGNORE; {HBr; Hypobromic acid}
 HC5A       = IGNORE; {C5H8O2; Isoprene-4,1-hydroxyaldehyde}
 HCFC123    = IGNORE; {C2HCl2F3; HCFC-123, R-123, Freon 123}
@@ -291,6 +305,36 @@ LBRO2H     = IGNORE; {Dummy spc to track oxidation of BRO2 by HO2}
 LBRO2N     = IGNORE; {Dummy spc to track oxidation of BRO2 by NO}
 LIMO       = IGNORE; {C10H16; Limonene}
 LIMO2      = IGNORE; {RO2 from LIMO}
+APINP      = IGNORE;
+APINN      = IGNORE;
+PINAL      = IGNORE;
+PINPAN     = IGNORE;
+PINONIC    = IGNORE;
+PINO3H     = IGNORE;
+C96O2H     = IGNORE;
+C96N       = IGNORE;
+BPINO      = IGNORE;
+BPINN      = IGNORE;
+BPINP      = IGNORE;
+BPINOOH    = IGNORE;
+BPINON     = IGNORE;
+LIMAL      = IGNORE;
+LIMN       = IGNORE;
+LIMKET     = IGNORE;
+LIMKB      = IGNORE;
+LIMNB      = IGNORE;
+LIMPAN     = IGNORE;
+LIMO2H     = IGNORE;
+LIMO3H     = IGNORE;
+MYRCO      = IGNORE;
+PIN        = IGNORE;
+APINO2     = IGNORE;
+PINO3      = IGNORE;
+C96O2      = IGNORE;
+BPINO2     = IGNORE;
+BPINOO2    = IGNORE;
+LIMKO2     = IGNORE;
+LIMO3      = IGNORE;
 LISOPOH    = IGNORE; {Dummy spc to track oxidation of ISOP by OH}
 LISOPNO3   = IGNORE; {Dummy spc to track oxidation of ISOP by NO3}
 LNRO2H     = IGNORE; {Dummy spc to track oxidation of NRO2 by HO2}
@@ -314,7 +358,9 @@ MCRHNB     = IGNORE; {O2NOCH2C(OH)(CH3)CHO; Hydroxynitrate from MACR}
 MCRHP      = IGNORE; {HOCH2C(OOH)(CH3)CHO; Hydroxy-hydroperoxy-MACR}
 MCROHOO    = IGNORE; {peroxy radical from MACR + OH}
 MCT        = IGNORE; {methylcatechols}
+MEKCO3     = IGNORE; {MEK peroxyacetyl radical}
 MEK        = IGNORE; {RC(O)R; Methyl ethyl ketone}
+MEKPN      = IGNORE; {MEK peroxynitrate, C3PAN1 from MCM}
 MENO3      = IGNORE; {CH3ONO2; methyl nitrate}
 MGLY       = IGNORE; {CH3COCHO; Methylglyoxal}
 MO2        = IGNORE; {CH3O2; Methylperoxy radical}
@@ -361,6 +407,7 @@ OLND       = IGNORE; {Monoterpene-derived NO3-alkene adduct}
 OLNN       = IGNORE; {Monoterpene-derived NO3 adduct}
 OTHRO2     = IGNORE; {Other C2 RO2 not from C2H6 oxidation}
 PAN        = IGNORE; {CH3C(O)OONO2; Peroxyacetylnitrate}
+PHAN       = IGNORE; {OCC(=O)OON(=O)=O; peroxyhydroxyacetic nitric anhydride}
 PHEN       = IGNORE; {phenol}
 PIO2       = IGNORE; {RO2 from MTPA}
 PIP        = IGNORE; {Peroxides from MTPA}
@@ -376,14 +423,20 @@ R4N1       = IGNORE; {RO2 from R4N2}
 R4N2       = IGNORE; {RO2NO; >= C4 alkylnitrates}
 R4O2       = IGNORE; {RO2 from ALK4}
 R4P        = IGNORE; {CH3CH2CH2CH2OOH; Peroxide from R4O2}
+R7O2       = IGNORE; {RO2 from ALK7}
+R7N1       = IGNORE; {RO2 from R7N2}
+R7P        = IGNORE; {Peroxide from R7O2}
+R7N2       = IGNORE; {RO2NO; >= C6 alkylnitrates}
 RA3P       = IGNORE; {CH3CH2CH2OOH; Peroxide from A3O2}
 RB3P       = IGNORE; {CH3CH(OOH)CH3; Peroxide from B3O2}
 RCHO       = IGNORE; {CH3CH2CHO; >= C3 aldehydes}
 RCO3       = IGNORE; {CH3CH2C(O)OO; Peroxypropionyl radical}
+RCOOH      = IGNORE; {C2H5C(O)OH; > C2 organic acids}
 RIPA       = IGNORE; {HOCH2C(OOH)(CH3)CH=CH2; 1,2-ISOPOOH}
 RIPB       = IGNORE; {HOCH2C(OOH)(CH3)CH=CH2; 4,3-ISOPOOH}
 RIPC       = IGNORE; {C5H10O3; d(1,4)-ISOPOOH}
 RIPD       = IGNORE; {C5H10O3; d(4,1)-ISOPOOH}
+RNO3       = IGNORE; {C7H9NO6; lumped aromatic alkyl nitrate}
 ROH        = IGNORE; {C3H7OH; > C2 alcohols}
 RP         = IGNORE; {CH3CH2C(O)OOH; Peroxide from RCO3}
 SALAAL     = IGNORE; {Accumulation mode seasalt aerosol alkalinity}
@@ -399,19 +452,22 @@ SO4        = IGNORE; {SO4; Sulfate}
 SO4s       = IGNORE; {SO4 on sea-salt; Sulfate}
 SOAGX      = IGNORE; {CHOCHO; Aerosol-phase glyoxal}
 SOAIE      = IGNORE; {C5H10O3; Aerosol-phase IEPOX}
+STYR       = IGNORE; {C6H5CHCH2; Styrene}
+TLFUONE    = IGNORE; {C5H6O2; lumped furanones}
+TLFUO2     = IGNORE; {C5H7O5; RO2 from TLFUONE}
+TMB        = IGNORE; {C6H3(CH3)3; Trimethylbenzenes}
 TOLU       = IGNORE; {C7H8; Toluene}
 TRO2       = IGNORE; {Peroxy radical from TOLU oxidation}
 XYLE       = IGNORE; {C8H10; Xylene}
 XRO2       = IGNORE; {Peroxy radical from XYLE oxidation}
 PH2SO4     = IGNORE; {SO4 from gas-phase chemistry}
 PSO4AQ     = IGNORE; {SO4 from cloud chemistry}
-
+ZRO2       = IGNORE; {Lumped RO2 from aromatics}
 #DEFFIX
 
 H2         = IGNORE; {H2; Molecular hydrogen}
 N2         = IGNORE; {N2; Molecular nitrogen}
 O2         = IGNORE; {O2; Molecular oxygen}
-RCOOH      = IGNORE; {C2H5C(O)OH; > C2 organic acids}
 
 #EQUATIONS
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -428,9 +484,9 @@ HNO3 + SALCAL       = NITs               : K_MT(6);
 //
 // Cloud
 // S(IV) --> S(VI)
-SO2 + H2O2          = SO4 + PSO4AQ       : K_CLD(1);
-SO2 + O3            = SO4 + PSO4AQ       : K_CLD(2) + SRO3; {Jan 2023; Added SRO3 here; BA}
-SO2 {+O2}           = SO4 + PSO4AQ       : K_CLD(3);        {Mn & Fe catalysis + HET_DROP_CHEM()}
+SO2 + H2O2          = SO4                : K_CLD(1);
+SO2 + O3            = SO4                : K_CLD(2);
+SO2 {+O2}           = SO4                : K_CLD(3);  {Mn & Fe catalysis + HET_DROP_CHEM()}
 //
 // HMS
 CH2O + SO2          = HMS                : K_CLD(4);        {Sep 2021; Moch2020; MSL}
@@ -519,6 +575,50 @@ C3H8 + OH = A3O2 :                           GCARR_abc(1.97d-12,1.23d0,-675.0d0)
 A3O2 + NO = NO2 + HO2 + RCHO :               GC_RO2NO_B2_aca(2.90d-12, 350.0d0, 3.0d0);                                        {2019/05/10; Fisher2018; JAF}
 A3O2 + NO = NPRNO3 :                         GC_RO2NO_A2_aca(2.90d-12, 350.0d0, 3.0d0);                                        {2019/05/10; Fisher2018; JAF}
 PO2 + NO = NO2 + HO2 + CH2O + ALD2 :         GCARR_ac(2.70d-12, 350.0d0);
+// --- ALK7 chemistry from Lurman et al., 1986
+ALK7 + OH = R7O2 :                           GCARR_ac(2.00d-11, -359.0d0);
+ALK7 + NO3 = HNO3 + R7O2 :                   6.0d-17;
+R7O2 + NO = NO2 + 0.750RCHO + 0.250R4O2 + 
+ 0.250MEK + 0.750HO2 :                       GC_RO2NO_B2_aca(2.70d-12, 350.0d0, 7.0d0);     
+R7O2 + NO = R7N2 :                           GC_RO2NO_A2_aca(2.70d-12, 350.0d0, 7.0d0);
+//R4O2 + MCO3 = MO2 + 0.320ACET + 0.190MEK +
+// 0.270HO2 + 0.320ALD2 + 0.130RCHO +
+//0.050A3O2 + 0.180B3O2 + 0.320OTHRO2 :       GCARR_ac(1.68d-12, 500.0d0);                  {}
+//R4O2 + MCO3 = MEK + ACTA :                   GCARR_ac(1.87d-13, 500.0d0);
+R7O2 + HO2 = R7P :                           3.0d-12;
+R7P + OH = 0.500OH + 0.500R7O2 + 0.500RCHO : 1.00d-11;                                     {}
+R7N2 + OH = R7N1 + H2O :                     4.00d-12;
+R7N1 + NO = 2.000NO2 + 0.980CH2O +
+ 0.650ALD2 + 1.240RCHO :                     GCARR_ac(4.20d-12, 180.0d0);                  {}
+R7N1 + HO2 = R7N2 :                          GCARR_ac(7.40d-13, 700.0d0);
+//R4N1 + MO2 = NO2 + 0.200CH2O + 0.380ALD2 +
+// 0.290RCHO + 0.150R4O2 + 0.250RCHO +
+// 0.750CH2O + 0.250MOH + 0.250ROH +
+// 0.500HO2 :                                  8.37d-14;
+//R4N1 + MCO3 = MO2 + NO2 + 0.390CH2O +
+// 0.750ALD2 + 0.570RCHO + 0.300R4O2 :         GCARR_ac(1.68d-12, 500.0d0);
+//R4N1 + MCO3 = RCHO + ACTA + NO2 :            GCARR_ac(1.87d-13, 500.0d0);
+// ----- C4H6 --> APAN --- currently no RO2 RO2
+C4H6 + OH = BUTO2 :                          GCARR_ac(1.48d-11, 448.0d0);
+C4H6 + NO3 = ACR + CH2O + NO2 :              1.03d-13;
+C4H6 + O3 = ACR + CH2O :                     GCARR_ac(1.34d-14,-2283.0d0);
+BUTO2 + NO = 0.058BUTN + 0.730ACR +
+ 0.603CH2O + 0.513HO2 + 0.942NO2 +
+ 0.326RCHO :                                 GCARR_ac(2.70d-12, 360.0d0); { krt, MCM}
+BUTO2 + HO2 = 0.659GLYC + 0.894RCHO :        GCARR_ac(1.82d-13,1300d0); {MCM}
+BUTN + OH = GLYC + NO2 + CH2O + HO2 +
+ CO :                                        3.59d-11; {krt, MCM}
+ACR + OH = 0.680ACO3 + 0.255ACRO2 +
+ 0.065CH2O + 0.065GLYX + 0.425HO2  :         2.00d-11; {krt, MCM} 
+ACRO2 + NO = GLYC + NO2 + HO2 + CO :         GCARR_ac(2.70d-12,360.0d0) ;{krt, MCM}
+ACRO2 + HO2 = GLYC + HO2 + CO :              GCARR_ac(1.51d-13,1300.0d0) ;{krt, MCM}
+ACO3 + HO2 = CO + CH2O + 0.500GLYC +
+ 0.250HO2 + 0.250OH :                        GCARR_ac(5.2d-13, 980.0d0) ; {krt, MCM}
+ACO3 + NO = HO2 + CO + CH2O + NO2 :          GCARR_ac(7.5d-12, 290.0d0) ; {krt, MCM}
+ACO3 + NO2 {+M} = APAN :                     GCJPLPR_abab(9.70d-29, 5.6d+00, 9.3d-12, 1.5d0, 0.6d0);
+APAN = ACO3 + NO2 :                          GCJPLEQ_acabab(9.30d-29, 14000.0d0, 9.7d-29, 5.6d0, 9.3d-12, 1.5d0, 0.6d0);
+APAN + OH = GLYC + CO + NO3 :                1.47d-11 ; {krt, MCM}
+//
 ALK4 + OH = R4O2 :                           GCARR_ac(9.10d-12, -405.0d0);
 R4O2 + NO = NO2 + 0.340ACET + 0.190MEK +
  0.190MO2 + 0.270HO2 + 0.340ALD2 +
@@ -556,7 +656,19 @@ KO2 + HO2 = 0.150OH + 0.150ALD2 +
  0.150MCO3 + 0.850ATOOH + 0.850MO2 :         GC_RO2HO2_aca(2.91d-13, 1300.0d0, 4.0d0);                                         {2013/03/22; Paulot2009; FP,EAM,JMAO,MJE; 2023/04/18; Bates2023; KHB}
 B3O2 + HO2 = RB3P :                          GC_RO2HO2_aca(2.91d-13, 1300.0d0, 3.0d0);                                         {2013/03/22; Paulot2009; FP,EAM,JMAO,MJE}
 PRN1 + HO2 = PRPN :                          GC_RO2HO2_aca(2.91d-13, 1300.0d0, 3.0d0);                                         {2013/03/22; Paulot2009; FP,EAM,JMAO,MJE}
-MEK + OH = KO2 + H2O :                       GCARR_ac(1.50d-12, -90.0d0);                                                      {2023/04/18; Atkinson2006; KHB}
+// -------- MEKPN -------------------
+MEK + OH = KO2 + H2O :                       GCARR_ac(1.50d-12, -90.0d0); {2023/04/18; Atkinson2006; KHB}
+KO2 + NO = 0.930NO2 + 0.620ALD2 +
+ 0.620MCO3 + 0.070R4N2 +
+ 0.310MEKCO3 + 0.310CH2O :                   GCARR_ac(2.70d-12, 350.0d0);
+MEKCO3 + NO2 {+M} = MEKPN :                  GCJPLPR_abab(9.70d-29, 5.6d+00, 9.3d-12, 1.5d0, 0.6d0);                           {JPL Eval 17}
+MEKPN = MEKCO3 + NO2 :                       GCJPLEQ_acabab(9.30d-29, 14000.0d0, 9.7d-29, 5.6d0, 9.3d-12, 1.5d0, 0.6d0);
+MEKPN + OH = GLYC + CO + NO2 :               4.51E-12;
+MEKCO3 + NO = NO2 + ETOO + CO2  :            GCARR_ac(7.50d-12, 290.0d0);
+MEKCO3 + HO2 = 0.150O3 + 0.150RCOOH +
+ 0.440CO2 + 0.440OH + 0.440ETOO +
+ 0.410RP :                                   GCARR_ac(5.20d-13, 980.0d0);
+//
 MO2 + ETO2 = 0.750CH2O + 0.750ALD2 + HO2 +
  0.250MOH + 0.250EOH :                       3.00d-13;
 MO2 + OTHRO2 = 0.750CH2O + 0.750ALD2 +
@@ -603,6 +715,19 @@ GLYC + OH = 0.732CH2O + 0.361CO2 +
  0.505CO + 0.227OH + 0.773HO2 +
  0.134GLYX + 0.134HCOOH :                    GC_GLYCOH_A_a(8.00d-12);                                                          {2013/03/22; Paulot2009; FP,EAM,JMAO,MJE}
 GLYC + OH = HCOOH + OH + CO :                GC_GLYCOH_B_a(8.00d-12);                                                          {2013/03/22; Paulot2009; FP,EAM,JMAO,MJE}
+// --- GLYC chemistry --> PHAN - currenty no RO2 RO2
+GLYC + OH = 0.200GLYX + 0.200HO2 +
+ 0.800GCO3 :                                 1.0d-11;                                                                          {krt, MCM}
+GLYC + NO3 = GCO3 + HNO3 :                   GCARR_ac(1.44d-12,-1862.0d0);                                                     {krt, MCM}
+GCO3 + NO2 {+M} = PHAN :                     GCJPLPR_abab(9.70d-29, 5.6d+00, 9.3d-12, 1.5d0, 0.6d0);                           {JPL Eval 17}
+PHAN = GCO3 + NO2 :                          GCJPLEQ_acabab(9.30d-29, 14000.0d0, 9.7d-29, 5.6d0, 9.3d-12, 1.5d0, 0.6d0);
+GCO3 + NO = NO2 + HO2 + CH2O :               GCARR_ac(7.5d-12,290d0);                              {krt, MCM}
+GCO3 + HO2 = 0.440HO2 + 0.440CH2O +
+ 0.440OH + 0.560HACTA + 0.150O3 + 0.440CO2 : GCARR_ac(5.2d-13,980d0);               {krt,MCM}
+GCO3 + NO3 = CH2O + HO2 + NO2 :              4.0d-12;
+PHAN + OH = CH2O + CO + NO2 :                1.12d-12;    {krt, MCM}
+HACTA + OH = CH2O + HO2 :                    2.73d-12;    {krt, MCM}
+//
 PRPE + NO3 = PRN1 :                          GCARR_ac(4.59d-13, -1156.0d0);
 GLYX + OH = HO2 + 2.000CO :                  GCARR_ac(3.10d-12, 340.0d0);                                                      {2013/03/22; Paulot2009; FP,EAM,JMAO,MJE}
 MGLY + OH = MCO3 + CO :                      GCARR_ac(1.90d-12, 575.0d0);                                                      {2023/04/18; Atkinson2006; KHB}
@@ -864,46 +989,126 @@ CH3CHOO + NO2 = ALD2 + NO3 :                 4.25d-12;                          
 CH3CHOO + SO2 = ALD2 + SO4 + PH2SO4 :        2.65d-11;                                                                         {2015/09/25; Millet2015; DBM,EAM; 2023/04/18; JPL 19-5; KHB}
 CH3CHOO + H2O = ALD2 + H2O2 :                6.00d-18;                                                                         {2015/09/25; Millet2015; DBM,EAM}
 CH3CHOO + H2O = ACTA :                       1.00d-17;                                                                         {2015/09/25; Millet2015; DBM,EAM}
-MTPA + OH = PIO2 :                           GCARR_ac(1.21d-11, 440.0d0);                                                      {2017/03/23; IUPAC2010; EVF}
-MTPO + OH = PIO2 :                           GCARR_ac(1.21d-11, 440.0d0);                                                      {2017/03/23; IUPAC2010; EVF}
-PIO2 + NO = 0.820HO2 + 0.820NO2 +
- 0.230CH2O + 0.430RCHO + 0.110ACET +
- 0.440MEK + 0.070HCOOH + 0.120MONITS +
- 0.060MONITU :                               4.00d-12;                                                                         {2017/07/14; Browne2014; KRT,JAF,CCM,EAM,KHB,RHS}
-PIO2 + HO2 = PIP :                           1.50d-11;                                                                         {2017/03/23; Roberts1992; EVF}
-PIO2 + MO2 = HO2 + 0.750CH2O + 0.250MOH +
- 0.250ROH + 0.750RCHO + 0.750MEK :           GCARR_ac(3.56d-14, 708.0d0);                                                      {2017/07/14; Roberts1992; KRT,JAF,CCM,EAM,KHB,RHS}
-PIO2 + MCO3 = 0.500HO2 + 0.500MO2 + CO2 +
- RCHO + 1.125MEK + RCOOH :                   GCARR_ac(7.40d-13, 765.0d0);                                                      {2017/03/23; Roberts1992; EVF; 2022/07/01; 2023/04/18; Bates2023; KHB}
-PIO2 + NO3 = HO2 + NO2 + RCHO + MEK :        1.20d-12;                                                                         {2017/03/23; Roberts1992; EVF}
-MTPA + O3 = 0.850OH + 0.100HO2 +
- 0.620KO2 + 0.140CO + 0.020H2O2 +
- 0.650RCHO + 0.530MEK :                      GCARR_ac(5.00d-16, -530.0d0);                                                     {2017/07/14; Atkinson2003; KRT,JAF,CCM,EAM,KHB,RHS}
-MTPO + O3 = 0.850OH + 0.100HO2 +
- 0.620KO2 + 0.140CO + 0.020H2O2 +
- 0.650RCHO + 0.530MEK :                      GCARR_ac(5.00d-16, -530.0d0);                                                     {2017/07/14; Atkinson2003; KRT,JAF,CCM,EAM,KHB,RHS}
+// Updated Monoterpene chemistry
 MTPA + NO3 = 0.100OLNN + 0.900OLND :         GCARR_ac(8.33d-13, 490.0d0);                                                      {2017/07/14; Fisher2016; KRT,JAF,CCM,EAM,KHB,RHS}
 MTPO + NO3 = 0.100OLNN + 0.900OLND :         GCARR_ac(8.33d-13, 490.0d0);                                                      {2017/07/14; Fisher2016; KRT,JAF,CCM,EAM,KHB,RHS}
-LIMO + OH = LIMO2 :                          GCARR_ac(4.20d-11, 401.0d0);                                                      {2017/07/14; Gill2002; KRT,JAF,CCM,EAM,KHB,RHS}
-LIMO + O3 = 0.850OH + 0.100HO2 +
- 0.160OTHRO2 + 0.420KO2 + 0.020H2O2 +
- 0.140CO + 0.460PRPE + 0.040CH2O +
- 0.790MACR + 0.010HCOOH + 0.070RCOOH :       GCARR_ac(2.95d-15, -783.0d0);                                                     {2017/07/14; Atkinson2003; KRT,JAF,CCM,EAM,KHB,RHS}
 LIMO + NO3 = 0.500OLNN + 0.500OLND :         1.22d-11;                                                                         {2017/07/14; Fry2014,Atkinson2003; KRT,JAF,CCM,EAM,KHB,RHS}
-LIMO2 + NO = 0.686HO2 + 0.780NO2 +
- 0.220MONITU + 0.289PRPE + 0.231CH2O +
- 0.491RCHO + 0.058HAC + 0.289MEK :           4.00d-12;                                                                         {2017/07/14; Browne2014,Roberts1992; KRT,JAF,CCM,EAM,KHB,RHS}
-LIMO2 + HO2 = PIP :                          1.50d-11;                                                                         {2017/07/14; Roberts1992; KRT,JAF,CCM,EAM,KHB,RHS}
-LIMO2 + MO2 = HO2 + 0.192PRPE +
- 1.040CH2O + 0.308MACR + 0.250MOH +
- 0.250ROH :                                  GCARR_ac(3.56d-14, 708.0d0);                                                      {2017/07/14; Roberts1992; KRT,JAF,CCM,EAM,KHB,RHS}
-LIMO2 + MCO3 = 0.500HO2 + 0.500MO2 +
- 0.192PRPE + 0.385CH2O + 0.308MACR +
- 0.500RCOOH :                                GCARR_ac(7.40d-13, 765.0d0);                                                      {2017/07/14; Roberts1992; KRT,JAF,CCM,EAM,KHB,RHS}
-LIMO2 + NO3 = HO2 + NO2 + 0.385PRPE +
- 0.385CH2O + 0.615MACR :                     1.20d-12;                                                                         {2017/07/14; Roberts1992; KRT,JAF,CCM,EAM,KHB,RHS}
-PIP + OH = 0.490OH + 0.440R4O2 +
- 0.080RCHO + 0.410MEK :                      GCARR_ac(3.40d-12, 190.0d0);                                                      {2017/07/14; Goliff2013; KRT,JAF,CCM,EAM,KHB,RHS}
+LIMO + OH = LIMO2 :                          GCARR_ac(4.20d-11, 401.0d0);
+LIMO + O3 = 0.865OH + 0.15CO + 0.15AROMRO2 +
+ 0.27LIMAL + 0.715LIMO3 :                    GCARR_ac(2.95d-15, -783.0d0);
+MTPO + OH = 0.15APINO2 + 0.15BPINO2 +
+ 0.2LIMO2 + 0.5PIO2 :                        GCARR_ac(1.21d-11, 440.0d0); 
+MTPO + O3 = 0.5ACET + 0.8OH + 0.1CH2O +
+ 0.5MEK + 0.15MVK + 0.4MYRCO + 0.5AROMRO2 +
+ 0.05HO2 + 0.3KO2 + 0.3RCHO :                GCARR_ac(2.7d-15, -520.0d0); 
+MTPA + OH = 0.075LIMO2 + 0.67APINO2 +
+ 0.255BPINO2 :                               GCARR_ac(1.34d-11, 410.0d0);
+MTPA + O3 = 0.65OH + 0.5APINO2 +
+ 0.1BPINOO2 + 0.2BPINO + 0.2PINAL +
+ 0.1CH2OO + 0.1CO + 0.1CH2O :                GCARR_ac(8.22d-16, -640.0d0);
+APINO2 + HO2 = APINP :                       GCARR_ac(2.66d-13, 1300.0d0);
+APINO2 + NO = 0.25APINN + 0.75PINAL +
+ 0.75NO2 + 0.75HO2 :                         GCARR_ac(2.7d-12, 360.0d0);
+APINO2 + NO3 = PINAL + NO2 + HO2 :           2.3d-12 ;
+APINP + OH = 0.4PINO3 + 0.6APINO2 :          1.83d-11 ;
+APINN + OH = 0.5PINAL + 0.5NO2 + 0.5HO2 +
+ 0.5C96N + 0.5CH2O + 0.5AROMRO2 :            5.50d-12 ;
+PINAL + NO3 = HNO3 + PINO3 :                 2.0d-14 ;
+PINAL + OH = PINO3 :                         GCARR_ac(5.2d-12, 600.0d0);
+PINO3 + HO2 = 0.44OH + 0.15O3 + 0.44C96O2 +
+ 0.41PINO3H + 0.15PINONIC :                  GCARR_ac(2.66d-13, 1300.0d0);
+PINO3 + NO = NO2 + CO2 + C96O2 :             GCARR_ac(2.7d-12, 360.0d0);
+PINO3 + NO2 = PINPAN :                       GCJPLPR_abab(9.70d-29, 5.6d+00, 9.3d-12, 1.5d0, 0.6d0);
+PINPAN = PINO3 + NO2 :                       GCJPLEQ_acabab(9.30d-29, 14000.0d0, 9.7d-29, 5.6d0, 9.3d-12, 1.5d0, 0.6d0);
+PINO3 + NO3 = NO2 + CO2 + C96O2 :            2.3d-12 ;
+PINO3H + OH = PINO3 :                        9.73d-12 ;
+PINONIC + OH = CO2 + C96O2 :                 6.65d-12 ;
+C96O2 + HO2 = C96O2H :                       GCARR_ac(2.66d-13, 1300.0d0);
+C96O2 + NO = 0.16C96N + 0.84NO2 +
+ 0.84AROMRO2 + 0.84ACET + 0.84CH2O +
+ 0.84RCO3 + 0.42MEK :                        GCARR_ac(2.7d-12, 360.0d0);
+C96O2 + NO3 = NO2 + AROMRO2 + ACET + CH2O +
+ RCO3 + 0.5MEK :                             2.3d-12 ;
+C96O2 + MO2 = HO2 + 0.75CH2O + 0.25MOH +
+ 0.25C96O2H + 0.75AROMRO2 + 0.75ACET +
+ 0.75CH2O + 0.75RCO3 + 0.375MEK :            GCARR_ac(3.75d-13, 500.0d0);
+C96O2H + OH = 0.5C96O2 + 0.5AROMRO2 +
+ 0.5ACET + 0.5CH2O + 0.5RCO3 + 0.25MEK :     2.6d-11 ;
+C96N + OH = 0.5NO2 + 0.5MONITS +
+ 0.55AROMRO2 + 0.4ACET + 0.4CH2O + 0.4RCO3 +
+ 0.3MEK :                                    2.88d-12 ;
+BPINO2 + HO2 = BPINP :                       GCARR_ac(2.66d-13, 1300.0d0);
+BPINO2 + NO = 0.25BPINN + 0.75CH2O +
+ 0.75NO2 + 0.75HO2 + 0.75BPINO :             GCARR_ac(2.7d-12, 360.0d0);
+BPINO2 + NO3 = CH2O + NO2 + HO2 + BPINO :    2.3d-12 ;
+BPINN + OH = 0.5BPINON + 0.5AROMRO2 + CH2O +
+ 0.5NO2 + 0.5HO2 + 0.5BPINO :                4.7d-12 ;
+BPINP + OH = BPINO2 :                        1.33d-11 ;
+BPINO + OH = BPINOO2 :                       1.55d-11 ;
+BPINOO2 + HO2 = BPINOOH :                    GCARR_ac(2.66d-13, 1300.0d0);
+BPINOO2 + NO = BPINON :                      GCARR_ac(4.32d-13, 360.0d0);
+BPINOO2 + NO = NO2 + HO2 + 0.27LIMO3 +
+ 0.6ACET + 0.6RCHO + 0.6R4O2 :               GCARR_ac(2.27d-12, 360.0d0);
+BPINOO2 + MO2 = HO2 + 0.23LIMO3 + 0.4ACET +
+ 0.4RCHO + 0.4R4O2 + 0.75CH2O + 0.25MOH +
+ 0.25BPINOOH :                               GCARR_ac(3.75d-13, 500.0d0);
+BPINOO2 + NO3 = NO2 + HO2 + 0.27LIMO3 +
+ 0.6ACET + 0.6RCHO + 0.6R4O2 :               2.3d-12 ;
+BPINOOH + OH = BPINOO2 :                     8.59d-11 ;
+BPINON + OH = 0.5MONITS + 0.5NO2 +
+ 0.085LIMO3 + 0.3ACET + 0.3RCHO + 0.3R4O2 :  3.24d-12 ;
+LIMO2 + HO2 = 0.37LIMKET + 0.63LIMAL : GCARR_ac(2.66d-13, 1300.0d0);
+LIMO2 + NO = 0.25LIMN + 0.75NO2 + 0.75HO2 + 0.28LIMKET + 0.47LIMAL : GCARR_ac(2.7d-12, 360.0d0);
+LIMO2 + NO3 = NO2 + HO2 + 0.37LIMKET + 0.63LIMAL : 2.3d-12 ;
+LIMAL + OH = LIMO3 : 1.1d-10 ;
+LIMAL + O3 = 0.3LIMKB + 0.33CH2OO + 0.67CH2O + 0.6LIMO3 + 0.6OH : 8.3d-18 ;
+LIMAL + NO3 = AROMRO2 + LIMNB : 2.6d-13 ;
+LIMKET + OH = LIMKO2 : 9.97d-11 ; 
+LIMKET + O3 = 0.27LIMKO2 + 0.865OH + 0.73LIMO3 : 1.5d-16 ; 
+LIMKET + NO3 = LIMNB + AROMRO2 : 9.4d-12 ; 
+LIMN + OH = 0.5LIMNB + 0.32LIMO3 + 0.18LIMKO2 + 0.5NO2 : 1.1d-10 ;
+LIMN + O3 = CH2O + 0.5NO2 + 0.4LIMO3 + 0.5LIMNB : 8.3d-18 ;
+LIMN + NO3 = NO2 + LIMNB + AROMRO2 : 2.6d-13 ;
+LIMKO2 + NO = 0.16LIMNB + 0.84NO2 + 0.84LIMKB + 0.84HO2 : GCARR_ac(2.7d-12, 360.0d0);
+LIMKO2 + HO2 = LIMO3H : GCARR_ac(2.66d-13, 1300.0d0);
+LIMKO2 + NO3 = NO2 + LIMKB + HO2 : 2.3d-12 ;
+LIMKO2 + MO2 = 0.75LIMKB + 0.25LIMO3H + 0.75CH2O + 0.25MOH + HO2 : GCARR_ac(3.75d-13, 500.0d0);
+LIMKB + OH = LIMO3 : 3.6d-11 ; 
+LIMKB + NO3 = NO2 + LIMO3 : GCARR_ac(1.22d-11, -1862.0d0);
+LIMNB + OH = 0.5MONITS + 0.5NO2 + 0.5LIMO3 : 6.3d-12 ; 
+LIMO3 + HO2 = 0.44OH + 0.15O3 + 0.44CO2 + 0.44MCO3 + 0.44RCHO + 0.176CH2O + 0.352R4O2 + 0.41LIMO3H + 0.15LIMO2H : GCARR_ac(2.66d-13, 1300.0d0);
+LIMO3 + NO = NO2 + CO2 + MCO3 + RCHO + 0.4CH2O + 0.8R4O2 : GCARR_ac(2.7d-12, 360.0d0);
+LIMO3 + NO2 = LIMPAN : GCJPLPR_abab(9.70d-29, 5.6d+00, 9.3d-12, 1.5d0, 0.6d0);
+LIMPAN = LIMO3 + NO2 : GCJPLEQ_acabab(9.30d-29, 14000.0d0, 9.7d-29, 5.6d0, 9.3d-12, 1.5d0, 0.6d0);
+LIMO3 + NO3 = NO2 + CO2 + MCO3 + RCHO + 0.4CH2O + 0.8R4O2 : 2.3d-12 ;
+LIMO3H + OH = LIMO3 : 9.73d-12 ;
+LIMO2H + OH = CO2 + MCO3 + RCHO + 0.4CH2O + 0.8R4O2 : 6.65d-12 ;
+PIO2 + HO2 = PIP : GCARR_ac(2.66d-13, 1300.0d0);
+PIO2 + NO = PIN : GCARR_ac(6.75d-13, 360.0d0);
+PIO2 + NO = NO2 + HO2 + 0.45MVK + 0.45ACET + 0.1CH2O + 0.675MYRCO : GCARR_ac(2.03d-12, 360.0d0);
+PIO2 + NO3 = NO2 + HO2 + 0.45MVK + 0.45ACET + 0.1CH2O + 0.675MYRCO : 2.3d-12 ;
+PIP + OH = 0.3OH + 0.7AROMRO2 + 0.3MVK + 0.3ACET + 0.1CH2O + 0.78MYRCO : GCARR_ac(6.05d-12, 440.0d0); 
+PIP + O3 = 0.3OH + 0.7AROMRO2 + 0.3MVK + 0.3ACET + 0.1CH2O + 0.78MYRCO : GCARR_ac(1.35d-15, -520.0d0); 
+PIP + NO3 = 0.5OLNN + 0.5NO2 + 0.15OH + 0.35AROMRO2 + 0.15MVK + 0.15ACET + 0.05CH2O + 0.39MYRCO : GCARR_ac(1.06d-12, 490.0d0); 
+PIN + OH = 0.7AROMRO2 + 0.7MONITU + 0.3NO2 + 0.3MYRCO : GCARR_ac(6.05d-12, 440.0d0); 
+PIN + O3 = 0.7AROMRO2 + 0.7MONITU + 0.3NO2 + 0.3MYRCO : GCARR_ac(1.35d-15, -520.0d0); 
+PIN + NO3 = 0.5OLNN + 1.15NO2 + 0.35AROMRO2 + 0.35MONITU + 0.15MYRCO : GCARR_ac(1.06d-12, 490.0d0); 
+MYRCO + OH = HO2 + AROMRO2 + 1.5CH2O + MEK + 0.5ACET + 0.5MVK + 0.5GLYC : GCARR_ac(6.05d-12, 440.0d0); 
+MYRCO + O3 = OH + AROMRO2 + 1.5CH2O + MEK + 0.5ACET + 0.5MVK + 0.5GLYC : GCARR_ac(1.35d-15, -520.0d0); 
+MYRCO + NO3 = 0.5OLNN + 0.5NO2 + 0.5HO2 + 0.5AROMRO2 + 0.75CH2O + 0.5MEK + 0.25ACET + 0.25MVK + 0.25GLYC: GCARR_ac(1.06d-12, 490.0d0); 
+APINO2 + MO2 = PINAL + 1.75HO2 + 0.25MOH + 0.75CH2O : GCARR_ac(3.75d-13, 500.0d0);
+APINO2 + MCO3 = PINAL + HO2 + 0.1ACTA + 0.9CO2 + 0.9MO2 : GCARR_ac(1.87d-12, 500.0d0);
+BPINO2 + MO2 = 1.75HO2 + 0.25MOH + 1.75CH2O + BPINO : GCARR_ac(3.75d-13, 500.0d0);
+BPINO2 + MCO3 = BPINO + CH2O + HO2 + 0.1ACTA + 0.9CO2 + 0.9MO2 : GCARR_ac(1.87d-12, 500.0d0);
+LIMO2 + MO2 = 0.37LIMKET + 0.63LIMAL + 1.75HO2 + 0.25MOH + 0.75CH2O : GCARR_ac(3.75d-13, 500.0d0);
+LIMO2 + MCO3 = 0.37LIMKET + 0.63LIMAL + HO2 + 0.1ACTA + 0.9CO2 + 0.9MO2 : GCARR_ac(1.87d-12, 500.0d0);
+PIO2 + MO2 = 0.45MVK + 0.45ACET + 0.675MYRCO + 1.75HO2 + 0.25MOH + 0.85CH2O : GCARR_ac(3.75d-13, 500.0d0);
+PIO2 + MCO3 = 0.45MVK + 0.45ACET + 0.1CH2O + 0.675MYRCO + HO2 + 0.1ACTA + 0.9CO2 + 0.9MO2 : GCARR_ac(1.87d-12, 500.0d0);
+PINO3 + MO2 = CH2O + 0.75HO2 + 0.25PINONIC + 0.75C96O2  + 0.75CO2 : GCARR_ac(1.87d-12, 500.0d0);
+PINO3 + MCO3 = C96O2 + 2CO2 + MO2 : GCARR_ac(3.75d-14, 500.0d0);
+LIMO3 + MO2 = 0.75HO2 + CH2O + 0.75CO2 + 0.75MCO3 + 0.75RCHO + 0.3CH2O + 0.6R4O2 + 0.25LIMO2H : GCARR_ac(1.87d-12, 500.0d0);
+LIMO3 + MCO3 = CO2 + MO2 + MCO3 + RCHO + 0.4CH2O + 0.8R4O2 : GCARR_ac(3.75d-14, 500.0d0);
+//
 OLNN + NO = HO2 + NO2 + MONITS :             4.00d-12;                                                                         {2017/07/14; Browne2014,Goliff2013; KRT,JAF,CCM,EAM,KHB,RHS}
 OLND + NO = 2.000NO2 + 0.287CH2O +
  1.240RCHO + 0.464MEK :                      4.00d-12;                                                                         {2017/07/14; Goliff2013; KRT,JAF,CCM,EAM,KHB,RHS}
@@ -1314,6 +1519,34 @@ NAP + OH = NRO2 + OH :                       GCARR_ac(1.56d-11, 117.0d0);       
 NRO2 + HO2 = LNRO2H + HO2 :                  GCARR_ac(1.40d-12, 700.0d0);                                                      {2013/08/12; Pye2010; HOTP}
 NRO2 + NO = LNRO2N + NO :                    GCARR_ac(2.60d-12, 350.0d0);                                                      {2013/08/12; Pye2010; HOTP}
 //
+// --- RCOOH chemistry (KRT)
+RCOOH + OH = ETO2 + CO2 + H2O :              1.20d-12;                                                                         {2022/10/22; krt}
+//
+// ----- STYR/EBZ/TMB chemistry (Bates et al., 2021)
+STYR + OH = 0.300ZRO2 + 0.700AROMRO2 +
+ 0.700HO2 + CH2O + 0.700BALD :               5.8d-11;                                                                          {krt, Bates et al., 2021}
+STYR + NO3 = AROMRO2 + NO2 + CH2O + BALD :   1.5d-12;                                                                          {krt, Bates et al., 2021}
+STYR + O3 = 0.500CH2OO + 0.500CH2O +
+ 0.620BALD + 0.100BENZ + 0.280BENZO2 +
+ 0.180CO + 0.180OH + 0.100HO2 :              1.7d-17;                                                                          {krt, Bates et al., 2021}
+EBZ + OH = 0.813AROMRO2 + 0.250CH2O +
+ 0.070ZRO2 + 0.180CSL + 0.400ALD2 +
+ 0.400AROMP5 + 0.800AROMP4 + 0.1800HO2 :     7.0d-12;                                                                          {krt, Bates et al., 2021}
+EBZ + NO3 = AROMRO2 + HNO3 + CH2O + BALD :   1.2d-16;                                                                          {krt, Bates et al., 2021}
+TMB + OH = 0.930AROMRO2 + 0.120CH2O + 
+ 0.050ZRO2 + 0.030CSL + 0.600AROMP5 +
+ 0.375AROMP4 + 0.250MGLY + 0.100GLYX +
+ 0.500RCOOH + 0.120CO + 0.030HO2 +
+ 0.150TLFUONE :                              3.92d-11; {krt, Bates et al., 2021}
+TMB + NO3 = AROMRO2 + HNO3 +
+  0.400AROMP5 + BALD :                       1.4d-15;                                                                          {krt, Bates et al., 2021}
+//
+// ------ Lumped aromatic nitrate ----
+ZRO2 + NO = 0.110RNO3 + 0.890BALD +
+  0.890NO2 + HO2 :                           GCARR_ac(2.7d-12,360.0d0);{MCM}
+ZRO2 + HO2 = BALD + OH :                     GCARR_ac(1.5d-13,1310.0d0);{MCM}
+RNO3 + OH = BALD + NO2 + HO2 :               7.16d-11;{MCM}
+//
 // --- C2H2 & C2H4 chemistry (per KHB)
 C2H4 + O3 = CH2O + CH2OO :                   GCARR_abc(1.20d-14, 0.0d0, -2630.0d0);                                            {2021/09/22; Kwon2020; KHB,MSL; 2023/04/18; JPL 19-5; KHB}
 C2H4 + OH = ETOO :                           GCJPLPR_abab(1.10d-28, 3.5d+00, 8.4d-12, 1.75d0, 0.5d0);                          {2021/09/22; Kwon2020; KHB,MSL}
@@ -1348,6 +1581,18 @@ AROMRO2 + NO = NO2 + HO2 :                   GCARR_abc(2.60d-12, 0.0d+00, 365.0d
 AROMRO2 + NO3 = NO2 + HO2 :                  2.30d-12;                                                                         {2021/09/29; Bates2021b; KHB,MSL}
 AROMRO2 + MO2 = CH2O + HO2 + HO2 :           GCARR_abc(1.70d-14, 0.0d0, 220.0d0);                                              {2021/09/29; Bates2021b; KHB,MSL}
 AROMRO2 + MCO3 = MO2 + HO2 + CO2 :           GCARR_abc(4.20d-14, 0.0d0, 220.0d0);                                              {2021/09/29; Bates2021b; KHB,MSL; 2022/07/01; fix C accounting; KHB}
+//-----Lumped aromatic PN------
+TLFUONE + OH = TLFUO2 :                      6.9d-11;
+TLFUO2 + NO = NO2 + AROMCHO + HO2 :          GCARR_abc(2.7d-12,0.0d0,360.0d0);
+TLFUO2 + HO2 = AROMCHO :                     GCARR_abc(2.05d-13,0.0d0,1300.0d0);
+AROMCHO + OH = AROMCO3 :                     7.09E-11;
+AROMCO3 + NO = NO2 + RCO3 + 2CO2 :           GCARR_abc(7.50d-12,0.0d0,290.0d0);
+AROMCO3 + HO2 = 0.15O3 + 0.15RCOOH +
+ 0.44CO2 + 0.44OH + 0.44RCO3+ 0.41RP :       GCARR_abc(5.20d-13,0.0d0,980.0d0);
+AROMCO3 + NO2 {+M} = AROMPN :                GC_PAN_acac(3.28d-28, -6.87d0, 1.125d-11, -1.105d0, 0.3d0);                       {Same as BZPAN}
+AROMPN = AROMCO3 + NO2 :                     GC_PAN_abab(1.10d-5, -10100.0d0, 1.90d+17, -14100.0d0, 0.3d0)*0.67d0;             {Same as BZPAN}
+AROMPN + OH = 2CO + NO2 + MCO3 + CH2O :      1.0d-14;        {MCM for ACCOMEPAN}
+//------
 PHEN + OH = 0.06BENZO + 0.06GLYX +
  0.18AROMP4 + 0.14AROMRO2 +
  0.8MCT + 0.8HO2 :                           GCARR_abc(4.70d-13, 0.0d0, 1220.0d0);                                             {2021/09/29; Bates2021b; KHB,MSL}
@@ -1545,6 +1790,10 @@ ALD2 + hv = 0.880MO2 + HO2 + 0.880CO +
 ALD2 + hv = CH4 + CO :                       PHOTOL(62);
 PAN + hv = 0.700MCO3 + 0.700NO2 +
  0.300MO2 + 0.300NO3 + 0.300CO2 :            PHOTOL(59);     {2014/05/23; Eastham2014; JMAO,SDE; 2023/04/18; Bates2023; KHB}
+APAN + hv = ACO3 + NO2 :                     PHOTOL(59);     {2014/05/23; Eastham2014; JMAO,SDE}
+ACR + hv = 0.700CO + 0.300HO2 + 
+ 0.300CH2O + 0.400C2H4 + 0.300ACO3 :         PHOTOL(66);
+AROMCHO + hv = HO2 + CO + MCO3 + CH2O :      PHOTOL(70);     {2019/05/10; Fisher2018; JAF}
 RCHO + hv = 0.490OTHRO2 + HO2 + CO +
  0.070A3O2 + 0.270B3O2 :                     PHOTOL(70);     {2019/05/10; Fisher2018; JAF; 2023/04/18; Bates2023; KHB}
 ACET + hv = MCO3 + MO2 :                     PHOTOL(76);
@@ -1568,12 +1817,16 @@ ETP + hv = OH + HO2 + ALD2 :                 PHOTOL(80);
 RA3P + hv = OH + HO2 + RCHO :                PHOTOL(81);
 RB3P + hv = OH + HO2 + ACET :                PHOTOL(82);
 R4P + hv = OH + HO2 + 1.500RCHO :            PHOTOL(83);     {2023/04/18; Bates2023; KHB}
+R7P + hv = OH + HO2 + RCHO :                 PHOTOL(83);
 PP + hv = OH + HO2 + ALD2 + CH2O :           PHOTOL(84);
 RP + hv = OH + HO2 + ALD2 + MO2 :            PHOTOL(85);     {2023/04/18; Bates2023; KHB}
 R4N2 + hv = NO2 + 0.340ACET + 0.190MEK +
  0.190MO2 + 0.270HO2 + 0.340ALD2 +
  0.150RCHO + 0.050A3O2 + 0.190B3O2 +
  0.340OTHRO2 :                               PHOTOL(98);     {2023/04/18; Bates2023; KHB}
+R7N2 + hv = NO2 + 0.348ALD2 + 1.558RCHO +
+ 0.326MCO3 + 0.326RCO3 + 0.326HO2 :          PHOTOL(98);
+RNO3 + hv = BALD + NO2 + HO2 + H2O :         PHOTOL(98);
 MAP + hv = OH + MO2 + CO2 :                  PHOTOL(99);     {2023/04/18; Bates2023; KHB}
 Br2 + hv = 2.000Br :                         PHOTOL(23);     {2012/06/07; Parrella2012; JPP}
 BrO + hv = Br + O :                          PHOTOL(28);     {2014/02/03; Eastham2014; SDE}
@@ -1726,3 +1979,19 @@ BZCO3H + hv = BENZO2 + OH + CO2 :            PHOTOL(164);    {2021/09/29; Bates2
 BENZP + hv = BENZO :                         PHOTOL(165);    {2021/09/29; Bates2021b; KHB,MSL}
 NPHEN + hv = HNO2 + CO +
  CO2 + AROMP4 + HO2 :                        PHOTOL(166);    {2021/09/29; Bates2021b; KHB,MSL}
+APINP + hv = PINAL + OH + HO2 :              PHOTOL(167) ; {use the same as }
+PINAL + hv = CO + HO2 + C96O2 :              PHOTOL(168) ;
+PINO3H + hv = OH + CO2 + C96O2 :             PHOTOL(169) ;
+PINONIC + hv = OH + CO2 + C96O2 :            PHOTOL(170) ;
+C96O2H + hv = OH + AROMRO2 + ACET +
+ CH2O + RCO3 + 0.5MEK :                      PHOTOL(171) ;
+BPINP + hv = OH + CH2O + HO2 + BPINO :       PHOTOL(172) ;
+BPINOOH + hv = OH + HO2 + 0.27LIMO3 +
+ 0.6ACET + 0.6RCHO + 0.6R4O2 :               PHOTOL(173) ;
+LIMO3H + hv = OH + CO2 + MCO3 + RCHO +
+ 0.4CH2O + 0.8R4O2 :                         PHOTOL(174) ;
+LIMO2H + hv = OH + CO2 + MCO3 + RCHO +
+ 0.4CH2O + 0.8R4O2 :                         PHOTOL(175) ;
+PIP + hv = OH + HO2 + 0.450MVK + 0.45ACET +
+ 0.100CH2O + 0.675MYRCO :                    PHOTOL(105) ;
+LIMAL + hv = CO + HO2 + 0.900LIMO3 :         PHOTOL(176) ;

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -123,18 +123,29 @@ operations:
     transported_species:
       - ACET
       - ACTA
+      - ACR
       - AERI
       - ALD2
       - ALK4
+      - ALK7
       - AONITA
+      - APAN
+      - APINP
+      - APINN
       - AROMP4
       - AROMP5
+      - AROMPN
       - ATOOH
       - BALD
       - BCPI
       - BCPO
       - BENZ
       - BENZP
+      - BPINO
+      - BPINN
+      - BPINP
+      - BPINOOH
+      - BPINON
       - Br
       - Br2
       - BrCl
@@ -144,12 +155,16 @@ operations:
       - BrSALA
       - BrSALC
       - BUTDI
+      - BUTN
       - BZCO3H
       - BZPAN
+      - C96O2H
+      - C96N
       - C2H2
       - C2H4
       - C2H6
       - C3H8
+      - C4H6
       - CCl4
       - CFC11
       - CFC113
@@ -184,6 +199,7 @@ operations:
       - DST2
       - DST3
       - DST4
+      - EBZ
       - EOH
       - ETHLN
       - ETHN
@@ -259,7 +275,15 @@ operations:
       - ISOP
       - ITCN
       - ITHN
+      - LIMAL
+      - LIMKB
+      - LIMKET
+      - LIMN
+      - LIMNB
       - LIMO
+      - LIMO2H
+      - LIMO3H
+      - LIMPAN
       - LVOC
       - LVOCOA
       - MACR
@@ -272,6 +296,7 @@ operations:
       - MCRHP
       - MCT
       - MEK
+      - MEKPN
       - MENO3
       - MGLY
       - MOH
@@ -291,6 +316,7 @@ operations:
       - MVKHP
       - MVKN
       - MVKPC
+      - MYRCO
       - N2O
       - N2O5
       - NH3
@@ -310,7 +336,13 @@ operations:
       - OIO
       - PAN
       - pFe
+      - PHAN
       - PHEN
+      - PIN
+      - PINAL
+      - PINONIC
+      - PINO3H
+      - PINPAN
       - PIP
       - PP
       - PPN
@@ -320,13 +352,17 @@ operations:
       - PYAC
       - R4N2
       - R4P
+      - R7N2
+      - R7P
       - RA3P
       - RB3P
       - RCHO
+      - RCOOH
       - RIPA
       - RIPB
       - RIPC
       - RIPD
+      - RNO3
       - RP
       - SALA
       - SALAAL
@@ -341,6 +377,8 @@ operations:
       - SOAIE
       - SOAP
       - SOAS
+      - STYR
+      - TMB
       - TOLU
       - XYLE
 

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -18,6 +18,18 @@ ACET:
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 58.09
+ACR:
+  DD_F0: 1.0
+  DD_Hstar: 7.3
+  Formula: C3H4O
+  FullName: Acrolein
+  Henry_CR: 5100.0
+  Henry_K0: 7.3
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  MW_g: 56.06
 ACTA:
   DD_F0: 1.0
   DD_Hstar: 4.1e+3
@@ -31,6 +43,16 @@ ACTA:
   Is_WetDep: true
   MW_g: 60.06
   WD_RetFactor: 2.0e-2
+ACO3:
+  Formula: C3H3O3
+  FullName: Peroxyacetyl radical for APAN
+  Is_Gas: true
+  MW_g: 87.054
+ACRO2:
+  Formula: C3H5O4
+  FullName: Peroxy radical from ACR
+  Is_Gas: true
+  MW_g: 105.07
 AERI:
   DD_DvzAerSnow: 0.03
   DD_DvzMinVal: [0.01, 0.01]
@@ -47,6 +69,20 @@ AERI:
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
   WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
+APAN:
+  DD_F0: 1.0
+  DD_Hstar: 3.6
+  Formula: C3H3NO5
+  FullName: Peroxyacryloyl nitrate
+  Henry_CR: 5700.0
+  Henry_K0: 2.94
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 133.06
+  WD_RetFactor: 2.0e-2
 DST1_PROP: &DST1properties
   DD_DustDryDep: true
   DD_F0: 0.0
@@ -132,11 +168,17 @@ ALD2:
   MW_g: 44.06
   WD_RetFactor: 2.0e-2
 ALK4:
-  FullName: Lumped >= C4 Alkanes
+  FullName: Lumped C4+C5 Alkanes
   Is_Advected: true
   Is_Gas: true
   MW_g: 58.12
-aoa_PROP: &aoaproperties
+ALK7:
+  FullName: Lumped >= C6 Alkanes
+  Is_Advected: true
+  Formula: C7H16
+  Is_Gas: true
+  MW_g: 100.20
+  aoa_PROP: &aoaproperties
   Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
@@ -213,6 +255,43 @@ AROMRO2:
   FullName: hydroxy-peroxy radical from aromatics
   Is_Gas: true
   MW_g: 127.00
+ZRO2:
+  Formula: C7H9O5
+  FullName: RO2 for making lumped aromatic nitrate
+  Is_Gas: true
+  MW_g: 173.16
+AROMCHO:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C5H6O4
+  FullName: ACCOMECHO from MCM
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 130.10
+  Henry_CR: 7500.0
+  Henry_K0: 2.0e+6
+  WD_RetFactor: 2.0e-2
+AROMCO3:
+  Formula: C5H5O6
+  FullName: Lumped aromatic peroxyacetyl radical
+  Is_Gas: true
+  MW_g: 161.09
+AROMPN:
+  DD_F0: 1.0
+  DD_Hstar: 3.6
+  Formula: C5H5NO8
+  FullName: Lumped PN from aromatics
+  Henry_CR: 5700.0
+  Henry_K0: 2.94
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 207.1
+  WD_RetFactor: 2.0e-2
 AsF1:
   << : *DST1properties
   Formula: As
@@ -478,6 +557,25 @@ BRO2:
   FullName: Peroxy radical from BENZ oxidation
   Is_Gas: true
   MW_g: 159.13
+BUTO2:
+  Formula: C4H7O3
+  FullName: peroxy radical from C4H6
+  Is_Gas: true
+  MW_g: 103.097
+BUTN:
+  DD_F0: 1.0
+  DD_Hstar: 5.0e+4
+  Formula: C4H7NO4
+  FullName: C4H6 alkyl nitrate
+  Henry_CR: 0.0
+  Henry_K0: 1.0e+3
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: false
+  Is_WetDep: true
+  MW_g: 133.10
+  WD_RetFactor: 2.0e-2
 SALA_PROP: &SALAproperties
   DD_AeroDryDep: true
   DD_F0: 0.0
@@ -589,6 +687,14 @@ C3H8:
   Is_Advected: true
   Is_Gas: true
   MW_g: 44.11
+C4H6:
+  Formula: C4H6
+  FullName: 1,3-butadiene
+  Henry_CR: 4500.0
+  Henry_K0: 1.40e-2
+  Is_Advected: true
+  Is_Gas: true
+  MW_g: 54.09
 C4HVP1:
   Formula: C4H7O3
   FullName: C4 hydroxy-vinyl peroxy radicals from HPALDS
@@ -1193,6 +1299,12 @@ e90_s:
   FullName: Constant burden Southern Hemisphere 90 day tracer
   Src_Horiz: lat_zone
   Src_Lats: [ -91.0, -40.0 ]
+EBZ:
+  Formula: C8H10
+  FullName: Ethylbenzene
+  Is_Advected: true
+  Is_Gas: true
+  MW_g: 106.167
 EOH:
   DD_F0: 0.0
   DD_Hstar: 1.9e+2
@@ -1325,6 +1437,11 @@ FURA:
   Is_WetDep: true
   MW_g: 68.07
   WD_RetFactor: 2.0e-2
+GCO3:
+  Formula: HOCH2CO3
+  FullName: Peroxyacetyl radical for PHAN
+  Is_Gas: true
+  MW_g: 91.0428
 GLYC:
   DD_F0: 1.0
   DD_Hstar: 4.1e+4
@@ -1422,6 +1539,19 @@ HAC:
   Is_Photolysis: true
   Is_WetDep: true
   MW_g: 74.08
+  WD_RetFactor: 2.0e-2
+HACTA:
+  DD_F0: 1.0
+  DD_Hstar: 2.83e+4
+  Formula: HOCH2CO2H
+  FullName: Hydroxyacetic/glycolic acid
+  Henry_CR: 4000.0
+  Henry_K0: 2.83e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 76.0514
   WD_RetFactor: 2.0e-2
 HBr:
   DD_F0: 0.0
@@ -2772,6 +2902,359 @@ LCO:
   FullName: Dummy species to track loss rate of CO
   Is_Gas: true
   MW_g: 28.01
+APINP:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+5
+  Formula: C10H18O3
+  FullName: Hydroperoxide from APIN
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+5
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+APINN:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C10H17NO4
+  FullName: 1st gen organic nitrate from APIN
+  Henry_CR: 9200.0
+  Henry_K0: 1.7e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 215.28
+  WD_RetFactor: 2.0e-2
+PINAL: 
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+3
+  Formula: C10H16O2
+  FullName: Pinonaldehyde
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+3
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+PINONIC:
+  DD_F0: 1.0
+  DD_Hstar: 3.14e+5
+  Formula: C10H18O3
+  FullName: Pinonic acid
+  Henry_CR: 6039.0
+  Henry_K0: 3.14e+5
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+PINPAN:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C10H17NO4
+  FullName: PAN from pinonaldehyde
+  Henry_CR: 9200.0
+  Henry_K0: 1.7e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 215.28
+  WD_RetFactor: 2.0e-2
+PINO3H:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+5
+  Formula: C10H18O4
+  FullName: Pinonic peracid
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+5
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+C96O2H:
+  DD_F0: 1.0
+  DD_Hstar: 3.14e+5
+  Formula: C9H16O3
+  FullName: Peroxide from APIN 2nd gen
+  Henry_CR: 6039.0
+  Henry_K0: 3.14e+5
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+C96N:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C9H15NO4
+  FullName: Saturated 2nd gen monoterpene organic nitrate
+  Henry_CR: 9200.0
+  Henry_K0: 1.7e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 215.28
+  WD_RetFactor: 2.0e-2
+BPINO:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+3
+  Formula: C9H14O
+  FullName: Ketone from BPIN
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+3
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+BPINN:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C10H17NO4
+  FullName: Saturated 1st gen BPIN organic nitrate
+  Henry_CR: 9200.0
+  Henry_K0: 1.7e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 215.28
+  WD_RetFactor: 2.0e-2
+BPINP:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+5
+  Formula: C10H18O3
+  FullName: Peroxide from BPIN
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+5
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+BPINOOH:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+5
+  Formula: C9H14O3
+  FullName: 2nd-gen peroxide from BPIN
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+5
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+BPINON:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C9H13NO4
+  FullName: Saturated 2nd gen BPIN organic nitrate
+  Henry_CR: 9200.0
+  Henry_K0: 1.7e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 215.28
+  WD_RetFactor: 2.0e-2
+LIMAL:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+3
+  Formula: C10H16O2
+  FullName: Aldehyde from limonene
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+3
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+LIMN:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C10H17NO4
+  FullName: Saturated 1st gen limonene organic nitrate
+  Henry_CR: 9200.0
+  Henry_K0: 1.7e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 215.28
+  WD_RetFactor: 2.0e-2
+LIMKET:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+3
+  Formula: C10H16O2
+  FullName: Ketone from limonene
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+3
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+LIMKB:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+3
+  Formula: C10H16O3
+  FullName: 2nd gen ketone from limonene
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+3
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+LIMNB:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C10H15NO4
+  FullName: Saturated 1st gen LIMO organic nitrate
+  Henry_CR: 9200.0
+  Henry_K0: 1.7e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 215.28
+  WD_RetFactor: 2.0e-2
+LIMO2H:
+  DD_F0: 1.0
+  DD_Hstar: 3.14e+5
+  Formula: C10H18O3
+  FullName: Acid from LIMO
+  Henry_CR: 6039.0
+  Henry_K0: 3.14e+5
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+LIMPAN:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C10H17NO4
+  FullName: PAN from LIMO
+  Henry_CR: 9200.0
+  Henry_K0: 1.7e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 215.28
+  WD_RetFactor: 2.0e-2
+LIMO3H:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+5
+  Formula: C10H18O4
+  FullName: Peracid from LIMO
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+5
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+MYRCO:
+  DD_F0: 1.0
+  DD_Hstar: 1.0e+3
+  Formula: C10H18O3
+  FullName: Aldehyde or ketone from myrcene
+  Henry_CR: 6039.0
+  Henry_K0: 1.0e+3
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 186.28
+  WD_RetFactor: 2.0e-2
+PIN:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C10H17NO4
+  FullName: Saturated 1st gen monoterpene organic nitrate
+  Henry_CR: 9200.0
+  Henry_K0: 1.7e+4
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 215.28
+  WD_RetFactor: 2.0e-2
+APINO2:
+  Formula: C10H17O3
+  FullName: Peroxy radical from APIN
+  Is_Gas: true
+  MW_g: 185.27
+PINO3:
+  Formula: C10H17O3
+  FullName: Acylperoxy radical from APIN
+  Is_Gas: true
+  MW_g: 185.27
+C96O2:
+  Formula: C10H17O3
+  FullName: 2nd-gen peroxy radical from APIN
+  Is_Gas: true
+  MW_g: 185.27
+BPINO2:
+  Formula: C10H17O3
+  FullName: Peroxy radical from BPIN
+  Is_Gas: true
+  MW_g: 185.27
+BPINOO2:
+  Formula: C10H17O3
+  FullName: 2nd-gen peroxy radical from BPIN
+  Is_Gas: true
+  MW_g: 185.27
+LIMKO2:
+  Formula: C10H17O3
+  FullName: 2nd-gen peroxy radical from LIMO
+  Is_Gas: true
+  MW_g: 185.27
+LIMO3:
+  Formula: C10H17O3
+  FullName: Acylperoxy radical from LIMO
+  Is_Gas: true
+  MW_g: 185.27
+LIMO2:
+  Formula: C10H17O3
+  FullName: Peroxy radical from LIMO
+  Is_Gas: true
+  MW_g: 185.27
+PIO2:
+  Formula: C10H17O3
+  FullName: Peroxy radical from MTPA
+  Is_Gas: true
+  MW_g: 185.27
 LIMO:
   DD_F0: 0.0
   DD_Hstar: 7.0e-2
@@ -2996,6 +3479,10 @@ MCT:
   Is_WetDep: true
   MW_g: 124.0
   WD_RetFactor: 2.0e-2
+MEKCO3:
+ Formula: C3H5O4
+ Is_Gas: true
+ MW_g: 105.07
 MEK:
   Formula: RC(O)R
   FullName: Methyl Ethyl Ketone
@@ -3006,6 +3493,20 @@ MEK:
   Is_Photolysis: true
   Is_WetDep: true
   MW_g: 72.11
+  WD_RetFactor: 2.0e-2
+MEKPN:
+  DD_F0: 1.0
+  DD_Hstar: 3.6
+  Formula: C3H5NO6
+  FullName: MEK peroxyacetyl nitrate
+  Henry_CR: 5700.0
+  Henry_K0: 2.94
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 151.07
   WD_RetFactor: 2.0e-2
 MENO3:
   DD_F0: 0.1
@@ -3840,6 +4341,20 @@ PH2SO4:
   FullName: SO4 from gas-phase chemistry
   Is_Gas: true
   MW_g: 96.06
+PHAN:
+  DD_F0: 1.0
+  DD_Hstar: 3.6
+  Formula: C2H3NO6
+  FullName: Peroxyhydroxyacetic nitric anhydride
+  Henry_CR: 5700.0
+  Henry_K0: 2.94
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 137.0483
+  WD_RetFactor: 2.0e-2
 PHEN:
   DD_F0: 1.0
   DD_Hstar: 2.8e+3
@@ -4233,6 +4748,20 @@ R4N1:
   FullName: Peroxy radical from R4N2
   Is_Gas: true
   MW_g: 150.13
+RNO3:
+  DD_F0: 1.0
+  DD_Hstar: 1.7e+4
+  Formula: RO2NO
+  FullName: Lumped alkyl nitrate
+  Henry_CR: 5800.0
+  Henry_K0: 1.0
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 203.15
+  WD_RetFactor: 2.0e-2
 R4N2:
   DD_F0: 1.0
   DD_Hstar: 1.7e+4
@@ -4246,6 +4775,25 @@ R4N2:
   Is_Photolysis: true
   Is_WetDep: true
   MW_g: 119.10
+  WD_RetFactor: 2.0e-2
+R7N1:
+  Formula: C7H15NO5
+  FullName: Peroxy radical from R7N2
+  Is_Gas: true
+  MW_g: 161.2
+R7N2:
+  DD_F0: 1.0
+  DD_Hstar: 1.7e+4
+  Formula: RO2NO
+  FullName: C7 Lumped alkyl nitrate
+  Henry_CR: 6700.0
+  Henry_K0: 0.77
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 161.2
   WD_RetFactor: 2.0e-2
 R4O2:
   Formula: C4H9O2
@@ -4265,6 +4813,25 @@ R4P:
   Is_Photolysis: true
   Is_WetDep: true
   MW_g: 90.14
+  WD_RetFactor: 2.0e-2
+R7O2:
+  Formula: C7H15O2
+  FullName: Peroxy radical from ALK7
+  Is_Gas: true
+  MW_g: 131.19
+R7P:
+  DD_F0: 1.0
+  DD_Hstar: 2.94e+2
+  Formula: C7H16O2
+  FullName: Peroxide from R7O2
+  Henry_CR: 5200.0
+  Henry_K0: 2.94e+2
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 132.20
   WD_RetFactor: 2.0e-2
 RA3P:
   DD_F0: 1.0
@@ -4310,10 +4877,18 @@ RCO3:
   Is_Gas: true
   MW_g: 89.08
 RCOOH:
+  DD_F0: 1.0
+  DD_Hstar: 1.52e+3
   Formula: C2H5C(O)OH
   FullName: '> C2 organic acids'
+  Henry_CR: 6800.0
+  Henry_K0: 1.52e+3
+  Is_Advected: true
+  Is_DryDep: true
+  Is_WetDep: true
   Is_Gas: true
   MW_g: 74.09
+  WD_RetFactor: 2.0e-2
 RIPA:
   DD_F0: 1.0
   DD_Hstar: 1.7e+6
@@ -4369,6 +4944,20 @@ RIPD:
   Is_Photolysis: true
   Is_WetDep: true
   MW_g: 118.15
+  WD_RetFactor: 2.0e-2
+RNO3:
+  DD_F0: 1.0
+  DD_Hstar: 1.7e+4
+  Formula: RO2NO
+  FullName: Lumped aromatic nitrate
+  Henry_CR: 5800.0
+  Henry_K0: 1.0
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 203.15
   WD_RetFactor: 2.0e-2
 Rn222:
   Formula: Rn222
@@ -4631,6 +5220,12 @@ stOX:
   Src_Horiz: all
   Src_Mode: model_field
   Src_Vert: stratosphere
+STYR:
+  Formula: C8H8
+  FullName: Styrene
+  Is_Advected: true
+  Is_Gas: true
+  MW_g: 104.1491
 TiF1:
   << : *DST1properties
   Formula: Ti
@@ -4642,6 +5237,28 @@ TiF2:
   Formula: Ti
   Fullname: Titanium on dust, Reff = 1.4 microns
   MW_g: 47.87
+TLFUO2:
+  Formula: C5H7O5
+  Is_Gas:true
+  MW_g: 147.1
+TLFUONE:
+  DD_F0: 1.0
+  DD_Hstar: 2.0e+6
+  Formula: C5H6O2
+  FullName: Aromatic furanones
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_WetDep: true
+  MW_g: 98.10
+  Henry_CR: 7500.0
+  Henry_K0: 2.0e+6
+  WD_RetFactor: 2.0e-2
+TMB:
+  Formula: C8H10
+  FullName: Trimethylbenzenes
+  Is_Gas: true
+  MW_g: 106.167
 TOLU:
   Formula: C7H8
   FullName: Toluene


### PR DESCRIPTION
### Name and Institution (Required)

Name: Katherine Travis
Institution: NASA LaRC

### Describe the update

This update provides new chemistry for RCOOH, monoterpenes, new PNs (PHAN, MEKPN, APAN, LIMPAN, PINPAN, AROMPN) and a new AN (RNO3). 

Must be merged concurrently with: https://github.com/geoschem/hemco/pull/285, which contains the corresponding emissions updates to GFED and FINN biomass extensions.

### Expected changes

The paper describes that there will be small (+/-1 ppb changes in ozone) as a result of the new peroxynitrate (PN) species.

### Reference(s)

https://egusphere.copernicus.org/preprints/2024/egusphere-2024-951/
