### PR TITLE
Fix several issues with the GEOS-Chem Classic satellite diagnostics (SatDiagn and SatDiagnEdge collections)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added number of levels with clouds for photolysis to geoschem_config.yml and Input_Opt to pass to Cloud-J
 
+### Changed
+- Now reset `State_Diag%SatDiagnCount` to zero in routine`History_Write` (instead of in `History_Netcdf_Write`)
+
 ### Fixed
 - Typo in `setCommonRunSettings.sh` that made GCHP always choose mass fluxes for meteorology
 - Fixed bug in # levels with cloud used in photolysis when using GCAP met or CESM
+- Fixed typos for `SatDiagnEdge` collection in `HISTORY.rc` templates
+- The `SatDiagnOH` diagnostic now works for the carbon simulation
+
+### Removed
+- Entry `SatDiagnPEDGE` from the `SatDiagn` collection; This needs to go into the `SatDiagnEdge` collection.
+
 
 ## [14.4.1] - 2024-06-28
 ### Added

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1425,9 +1425,12 @@ CONTAINS
             Input_Opt%ITS_A_FULLCHEM_SIM ) THEN
           id_OH  = Ind_('OH')
           IF ( id_OH < 0 ) THEN
-             errMsg = 'OH is not a defined species in this simulation!!!'
-             CALL GC_Error( errMsg, RC, thisLoc )
-             RETURN
+             id_OH = Ind_('FixedOH')
+             IF ( id_OH < 0 ) THEN
+                errMsg = 'OH is not a defined species in this simulation!!!'
+                CALL GC_Error( errMsg, RC, thisLoc )
+                RETURN
+             ENDIF
           ENDIF
        ENDIF
        first= .FALSE.

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -3091,6 +3091,19 @@ CONTAINS
 
     ENDDO
 
+    !=======================================================================
+    ! Cleanup & quit
+    !=======================================================================
+
+    ! If we have called History_Netcdf_Write (i.e. DoWrite == T), then
+    ! reset the satellite diagnostics counter, as we have now entered the
+    ! next diagnostic interval.  We need to do this here instead of in
+    ! History_Netcdf_Write as there are multiple satellite diagnostic
+    ! collections (SatDiagn, SatDiagnEdge).
+    IF ( State_Diag%Archive_SatDiagnCount .and. DoWrite ) THEN
+       State_Diag%SatDiagnCount = 0.0_f8
+    ENDIF
+
     ! Free pointers
     Container  => NULL()
     Collection => NULL()

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
@@ -213,22 +213,13 @@ COLLECTIONS: 'Restart',
   SatDiagn.hrrange:           11.98 15.02
   SatDiagn.mode:              'time-averaged'
   SatDiagn.fields:            'SatDiagnConc_CH4               ',
+                              'SatDiagnOH                     ',
                               'SatDiagnRH                     ',
                               'SatDiagnAirDen                 ',
                               'SatDiagnBoxHeight              ',
-                              'SatDiagnPEdge                  ',
                               'SatDiagnTROPP                  ',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
-                              'SatDiagnTAir                   ',
-                              'SatDiagnGWETROOT               ',
-                              'SatDiagnGWETTOP                ',
-                              'SatDiagnPARDR                  ',
-                              'SatDiagnPARDF                  ',
-                              'SatDiagnPRECTOT                ',
-                              'SatDiagnSLP                    ',
-                              'SatDiagnSPHU                   ',
-                              'SatDiagnTS                     ',
                               'SatDiagnPBLTOPL                ',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnColEmis_CH4            ',
@@ -247,7 +238,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                  ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -178,15 +178,6 @@ COLLECTIONS: 'Restart',
                               'SatDiagnTROPP                  ',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
-                              'SatDiagnTAir                   ',
-                              'SatDiagnGWETROOT               ',
-                              'SatDiagnGWETTOP                ',
-                              'SatDiagnPARDR                  ',
-                              'SatDiagnPARDF                  ',
-                              'SatDiagnPRECTOT                ',
-                              'SatDiagnSLP                    ',
-                              'SatDiagnSPHU                   ',
-                              'SatDiagnTS                     ',
                               'SatDiagnPBLTOPL                ',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnColEmis_CO2            ',
@@ -205,7 +196,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                  ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
@@ -268,19 +268,9 @@ COLLECTIONS: 'Restart',
                               'SatDiagnRH                     ',
                               'SatDiagnAirDen                 ',
                               'SatDiagnBoxHeight              ',
-                              'SatDiagnPEdge                  ',
                               'SatDiagnTROPP                  ',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
-                              'SatDiagnTAir                   ',
-                              'SatDiagnGWETROOT               ',
-                              'SatDiagnGWETTOP                ',
-                              'SatDiagnPARDR                  ',
-                              'SatDiagnPARDF                  ',
-                              'SatDiagnPRECTOT                ',
-                              'SatDiagnSLP                    ',
-                              'SatDiagnSPHU                   ',
-                              'SatDiagnTS                     ',
                               'SatDiagnPBLTOPL                ',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnWetLossLS_Hg0          ',
@@ -310,7 +300,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                  ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -206,19 +206,10 @@ COLLECTIONS: 'Restart',
                               'SatDiagnRH                     ',
                               'SatDiagnAirDen                 ',
                               'SatDiagnBoxHeight              ',
-                              'SatDiagnPEdge                  ',
                               'SatDiagnTROPP                  ',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
                               'SatDiagnTAir                   ',
-                              'SatDiagnGWETROOT               ',
-                              'SatDiagnGWETTOP                ',
-                              'SatDiagnPARDR                  ',
-                              'SatDiagnPARDF                  ',
-                              'SatDiagnPRECTOT                ',
-                              'SatDiagnSLP                    ',
-                              'SatDiagnSPHU                   ',
-                              'SatDiagnTS                     ',
                               'SatDiagnPBLTOPL                ',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnWetLossLS_Pb210        ',
@@ -250,7 +241,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                  ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
@@ -319,11 +319,6 @@ COLLECTIONS: 'Restart',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
                               'SatDiagnTAir                   ',
-                              'SatDiagnGWETROOT               ',
-                              'SatDiagnGWETTOP                ',
-                              'SatDiagnPARDR                  ',
-                              'SatDiagnPARDF                  ',
-                              'SatDiagnPRECTOT                ',
                               'SatDiagnSLP                    ',
                               'SatDiagnSPHU                   ',
                               'SatDiagnTS                     ',
@@ -351,7 +346,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                  ',
 ::
 #==============================================================================
 # %%%%% THE StateChm COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -214,22 +214,13 @@ COLLECTIONS: 'Restart',
                               'SatDiagnConc_CO                ',
                               'SatDiagnConc_CO2               ',
                               'SatDiagnConc_OCS               ',
+                              'SatDiagnOH                     ',
                               'SatDiagnRH                     ',
                               'SatDiagnAirDen                 ',
                               'SatDiagnBoxHeight              ',
-                              'SatDiagnPEdge                  ',
                               'SatDiagnTROPP                  ',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
-                              'SatDiagnTAir                   ',
-                              'SatDiagnGWETROOT               ',
-                              'SatDiagnGWETTOP                ',
-                              'SatDiagnPARDR                  ',
-                              'SatDiagnPARDF                  ',
-                              'SatDiagnPRECTOT                ',
-                              'SatDiagnSLP                    ',
-                              'SatDiagnSPHU                   ',
-                              'SatDiagnTS                     ',
                               'SatDiagnPBLTOPL                ',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnColEmis_CH4            ',
@@ -248,7 +239,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                  ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -620,7 +620,6 @@ COLLECTIONS: 'Restart',
                               'SatDiagnRH                     ',
                               'SatDiagnAirDen                 ',
                               'SatDiagnBoxHeight              ',
-                              'SatDiagnPEdge                  ',
                               'SatDiagnTROPP                  ',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
@@ -676,7 +675,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                   ',
 ::
 #==============================================================================
 # %%%%% THE StateChm COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
@@ -182,19 +182,9 @@ COLLECTIONS: 'Restart',
                               'SatDiagnRH                     ',
                               'SatDiagnAirDen                 ',
                               'SatDiagnBoxHeight              ',
-                              'SatDiagnPEdge                  ',
                               'SatDiagnTROPP                  ',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
-                              'SatDiagnTAir                   ',
-                              'SatDiagnGWETROOT               ',
-                              'SatDiagnGWETTOP                ',
-                              'SatDiagnPARDR                  ',
-                              'SatDiagnPARDF                  ',
-                              'SatDiagnPRECTOT                ',
-                              'SatDiagnSLP                    ',
-                              'SatDiagnSPHU                   ',
-                              'SatDiagnTS                     ',
                               'SatDiagnPBLTOPL                ',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnWetLossLS_AlF1         ',
@@ -217,7 +207,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                  ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
@@ -189,19 +189,9 @@ COLLECTIONS: 'Restart',
                               'SatDiagnRH                     ',
                               'SatDiagnAirDen                 ',
                               'SatDiagnBoxHeight              ',
-                              'SatDiagnPEdge                  ',
                               'SatDiagnTROPP                  ',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
-                              'SatDiagnTAir                   ',
-                              'SatDiagnGWETROOT               ',
-                              'SatDiagnGWETTOP                ',
-                              'SatDiagnPARDR                  ',
-                              'SatDiagnPARDF                  ',
-                              'SatDiagnPRECTOT                ',
-                              'SatDiagnSLP                    ',
-                              'SatDiagnSPHU                   ',
-                              'SatDiagnTS                     ',
                               'SatDiagnPBLTOPL                ',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnColEmis_CO             ',
@@ -220,7 +210,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                  ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
@@ -217,15 +217,6 @@ COLLECTIONS: 'Restart',
                               'SatDiagnTROPP                  ',
                               'SatDiagnPBLHeight              ',
                               'SatDiagnPBLTop                 ',
-                              'SatDiagnTAir                   ',
-                              'SatDiagnGWETROOT               ',
-                              'SatDiagnGWETTOP                ',
-                              'SatDiagnPARDR                  ',
-                              'SatDiagnPARDF                  ',
-                              'SatDiagnPRECTOT                ',
-                              'SatDiagnSLP                    ',
-                              'SatDiagnSPHU                   ',
-                              'SatDiagnTS                     ',
                               'SatDiagnPBLTOPL                ',
                               'SatDiagnMODISLAI               ',
                               'SatDiagnDryDep_O3              ',
@@ -246,7 +237,7 @@ COLLECTIONS: 'Restart',
   SatDiagnEdge.duration:      00000100 000000
   SatDiagnEdge.hrrange:       11.98 15.02
   SatDiagnEdge.mode:          'time-averaged'
-  SatDiagnEdge.fields:        'SatDiagnConc_PEDGE             ',
+  SatDiagnEdge.fields:        'SatDiagnPEDGE                  ',
 ::
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This is the companion PR to #2368 and #2017.  We have fixed several issues with the GEOS-Chem Classic satellite diagnostics, namely:

1. We have moved the IF block that resets the satellite diagnostic counter array (`State_Diag%SatDiagnCount`) to zero out of `History_Netcdf_Write` (in `History/history_netcdf_mod.F90`) to the end of the `History_Write` routine (in `History/history_mod.F90)`, outside of the loop over container names.   Because there are now two satellite diagnostic containers (`SatDiagn` and `SatDiagnEdge`), the counter array was being reset after the first container was written out to disk.

2. We have removed the `SatDiagnPEDGE` entry from the `SatDiagn` collection in all GEOS-Chem Classic `HISTORY.rc.*` template files.  This needs to go into the `SatDiagnEdge` collection.

3. We have fixed a typo in the `SatDiagnEdge` collection in all GEOS-Chem Classic `HISTORY.rc.*` template files.  The erroneous entry was `SatDiagnConc_PEDGE`, which should be `SatDiagnPEDGE`.

4. The `SatDiagnOH` field now works properly for the carbon simulation (which has the species name `FixedOH` instead of `OH). 
 
### Expected changes
The satellite diagnostics should now work as expected for all simulations.

### Related Github Issue

- Closes #2368
- Closes #2017