### PR TITLE
Correct alphabetical order of complex SOA species in geoschem_config.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Alphabetically sort Complex SOA species into `geoschem_config.yml` in run directory creation
+
 ## [14.4.0] - 2024-05-30
 ### Added
 - Added `SpcConc%Units` for species-specific unit conversion

--- a/run/CESM/geoschem_config.yml
+++ b/run/CESM/geoschem_config.yml
@@ -94,6 +94,9 @@ operations:
       - AERI
       - ALD2
       - ALK4
+      - AONITA
+      - AROMP4
+      - AROMP5
       - ASOA1
       - ASOA2
       - ASOA3
@@ -101,9 +104,6 @@ operations:
       - ASOG1
       - ASOG2
       - ASOG3
-      - AONITA
-      - AROMP4
-      - AROMP5
       - ATOOH
       - BALD
       - BCPI

--- a/run/shared/setupConfigFiles.sh
+++ b/run/shared/setupConfigFiles.sh
@@ -156,8 +156,8 @@ function set_common_settings() {
        [[ ${sim_extra_option}    =~ "complexSOA" ]] || \
        [[ "x${sim_extra_option}" == "xAPM"       ]]; then
 
-	# Add complex SOA species ASOA* and ASOG* following ALK4
-        prev_line='      - ALK4'
+	# Add complex SOA species ASOA* and ASOG* following AROMP5
+        prev_line='      - AROMP5'
         new_line='\      - ASOA1\
       - ASOA2\
       - ASOA3\


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard Univ.

### Describe the update

This puts complex SOA species in the correct alphabetical order within the advected species list in `geoschem_config.yml`.

Due to introduction of new species, `ASOA1` should be inserted after `AROMP5` instead of ALK4 in order to be correctly alphabetically ordered.

This facilitates coupling to CESM and WRF by allowing scripts to generate the correct order programmatically. CESM in particular needs to match the species in their exact order of appearance in the geoschem_config.yml (by advected species ID) to a compile-time generated list, and this will facilitate correct generation of such list.

### Expected changes

Zero-diff.

### Reference(s)

N/A

### Related Github Issue

N/A
