### PR TITLE
Turn off the MEGAN extension for fullchem "non-benchmark" simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Now reset `State_Diag%SatDiagnCount` to zero in routine`History_Write` (instead of in `History_Netcdf_Write`)
+- Update rundir creation scripts to turn off the MEGAN extension for "standard" fullchem simulations
 
 ### Fixed
 - Typo in `setCommonRunSettings.sh` that made GCHP always choose mass fluxes for meteorology

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -171,7 +171,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> N per snowflake        :       5.0
     --> Model sea salt Br-     :       false
     --> Br- mass ratio         :       2.11e-3
-108     MEGAN                  : off   ISOP/ACET/PRPE/C2H4/ALD2/MOH/EOH/MTPA/MTPO/LIMO/SESQ/SOAP/SOAS
+108     MEGAN                  : ${RUNDIR_MEGAN_EXT}   ISOP/ACET/PRPE/C2H4/ALD2/MOH/EOH/MTPA/MTPO/LIMO/SESQ/SOAP/SOAS
     --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -194,7 +194,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> N per snowflake        :       5.0
     --> Model sea salt Br-     :       true
     --> Br- mass ratio         :       2.11e-3
-108     MEGAN                  : on    ISOP/ACET/PRPE/C2H4/ALD2/MOH/EOH/MTPA/MTPO/LIMO/SESQ/SOAP/SOAS
+108     MEGAN                  : ${RUNDIR_MEGAN_EXT}    ISOP/ACET/PRPE/C2H4/ALD2/MOH/EOH/MTPA/MTPO/LIMO/SESQ/SOAP/SOAS
     --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -486,6 +486,11 @@ else
 
  fi
 
+# Turn off MEGAN for the aerosol-only simulation
+if [[ "x${sim_name}" == "xaerosol"  ]]; then
+    RUNDIR_VARS+="RUNDIR_MEGAN_EXT='off'\n"
+fi
+
 #-----------------------------------------------------------------
 # Ask user to select horizontal resolution
 #-----------------------------------------------------------------
@@ -976,6 +981,7 @@ else
 	RUNDIR_VARS+="RUNDIR_DUSTDEAD_EXT='on '\n"
 	RUNDIR_VARS+="RUNDIR_SEASALT_EXT='on '\n"
 	RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='on '\n"
+	RUNDIR_VARS+="RUNDIR_MEGAN_EXT='on '\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='false'\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_BIOVOC='false'\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_SEASALT='false'\n"
@@ -1006,6 +1012,7 @@ else
 	fi
 	RUNDIR_VARS+="RUNDIR_DUSTDEAD_EXT='off'\n"
 	RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='off'\n"
+	RUNDIR_VARS+="RUNDIR_MEGAN_EXT='off'\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_BIOVOC='true '\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_SOILNOX='true '\n"
     fi

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -967,6 +967,7 @@ fi
 # Assign appropriate file paths and settings in HEMCO_Config.rc
 if [[ ${met} = "ModelE2.1" ]]; then
     RUNDIR_VARS+="RUNDIR_DUSTDEAD_EXT='on '\n"
+    RUNDIR_VARS+="RUNDIR_MEGAN_EXT='on '\n"
     RUNDIR_VARS+="RUNDIR_SEASALT_EXT='on '\n"
     RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='on '\n"
     RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='false'\n"
@@ -979,9 +980,9 @@ if [[ ${met} = "ModelE2.1" ]]; then
 else
     if [[ "${sim_extra_option}" == "benchmark" ]]; then
 	RUNDIR_VARS+="RUNDIR_DUSTDEAD_EXT='on '\n"
+	RUNDIR_VARS+="RUNDIR_MEGAN_EXT='on '\n"
 	RUNDIR_VARS+="RUNDIR_SEASALT_EXT='on '\n"
 	RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='on '\n"
-	RUNDIR_VARS+="RUNDIR_MEGAN_EXT='on '\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='false'\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_BIOVOC='false'\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_SEASALT='false'\n"
@@ -1011,8 +1012,8 @@ else
 	    RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='true '\n"
 	fi
 	RUNDIR_VARS+="RUNDIR_DUSTDEAD_EXT='off'\n"
-	RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='off'\n"
 	RUNDIR_VARS+="RUNDIR_MEGAN_EXT='off'\n"
+	RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='off'\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_BIOVOC='true '\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_SOILNOX='true '\n"
     fi

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -193,7 +193,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> N per snowflake        :       5.0
     --> Model sea salt Br-     :       true
     --> Br- mass ratio         :       2.11e-3
-108     MEGAN                  : on    ISOP/ACET/PRPE/C2H4/ALD2/MOH/EOH/MTPA/MTPO/LIMO/SESQ/SOAP/SOAS
+108     MEGAN                  : ${RUNDIR_MEGAN_EXT}    ISOP/ACET/PRPE/C2H4/ALD2/MOH/EOH/MTPA/MTPO/LIMO/SESQ/SOAP/SOAS
     --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -720,6 +720,7 @@ fi
 # Assign appropriate file paths and settings in HEMCO_Config.rc
 if [[ "${sim_extra_option}" == "benchmark" ]]; then
     RUNDIR_VARS+="RUNDIR_DUSTDEAD_EXT='on '\n"
+    RUNDIR_VARS+="RUNDIR_MEGAN_EXT='on '\n"
     RUNDIR_VARS+="RUNDIR_SEASALT_EXT='on '\n"
     RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='on '\n"
     RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='false'\n"
@@ -751,6 +752,7 @@ else
 	RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='true '\n" 
     fi
     RUNDIR_VARS+="RUNDIR_DUSTDEAD_EXT='off'\n"
+    RUNDIR_VARS+="RUNDIR_MEGAN_EXT='off'\n"
     RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='off'\n"
     RUNDIR_VARS+="RUNDIR_OFFLINE_BIOVOC='true '\n"
     RUNDIR_VARS+="RUNDIR_OFFLINE_SOILNOX='true '\n"


### PR DESCRIPTION
### Name and Institution (Required)
Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #2319.  We have updated the run directory creation scripts and HEMCO_Config.rc template files so that the MEGAN emissions are enabled for the full-chemistry "benchmark" simulation and disabled for all other full-chemistry simulations. 

### Expected changes
This should be a zero-diff update

### Related Github Issue
- Closes #2319
