### PR TITLE
Update standard emissions in CESM to match standard model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Now reset `State_Diag%SatDiagnCount` to zero in routine`History_Write` (instead of in `History_Netcdf_Write`)
 - Update rundir creation scripts to turn off the MEGAN extension for "standard" fullchem simulations
+- Updated emissions used in CESM to match standard emissions used in the 14.4 offline model
 
 ### Fixed
 - Typo in `setCommonRunSettings.sh` that made GCHP always choose mass fluxes for meteorology

--- a/run/CESM/HEMCO_Config.rc
+++ b/run/CESM/HEMCO_Config.rc
@@ -69,6 +69,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> XIAO_C3H8              :       true     # 1985
     --> LIANG_BROMOCARB        :       true     # 2000
     --> ORDONEZ_IODOCARB       :       true     # 2000
+    --> GT_Chlorine            :       true     # 1960-2014
     --> DECAYING_PLANTS        :       true     # 1985
     --> AFCID                  :       true     # 2015
 # ----- AIRCRAFT EMISSIONS ----------------------------------------------------
@@ -226,8 +227,8 @@ VerboseOnCores:              root       # Accepted values: root all
 115     DustAlk                : off   DSTAL1/DSTAL2/DSTAL3/DSTAL4
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
-    --> Volcano_Table          :       $ROOT/VOLCANO/v2021-09/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
-    --> Volcano_Climatology    :       $ROOT/VOLCANO/v2021-09/so2_volcanic_emissions_CARN_v202005.degassing_only.rc
+    --> Volcano_Table          :       $ROOT/VOLCANO/v2024-04/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
+    --> Volcano_Climatology    :       $ROOT/VOLCANO/v2024-04/so2_volcanic_emissions_CARN_v202401.degassing_only.rc
 120     Inorg_Iodine           : on    HOI/I2
     --> Emit HOI               :       true
     --> Emit I2                :       true
@@ -1369,6 +1370,8 @@ VerboseOnCores:              root       # Accepted values: root all
 # %%% This is the default global inventory. You may select either CEDS,
 # EDGAR, HTAPv3 or CMIP6_SFC_LAND_ANTHRO for the global base emissions %%%
 #
+# NOTE: CO2 and CH4 are excluded in CEDS emissions for fullchem simulations.
+#
 # Note for CESM:
 # Scaling of enegy and industrial sectors is applied the same way
 # as in the GEOS-Chem offline model except for aerosols SO2, SO4,
@@ -1377,285 +1380,271 @@ VerboseOnCores:              root       # Accepted values: root all
 # "CEDS to CAM-Chem scale factors" for reference.
 #==============================================================================
 (((CEDSv2
-0 CEDS_NO_AGR     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_agr            1750-2019/1-12/1/0 C xy   kg/m2/s NO    25        1 5
-0 CEDS_NO_ENE     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ene            1750-2019/1-12/1/0 C xyL* kg/m2/s NO    25/315    1 5
-0 CEDS_NO_IND     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ind            1750-2019/1-12/1/0 C xyL* kg/m2/s NO    25/316    1 5
-0 CEDS_NO_TRA     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_tra            1750-2019/1-12/1/0 C xy   kg/m2/s NO    25        1 5
-0 CEDS_NO_RCO     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_rco            1750-2019/1-12/1/0 C xy   kg/m2/s NO    25        1 5
-0 CEDS_NO_SLV     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_slv            1750-2019/1-12/1/0 C xy   kg/m2/s NO    25        1 5
-0 CEDS_NO_WST     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_wst            1750-2019/1-12/1/0 C xy   kg/m2/s NO    25        1 5
+0 CEDS_NO_AGR     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_agr            1750-2019/1-12/1/0 C xy   kg/m2/s NO    2401                1 5
+0 CEDS_NO_ENE     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ene            1750-2019/1-12/1/0 C xyL* kg/m2/s NO    2406/706/315        1 5
+0 CEDS_NO_IND     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_ind            1750-2019/1-12/1/0 C xyL* kg/m2/s NO    2407/707/316        1 5
+0 CEDS_NO_TRA     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_tra            1750-2019/1-12/1/0 C xy   kg/m2/s NO    2411/711            1 5
+0 CEDS_NO_RCO     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_rco            1750-2019/1-12/1/0 C xy   kg/m2/s NO    2409/709            1 5
+0 CEDS_NO_SLV     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_slv            1750-2019/1-12/1/0 C xy   kg/m2/s NO    2407/707            1 5
+0 CEDS_NO_WST     $ROOT/CEDS/v2021-06/$YYYY/NO-em-anthro_CMIP_CEDS_$YYYY.nc            NO_wst            1750-2019/1-12/1/0 C xy   kg/m2/s NO    25                  1 5
 
-0 CEDS_CO_AGR     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_agr            1750-2019/1-12/1/0 C xy   kg/m2/s CO    26         1 5
-0 CEDS_SOAP_AGR   -                                                                    -                 -                  - -    -       SOAP  26/280     1 5
-0 CEDS_CO_ENE     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ene            1750-2019/1-12/1/0 C xyL* kg/m2/s CO    26/315     1 5
-0 CEDS_SOAP_ENE   -                                                                    -                 -                  - -    -       SOAP  26/280/315 1 5
-0 CEDS_CO_IND     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ind            1750-2019/1-12/1/0 C xyL* kg/m2/s CO    26/316     1 5
-0 CEDS_SOAP_IND   -                                                                    -                 -                  - -    -       SOAP  26/280     1 5
-0 CEDS_CO_TRA     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_tra            1750-2019/1-12/1/0 C xy   kg/m2/s CO    26         1 5
-0 CEDS_SOAP_TRA   -                                                                    -                 -                  - -    -       SOAP  26/280     1 5
-0 CEDS_CO_RCO     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_rco            1750-2019/1-12/1/0 C xy   kg/m2/s CO    26         1 5
-0 CEDS_SOAP_RCO   -                                                                    -                 -                  - -    -       SOAP  26/280     1 5
-0 CEDS_CO_SLV     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_slv            1750-2019/1-12/1/0 C xy   kg/m2/s CO    26         1 5
-0 CEDS_SOAP_SLV   -                                                                    -                 -                  - -    -       SOAP  26/280     1 5
-0 CEDS_CO_WST     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_wst            1750-2019/1-12/1/0 C xy   kg/m2/s CO    26         1 5
-0 CEDS_SOAP_WST   -                                                                    -                 -                  - -    -       SOAP  26/280     1 5
+0 CEDS_CO_AGR     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_agr            1750-2019/1-12/1/0 C xy   kg/m2/s CO    2401                1 5
+0 CEDS_SOAP_AGR   -                                                                    -                 -                  - -    -       SOAP  280/2401            1 5
+0 CEDS_CO_ENE     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ene            1750-2019/1-12/1/0 C xyL* kg/m2/s CO    2406/706/315        1 5
+0 CEDS_SOAP_ENE   -                                                                    -                 -                  - -    -       SOAP  280/2406/706/315    1 5
+0 CEDS_CO_IND     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_ind            1750-2019/1-12/1/0 C xyL* kg/m2/s CO    2407/707/316        1 5
+0 CEDS_SOAP_IND   -                                                                    -                 -                  - -    -       SOAP  280/2407/707/316    1 5
+0 CEDS_CO_TRA     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_tra            1750-2019/1-12/1/0 C xy   kg/m2/s CO    2411/711            1 5
+0 CEDS_SOAP_TRA   -                                                                    -                 -                  - -    -       SOAP  280/2411/711        1 5
+0 CEDS_CO_RCO     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_rco            1750-2019/1-12/1/0 C xy   kg/m2/s CO    2409/709            1 5
+0 CEDS_SOAP_RCO   -                                                                    -                 -                  - -    -       SOAP  280/2409/709        1 5
+0 CEDS_CO_SLV     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_slv            1750-2019/1-12/1/0 C xy   kg/m2/s CO    2407/707            1 5
+0 CEDS_SOAP_SLV   -                                                                    -                 -                  - -    -       SOAP  280/2407/707        1 5
+0 CEDS_CO_WST     $ROOT/CEDS/v2021-06/$YYYY/CO-em-anthro_CMIP_CEDS_$YYYY.nc            CO_wst            1750-2019/1-12/1/0 C xy   kg/m2/s CO    26                  1 5
+0 CEDS_SOAP_WST   -                                                                    -                 -                  - -    -       SOAP  26/280              1 5
 
-0 CEDS_SO2_AGR    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_agr           1750-2019/1-12/1/0 C xy            kg/m2/s SO2    -    1 5
-0 CEDS_SO4_AGR    -                                                                    -                 -                  - -             -       so4_a1 8902 1 5
-0 CEDS_pFe_AGR    -                                                                    -                 -                  - -             -       pFe    66   1 5
-0 CEDS_SO2_ENE    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xy            kg/m2/s SO2    -    1 5
-0 CEDS_SO4_ENE    -                                                                    -                 -                  - xyL=100m:300m -       so4_a1 8907 1 5
-0 CEDS_pFe_ENE    -                                                                    -                 -                  - -             -       pFe    66   1 5
-0 CEDS_SO2_IND    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xy            kg/m2/s SO2    -    1 5
-0 CEDS_SO4_IND    -                                                                    -                 -                  - xyL=100m:300m -       so4_a1 8908 1 5
-0 CEDS_pFe_IND    -                                                                    -                 -                  - -             -       pFe    66   1 5
-0 CEDS_SO2_TRA    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_tra           1750-2019/1-12/1/0 C xy            kg/m2/s SO2    -    1 5
-0 CEDS_SO4_TRA    -                                                                    -                 -                  - -             -       so4_a1 8906 1 5
-0 CEDS_pFe_TRA    -                                                                    -                 -                  - -             -       pFe    66   1 5
-0 CEDS_SO2_RCO    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_rco           1750-2019/1-12/1/0 C xy            kg/m2/s SO2    -    1 5
-0 CEDS_SO4_RCO    -                                                                    -                 -                  - -             -       so4_a1 8905 1 5
-0 CEDS_pFe_RCO    -                                                                    -                 -                  - -             -       pFe    66   1 5
-0 CEDS_SO2_SLV    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_slv           1750-2019/1-12/1/0 C xy            kg/m2/s SO2    -    1 5
-0 CEDS_SO4_SLV    -                                                                    -                 -                  - -             -       so4_a1 8904 1 5
-0 CEDS_pFe_SLV    -                                                                    -                 -                  - -             -       pFe    66   1 5
-0 CEDS_SO2_WST    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_wst           1750-2019/1-12/1/0 C xy            kg/m2/s SO2    -    1 5
-0 CEDS_SO4_WST    -                                                                    -                 -                  - -             -       so4_a1 8903 1 5
-0 CEDS_pFe_WST    -                                                                    -                 -                  - -             -       pFe    66   1 5
+# Note for CESM: Apply SO4 to so4_a1
+0 CEDS_SO2_AGR    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_agr           1750-2019/1-12/1/0 C xy   kg/m2/s SO2    2401                1 5
+0 CEDS_SO4_AGR    -                                                                    -                 -                  - -    -       so4_a1 8902/2401           1 5
+0 CEDS_pFe_AGR    -                                                                    -                 -                  - -    -       pFe    66/2401             1 5
+0 CEDS_SO2_ENE    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xyL* kg/m2/s SO2    2406/706/315        1 5
+0 CEDS_SO4_ENE    -                                                                    -                 -                  - -    -       so4_a1 8907/2406/706/315   1 5
+0 CEDS_pFe_ENE    -                                                                    -                 -                  - -    -       pFe    66/2406/706/315     1 5
+0 CEDS_SO2_IND    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xyL* kg/m2/s SO2    2407/707/316        1 5
+0 CEDS_SO4_IND    -                                                                    -                 -                  - -    -       so4_a1 8908/2407/707/316   1 5
+0 CEDS_pFe_IND    -                                                                    -                 -                  - -    -       pFe    66/2407/707/316     1 5
+0 CEDS_SO2_TRA    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_tra           1750-2019/1-12/1/0 C xy   kg/m2/s SO2    2411/711            1 5
+0 CEDS_SO4_TRA    -                                                                    -                 -                  - -    -       so4_a1 8906/2411/711       1 5
+0 CEDS_pFe_TRA    -                                                                    -                 -                  - -    -       pFe    66/2411/711         1 5
+0 CEDS_SO2_RCO    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_rco           1750-2019/1-12/1/0 C xy   kg/m2/s SO2    2409/709            1 5
+0 CEDS_SO4_RCO    -                                                                    -                 -                  - -    -       so4_a1 8905/2409/709       1 5
+0 CEDS_pFe_RCO    -                                                                    -                 -                  - -    -       pFe    66/2409/709         1 5
+0 CEDS_SO2_SLV    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_slv           1750-2019/1-12/1/0 C xy   kg/m2/s SO2    2407/707            1 5
+0 CEDS_SO4_SLV    -                                                                    -                 -                  - -    -       so4_a1 8904/2407/707       1 5
+0 CEDS_pFe_SLV    -                                                                    -                 -                  - -    -       pFe    66/2407/707         1 5
+0 CEDS_SO2_WST    $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_wst           1750-2019/1-12/1/0 C xy   kg/m2/s SO2    -                   1 5
+0 CEDS_SO4_WST    -                                                                    -                 -                  - -    -       so4_a1 8903                1 5
+0 CEDS_pFe_WST    -                                                                    -                 -                  - -    -       pFe    66                  1 5
+ch
 
-0 CEDS_NH3_AGR    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_agr           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   -         1 5
-0 CEDS_NH3_ENE    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ene           1750-2019/1-12/1/0 C xyL* kg/m2/s NH3   315       1 5
-0 CEDS_NH3_IND    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ind           1750-2019/1-12/1/0 C xyL* kg/m2/s NH3   316       1 5
-0 CEDS_NH3_TRA    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_tra           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   -         1 5
-0 CEDS_NH3_RCO    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_rco           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   -         1 5
-0 CEDS_NH3_SLV    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_slv           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   -         1 5
-0 CEDS_NH3_WST    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_wst           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   -         1 5
+0 CEDS_NH3_AGR    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_agr           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   2401                1 5
+0 CEDS_NH3_ENE    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ene           1750-2019/1-12/1/0 C xyL* kg/m2/s NH3   2406/706/315        1 5
+0 CEDS_NH3_IND    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_ind           1750-2019/1-12/1/0 C xyL* kg/m2/s NH3   2407/707/316        1 5
+0 CEDS_NH3_TRA    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_tra           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   2411/711            1 5
+0 CEDS_NH3_RCO    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_rco           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   2409/709            1 5
+0 CEDS_NH3_SLV    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_slv           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   2407/707            1 5
+0 CEDS_NH3_WST    $ROOT/CEDS/v2021-06/$YYYY/NH3-em-anthro_CMIP_CEDS_$YYYY.nc           NH3_wst           1750-2019/1-12/1/0 C xy   kg/m2/s NH3   -                   1 5
 
 #-----------------------------------------------------
 # AEROSOL NUMBER EMISSIONS FOR CEDS in CESM - hplin 8/11/22
 # note shp emiss in ship section
 #-----------------------------------------------------
 
-0 CEDS_SO4n_AGR   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_agr           1750-2019/1-12/1/0 C xy   kg/m2/s num_a1  8902/8014    1 5
-0 CEDS_SO4n_WST   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_wst           1750-2019/1-12/1/0 C xy   kg/m2/s num_a1  8903/8014    1 5
-0 CEDS_SO4n_SLV   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_slv           1750-2019/1-12/1/0 C xy   kg/m2/s num_a1  8904/8014    1 5
-0 CEDS_SO4n_TRA   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_tra           1750-2019/1-12/1/0 C xy   kg/m2/s num_a2  8906/8022    1 5
-0 CEDS_SO4n_RCO   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_rco           1750-2019/1-12/1/0 C xy   kg/m2/s num_a2  8905/8022    1 5
-0 CEDS_SO4n_ENE   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xyL=100m:300m kg/m2/s num_a1 8907/8011 1 5
-0 CEDS_SO4n_IND   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xyL=100m:300m kg/m2/s num_a1 8908/8011 1 5
+0 CEDS_SO4n_AGR   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_agr           1750-2019/1-12/1/0 C xy   kg/m2/s num_a1  8902/2401/8014         1 5
+0 CEDS_SO4n_ENE   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ene           1750-2019/1-12/1/0 C xyL* kg/m2/s num_a1  8907/2406/706/315/8011 1 5
+0 CEDS_SO4n_IND   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_ind           1750-2019/1-12/1/0 C xyL* kg/m2/s num_a1  8908/2407/707/316/8011 1 5
+0 CEDS_SO4n_TRA   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_tra           1750-2019/1-12/1/0 C xy   kg/m2/s num_a2  8906/2411/711/8022     1 5
+0 CEDS_SO4n_RCO   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_rco           1750-2019/1-12/1/0 C xy   kg/m2/s num_a2  8905/2407/709/8022     1 5
+0 CEDS_SO4n_SLV   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_slv           1750-2019/1-12/1/0 C xy   kg/m2/s num_a1  8904/2407/707/8014     1 5
+0 CEDS_SO4n_WST   $ROOT/CEDS/v2021-06/$YYYY/SO2-em-anthro_CMIP_CEDS_$YYYY.nc           SO2_wst           1750-2019/1-12/1/0 C xy   kg/m2/s num_a1  8903/8014              1 5
 
 # BC emiss are classified as a4 for all anthro
-0 CEDS_BCn_AGR    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_agr            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/8041    1 5
-0 CEDS_BCn_WST    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_wst            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/8041    1 5
-0 CEDS_BCn_SLV    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_slv            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/8041    1 5
-0 CEDS_BCn_TRA    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_tra            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/8041    1 5
-0 CEDS_BCn_RCO    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_rco            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/8041    1 5
-0 CEDS_BCn_ENE    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/8041    1 5
-0 CEDS_BCn_IND    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/8041    1 5
+0 CEDS_BCn_AGR    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_agr            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/2401/8041         1 5
+0 CEDS_BCn_ENE    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/2406/706/315/8041 1 5
+0 CEDS_BCn_IND    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/2407/707/316/8041 1 5
+0 CEDS_BCn_TRA    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_tra            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/2411/711/8041     1 5
+0 CEDS_BCn_RCO    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_rco            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/2409/709/8041     1 5
+0 CEDS_BCn_SLV    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_slv            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/2407/707/8041     1 5
+0 CEDS_BCn_WST    $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_wst            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8920/8041              1 5
 
 # OC emiss are classified as a4 for all anthro
-0 CEDS_OCn_AGR    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_agr            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/8042    1 5
-0 CEDS_OCn_WST    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_wst            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/8042    1 5
-0 CEDS_OCn_SLV    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_slv            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/8042    1 5
-0 CEDS_OCn_TRA    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_tra            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/8042    1 5
-0 CEDS_OCn_RCO    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_rco            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/8042    1 5
-0 CEDS_OCn_ENE    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/8042    1 5
-0 CEDS_OCn_IND    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/8042    1 5
+0 CEDS_OCn_AGR    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_agr            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/2401/8042         1 5
+0 CEDS_OCn_ENE    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/2406/706/315/8042 1 5
+0 CEDS_OCn_IND    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/2407/707/316/8042 1 5
+0 CEDS_OCn_TRA    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_tra            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/2411/711/8042     1 5
+0 CEDS_OCn_RCO    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_rco            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/2409/709/8042     1 5
+0 CEDS_OCn_SLV    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_slv            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/2407/707/8042     1 5
+0 CEDS_OCn_WST    $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_wst            1750-2019/1-12/1/0 C xy   kg/m2/s num_a4  8930/8042              1 5
 
 #-----------------------------------------------------
 # // end AEROSOL NUMBER EMISSIONS FOR CEDS in CESM
 #-----------------------------------------------------
 
-0 CEDS_BCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_agr            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920     1 5
-0 CEDS_BCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920     1 5
-0 CEDS_BCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920     1 5
-0 CEDS_BCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_tra            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920     1 5
-0 CEDS_BCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_rco            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920     1 5
-0 CEDS_BCPI_SLV   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_slv            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920     1 5
-0 CEDS_BCPI_WST   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_wst            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920     1 5
+# Note for CESM: Apply BCPI to bc_a4
+0 CEDS_BCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_agr            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920/2401             1 5
+0 CEDS_BCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ene            1750-2019/1-12/1/0 C xyL* kg/m2/s bc_a4  8920/2406/706/315     1 5
+0 CEDS_BCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_ind            1750-2019/1-12/1/0 C xyL* kg/m2/s bc_a4  8920/2407/707/316     1 5
+0 CEDS_BCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_tra            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920/2411/711         1 5
+0 CEDS_BCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_rco            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920/2409/709         1 5
+0 CEDS_BCPI_SLV   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_slv            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920/2407/707         1 5
+0 CEDS_BCPI_WST   $ROOT/CEDS/v2021-06/$YYYY/BC-em-anthro_CMIP_CEDS_$YYYY.nc            BC_wst            1750-2019/1-12/1/0 C xy   kg/m2/s bc_a4  8920                  1 5
 
-0 CEDS_OCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_agr            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930     1 5
-0 CEDS_POG1_AGR   -                                                                    -                 -                  - -    -       POG1   73/74/76 1 5
-0 CEDS_POG2_AGR   -                                                                    -                 -                  - -    -       POG2   73/74/77 1 5
-0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930     1 5
-0 CEDS_POG1_ENE   -                                                                    -                 -                  - -    -       POG1   73/74/76 1 5
-0 CEDS_POG2_ENE   -                                                                    -                 -                  - -    -       POG2   73/74/77 1 5
-0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930     1 5
-0 CEDS_POG1_IND   -                                                                    -                 -                  - -    -       POG1   73/74/76 1 5
-0 CEDS_POG2_IND   -                                                                    -                 -                  - -    -       POG2   73/74/77 1 5
-0 CEDS_OCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_tra            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930     1 5
-0 CEDS_POG1_TRA   -                                                                    -                 -                  - -    -       POG1   73/74/76 1 5
-0 CEDS_POG2_TRA   -                                                                    -                 -                  - -    -       POG2   73/74/77 1 5
-0 CEDS_OCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_rco            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930     1 5
-0 CEDS_POG1_RCO   -                                                                    -                 -                  - -    -       POG1   73/74/76 1 5
-0 CEDS_POG2_RCO   -                                                                    -                 -                  - -    -       POG2   73/74/77 1 5
-0 CEDS_OCPI_SLV   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_slv            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930     1 5
-0 CEDS_POG1_SLV   -                                                                    -                 -                  - -    -       POG1   73/74/76 1 5
-0 CEDS_POG2_SLV   -                                                                    -                 -                  - -    -       POG2   73/74/77 1 5
-0 CEDS_OCPI_WST   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_wst            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930     1 5
-0 CEDS_POG1_WST   -                                                                    -                 -                  - -    -       POG1   73/74/76 1 5
-0 CEDS_POG2_WST   -                                                                    -                 -                  - -    -       POG2   73/74/77 1 5
-
-# Comment out CO2 for fullchem simulations: CO2 not advected
-#0 CEDS_CO2_AGR   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_agr           1750-2019/1-12/1/0 C xy   kg/m2/s CO2   -         1 5
-#0 CEDS_CO2_ENE   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ene           1750-2019/1-12/1/0 C xyL* kg/m2/s CO2   315       1 5
-#0 CEDS_CO2_IND   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_ind           1750-2019/1-12/1/0 C xyL* kg/m2/s CO2   316       1 5
-#0 CEDS_CO2_TRA   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_tra           1750-2019/1-12/1/0 C xy   kg/m2/s CO2   -         1 5
-#0 CEDS_CO2_RCO   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_rco           1750-2019/1-12/1/0 C xy   kg/m2/s CO2   -         1 5
-#0 CEDS_CO2_SLV   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_slv           1750-2019/1-12/1/0 C xy   kg/m2/s CO2   -         1 5
-#0 CEDS_CO2_WST   $ROOT/CEDS/v2021-06/$YYYY/CO2-em-anthro_CMIP_CEDS_$YYYY.nc           CO2_wst           1750-2019/1-12/1/0 C xy   kg/m2/s CO2   -         1 5
-
-# Comment out CH4 for fullchem simulations: do not use CH4 emissions
-# CEDS CH4 emissions are only available for 1970-2014
-#0 CEDS_CH4_AGR   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_agr           1970-2014/1-12/1/0 C xy   kg/m2/s CH4   -         1 5
-#0 CEDS_CH4_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ene           1970-2014/1-12/1/0 C xyL* kg/m2/s CH4   315       1 5
-#0 CEDS_CH4_IND   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_ind           1970-2014/1-12/1/0 C xyL* kg/m2/s CH4   316       1 5
-#0 CEDS_CH4_TRA   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_tra           1970-2014/1-12/1/0 C xy   kg/m2/s CH4   -         1 5
-#0 CEDS_CH4_RCO   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_rco           1970-2014/1-12/1/0 C xy   kg/m2/s CH4   -         1 5
-#0 CEDS_CH4_SLV   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_slv           1970-2014/1-12/1/0 C xy   kg/m2/s CH4   -         1 5
-#0 CEDS_CH4_WST   $ROOT/CEDS/v2021-06/$YYYY/CH4-em-anthro_CMIP_CEDS_$YYYY.nc           CH4_wst           1970-2014/1-12/1/0 C xy   kg/m2/s CH4   -         1 5
+# Note for CESM: Apply OCPI to pom_a4
+0 CEDS_OCPI_AGR   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_agr            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930/2401           1 5
+0 CEDS_POG1_AGR   -                                                                    -                 -                  - -    -       POG1   74/76/2401          1 5
+0 CEDS_POG2_AGR   -                                                                    -                 -                  - -    -       POG2   74/77/2401          1 5
+0 CEDS_OCPI_ENE   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ene            1750-2019/1-12/1/0 C xyL* kg/m2/s pom_a4 8930/2406/706/315   1 5
+0 CEDS_POG1_ENE   -                                                                    -                 -                  - -    -       POG1   74/76/2406/706/315  1 5
+0 CEDS_POG2_ENE   -                                                                    -                 -                  - -    -       POG2   74/77/2406/706/315  1 5
+0 CEDS_OCPI_IND   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_ind            1750-2019/1-12/1/0 C xyL* kg/m2/s pom_a4 8930/2407/707/316   1 5
+0 CEDS_POG1_IND   -                                                                    -                 -                  - -    -       POG1   74/76/2407/707/316  1 5
+0 CEDS_POG2_IND   -                                                                    -                 -                  - -    -       POG2   74/77/2407/707/316  1 5
+0 CEDS_OCPI_TRA   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_tra            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930/2411/711       1 5
+0 CEDS_POG1_TRA   -                                                                    -                 -                  - -    -       POG1   74/76/2411/711      1 5
+0 CEDS_POG2_TRA   -                                                                    -                 -                  - -    -       POG2   74/77/2411/711      1 5
+0 CEDS_OCPI_RCO   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_rco            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930/2409/709       1 5
+0 CEDS_POG1_RCO   -                                                                    -                 -                  - -    -       POG1   74/76/2409/709      1 5
+0 CEDS_POG2_RCO   -                                                                    -                 -                  - -    -       POG2   74/77/2409/709      1 5
+0 CEDS_OCPI_SLV   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_slv            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930/2407/707       1 5
+0 CEDS_POG1_SLV   -                                                                    -                 -                  - -    -       POG1   74/76/2407/707      1 5
+0 CEDS_POG2_SLV   -                                                                    -                 -                  - -    -       POG2   74/77/2407/707      1 5
+0 CEDS_OCPI_WST   $ROOT/CEDS/v2021-06/$YYYY/OC-em-anthro_CMIP_CEDS_$YYYY.nc            OC_wst            1750-2019/1-12/1/0 C xy   kg/m2/s pom_a4 8930                1 5
+0 CEDS_POG1_WST   -                                                                    -                 -                  - -    -       POG1   74/76               1 5
+0 CEDS_POG2_WST   -                                                                    -                 -                  - -    -       POG2   74/77               1 5
 
 # NOTE: EOH files in CEDS/v2021-06 are actually VOC1 (total alchohols) and are split into MOH, EOH, ROH here
-0 CEDS_MOH_AGR    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_agr           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   26/90     1 5
-0 CEDS_EOH_AGR    -                                                                    -                 -                  - -    -       EOH   26/91     1 5
-0 CEDS_ROH_AGR    -                                                                    -                 -                  - -    -       ROH   26/92     1 5
-0 CEDS_MOH_ENE    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ene           1750-2019/1-12/1/0 C xyL* kg/m2/s MOH   26/90/315 1 5
-0 CEDS_EOH_ENE    -                                                                    -                 -                  - -    -       EOH   26/91/315 1 5
-0 CEDS_ROH_ENE    -                                                                    -                 -                  - -    -       ROH   26/92/315 1 5
-0 CEDS_MOH_IND    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ind           1750-2019/1-12/1/0 C xyL* kg/m2/s MOH   26/90/316 1 5
-0 CEDS_EOH_IND    -                                                                    -                 -                  - -    -       EOH   26/91/316 1 5
-0 CEDS_ROH_IND    -                                                                    -                 -                  - -    -       ROH   26/92/316 1 5
-0 CEDS_MOH_TRA    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_tra           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   26/90     1 5
-0 CEDS_EOH_TRA    -                                                                    -                 -                  - -    -       EOH   26/91     1 5
-0 CEDS_ROH_TRA    -                                                                    -                 -                  - -    -       ROH   26/92     1 5
-0 CEDS_MOH_RCO    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_rco           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   26/90     1 5
-0 CEDS_EOH_RCO    -                                                                    -                 -                  - -    -       EOH   26/91     1 5
-0 CEDS_ROH_RCO    -                                                                    -                 -                  - -    -       ROH   26/92     1 5
-0 CEDS_MOH_SLV    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_slv           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   26/90     1 5
-0 CEDS_EOH_SLV    -                                                                    -                 -                  - -    -       EOH   26/91     1 5
-0 CEDS_ROH_SLV    -                                                                    -                 -                  - -    -       ROH   26/92     1 5
-0 CEDS_MOH_WST    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_wst           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   26/90     1 5
-0 CEDS_EOH_WST    -                                                                    -                 -                  - -    -       EOH   26/91     1 5
-0 CEDS_ROH_WST    -                                                                    -                 -                  - -    -       ROH   26/92     1 5
+0 CEDS_MOH_AGR    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_agr           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   90/2401             1 5
+0 CEDS_EOH_AGR    -                                                                    -                 -                  - -    -       EOH   91/2401             1 5
+0 CEDS_ROH_AGR    -                                                                    -                 -                  - -    -       ROH   92/2401             1 5
+0 CEDS_MOH_ENE    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ene           1750-2019/1-12/1/0 C xyL* kg/m2/s MOH   90/2406/706/315     1 5
+0 CEDS_EOH_ENE    -                                                                    -                 -                  - -    -       EOH   91/2406/706/315     1 5
+0 CEDS_ROH_ENE    -                                                                    -                 -                  - -    -       ROH   92/2406/706/315     1 5
+0 CEDS_MOH_IND    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_ind           1750-2019/1-12/1/0 C xyL* kg/m2/s MOH   90/2407/707/316     1 5
+0 CEDS_EOH_IND    -                                                                    -                 -                  - -    -       EOH   91/2407/707/316     1 5
+0 CEDS_ROH_IND    -                                                                    -                 -                  - -    -       ROH   92/2407/707/316     1 5
+0 CEDS_MOH_TRA    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_tra           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   90/2411/711         1 5
+0 CEDS_EOH_TRA    -                                                                    -                 -                  - -    -       EOH   91/2411/711         1 5
+0 CEDS_ROH_TRA    -                                                                    -                 -                  - -    -       ROH   92/2411/711         1 5
+0 CEDS_MOH_RCO    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_rco           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   90/2409/709         1 5
+0 CEDS_EOH_RCO    -                                                                    -                 -                  - -    -       EOH   91/2409/709         1 5
+0 CEDS_ROH_RCO    -                                                                    -                 -                  - -    -       ROH   92/2409/709         1 5
+0 CEDS_MOH_SLV    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_slv           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   90/2407/707         1 5
+0 CEDS_EOH_SLV    -                                                                    -                 -                  - -    -       EOH   91/2407/707         1 5
+0 CEDS_ROH_SLV    -                                                                    -                 -                  - -    -       ROH   92/2407/707         1 5
+0 CEDS_MOH_WST    $ROOT/CEDS/v2021-06/$YYYY/EOH-em-anthro_CMIP_CEDS_$YYYY.nc           EOH_wst           1750-2019/1-12/1/0 C xy   kg/m2/s MOH   26/90               1 5
+0 CEDS_EOH_WST    -                                                                    -                 -                  - -    -       EOH   26/91               1 5
+0 CEDS_ROH_WST    -                                                                    -                 -                  - -    -       ROH   26/92               1 5
 
-0 CEDS_C2H6_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_agr          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  26        1 5
-0 CEDS_C2H6_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H6  26/315    1 5
-0 CEDS_C2H6_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H6  26/316    1 5
-0 CEDS_C2H6_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_tra          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  26        1 5
-0 CEDS_C2H6_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_rco          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  26        1 5
-0 CEDS_C2H6_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_slv          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  26        1 5
-0 CEDS_C2H6_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_wst          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  26        1 5
+0 CEDS_C2H6_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_agr          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  2401                1 5
+0 CEDS_C2H6_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H6  2406/706/315        1 5
+0 CEDS_C2H6_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H6  2407/707/316        1 5
+0 CEDS_C2H6_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_tra          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  2411/711            1 5
+0 CEDS_C2H6_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_rco          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  2409/709            1 5
+0 CEDS_C2H6_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_slv          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  2407/707            1 5
+0 CEDS_C2H6_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H6-em-anthro_CMIP_CEDS_$YYYY.nc          C2H6_wst          1750-2019/1-12/1/0 C xy   kg/m2/s C2H6  26                  1 5
 
-0 CEDS_C3H8_AGR   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_agr          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  26        1 5
-0 CEDS_C3H8_ENE   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s C3H8  26/315    1 5
-0 CEDS_C3H8_IND   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s C3H8  26/316    1 5
-0 CEDS_C3H8_TRA   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_tra          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  26        1 5
-0 CEDS_C3H8_RCO   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_rco          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  26        1 5
-0 CEDS_C3H8_SLV   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_slv          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  26        1 5
-0 CEDS_C3H8_WST   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_wst          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  26        1 5
+0 CEDS_C3H8_AGR   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_agr          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  2401                1 5
+0 CEDS_C3H8_ENE   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s C3H8  2406/706/315        1 5
+0 CEDS_C3H8_IND   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s C3H8  2407/707/316        1 5
+0 CEDS_C3H8_TRA   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_tra          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  2411/711            1 5
+0 CEDS_C3H8_RCO   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_rco          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  2409/709            1 5
+0 CEDS_C3H8_SLV   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_slv          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  2407/707            1 5
+0 CEDS_C3H8_WST   $ROOT/CEDS/v2021-06/$YYYY/C3H8-em-anthro_CMIP_CEDS_$YYYY.nc          C3H8_wst          1750-2019/1-12/1/0 C xy   kg/m2/s C3H8  26                  1 5
 
-0 CEDS_C4H10_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_agr  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C4H10_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ene  1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  26/315    1 5
-0 CEDS_C4H10_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ind  1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  26/316    1 5
-0 CEDS_C4H10_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_tra  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C4H10_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_rco  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C4H10_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_slv  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C4H10_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_wst  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
+0 CEDS_C4H10_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_agr  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2401                1 5
+0 CEDS_C4H10_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ene  1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  2406/706/315        1 5
+0 CEDS_C4H10_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_ind  1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  2407/707/316        1 5
+0 CEDS_C4H10_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_tra  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2411/711            1 5
+0 CEDS_C4H10_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_rco  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2409/709            1 5
+0 CEDS_C4H10_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_slv  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2407/707            1 5
+0 CEDS_C4H10_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_butanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_butanes_wst  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26                  1 5
 
-0 CEDS_C5H12_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_agr 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C5H12_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ene 1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  26/315    1 5
-0 CEDS_C5H12_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ind 1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  26/316    1 5
-0 CEDS_C5H12_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_tra 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C5H12_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_rco 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C5H12_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_slv 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C5H12_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_wst 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
+0 CEDS_C5H12_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_agr 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2401                1 5
+0 CEDS_C5H12_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ene 1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  2406/706/315        1 5
+0 CEDS_C5H12_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_ind 1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  2407/707/316        1 5
+0 CEDS_C5H12_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_tra 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2411/711            1 5
+0 CEDS_C5H12_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_rco 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2409/709            1 5
+0 CEDS_C5H12_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_slv 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2407/707            1 5
+0 CEDS_C5H12_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_pentanes-em-anthro_CMIP_CEDS_$YYYY.nc ALK4_pentanes_wst 1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26                  1 5
 
-0 CEDS_C6H14_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_agr  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C6H14_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ene  1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  26/315    1 5
-0 CEDS_C6H14_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ind  1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  26/316    1 5
-0 CEDS_C6H14_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_tra  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C6H14_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_rco  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C6H14_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_slv  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
-0 CEDS_C6H14_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_wst  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26        1 5
+0 CEDS_C6H14_AGR  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_agr  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2401                1 5
+0 CEDS_C6H14_ENE  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ene  1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  2406/706/315        1 5
+0 CEDS_C6H14_IND  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_ind  1750-2019/1-12/1/0 C xyL* kg/m2/s ALK4  2407/707/316        1 5
+0 CEDS_C6H14_TRA  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_tra  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2411/711            1 5
+0 CEDS_C6H14_RCO  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_rco  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2409/709            1 5
+0 CEDS_C6H14_SLV  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_slv  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  2407/707            1 5
+0 CEDS_C6H14_WST  $ROOT/CEDS/v2021-06/$YYYY/ALK4_hexanes-em-anthro_CMIP_CEDS_$YYYY.nc  ALK4_hexanes_wst  1750-2019/1-12/1/0 C xy   kg/m2/s ALK4  26                  1 5
 
-0 CEDS_C2H4_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_agr          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  26        1 5
-0 CEDS_C2H4_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H4  26/315    1 5
-0 CEDS_C2H4_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H4  26/316    1 5
-0 CEDS_C2H4_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_tra          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  26        1 5
-0 CEDS_C2H4_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_rco          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  26        1 5
-0 CEDS_C2H4_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_slv          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  26        1 5
-0 CEDS_C2H4_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_wst          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  26        1 5
+0 CEDS_C2H4_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_agr          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  2401                1 5
+0 CEDS_C2H4_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H4  2406/706/315        1 5
+0 CEDS_C2H4_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H4  2407/707/316        1 5
+0 CEDS_C2H4_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_tra          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  2411/711            1 5
+0 CEDS_C2H4_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_rco          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  2409/709            1 5
+0 CEDS_C2H4_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_slv          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  2407/707            1 5
+0 CEDS_C2H4_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H4-em-anthro_CMIP_CEDS_$YYYY.nc          C2H4_wst          1750-2019/1-12/1/0 C xy   kg/m2/s C2H4  26                  1 5
 
-0 CEDS_PRPE_AGR   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_agr          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  26        1 5
-0 CEDS_PRPE_ENE   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s PRPE  26/315    1 5
-0 CEDS_PRPE_IND   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s PRPE  26/316    1 5
-0 CEDS_PRPE_TRA   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_tra          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  26        1 5
-0 CEDS_PRPE_RCO   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_rco          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  26        1 5
-0 CEDS_PRPE_SLV   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_slv          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  26        1 5
-0 CEDS_PRPE_WST   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_wst          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  26        1 5
+0 CEDS_PRPE_AGR   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_agr          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  2401                1 5
+0 CEDS_PRPE_ENE   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s PRPE  2406/706/315        1 5
+0 CEDS_PRPE_IND   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s PRPE  2407/707/316        1 5
+0 CEDS_PRPE_TRA   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_tra          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  2411/711            1 5
+0 CEDS_PRPE_RCO   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_rco          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  2409/709            1 5
+0 CEDS_PRPE_SLV   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_slv          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  2407/707            1 5
+0 CEDS_PRPE_WST   $ROOT/CEDS/v2021-06/$YYYY/PRPE-em-anthro_CMIP_CEDS_$YYYY.nc          PRPE_wst          1750-2019/1-12/1/0 C xy   kg/m2/s PRPE  26                  1 5
 
-0 CEDS_C2H2_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_agr          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  26        1 5
-0 CEDS_C2H2_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H2  26/315    1 5
-0 CEDS_C2H2_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H2  26/316    1 5
-0 CEDS_C2H2_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_tra          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  26        1 5
-0 CEDS_C2H2_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_rco          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  26        1 5
-0 CEDS_C2H2_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_slv          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  26        1 5
-0 CEDS_C2H2_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_wst          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  26        1 5
+0 CEDS_C2H2_AGR   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_agr          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  2401                1 5
+0 CEDS_C2H2_ENE   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H2  2406/706/315        1 5
+0 CEDS_C2H2_IND   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s C2H2  2407/707/316        1 5
+0 CEDS_C2H2_TRA   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_tra          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  2411/711            1 5
+0 CEDS_C2H2_RCO   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_rco          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  2409/709            1 5
+0 CEDS_C2H2_SLV   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_slv          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  2407/707            1 5
+0 CEDS_C2H2_WST   $ROOT/CEDS/v2021-06/$YYYY/C2H2-em-anthro_CMIP_CEDS_$YYYY.nc          C2H2_wst          1750-2019/1-12/1/0 C xy   kg/m2/s C2H2  26                  1 5
 
-0 CEDS_BENZ_AGR   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_agr          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  26        1 5
-0 CEDS_BENZ_ENE   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s BENZ  26/315    1 5
-0 CEDS_BENZ_IND   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s BENZ  26/316    1 5
-0 CEDS_BENZ_TRA   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_tra          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  26        1 5
-0 CEDS_BENZ_RCO   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_rco          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  26        1 5
-0 CEDS_BENZ_SLV   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_slv          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  26        1 5
-0 CEDS_BENZ_WST   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_wst          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  26        1 5
+0 CEDS_BENZ_AGR   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_agr          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  2401                1 5
+0 CEDS_BENZ_ENE   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s BENZ  2406/706/315        1 5
+0 CEDS_BENZ_IND   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s BENZ  2407/707/316        1 5
+0 CEDS_BENZ_TRA   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_tra          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  2411/711            1 5
+0 CEDS_BENZ_RCO   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_rco          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  2409/709            1 5
+0 CEDS_BENZ_SLV   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_slv          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  2407/707            1 5
+0 CEDS_BENZ_WST   $ROOT/CEDS/v2021-06/$YYYY/BENZ-em-anthro_CMIP_CEDS_$YYYY.nc          BENZ_wst          1750-2019/1-12/1/0 C xy   kg/m2/s BENZ  26                  1 5
 
-0 CEDS_TOLU_AGR   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_agr          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  26        1 5
-0 CEDS_TOLU_ENE   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s TOLU  26/315    1 5
-0 CEDS_TOLU_IND   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s TOLU  26/316    1 5
-0 CEDS_TOLU_TRA   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_tra          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  26        1 5
-0 CEDS_TOLU_RCO   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_rco          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  26        1 5
-0 CEDS_TOLU_SLV   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_slv          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  26        1 5
-0 CEDS_TOLU_WST   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_wst          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  26        1 5
+0 CEDS_TOLU_AGR   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_agr          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  2401                1 5
+0 CEDS_TOLU_ENE   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s TOLU  2406/706/315        1 5
+0 CEDS_TOLU_IND   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s TOLU  2407/707/316        1 5
+0 CEDS_TOLU_TRA   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_tra          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  2411/711            1 5
+0 CEDS_TOLU_RCO   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_rco          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  2409/709            1 5
+0 CEDS_TOLU_SLV   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_slv          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  2407/707            1 5
+0 CEDS_TOLU_WST   $ROOT/CEDS/v2021-06/$YYYY/TOLU-em-anthro_CMIP_CEDS_$YYYY.nc          TOLU_wst          1750-2019/1-12/1/0 C xy   kg/m2/s TOLU  26                  1 5
 
-0 CEDS_XYLE_AGR   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_agr          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  26        1 5
-0 CEDS_XYLE_ENE   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s XYLE  26/315    1 5
-0 CEDS_XYLE_IND   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s XYLE  26/316    1 5
-0 CEDS_XYLE_TRA   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_tra          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  26        1 5
-0 CEDS_XYLE_RCO   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_rco          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  26        1 5
-0 CEDS_XYLE_SLV   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_slv          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  26        1 5
-0 CEDS_XYLE_WST   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_wst          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  26        1 5
+0 CEDS_XYLE_AGR   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_agr          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  2401                1 5
+0 CEDS_XYLE_ENE   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s XYLE  2406/706/315        1 5
+0 CEDS_XYLE_IND   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s XYLE  2407/707/316        1 5
+0 CEDS_XYLE_TRA   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_tra          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  2411/711            1 5
+0 CEDS_XYLE_RCO   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_rco          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  2409/709            1 5
+0 CEDS_XYLE_SLV   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_slv          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  2407/707            1 5
+0 CEDS_XYLE_WST   $ROOT/CEDS/v2021-06/$YYYY/XYLE-em-anthro_CMIP_CEDS_$YYYY.nc          XYLE_wst          1750-2019/1-12/1/0 C xy   kg/m2/s XYLE  26                  1 5
 
-0 CEDS_CH2O_AGR   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_agr          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  26        1 5
-0 CEDS_CH2O_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s CH2O  26/315    1 5
-0 CEDS_CH2O_IND   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s CH2O  26/316    1 5
-0 CEDS_CH2O_TRA   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_tra          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  26        1 5
-0 CEDS_CH2O_RCO   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_rco          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  26        1 5
-0 CEDS_CH2O_SLV   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_slv          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  26        1 5
-0 CEDS_CH2O_WST   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_wst          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  26        1 5
+0 CEDS_CH2O_AGR   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_agr          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  2401                1 5
+0 CEDS_CH2O_ENE   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s CH2O  2406/706/315        1 5
+0 CEDS_CH2O_IND   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s CH2O  2407/707/316        1 5
+0 CEDS_CH2O_TRA   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_tra          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  2411/711            1 5
+0 CEDS_CH2O_RCO   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_rco          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  2409/709            1 5
+0 CEDS_CH2O_SLV   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_slv          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  2407/707            1 5
+0 CEDS_CH2O_WST   $ROOT/CEDS/v2021-06/$YYYY/CH2O-em-anthro_CMIP_CEDS_$YYYY.nc          CH2O_wst          1750-2019/1-12/1/0 C xy   kg/m2/s CH2O  26                  1 5
 
-0 CEDS_ALD2_AGR   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_agr          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  26        1 5
-0 CEDS_ALD2_ENE   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s ALD2  26/315    1 5
-0 CEDS_ALD2_IND   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s ALD2  26/316    1 5
-0 CEDS_ALD2_TRA   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_tra          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  26        1 5
-0 CEDS_ALD2_RCO   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_rco          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  26        1 5
-0 CEDS_ALD2_SLV   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_slv          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  26        1 5
-0 CEDS_ALD2_WST   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_wst          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  26        1 5
+0 CEDS_ALD2_AGR   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_agr          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  2401                1 5
+0 CEDS_ALD2_ENE   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ene          1750-2019/1-12/1/0 C xyL* kg/m2/s ALD2  2406/706/315        1 5
+0 CEDS_ALD2_IND   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_ind          1750-2019/1-12/1/0 C xyL* kg/m2/s ALD2  2407/707/316        1 5
+0 CEDS_ALD2_TRA   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_tra          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  2411/711            1 5
+0 CEDS_ALD2_RCO   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_rco          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  2409/709            1 5
+0 CEDS_ALD2_SLV   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_slv          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  2407/707            1 5
+0 CEDS_ALD2_WST   $ROOT/CEDS/v2021-06/$YYYY/ALD2-em-anthro_CMIP_CEDS_$YYYY.nc          ALD2_wst          1750-2019/1-12/1/0 C xy   kg/m2/s ALD2  26                  1 5
 
-0 CEDS_MEK_AGR    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_agr           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   26        1 5
-0 CEDS_MEK_ENE    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ene           1750-2019/1-12/1/0 C xyL* kg/m2/s MEK   26/315    1 5
-0 CEDS_MEK_IND    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ind           1750-2019/1-12/1/0 C xyL* kg/m2/s MEK   26/316    1 5
-0 CEDS_MEK_TRA    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_tra           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   26        1 5
-0 CEDS_MEK_RCO    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_rco           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   26        1 5
-0 CEDS_MEK_SLV    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_slv           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   26        1 5
-0 CEDS_MEK_WST    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_wst           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   26        1 5
+0 CEDS_MEK_AGR    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_agr           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   2401                1 5
+0 CEDS_MEK_ENE    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ene           1750-2019/1-12/1/0 C xyL* kg/m2/s MEK   2406/706/315        1 5
+0 CEDS_MEK_IND    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_ind           1750-2019/1-12/1/0 C xyL* kg/m2/s MEK   2407/707/316        1 5
+0 CEDS_MEK_TRA    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_tra           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   2411/711            1 5
+0 CEDS_MEK_RCO    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_rco           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   2409/709            1 5
+0 CEDS_MEK_SLV    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_slv           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   2407/707            1 5
+0 CEDS_MEK_WST    $ROOT/CEDS/v2021-06/$YYYY/MEK-em-anthro_CMIP_CEDS_$YYYY.nc           MEK_wst           1750-2019/1-12/1/0 C xy   kg/m2/s MEK   26                  1 5
 
-0 CEDS_HCOOH_AGR  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_agr         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 26        1 5
-0 CEDS_HCOOH_ENE  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ene         1750-2019/1-12/1/0 C xyL* kg/m2/s HCOOH 26/315    1 5
-0 CEDS_HCOOH_IND  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ind         1750-2019/1-12/1/0 C xyL* kg/m2/s HCOOH 26/316    1 5
-0 CEDS_HCOOH_TRA  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_tra         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 26        1 5
-0 CEDS_HCOOH_RCO  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_rco         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 26        1 5
-0 CEDS_HCOOH_SLV  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_slv         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 26        1 5
-0 CEDS_HCOOH_WST  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_wst         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 26        1 5
+0 CEDS_HCOOH_AGR  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_agr         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 2401                1 5
+0 CEDS_HCOOH_ENE  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ene         1750-2019/1-12/1/0 C xyL* kg/m2/s HCOOH 2406/706/315        1 5
+0 CEDS_HCOOH_IND  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_ind         1750-2019/1-12/1/0 C xyL* kg/m2/s HCOOH 2407/707/316        1 5
+0 CEDS_HCOOH_TRA  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_tra         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 2411/711            1 5
+0 CEDS_HCOOH_RCO  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_rco         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 2409/709            1 5
+0 CEDS_HCOOH_SLV  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_slv         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 2407/707            1 5
+0 CEDS_HCOOH_WST  $ROOT/CEDS/v2021-06/$YYYY/HCOOH-em-anthro_CMIP_CEDS_$YYYY.nc         HCOOH_wst         1750-2019/1-12/1/0 C xy   kg/m2/s HCOOH 26                  1 5
+
 )))CEDSv2
 
 #==============================================================================
@@ -2597,6 +2586,39 @@ VerboseOnCores:              root       # Accepted values: root all
 )))ORDONEZ_IODOCARB
 
 #==============================================================================
+# --- GT_Chlorine ---
+#
+# Emission inventory for HCl and particulate Cl from continental sources
+#
+# Reference:
+#  Zhang, B., & Liu, P., et al (2022). Global Emissions of Hydrogen Chloride
+#  and Particulate Chloride from Continental Sources. Environmental Science &
+#  Technology, 56(7), 3894-3904. https://doi.org/10.1021/acs.est.1c05634 
+#
+# Notes:
+# - The HCl emission from open biomass burning (HCL_BIO, HCL_AGR) used the same
+#   activity data for GFED4 (1998-2014) and BB4CMIP (1960-2014). If your
+#   emission inventory for open biomass burning has already include HCl
+#   emissions, shut down either of them to avoid the duplicated emission sources
+# - Emissions of particulate Cl are added as HCl as ISORROPIA will reparition
+#   Cl between particle phase and gas phase. 
+#==============================================================================
+(((GT_Chlorine
+0 HCL_ENE $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc HCl_ene   1960-2014/1-12/1/0 C xy kg/m2/s HCl 26 1/2 1 
+0 HCL_IND $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc HCl_ind   1960-2014/1-12/1/0 C xy kg/m2/s HCl 26 1/2 1 
+0 HCL_RES $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc HCl_res   1960-2014/1-12/1/0 C xy kg/m2/s HCl 26 1/2 1 
+0 HCL_WST $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc HCl_wstop 1960-2014/1-12/1/0 C xy kg/m2/s HCl 26 1/2 1
+0 HCL_BIO $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc HCl_bbop  1960-2014/1-12/1/0 C xy kg/m2/s HCl 75 1/2 1
+0 HCL_AGR $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc HCl_agri  1960-2014/1-12/1/0 C xy kg/m2/s HCl 75 1/2 1
+0 PCL_ENE $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc pCl_ene   1960-2014/1-12/1/0 C xy kg/m2/s HCl 26 1/2 1
+0 PCL_IND $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc pCl_ind   1960-2014/1-12/1/0 C xy kg/m2/s HCl 26 1/2 1
+0 PCL_RES $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc pCl_res   1960-2014/1-12/1/0 C xy kg/m2/s HCl 26 1/2 1
+0 PCL_WST $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc pCl_wstop 1960-2014/1-12/1/0 C xy kg/m2/s HCl 26 1/2 1
+0 PCL_BIO $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc pCl_bbop  1960-2014/1-12/1/0 C xy kg/m2/s HCl 75 1/2 1
+0 PCL_AGR $ROOT/GT_Chlorine/v2024-05/GT_Chlorine_01_01_$YYYY_V1.0.0.nc pCl_agri  1960-2014/1-12/1/0 C xy kg/m2/s HCl 75 1/2 1
+)))GT_Chlorine
+
+#==============================================================================
 # --- Ship emissions ---
 #
 # ==> CEDS ship emissions are now the default.
@@ -3494,7 +3516,7 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 # --- Time zones (offset to UTC) ---
 #==============================================================================
-* TIMEZONES $ROOT/TIMEZONES/v2015-02/timezones_voronoi_1x1.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+* TIMEZONES $ROOT/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc UTC_OFFSET 2017/1-12/1/0 C xy count * - 1 1
 
 (((CHEMISTRY_INPUT
 
@@ -3796,9 +3818,10 @@ VerboseOnCores:              root       # Accepted values: root all
 
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 ---
+# NOTE: Turn off in CESM since GHGs are prescribed from CAM
 #==============================================================================
 (((GMD_SFC_CH4
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 RY xy ppbv * - 1 1
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2023-10/monthly.gridded.surface.methane.1975-2022.1x1.nc SFC_CH4 1975-2022/1-12/1/0 RY xy ppbv * - 1 1
 )))GMD_SFC_CH4
 
 #==============================================================================
@@ -4647,6 +4670,27 @@ VerboseOnCores:              root       # Accepted values: root all
 1211 SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.Seasonal.1x1.nc SWD 2010/1-12/1/0 C xy unitless 1
 1212 FFF $ROOT/EDGARv43/v2016-11/EDGAR_v43.Seasonal.1x1.nc FFF 2010/1-12/1/0 C xy unitless 1
 )))EDGARv43.or.DICE_Africa
+
+(((CEDSv2
+#=========================================================================
+# --- Sector-wise diel scale factors for CEDSv2 ---
+# These scale factors could potentially be used for other global base emissions if modified accordingly.
+#=========================================================================
+2401 TOD_AGRICULTURE 0.599/0.599/0.599/0.599/0.599/0.649/0.748/0.898/1.098/1.247/1.447/1.597/1.796/1.746/1.696/1.547/1.347/1.098/0.898/0.748/0.649/0.599/0.599/0.599 - - - xy unitless 1
+2406 TOD_ENERGY      0.790/0.720/0.720/0.710/0.740/0.800/0.920/1.080/1.190/1.220/1.210/1.210/1.170/1.150/1.140/1.130/1.100/1.070/1.040/1.020/1.020/1.010/0.960/0.880 - - - xy unitless 1
+2407 TOD_INDUSTRY    0.750/0.750/0.780/0.820/0.880/0.950/1.020/1.090/1.160/1.220/1.280/1.300/1.220/1.240/1.250/1.160/1.080/1.010/0.950/0.900/0.850/0.810/0.780/0.750 - - - xy unitless 1
+2409 TOD_RESIDENTIAL 0.393/0.393/0.393/0.393/0.393/0.492/1.180/1.475/1.574/1.574/1.377/1.180/1.082/1.082/0.984/0.984/0.984/1.082/1.377/1.475/1.377/1.377/0.984/0.393 - - - xy unitless 1
+2411 TOD_TRANSPORT   0.190/0.090/0.060/0.050/0.090/0.220/0.860/1.840/1.860/1.410/1.240/1.200/1.320/1.440/1.450/1.590/2.030/2.080/1.510/1.060/0.740/0.620/0.610/0.440 - - - xy unitless 1
+
+#=========================================================================
+# --- Sector-wise day-of-week scale factors for CEDSv2 ---
+# These scale factors could potentially be used for other global base emissions if modified accordingly.
+#=========================================================================
+706 DOW_ENERGY      0.850/1.060/1.060/1.060/1.060/1.060/0.850 - - - xy unitless 1
+707 DOW_INDUSTRY    0.800/1.080/1.080/1.080/1.080/1.080/0.800 - - - xy unitless 1
+709 DOW_RESIDENTIAL 0.800/1.080/1.080/1.080/1.080/1.080/0.800 - - - xy unitless 1
+711 DOW_TRANSPORT   0.790/1.020/1.060/1.080/1.100/1.140/0.810 - - - xy unitless 1
+)))CEDSv2
 
 ### END SECTION SCALE FACTORS ###
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR updates CESM version of `HEMCO_Config.rc` to match what is used in GC-Classic and GCHP 14.4.0. Previously it was consistent with standard emissions in 14.1. Updates, along with their PRs for inclusion in the standard model, include:

- https://github.com/geoschem/geos-chem/pull/1712
- https://github.com/geoschem/geos-chem/pull/2246
- https://github.com/geoschem/geos-chem/pull/1828
- https://github.com/geoschem/geos-chem/pull/2145
- https://github.com/geoschem/geos-chem/pull/2275

In addition, the `NOAA_GMD_CH4` inventory is now turned off in CESM. CESM uses CH4 prescribed in CAM instead.

### Expected changes

This is a zero-diff update for the standard offline model.

### Reference(s)

None

### Related Github Issue

None
