### PR TITLE
Fixes for HEMCO diagnostic config file HEMCO_Diagn.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added ModelEe.2 (GCAP 2.0) simulation to integration tests for GCClassic
 - Added simulation with all diagnostics on in HISTORY.rc to integration tests for GCClassic (including Planeflight + ObsPack) and GCHP
 - Added descriptive error message in `Interfaces/GCHP/gchp_historyexportsmod.F90`
+- Auto-update GCHP HEMCO_Diagn.rc settings at run-time to ensure seasalt, dust, soil NOx, and biogenic emissions match settings in HEMCO_Config.rc
 
 ### Fixed
 - Added brackets around `exempt-issue-labels` list in `.github/workflows/stale.yml`

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
@@ -297,7 +297,7 @@ EmisMGLY_BioBurn   MGLY   111    -1  -1   2   kg/m2/s  MGLY_emission_flux_from_b
 EmisMOH_Total      MOH    -1     -1  -1   3   kg/m2/s  MOH_emission_flux_from_all_sectors
 EmisMOH_Anthro     MOH    0      1   -1   3   kg/m2/s  MOH_emission_flux_from_anthropogenic
 EmisMOH_BioBurn    MOH    111    -1  -1   2   kg/m2/s  MOH_emission_flux_from_biomass_burning
-EmisMOH_Biogenic   MOH    108    -1  -1   2   kg/m2/s  MOH_emission_flux_from_biogenic_sources
+EmisMOH_Biogenic   MOH    0      4   -1   2   kg/m2/s  MOH_emission_flux_from_biogenic_sources
 EmisMOH_Ocean      MOH    101    -1  -1   2   kg/m2/s  MOH_emission_flux_from_ocean
 EmisMOH_Ship       MOH    0      10  -1   2   kg/m2/s  MOH_emission_flux_from_ships
 

--- a/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
+++ b/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
@@ -297,7 +297,7 @@ EmisMGLY_BioBurn   MGLY   111    -1  -1   2   kg/m2/s  MGLY_emission_flux_from_b
 EmisMOH_Total      MOH    -1     -1  -1   3   kg/m2/s  MOH_emission_flux_from_all_sectors
 EmisMOH_Anthro     MOH    0      1   -1   3   kg/m2/s  MOH_emission_flux_from_anthropogenic
 EmisMOH_BioBurn    MOH    111    -1  -1   2   kg/m2/s  MOH_emission_flux_from_biomass_burning
-EmisMOH_Biogenic   MOH    108    -1  -1   2   kg/m2/s  MOH_emission_flux_from_biogenic_sources
+EmisMOH_Biogenic   MOH    0      4   -1   2   kg/m2/s  MOH_emission_flux_from_biogenic_sources
 EmisMOH_Ocean      MOH    101    -1  -1   2   kg/m2/s  MOH_emission_flux_from_ocean
 EmisMOH_Ship       MOH    0      10  -1   2   kg/m2/s  MOH_emission_flux_from_ships
 

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -773,6 +773,62 @@ if [[ ${lightningClimEntry} != "missing" ]]; then
     fi
 fi
 
+#### Auto-update offline/online emissions settings in HEMCO_Diagn.rc based on HEMCO_Config.rc
+# NOTES:
+#  - Includes seasalt, soilNOx, dust, and biogenic emissions only
+#  - Sets Emis* diagnostics to extension emissions if extension is on in HEMCO_Config.rc
+#  - Sets Emis* diagnostics to base emissions (offline) if extension is off in HEMCO_Config.rc
+
+# Dust
+dustExt=$(grep "105.*DustDead" HEMCO_Config.rc || echo "missing")
+if [[ ${dustExt} != "missing" ]]; then
+    dustSetting=(${dustExt// / })
+    if [[ ${dustSetting[3]} = "on" ]]; then
+	sed -i -e 's|0      3 |105    -1|' HEMCO_Diagn.rc
+    else
+	sed -i -e 's|105    -1|0      3 |' HEMCO_Diagn.rc
+    fi
+fi
+
+# Sea salt
+seasExt=$(grep "107.*SeaSalt"  HEMCO_Config.rc || echo "missing")
+if [[ ${seasExt} != "missing" ]]; then
+    seasSetting=(${seasExt// / })
+    if [[ ${seasSetting[3]} = "on" ]]; then
+	sed -i -e 's|SALA  0      3 |SALA  107    -1|' HEMCO_Diagn.rc
+	sed -i -e 's|SALC  0      3 |SALC  107    -1|' HEMCO_Diagn.rc
+	sed -i -e 's|AL  0      3 |AL  107    -1|'     HEMCO_Diagn.rc
+	sed -i -e 's|CL  0      3 |CL  107    -1|'     HEMCO_Diagn.rc
+    else
+	sed -i -e 's|SALA  107    -1|SALA  0      3 |' HEMCO_Diagn.rc
+	sed -i -e 's|SALC  107    -1|SALC  0      3 |' HEMCO_Diagn.rc
+	sed -i -e 's|AL  107    -1|AL  0      3 |'     HEMCO_Diagn.rc
+	sed -i -e 's|CL  107    -1|CL  0      3 |'     HEMCO_Diagn.rc
+    fi
+fi
+
+# Biogenic
+biogExt=$(grep "108.*MEGAN"    HEMCO_Config.rc || echo "missing")
+if [[ ${biogExt} != "missing" ]]; then
+    biogSetting=(${biogExt// / })
+    if [[ ${biogSetting[3]} = "on" ]]; then
+	sed -i -e 's|0      4 |108    -1|'               HEMCO_Diagn.rc
+    else
+	sed -i -e 's|108    -1|0      4 |'               HEMCO_Diagn.rc
+    fi
+fi
+
+# SoilNOx
+soilExt=$(grep "104.*SoilNOx"  HEMCO_Config.rc || echo "missing")
+if [[ ${soilExt} != "missing" ]]; then
+    soilSetting=(${soilExt// / })
+    if [[ ${soilSetting[3]} = "on" ]]; then
+	sed -i -e 's|NO     0      3 |NO     104    -1|' HEMCO_Diagn.rc
+    else
+	sed -i -e 's|NO     104    -1|NO     0      3 |'  HEMCO_Diagn.rc
+    fi
+fi
+
 #### Done
 print_msg " "
 print_msg "setCommonRunSettings.sh done"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR contains two bug fixes:

1. Update GC-Classic and GCHP `HEMCO_Diagn.rc` fullchem templates to use offline MOH biogenic emissions rather than online unless using the benchmark simulation. This corrects a problem where `EmisMOH_Biogenic` was filled with all zeros for non-benchmark fullchem simulations in 14.4.2 since MEGAN is no longer on starting in that version.
2. Auto-set GCHP emissions sources in `HEMCO_Diagn.rc` based on `HEMCO_Config.rc`.  This update impacts only GCHP emissions for which we have both online and offline sources, namely seasalt, soil NOx, biogenic, and dust emissions. Previously `HEMCO_Diagn.rc` always specified offline emissions for use in emissions diagnostics unless using the benchmark simulation. This resulted in empty emissions diagnostics if the user changed from offline to online.

### Expected changes

This is a no-diff update for benchmark simulations. There are expected changes in the emissions diagnostic collection for non-benchmark full chemistry simulations and they are as follows:
- `EmisMOH_Biogenic` will no longer be all zeros if using GC-Classic and GCHP
- GCHP emission diagnostics will no longer be zero if offline emissions are changed to online

### Reference(s)

None

### Related Github Issue

closes https://github.com/geoschem/geos-chem/issues/2382
Also related to https://github.com/geoschem/geos-chem/issues/2319
