### PR TITLE
Correct the issue that injection height has been artifically decreased by HEMCO

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -4450,7 +4450,7 @@ ${RUNDIR_TES_CLIM_N2O}
 # --- GFAS scale factors ---
 #==============================================================================
 (((GFAS
-300 GFAS_EMITL $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc mami 2003-2021/1-12/1-31/0 C xy m 1
+300 GFAS_EMITL $ROOT/GFAS/v2021-09/$YYYY/GFAS_$YYYY$MM_hgts_$RES.nc mami_avg_weight 2003-2021/1-12/1-31/0 C xy m 1
 )))GFAS
 
 #==============================================================================


### PR DESCRIPTION
### Name and Institution (Required)
Name: Lixu Jin
Institution: University of Montana

### Describe the update
This update reads injection heights to account for grid-dependent issues in GFAS, as detailed in Jin et al. (2023).

This update also requires that users create the corrected injection height data first, using the code in #2330. A better approach would be to have the data created and placed in the GEOS-Chem data portals for community use.

### Expected changes
Correct the issue that injection height has been artifically decreased by HEMCO.

The independent injection height could be further used for other fire inventories.

### Reference(s)
Jin, Lixu, et al. "Constraining emissions of volatile organic compounds from western US wildfires with WE-CAN and FIREX-AQ airborne observations." Atmospheric Chemistry and Physics 23.10 (2023): 5969-5991.

### Related Github Issue
- Closes #2330 
