### PR TITLE
Initialization fix to avoid run-time error in UCX in CESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run
 - Fixed typo `$GCAPVERTRESL` -> `$GCAPVERTRES` in `HEMCO_Config.rc.fullchem` template file
 
+### Added
+- Added initialization of PHOTDELTA in ucx_h2so4phot to avoid run-time error in CESM
+
 ## [14.4.0] - 2024-05-30
 ### Added
 - Added `SpcConc%Units` for species-specific unit conversion

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -3825,6 +3825,9 @@ CONTAINS
     ! UCX_H2SO4PHOT begins here!
     !=================================================================
 
+    ! Initialize
+    PHOTDELTA = 0.0_fp
+
     ! Copy fields from species database
     SO2_MW_G = State_Chm%SpcData(id_SO2)%Info%MW_g ! g/mol
     SO4_MW_G = State_Chm%SpcData(id_SO4)%Info%MW_g ! g/mol


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update fixes a bug in `ucx_h2so4phot` where there is a pathway for local variable `PHOTDELTA` to be used prior to assigning it a value. This trips up CESM when running in debug mode. This bug has only been detected in CESM due to the configuration of the run.

### Expected changes

`PHOTDELTA` is now always initialized to avoid the potential run-time error in CESM.

### Reference(s)

none

### Related Github Issue

none
