### PR TITLE
Disallow legacy FAST-JX unless using mercury simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added number of levels with clouds for photolysis to geoschem_config.yml and Input_Opt to pass to Cloud-J
 - Added `State_Grid%CPU_Subdomain_ID` and `State_Grid%CPU_Subdomain_FirstID` as "identifier numbers" for multiple instances of GEOS-Chem on one core in WRF and CESM
+- Added error for using legacy FAST-JX for any simulation other than mercury
 
 ### Changed
 - Now reset `State_Diag%SatDiagnCount` to zero in routine`History_Write` (instead of in `History_Netcdf_Write`)

--- a/GeosCore/photolysis_mod.F90
+++ b/GeosCore/photolysis_mod.F90
@@ -135,6 +135,11 @@ CONTAINS
     !--------------------------------------------------------------------
     IF ( Input_Opt%Do_Photolysis ) THEN
 #ifdef FASTJX
+       IF ( .not. Input_Opt%Its_A_Mercury_Sim ) THEN
+          ErrMsg = 'Legacy FAST-JX is only an option for the mercury simulation!'
+          CALL GC_Error( ErrMsg, RC, ThisLoc )
+          RETURN
+       ENDIF
        IF ( TRIM(Input_Opt%Fast_JX_Dir) == MISSING_STR ) THEN
           ErrMsg = 'Init_Photolysis: Fast-JX directory missing in ' // &
                    'in geoschem_config.yml!'


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This is a companion PR to https://github.com/geoschem/GCClassic/pull/62 and https://github.com/geoschem/GCHP/pull/426. Those PRs update GC-Classic and GCHP CMake files to throw an error if the FASTJX compile option is selected for any mechanism except Hg. For other models that use GEOS-Chem we also need to have a run-time error if using legacy FAST-JX with any simulation other than mercury. This prevents having to update build settings for all external models that use GEOS-Chem.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issues/PRs

https://github.com/geoschem/GCHP/pull/426
https://github.com/geoschem/GCClassic/pull/62
