### PR TITLE
Add tropopause pressure to the GEOS-Chem Classic "SatDiagn" collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,6 +378,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed State_Met%LWI and input meteorology LWI from carbon simulation run config files
 - Removed function `CLEANUP_UCX`; deallocations are now done in `state_chm_mod.F90`
 
+## [Unreleased] - TBD
+### Added
+- Tropopause pressure field in the satellite diagnostic (by @eamarais)
+
 ## [14.1.0] - 2023-02-01
 ### Added
 - Added dry deposition updates to Hg0 from Feinberg22 ESPI publication + AMAP emissions

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1519,6 +1519,13 @@ CONTAINS
        ENDIF
 
        !---------------------------------------------------------------------
+       ! Tropopause level [unitless]:
+       !---------------------------------------------------------------------
+       IF ( State_Diag%Archive_SatDiagnTropLev ) THEN
+          State_Diag%SatDiagnTropLev(I,:) = State_Met%TropLev(I,:) * good
+       ENDIF
+
+       !---------------------------------------------------------------------
        ! PBL Height [m]:
        !---------------------------------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPBLHeight ) THEN

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -945,6 +945,9 @@ MODULE State_Diag_Mod
      REAL(f8),           POINTER :: SatDiagnTROPP(:,:)
      LOGICAL                     :: Archive_SatDiagnTROPP
 
+     REAL(f8),           POINTER :: SatDiagnTropLev(:,:)
+     LOGICAL                     :: Archive_SatDiagnTropLev
+
      REAL(f8),           POINTER :: SatDiagnPBLHeight(:,:)
      LOGICAL                     :: Archive_SatDiagnPBLHeight
 
@@ -2408,6 +2411,9 @@ CONTAINS
 
     State_Diag%SatDiagnTROPP                       => NULL()
     State_Diag%Archive_SatDiagnTROPP               = .FALSE.
+
+    State_Diag%SatDiagnTropLev                     => NULL()
+    State_Diag%Archive_SatDiagnTropLev             = .FALSE.
 
     State_Diag%SatDiagnPBLHeight                   => NULL()
     State_Diag%Archive_SatDiagnPBLHeight           = .FALSE.
@@ -4894,6 +4900,28 @@ CONTAINS
     ENDIF
 
     !------------------------------------------------------------------------
+    ! Satellite diagnostic: Tropopause level (TropLev)
+    !------------------------------------------------------------------------
+    diagId  = 'SatDiagnTropLev'
+    CALL Init_and_Register(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Diag     = State_Diag,                                        &
+         State_Grid     = State_Grid,                                        &
+         DiagList       = Diag_List,                                         &
+         TaggedDiagList = TaggedDiag_List,                                   &
+         Ptr2Data       = State_Diag%SatDiagnTropLev,                        &
+         archiveData    = State_Diag%Archive_SatDiagnTropLev,                &
+         diagId         = diagId,                                            &
+         RC             = RC                                                )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
     ! Satellite diagnostic: PBL Height (m)
     !------------------------------------------------------------------------
     diagId  = 'SatDiagnPBLHeight'
@@ -5190,6 +5218,12 @@ CONTAINS
          State_Diag%Archive_SatDiagnConc                                .or. &
          State_Diag%Archive_SatDiagnDryDep                              .or. &
          State_Diag%Archive_SatDiagnDryDepVel                           .or. &
+         State_Diag%Archive_SatDiagnPEdge                               .or. &
+         State_Diag%Archive_SatDiagnTROPP                               .or. &
+         State_Diag%Archive_SatDiagnTropLev                             .or. &
+         State_Diag%Archive_SatDiagnPBLHeight                           .or. &
+         State_Diag%Archive_SatDiagnPBLTop                              .or. &
+         State_Diag%Archive_SatDiagnTAir                                .or. &
          State_Diag%Archive_SatDiagnGWETROOT                            .or. &
          State_Diag%Archive_SatDiagnGWETTOP                             .or. &
          State_Diag%Archive_SatDiagnJval                                .or. &
@@ -12999,6 +13033,11 @@ CONTAINS
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
+    CALL Finalize( diagId   = 'SatDiagnTropLev',                           &
+                   Ptr2Data = State_Diag%SatDiagnTropLev,                  &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
     CALL Finalize( diagId   = 'SatDiagnPBLHeight',                         &
                    Ptr2Data = State_Diag%SatDiagnPBLHeight,                &
                    RC       = RC                                            )
@@ -15144,6 +15183,11 @@ CONTAINS
     ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNTROPP' ) THEN
        IF ( isDesc    ) Desc  = 'Tropopause pressure'
        IF ( isUnits   ) Units = 'hPa'
+       IF ( isRank    ) Rank  = 2
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNTROPLEV' ) THEN
+       IF ( isDesc    ) Desc  = 'Tropopause level'
+       IF ( isUnits   ) Units = 'unitless'
        IF ( isRank    ) Rank  = 2
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'SATDIAGNPBLHEIGHT' ) THEN


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #2407.  We have implemented the patch submitted by @eamarais to add the tropopause pressure field to the GEOS-Chem Classic "SatDiagn" History collection.  We have rebased these updates atop PR #2399, as the original update was created in version 14.1.0.

### Expected changes
This is a "zero-diff-to-benchmark" update.  It only adds a new field to an existing diagnostic collection, and will not affect any scientific results.

### Related Github Issue

- Closes #2407