### PR TITLE
Changes for GEOS-Chem v14.4 within CESM compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Updated `run/CESM` with alphabetical sorting of species in `geoschem_config.yml`
+
+### Removed
+- Disabled `run/CESM` ParaNOx extension by default in `HEMCO_Config.rc`
+- Removed MPI broadcasts in CESM-only UCX code; MPI broadcast done at coupler level
+
 ## [14.4.0] - 2024-05-30
 ### Added
 - Added `SpcConc%Units` for species-specific unit conversion

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -3903,8 +3903,6 @@ CONTAINS
     USE State_Chm_Mod,      ONLY : ChmState
 #if defined( MODEL_CESM )
     USE UNITS,              ONLY : freeUnit
-    USE CAM_ABORTUTILS,     ONLY : endrun
-    USE SPMD_UTILS,         ONLY : mpicom, masterprocid, mpi_success, mpi_real8
 #endif
 !
 ! !INPUT PARAMETERS:
@@ -3930,10 +3928,6 @@ CONTAINS
     INTEGER            :: I, AS, IOS
     INTEGER            :: IMON, ITRAC, ILEV
     INTEGER            :: IU_FILE
-#if defined( MODEL_CESM )
-    INTEGER            :: nSize ! Number of elements in State_Chm%NOXCOEFF
-    INTEGER            :: ierr
-#endif
 
     ! Strings
     CHARACTER(LEN=255) :: NOX_FILE
@@ -4057,7 +4051,6 @@ CONTAINS
     State_Chm%NOXCOEFF = 0.0e+0_fp
 
 #if defined( MODEL_CESM )
-    nSize = State_Chm%JJNOXCOEFF * UCX_NLEVS * 6 * 12
     IF ( Input_Opt%amIRoot ) THEN
 #endif
     ! Fill array
@@ -4138,8 +4131,6 @@ CONTAINS
     ENDDO !IMON
 #if defined( MODEL_CESM )
     ENDIF
-
-    IF ( ierr /= mpi_success ) CALL endrun(subname//': MPI_BCAST ERROR: NOXCOEFF')
 #endif
 
   END SUBROUTINE NOXCOEFF_INIT

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -4139,7 +4139,6 @@ CONTAINS
 #if defined( MODEL_CESM )
     ENDIF
 
-    CALL MPI_BCAST( State_Chm%NOXCOEFF, nSize, mpi_real8, masterprocid, mpicom, ierr )
     IF ( ierr /= mpi_success ) CALL endrun(subname//': MPI_BCAST ERROR: NOXCOEFF')
 #endif
 

--- a/run/CESM/HEMCO_Config.rc
+++ b/run/CESM/HEMCO_Config.rc
@@ -162,7 +162,7 @@ VerboseOnCores:              root       # Accepted values: root all
 # -----------------------------------------------------------------------------
 100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2/MENO3/ETNO3/MOH
-102     ParaNOx                : on    NO/NO2/O3/HNO3
+102     ParaNOx                : off   NO/NO2/O3/HNO3
     --> LUT data format        :       nc
     --> LUT source dir         :       $ROOT/PARANOX/v2015-02
 103     LightNOx               : off   NO

--- a/run/CESM/geoschem_config.yml
+++ b/run/CESM/geoschem_config.yml
@@ -94,6 +94,9 @@ operations:
       - AERI
       - ALD2
       - ALK4
+      - AONITA
+      - AROMP4
+      - AROMP5
       - ASOA1
       - ASOA2
       - ASOA3
@@ -101,9 +104,6 @@ operations:
       - ASOG1
       - ASOG2
       - ASOG3
-      - AONITA
-      - AROMP4
-      - AROMP5
       - ATOOH
       - BALD
       - BCPI


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard Univ.

### Describe the update

These are updates that only affect GEOS-Chem within CESM to make the model compatible with coupling to CESM.

There are several (minor) changes bundled in this update.
* `GeosCore/ucx_mod.F90`: remove `MPI_Bcast` call. This was previously removed in https://github.com/geoschem/geos-chem/pull/1993 but was somehow regressed in the latest version.
* `run/CESM/geoschem_config.yml`: Alphabetical ordering of complex SOA species. The `run/CESM` config file is not generated by the run directory script, but the run directory script is also updated in https://github.com/geoschem/geos-chem/pull/2346 for consistency across versions.
* `run/CESM/HEMCO_Config.rc`: disable ParaNOx extension by default in CESM due to causing issues.

### Expected changes

Affects GEOS-Chem within CESM only.

### Reference(s)

N/A

### Related Github Issue

Companion PR in geoschem/CAM development repository for GEOS-Chem within CESM: https://github.com/geoschem/CAM/pull/34

Tagging @lizziel. Thanks!
