### PR TITLE
Update setCommonRunSettings.sh.template to avoid incorrect GCHP error catch

### DIFF
--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -386,7 +386,7 @@ fi
 
 #### Mass flux checks for grid resolution and domain decomposition
 MassFlux_Entry=$(grep "MFXC" ExtData.rc || echo "missing")
-if [[ ${MassFluxEntry} != "missing" ]]; then
+if [[ ${MassFlux_Entry} != "missing" ]]; then
 
     #### Get met grid res (assume GEOS-IT and GEOS-FP are the only options)
     C180_Entry=$(grep "MFXC.*C180x180x6" ExtData.rc || echo "missing")


### PR DESCRIPTION
Fix typo for MassFlux_Entry

### Name and Institution (Required)

Name: Lee T. Murray
Institution: University of Rochester

### Describe the update

Fix small typo in setCommonRunSettings.sh that makes the script think that all simulations are using mass fluxes instead of winds.