### PR TITLE
Disable support for FAST-JX except for the Hg simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Now reset `State_Diag%SatDiagnCount` to zero in routine`History_Write` (instead of in `History_Netcdf_Write`)
 - Update rundir creation scripts to turn off the MEGAN extension for "standard" fullchem simulations
+- Disable support For FAST-JX for all simulations except Hg
 
 ### Fixed
 - Typo in `setCommonRunSettings.sh` that made GCHP always choose mass fluxes for meteorology

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -143,7 +143,7 @@ CONTAINS
 
 #ifdef FASTJX
     ! Throw an error if FAST-JX is used for simulations other than Hg
-    IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or. Input_Opt%ITS_A_CARBON_SIM ) THEN
+    IF ( .not. Input_Opt%ITS_A_MERCURY_SIM ) THEN
        ErrMsg = 'FAST-JX is only supported in the Hg simulation!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
        RETURN

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -142,6 +142,13 @@ CONTAINS
        ' -> at GC_Allocate_All  (in module GeosCore/gc_environment_mod.F90)'
 
 #ifdef FASTJX
+    ! Throw an error if FAST-JX is used for simulations other than Hg
+    IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or. Input_Opt%ITS_A_CARBON_SIM ) THEN
+       ErrMsg = 'FAST-JX is only supported in the Hg simulation!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+
     ! Initialize CMN_FJX_mod.F90
     CALL Init_CMN_FJX( Input_Opt,State_Grid, RC )
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is a corresponding PR to https://github.com/geoschem/GCClassic/pull/62 and https://github.com/geoschem/GCHP/pull/426, which are intended to disable support for FAST-JX except for the Hg simulation.

We have added an error trap in `GeosCore/gc_environment_mod.F90`, right before the call to `Init_CMN_FJX`, which will stop the run if FAST-JX is enabled for simulations using the `fullchem`, `custom`, or `carbon` KPP mechanisms.

### Expected changes
This will be a no-diff-to-benchmark update.  An error message will halt simulations (other than Hg) that use FAST-JX photolysis, with error output such as:
```console
*************   S T A R T I N G   G E O S - C H E M   *************

===> Mode of operation         : GEOS-Chem "Classic"
===> GEOS-Chem version         : 14.4.1
===> Compiler                  : GNU Fortran compiler (aka gfortran)
===> Flexible precision set to : 8-byte real (aka REAL*8)
===> Parallelization w/ OpenMP : ON
===> netCDF diagnostics        : ON
===> netCDF file compression   : SUPPORTED
===> Luo et al (2019) wetdep?  : OFF

===> SIMULATION START TIME: 2024/07/15 14:54 <===

===============================================================================
G E O S - C H E M   U S E R   I N P U T

READ_INPUT_FILE: Opening ./geoschem_config.yml

SIMULATION SETTINGS
-------------------
Simulation name             : fullchem
CHEM_INPUTS directory       : /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/
Species database file       : ./species_database.yml
Turn on verbose output      :     F
Verbose output printed on   : root core only
Start time of run           : 20190701 000000
End time of run             : 20190801 000000
Data Directory              : /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/
Meteorology field           : MERRA2
Turn on GEOS-Chem timers    :     T

GRID SETTINGS
------------
Grid resolution             : 4.0x5.0
Min/max longitude           :  -180.0000   180.0000
Min/max latitude            :   -90.0000    90.0000
X grid dimension            :    72
Y grid dimension            :    46
Z grid dimension            :    72
Use half-sized polar boxes? :     T
Center on Intl Date Line?   :     T
Is this a nested-grid sim?  :     F
 --> Buffer zone (N S E W ) :     0    0    0    0

TIMESTEP SETTINGS
-----------------
Transport/Convection [sec]  :   600
Chemistry/Emissions  [sec]  :  1200
RRTMG rad transfer   [sec]  : 10800

TRANSPORT SETTINGS
------------------
Turn on transport?          :     T
Let TPCORE Fill negatives?  :     T
IORD, JORD, KORD for TPCORE?:     3    3    7

CONVECTION SETTINGS
-------------------
Turn on cloud convection?   :     T

PBL MIXING SETTINGS
-------------------
Turn on PBL mixing?         :     T
Turn on non-local PBL?      :     T

AEROSOL SETTINGS
----------------
Online SULFATE AEROSOLS?    :     T
Metal catalyzed SO2 ox.?    :     T
Online CARBON AEROSOLS?     :     T
Brown Carbon Aerosol?       :     F
BC Absorption Enhancement?  :     T
Hydrophilic BC AE factor    :     1.50
Hydrophobic BC AE factor    :     1.00
Online COMPLEX SOA?         :     T
Semivolatile POA?           :     F
Online DUST AEROSOLS?       :     T
Acid uptake on dust?        :     F
Online SEA SALT AEROSOLS?   :     T
Accum  SEA SALT radii [um]  :     0.01 -     0.50
Coarse SEA SALT radii [um]  :     0.50 -     8.00
MARINE ORGANIC AEROSOLS?    :     F
Settle strat. aerosols?     :     T
Online SOLID PSC aerosols?  :     T
Allow hom. NAT nucleation?  :     F
NAT supercooling requirement:     3.00K
Ice supersaturation req.    :    20.00K
Perform PSC het. chemistry? :     T
Use strat. aerosol OD?      :     T

DRY DEPOSITION SETTINGS
-----------------------
Turn on dry deposition?     :     T
Dry dep over full PBL?      :     F
Turn on CO2 effect?         :     F
CO2 level                   :   600.00
CO2 reference level         :   380.00
RIX scaling factor          :     1.00

WET DEPOSITION SETTINGS
-----------------------
Turn on wet deposition?     :     T

CHEMISTRY SETTINGS
------------------
Turn on chemistry?          :     T
Use linear. mesospheric chem:     T
 => Use Linoz for O3?       :     T
Online strat. H2O?          :     T
Use robust strat H2O BC?    :     T
GAMMA HO2                   : 0.20
Use auto-reduce solver?     :     F
Use target species threshold:     T
OH tuning factor:             5.0E-05
NO2 tuning factor:            1.0E-04
Keep halogen spec. active?  :     F
Use append in auto-reduce?  :     F

PHOTOLYSIS SETTINGS
-------------------
Turn on photolysis?         :     T
Number levels with cloud    :    34
FAST-JX input directory     : /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/FAST_JX/v2024-05/
Cloud-J input directory     : /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/CLOUD_J/v2023-05/
Use online ozone?           :     T
Use ozone from met?         :     T
Use TOMS/SBUV ozone?        :     F
Photolyse nitrate aerosol?  :     T
JNITs scaling of JHNO3      :  100.000
JNIT scaling of JHNO3       :  100.000
JNIT(s) channel A (HONO)    :   66.667
JNIT(s) channel B (NO2)     :   33.333

NOTE ABOUT OVERHEAD O3 FOR FAST-JX:
 Online O3 from GEOS-Chem will be used
 to weight the O3 column within the
 chemistry grid and O3 from met or TOMS
 will be used outside the chemistry grid.

RRTMG SETTINGS
--------------
AOD output wavelength (nm)  :   550.0
Turn on radiation?          :     F
Consider longwave?          :     F
Consider shortwave?         :     F
Clear-sky flux?             :     F
All-sky flux?               :     F
CO2 VMR in ppmv             :   390.0
Fixed dyn. heat. assumption?:     F
 --> Seasonal evolution?    :     F
 --> Extend to TOA?         :     F
 --> Read in dyn. heating?  :     F

OBSPACK SETTINGS
----------------
Turn on ObsPack diagnostic? :     F
Suppress logfile output?    :     F
ObsPack input file          : ./obspack_co2_1_OCO2MIP_2018-11-28.YYYYMMDD.nc
ObsPack output file         : ./OutputDir/GEOSChem.ObsPack.YYYYMMDD_hhmmz.nc4

PLANEFLIGHT DIAGNOSTIC SETTINGS
-------------------------------
Turn on planeflight diag?   :     F
Flight track input file     : Planeflight.dat.YYYYMMDD
Output file name            : plane.log.YYYYMMDD

TIMESTEPS SETTINGS
------------------
Chemistry  Timestep [sec]   :   1200
Convection Timestep [sec]   :    600
Dynamics   Timestep [sec]   :    600
Emission   Timestep [sec]   :   1200
Unit Conv  Timestep [sec]   :    600
Diagnostic Timestep [sec]   :   1200
Radiation  Timestep [sec]   :  10800

%%%%%%%%%%%%%%% GLOBAL GRID %%%%%%%%%%%%%%%

Grid box longitude centers [degrees]: 
-180.00000 -175.00000 -170.00000 -165.00000 -160.00000 -155.00000 -150.00000
-145.00000 -140.00000 -135.00000 -130.00000 -125.00000 -120.00000 -115.00000
-110.00000 -105.00000 -100.00000  -95.00000  -90.00000  -85.00000  -80.00000
 -75.00000  -70.00000  -65.00000  -60.00000  -55.00000  -50.00000  -45.00000
 -40.00000  -35.00000  -30.00000  -25.00000  -20.00000  -15.00000  -10.00000
  -5.00000    0.00000    5.00000   10.00000   15.00000   20.00000   25.00000
  30.00000   35.00000   40.00000   45.00000   50.00000   55.00000   60.00000
  65.00000   70.00000   75.00000   80.00000   85.00000   90.00000   95.00000
 100.00000  105.00000  110.00000  115.00000  120.00000  125.00000  130.00000
 135.00000  140.00000  145.00000  150.00000  155.00000  160.00000  165.00000
 170.00000  175.00000

Grid box latitude centers [degrees]: 
 -89.00000  -86.00000  -82.00000  -78.00000  -74.00000  -70.00000  -66.00000
 -62.00000  -58.00000  -54.00000  -50.00000  -46.00000  -42.00000  -38.00000
 -34.00000  -30.00000  -26.00000  -22.00000  -18.00000  -14.00000  -10.00000
  -6.00000   -2.00000    2.00000    6.00000   10.00000   14.00000   18.00000
  22.00000   26.00000   30.00000   34.00000   38.00000   42.00000   46.00000
  50.00000   54.00000   58.00000   62.00000   66.00000   70.00000   74.00000
  78.00000   82.00000   86.00000   89.00000

%%%%%%%%%%%% USER-DEFINED GRID %%%%%%%%%%%%

  XMinOffset :            0
  XMaxOffset :           71
  YMinOffset :            0
  YMaxOffset :           45


Grid box longitude centers [degrees]: 
-180.00000 -175.00000 -170.00000 -165.00000 -160.00000 -155.00000 -150.00000
-145.00000 -140.00000 -135.00000 -130.00000 -125.00000 -120.00000 -115.00000
-110.00000 -105.00000 -100.00000  -95.00000  -90.00000  -85.00000  -80.00000
 -75.00000  -70.00000  -65.00000  -60.00000  -55.00000  -50.00000  -45.00000
 -40.00000  -35.00000  -30.00000  -25.00000  -20.00000  -15.00000  -10.00000
  -5.00000    0.00000    5.00000   10.00000   15.00000   20.00000   25.00000
  30.00000   35.00000   40.00000   45.00000   50.00000   55.00000   60.00000
  65.00000   70.00000   75.00000   80.00000   85.00000   90.00000   95.00000
 100.00000  105.00000  110.00000  115.00000  120.00000  125.00000  130.00000
 135.00000  140.00000  145.00000  150.00000  155.00000  160.00000  165.00000
 170.00000  175.00000

Grid box longitude edges [degrees]: 
-182.50000 -177.50000 -172.50000 -167.50000 -162.50000 -157.50000 -152.50000
-147.50000 -142.50000 -137.50000 -132.50000 -127.50000 -122.50000 -117.50000
-112.50000 -107.50000 -102.50000  -97.50000  -92.50000  -87.50000  -82.50000
 -77.50000  -72.50000  -67.50000  -62.50000  -57.50000  -52.50000  -47.50000
 -42.50000  -37.50000  -32.50000  -27.50000  -22.50000  -17.50000  -12.50000
  -7.50000   -2.50000    2.50000    7.50000   12.50000   17.50000   22.50000
  27.50000   32.50000   37.50000   42.50000   47.50000   52.50000   57.50000
  62.50000   67.50000   72.50000   77.50000   82.50000   87.50000   92.50000
  97.50000  102.50000  107.50000  112.50000  117.50000  122.50000  127.50000
 132.50000  137.50000  142.50000  147.50000  152.50000  157.50000  162.50000
 167.50000  172.50000  177.50000

Grid box latitude centers [degrees]: 
 -89.00000  -86.00000  -82.00000  -78.00000  -74.00000  -70.00000  -66.00000
 -62.00000  -58.00000  -54.00000  -50.00000  -46.00000  -42.00000  -38.00000
 -34.00000  -30.00000  -26.00000  -22.00000  -18.00000  -14.00000  -10.00000
  -6.00000   -2.00000    2.00000    6.00000   10.00000   14.00000   18.00000
  22.00000   26.00000   30.00000   34.00000   38.00000   42.00000   46.00000
  50.00000   54.00000   58.00000   62.00000   66.00000   70.00000   74.00000
  78.00000   82.00000   86.00000   89.00000

Grid box latitude edges [degrees]: 
 -90.00000  -88.00000  -84.00000  -80.00000  -76.00000  -72.00000  -68.00000
 -64.00000  -60.00000  -56.00000  -52.00000  -48.00000  -44.00000  -40.00000
 -36.00000  -32.00000  -28.00000  -24.00000  -20.00000  -16.00000  -12.00000
  -8.00000   -4.00000    0.00000    4.00000    8.00000   12.00000   16.00000
  20.00000   24.00000   28.00000   32.00000   36.00000   40.00000   44.00000
  48.00000   52.00000   56.00000   60.00000   64.00000   68.00000   72.00000
  76.00000   80.00000   84.00000   88.00000   90.00000

SIN( grid box latitude edges )
  -1.00000   -0.99939   -0.99452   -0.98481   -0.97030   -0.95106   -0.92718
  -0.89879   -0.86603   -0.82904   -0.78801   -0.74314   -0.69466   -0.64279
  -0.58779   -0.52992   -0.46947   -0.40674   -0.34202   -0.27564   -0.20791
  -0.13917   -0.06976    0.00000    0.06976    0.13917    0.20791    0.27564
   0.34202    0.40674    0.46947    0.52992    0.58779    0.64279    0.69466
   0.74314    0.78801    0.82904    0.86603    0.89879    0.92718    0.95106
   0.97030    0.98481    0.99452    0.99939    1.00000
===============================================================================
GEOS-Chem ERROR: FAST-JX is only supported in the Hg simulation!
 -> at GC_Allocate_All  (in module GeosCore/gc_environment_mod.F90)
===============================================================================

===============================================================================
GEOS-CHEM ERROR: Error encountered in "GC_Allocate_All"!
STOP at  -> at GEOS-Chem (in GeosCore/main.F90)
===============================================================================
```

### Related Github Issue
- See https://github.com/geoschem/GCClassic/pull/62
- See https://github.com/geoschem/GCHP/pull/426
