### PR TITLE
Support for Cloud-J version 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Four new species ALK4N1, ALK4N2, ALK4O2, and ALK4P to address issues in ALK4 and R4N2 chemistry following Brewer et al. (2023, JGR)
 - ALK4N1 and ALK4N2 to Ox family in KPP
 - PPN photolysis from Horner et al (2024)
+- Added vectors `State_Chm%KPP_AbsTol` and `State_Chm%KPP_RelTol`
+- Added four new species ALK4N1, ALK4N2, ALK4O2, and ALK4P to address issues in ALK4 and R4N2 chemistry following Brewer et al. (2023, JGR)
+- Added new species ALK4N1 and ALK4N2 to Ox family in KPP
+- Added Cloud-J input parameters to geoschem_config.yml in new photolysis sub-menu called cloud-j
+- Added computation of water concentration to use in photolysis for application of UV absorption by water in Cloud-J v8
 
 ### Changed
 - Copy values from `State_Chm%KPP_AbsTol` to `ATOL` and `State_Chm%KPP_RelTol` to `RTOL` for fullchem and Hg simulations

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -143,6 +143,7 @@ CONTAINS
                    Input_Opt%Cloud_Flag,         &
                    Input_Opt%Cloud_Corr,         &
                    Input_Opt%Num_Max_Overlap,    &
+                   Input_Opt%Sphere_Correction,  &
                    Input_Opt%Use_H2O_UV_Abs,     &
                    NJXX,                         &
                    RC)

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -131,9 +131,21 @@ CONTAINS
     ! Initialize Cloud-J. Includes reading input data files
     ! FJX_spec.dat (RD_XXX), FJX_scat-aer.dat (RD_MIE), and 
     ! FJX_j2j.dat (RD_JS_JX)
-    CALL Init_CldJ(Input_Opt%amIRoot, Input_Opt%CloudJ_Dir,   &
-                   State_Grid%NZ, Input_Opt%Nlevs_Phot_Cloud, &
-                   TITLEJXX, JVN_, NJXX, RC)
+    CALL Init_CldJ(Input_Opt%amIRoot,            &
+                   Input_Opt%CloudJ_Dir,         &
+                   State_Grid%NZ,                &
+                   Input_Opt%Nlevs_Phot_Cloud,   &
+                   TITLEJXX,                     &
+                   JVN_,                         &
+                   Input_Opt%OD_Increase_Factor, &
+                   Input_Opt%Min_Cloud_OD,       &
+                   Input_Opt%Num_WV_Bins,        &
+                   Input_Opt%Cloud_Flag,         &
+                   Input_Opt%Cloud_Corr,         &
+                   Input_Opt%Num_Max_Overlap,    &
+                   Input_Opt%Use_H2O_UV_Abs,     &
+                   NJXX,                         &
+                   RC)
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered in subroutine Init_Cldj within Cloud-J photolysis'
        CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -182,7 +182,7 @@ CONTAINS
     USE Cmn_Size_Mod,   ONLY : NRHAER, NRH, NDUST
     USE ErrCode_Mod
     USE Input_Opt_Mod,  ONLY : OptInput
-    USE PhysConstants,  ONLY : AVO, H2OMW, AIRMW, G0_100, PI, PI_180
+    USE PhysConstants,  ONLY : AVO, H2OMW, G0_100, PI, PI_180
     USE State_Chm_Mod,  ONLY : ChmState, Ind_
     USE State_Diag_Mod, ONLY : DgnState
     USE State_Grid_Mod, ONLY : GrdState
@@ -295,7 +295,7 @@ CONTAINS
     REAL(8)  :: VALJXX(L_,JVN_)
 
     !------------------------------------------------------------------------
-    ! For diagnostics
+    ! Other local variables
     !------------------------------------------------------------------------
 
     ! These are currently never set. Should they be output from Cloud-J?
@@ -309,7 +309,13 @@ CONTAINS
     REAL(fp) :: FDIFFUSE(L1_)
     REAL(fp) :: UVX_CONST
 
+    ! For computing water concentration from specific humidity
+    REAL(fp) :: SPHU_kgkg
+    REAL(fp) :: H2O_kgkgdry
+    REAL(fp) :: MW_kg
+
     ! Species ids
+    INTEGER, SAVE :: id_H2O
     INTEGER, SAVE :: id_O3
     INTEGER, SAVE :: id_SO4
 
@@ -382,10 +388,11 @@ CONTAINS
 
     ! Set species ids for use in diagnostics
     IF ( FIRST ) THEN
+       id_H2O  = Ind_('H2O')
        id_O3   = Ind_('O3')
        id_SO4  = Ind_('SO4')
-       IF ( id_O3 < 0 ) THEN
-          ErrMsg = 'O3 is not a defined species!'
+       IF ( id_O3 <= 0 ) THEN
+          ErrMsg = 'O3 is not a defined species but is required for Cloud-J photolysis!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
@@ -416,7 +423,7 @@ CONTAINS
     !$OMP DEFAULT( SHARED ) &
     !$OMP PRIVATE( A, I, J, L, K, N, S, MW_g, BoxHt, RH_ind                    ) &
     !$OMP PRIVATE( S_rh0, S_rhx, K_rh0, K_rhx, FRAC, RAA_eff, QAA_eff, SAA_eff ) &
-    !$OMP PRIVATE( dry_to_wet_factor                                           ) &
+    !$OMP PRIVATE( dry_to_wet_factor, SPHU_kgkg, H2O_kgkgdry, MW_kg            ) &
     !$OMP PRIVATE( R_interp_factor, Q_interp_factor                            ) &
     !$OMP PRIVATE( U0, SZA, SOLF, T_CTM, P_CTM,  O3_CTM                        ) &
     !$OMP PRIVATE( T_CLIM, O3_CLIM, AIR_CLIM, Z_CLIM                           ) &
@@ -551,7 +558,38 @@ CONTAINS
        ENDDO
 
        !-----------------------------------------------------------------
-       ! Compute concentrations per aerosol [g/m2]
+       ! Water concentration [molecules/cm2] for UV absorption by H2O
+       !-----------------------------------------------------------------
+       IF ( id_H2O > 0 ) THEN
+
+          ! Set water concentration from species concentration currently in [molecules/cm3]
+          DO L= 1, State_Grid%NZ
+             HHH(L) = State_Chm%Species(id_H2O)%Conc(I,J,L) * State_Met%BXHEIGHT(I,J,L) * 1.0e+2_fp
+          ENDDO
+
+       ELSE
+
+          DO L= 1, State_Grid%NZ
+
+             ! Convert specific humidity from [g H2O/kg total air] to [kg H2O/kg total air]
+             SPHU_kgkg = State_Met%SPHU(I,J,L) * 1.e-3_fp
+
+             ! Compute H2O concentration as [kg/kg dry air]
+             H2O_kgkgdry = SPHU_kgkg / ( 1.0e+0_fp - SPHU_kgkg )
+
+             ! Compute H2O molecular weight as [kg/mol]
+             MW_kg = H2OMW * 1.e-3_fp
+
+             ! Convert [kg/kg dry] to [molecules/cm2]
+             HHH(L) = H2O_kgkgdry * State_Met%AIRDEN(I,J,L) * State_Met%BXHEIGHT(I,J,L) &
+                  * 1.0e-4_fp * AVO / MW_kg
+
+       ENDDO
+       ENDIF
+       HHH(State_Grid%NZ+1) = HHH(State_Grid%NZ)
+
+       !-----------------------------------------------------------------
+       ! Compute aerosol concentrations [g/m2]
        !-----------------------------------------------------------------
        ! AERSP is column concentration in g/m2 for each aerosol. The array currently
        ! includes entries for clouds but these are not used in Cloud-J and can be
@@ -865,7 +903,6 @@ CONTAINS
        IRAN = 1
 
        ! Required variables that are not used
-       HHH = 0.d0
        CCC = 0.d0
 
        !-----------------------------------------------------------------

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -2797,7 +2797,7 @@ CONTAINS
     !------------------------------------------------------------------------
     ! Number levels with clouds to use in photolysis (Cloud-J var LWEPAR)
     !------------------------------------------------------------------------
-    key   = "operations%photolysis%num_levs_with_cloud"
+    key   = "operations%photolysis%cloud-j%num_levs_with_cloud"
     v_int = MISSING_INT
     CALL QFYAML_Add_Get( Config, TRIM( key ), v_int, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -2810,7 +2810,7 @@ CONTAINS
     !------------------------------------------------------------------------
     ! Cloud-J cloud scheme flag (Cloud-J var CLDFLAG)
     !------------------------------------------------------------------------
-    key   = "operations%photolysis%cloud_scheme_flag"
+    key   = "operations%photolysis%cloud-j%cloud_scheme_flag"
     v_int = MISSING_INT
     CALL QFYAML_Add_Get( Config, TRIM( key ), v_int, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -2822,9 +2822,9 @@ CONTAINS
 
     !------------------------------------------------------------------------
     ! Factor increase in cloud OD from layer to next below (Cloud-J var ATAU)
-    ! NOTE: used for inserting extra cloud layers in Cloud-J
+    !  - used for inserting extra cloud layers in Cloud-J
     !------------------------------------------------------------------------
-    key    = "operations%photolysis%opt_depth_increase_factor"
+    key    = "operations%photolysis%cloud-j%opt_depth_increase_factor"
     v_str = MISSING_STR
     CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -2836,9 +2836,9 @@ CONTAINS
 
     !------------------------------------------------------------------------
     ! Minimum cloud OD in uppermost inserted layer (Cloud-J var ATAU0)
-    ! NOTE: used for inserting extra cloud layers in Cloud-J
+    !  - used for inserting extra cloud layers in Cloud-J
     !------------------------------------------------------------------------
-    key    = "operations%photolysis%min_top_inserted_cloud_OD"
+    key    = "operations%photolysis%cloud-j%min_top_inserted_cloud_OD"
     v_str = MISSING_STR
     CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -2854,7 +2854,7 @@ CONTAINS
     !  - only used for cloud schemes 5 and above
     !  - 0.00 = random
     !------------------------------------------------------------------------
-    key   = "operations%photolysis%cloud_overlap_correlation"
+    key   = "operations%photolysis%cloud-j%cloud_overlap_correlation"
     v_str = MISSING_STR
     CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -2866,11 +2866,10 @@ CONTAINS
 
     !------------------------------------------------------------------------
     ! Number of blocks with correlated cloud overlap (will set Cloud-J var LNRG)
-    ! NOTE:
     !  - only used for cloud schemes 5 and above
     !  - limited values possible: 0 = max-ran @ gaps, 3 = alt blocks, 6 = max-overlap
     !------------------------------------------------------------------------
-    key   = "operations%photolysis%num_cloud_overlap_blocks"
+    key   = "operations%photolysis%cloud-j%num_cloud_overlap_blocks"
     v_int = MISSING_INT
     CALL QFYAML_Add_Get( Config, TRIM( key ), v_int, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -2881,13 +2880,30 @@ CONTAINS
     Input_Opt%Num_Max_Overlap = v_int
 
     !------------------------------------------------------------------------
+    ! Spherical Earth atmospheric correction (will set Cloud-J var ATM0)
+    !  0 = flag
+    !  1 = spherical (standard)
+    !  2 = refractive
+    !  3 = geometric
+    !------------------------------------------------------------------------
+    key   = "operations%photolysis%cloud-j%sphere_correction"
+    v_int = MISSING_INT
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_int, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%Sphere_Correction = v_int
+
+    !------------------------------------------------------------------------
     ! Number of wavelength bins in UV-Vis (will set Cloud-J var NWBIN)
-    ! NOTE: limited values possible
+    ! - limited values possible
     !  18 = standard full Fast-J
     !  12 = trop-only (0% err in trop, 33% performance savings)
     !   8 = trop-only (1-2% error in J-02 and J-OCS in upper trop, big savings)
     !------------------------------------------------------------------------
-    key   = "operations%photolysis%num_wavelength_bins"
+    key   = "operations%photolysis%cloud-j%num_wavelength_bins"
     v_int = MISSING_INT
     CALL QFYAML_Add_Get( Config, TRIM( key ), v_int, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -2900,7 +2916,7 @@ CONTAINS
     !------------------------------------------------------------------------
     ! Whether to use absorption of UV by water vapor
     !------------------------------------------------------------------------
-    key    = "operations%photolysis%use_H2O_UV_absorption"
+    key    = "operations%photolysis%cloud-j%use_H2O_UV_absorption"
     v_bool = MISSING_BOOL
     CALL QFYAML_Add_Get( Config, TRIM( key ), v_bool, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN
@@ -3128,6 +3144,7 @@ CONTAINS
        WRITE( 6,105 ) 'Min cloud OD at top         : ', Input_Opt%Min_Cloud_OD
        WRITE( 6,105 ) 'Cloud correlation           : ', Input_Opt%Cloud_Corr
        WRITE( 6,130 ) 'Max # of overlap bins       : ', Input_Opt%Num_Max_Overlap
+       WRITE( 6,130 ) 'Sphere correction           : ', Input_Opt%Sphere_Correction
        WRITE( 6,130 ) 'Number of wavelength bins   : ', Input_Opt%Num_WV_Bins
        WRITE( 6,100 ) 'Use H2O UV absorption?      : ', Input_Opt%USE_H2O_UV_Abs
        WRITE( 6,100 ) 'Use online ozone?           : ', Input_Opt%USE_ONLINE_O3

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -2795,7 +2795,7 @@ CONTAINS
     Input_Opt%Do_Photolysis = v_bool
 
     !------------------------------------------------------------------------
-    ! Number levels with clouds to use in photolysis
+    ! Number levels with clouds to use in photolysis (Cloud-J var LWEPAR)
     !------------------------------------------------------------------------
     key   = "operations%photolysis%num_levs_with_cloud"
     v_int = MISSING_INT
@@ -2806,6 +2806,109 @@ CONTAINS
        RETURN
     ENDIF
     Input_Opt%NLevs_Phot_Cloud = v_int
+
+    !------------------------------------------------------------------------
+    ! Cloud-J cloud scheme flag (Cloud-J var CLDFLAG)
+    !------------------------------------------------------------------------
+    key   = "operations%photolysis%cloud_scheme_flag"
+    v_int = MISSING_INT
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_int, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%Cloud_Flag = v_int
+
+    !------------------------------------------------------------------------
+    ! Factor increase in cloud OD from layer to next below (Cloud-J var ATAU)
+    ! NOTE: used for inserting extra cloud layers in Cloud-J
+    !------------------------------------------------------------------------
+    key    = "operations%photolysis%opt_depth_increase_factor"
+    v_str = MISSING_STR
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%OD_Increase_Factor = Cast_and_RoundOff( v_str, places=4 )
+
+    !------------------------------------------------------------------------
+    ! Minimum cloud OD in uppermost inserted layer (Cloud-J var ATAU0)
+    ! NOTE: used for inserting extra cloud layers in Cloud-J
+    !------------------------------------------------------------------------
+    key    = "operations%photolysis%min_top_inserted_cloud_OD"
+    v_str = MISSING_STR
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%Min_Cloud_OD = Cast_and_RoundOff( v_str, places=4 )
+
+    !------------------------------------------------------------------------
+    ! Cloud correlation between max-overlap blocks (will set Cloud-J var CLDCOR)
+    ! NOTE:
+    !  - only used for cloud schemes 5 and above
+    !  - 0.00 = random
+    !------------------------------------------------------------------------
+    key   = "operations%photolysis%cloud_overlap_correlation"
+    v_str = MISSING_STR
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_str, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%Cloud_Corr = Cast_and_RoundOff( v_str, places=3 )
+
+    !------------------------------------------------------------------------
+    ! Number of blocks with correlated cloud overlap (will set Cloud-J var LNRG)
+    ! NOTE:
+    !  - only used for cloud schemes 5 and above
+    !  - limited values possible: 0 = max-ran @ gaps, 3 = alt blocks, 6 = max-overlap
+    !------------------------------------------------------------------------
+    key   = "operations%photolysis%num_cloud_overlap_blocks"
+    v_int = MISSING_INT
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_int, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%Num_Max_Overlap = v_int
+
+    !------------------------------------------------------------------------
+    ! Number of wavelength bins in UV-Vis (will set Cloud-J var NWBIN)
+    ! NOTE: limited values possible
+    !  18 = standard full Fast-J
+    !  12 = trop-only (0% err in trop, 33% performance savings)
+    !   8 = trop-only (1-2% error in J-02 and J-OCS in upper trop, big savings)
+    !------------------------------------------------------------------------
+    key   = "operations%photolysis%num_wavelength_bins"
+    v_int = MISSING_INT
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_int, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%Num_WV_Bins = v_int
+
+    !------------------------------------------------------------------------
+    ! Whether to use absorption of UV by water vapor
+    !------------------------------------------------------------------------
+    key    = "operations%photolysis%use_H2O_UV_absorption"
+    v_bool = MISSING_BOOL
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_bool, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+    Input_Opt%USE_H2O_UV_Abs = v_bool
 
     !------------------------------------------------------------------------
     ! Directories with photolysis input files
@@ -3014,12 +3117,19 @@ CONTAINS
        WRITE( 6,90  ) 'PHOTOLYSIS SETTINGS'
        WRITE( 6,95  ) '-------------------'
        WRITE( 6,100 ) 'Turn on photolysis?         : ', Input_Opt%Do_Photolysis
-       WRITE( 6,130 ) 'Number levels with cloud    : ',                      &
-                       Input_Opt%Nlevs_Phot_Cloud
        WRITE( 6,120 ) 'FAST-JX input directory     : ',                      &
                        TRIM( Input_Opt%FAST_JX_DIR )
        WRITE( 6,120 ) 'Cloud-J input directory     : ',                      &
                        TRIM( Input_Opt%CloudJ_Dir )
+       WRITE( 6,130 ) 'Number levels with cloud    : ',                      &
+                       Input_Opt%Nlevs_Phot_Cloud
+       WRITE( 6,130 ) 'Cloud-J cloud flag          : ', Input_Opt%Cloud_Flag
+       WRITE( 6,105 ) 'Layer OD increase factor    : ', Input_Opt%OD_Increase_Factor
+       WRITE( 6,105 ) 'Min cloud OD at top         : ', Input_Opt%Min_Cloud_OD
+       WRITE( 6,105 ) 'Cloud correlation           : ', Input_Opt%Cloud_Corr
+       WRITE( 6,130 ) 'Max # of overlap bins       : ', Input_Opt%Num_Max_Overlap
+       WRITE( 6,130 ) 'Number of wavelength bins   : ', Input_Opt%Num_WV_Bins
+       WRITE( 6,100 ) 'Use H2O UV absorption?      : ', Input_Opt%USE_H2O_UV_Abs
        WRITE( 6,100 ) 'Use online ozone?           : ', Input_Opt%USE_ONLINE_O3
        WRITE( 6,100 ) 'Use ozone from met?         : ',                      &
                        Input_Opt%USE_O3_FROM_MET

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -183,7 +183,14 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: Do_Photolysis
      CHARACTER(LEN=255)          :: FAST_JX_DIR
      CHARACTER(LEN=255)          :: CloudJ_Dir
-     INTEGER                     :: Nlevs_Phot_Cloud
+     INTEGER                     :: Nlevs_Phot_Cloud   ! Cloud-J var LWEPAR
+     INTEGER                     :: Cloud_Flag         ! Cloud-J var CLDFLAG
+     REAL(fp)                    :: OD_Increase_Factor ! Cloud-J var ATAU
+     REAL(fp)                    :: Min_Cloud_OD       ! Cloud-J var ATAU0
+     REAL(fp)                    :: Cloud_Corr         ! Cloud-J var CLDCOR
+     INTEGER                     :: Num_Max_Overlap    ! Cloud-J var LNRG
+     INTEGER                     :: Num_WV_Bins        ! Cloud-J var NWBIN
+     LOGICAL                     :: USE_H2O_UV_Abs     ! Cloud-J var USEH2OUV
      LOGICAL                     :: USE_ONLINE_O3
      LOGICAL                     :: USE_O3_FROM_MET
      LOGICAL                     :: USE_TOMS_O3
@@ -673,6 +680,13 @@ CONTAINS
     Input_Opt%FAST_JX_DIR           = ''
     Input_Opt%CloudJ_Dir            = ''
     Input_Opt%Nlevs_Phot_Cloud      = 0
+    Input_Opt%Cloud_Flag            = 0
+    Input_Opt%OD_Increase_Factor    = 0.0_fp
+    Input_Opt%Min_Cloud_OD          = 0.0_fp
+    Input_Opt%Cloud_Corr            = 0
+    Input_Opt%Num_Max_Overlap       = 0
+    Input_Opt%Num_WV_Bins           = 0
+    Input_Opt%USE_H2O_UV_Abs        = .FALSE.
     Input_Opt%USE_ONLINE_O3         = .FALSE.
     Input_Opt%USE_O3_FROM_MET       = .FALSE.
     Input_Opt%USE_TOMS_O3           = .FALSE.

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -189,6 +189,7 @@ MODULE Input_Opt_Mod
      REAL(fp)                    :: Min_Cloud_OD       ! Cloud-J var ATAU0
      REAL(fp)                    :: Cloud_Corr         ! Cloud-J var CLDCOR
      INTEGER                     :: Num_Max_Overlap    ! Cloud-J var LNRG
+     INTEGER                     :: Sphere_Correction  ! Cloud-J var ATM0
      INTEGER                     :: Num_WV_Bins        ! Cloud-J var NWBIN
      LOGICAL                     :: USE_H2O_UV_Abs     ! Cloud-J var USEH2OUV
      LOGICAL                     :: USE_ONLINE_O3
@@ -685,6 +686,7 @@ CONTAINS
     Input_Opt%Min_Cloud_OD          = 0.0_fp
     Input_Opt%Cloud_Corr            = 0
     Input_Opt%Num_Max_Overlap       = 0
+    Input_Opt%Sphere_Correction     = 0
     Input_Opt%Num_WV_Bins           = 0
     Input_Opt%USE_H2O_UV_Abs        = .FALSE.
     Input_Opt%USE_ONLINE_O3         = .FALSE.

--- a/run/CESM/geoschem_config.yml
+++ b/run/CESM/geoschem_config.yml
@@ -46,14 +46,16 @@ operations:
 
   photolysis:
     activate: true
-    num_levs_with_cloud: 22
-    cloud_scheme_flag: 3
-    opt_depth_increase_factor: 1.050
-    min_top_inserted_cloud_OD: 0.005
-    cloud_overlap_correlation: 0.33
-    num_cloud_overlap_blocks: 6
-    num_wavelength_bins: 18
-    use_H2O_UV_absorption: true
+    cloud-j:
+      num_levs_with_cloud: 22
+      cloud_scheme_flag: 3
+      opt_depth_increase_factor: 1.050
+      min_top_inserted_cloud_OD: 0.005
+      cloud_overlap_correlation: 0.33
+      num_cloud_overlap_blocks: 6
+      sphere_correction: 1
+      num_wavelength_bins: 18
+      use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: /see/namelist/file
       cloudj_input_dir: /see/namelist/file

--- a/run/CESM/geoschem_config.yml
+++ b/run/CESM/geoschem_config.yml
@@ -47,6 +47,13 @@ operations:
   photolysis:
     activate: true
     num_levs_with_cloud: 22
+    cloud_scheme_flag: 3
+    opt_depth_increase_factor: 1.050
+    min_top_inserted_cloud_OD: 0.005
+    cloud_overlap_correlation: 0.33
+    num_cloud_overlap_blocks: 6
+    num_wavelength_bins: 18
+    use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: /see/namelist/file
       cloudj_input_dir: /see/namelist/file

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
@@ -65,14 +65,16 @@ operations:
 
   photolysis:
     activate: true
-    num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
-    cloud_scheme_flag: 3
-    opt_depth_increase_factor: 1.050
-    min_top_inserted_cloud_OD: 0.005
-    cloud_overlap_correlation: 0.33
-    num_cloud_overlap_blocks: 6
-    num_wavelength_bins: 18
-    use_H2O_UV_absorption: true
+    cloud-j:
+      num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
+      cloud_scheme_flag: 3
+      opt_depth_increase_factor: 1.050
+      min_top_inserted_cloud_OD: 0.005
+      cloud_overlap_correlation: 0.33
+      num_cloud_overlap_blocks: 6
+      sphere_correction: 1
+      num_wavelength_bins: 18
+      use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05-Hg/
       cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
@@ -66,9 +66,16 @@ operations:
   photolysis:
     activate: true
     num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
+    cloud_scheme_flag: 3
+    opt_depth_increase_factor: 1.050
+    min_top_inserted_cloud_OD: 0.005
+    cloud_overlap_correlation: 0.33
+    num_cloud_overlap_blocks: 6
+    num_wavelength_bins: 18
+    use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05-Hg/
-      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-05/
+      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/
     overhead_O3:
       use_online_O3_from_model: ${RUNDIR_USE_ONLINE_O3}
       use_column_O3_from_met: true

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
@@ -77,7 +77,7 @@ operations:
       use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05-Hg/
-      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/
+      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-09-Hg/
     overhead_O3:
       use_online_O3_from_model: ${RUNDIR_USE_ONLINE_O3}
       use_column_O3_from_met: true

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
@@ -66,9 +66,16 @@ operations:
   photolysis:
     activate: true
     num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
+    cloud_scheme_flag: 3
+    opt_depth_increase_factor: 1.050
+    min_top_inserted_cloud_OD: 0.005
+    cloud_overlap_correlation: 0.33
+    num_cloud_overlap_blocks: 6
+    num_wavelength_bins: 18
+    use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05/
-      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2023-05/
+      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/
     overhead_O3:
       use_online_O3_from_model: false
       use_column_O3_from_met: true

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
@@ -77,7 +77,7 @@ operations:
       use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05/
-      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/
+      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-09/
     overhead_O3:
       use_online_O3_from_model: false
       use_column_O3_from_met: true

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
@@ -65,14 +65,16 @@ operations:
 
   photolysis:
     activate: true
-    num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
-    cloud_scheme_flag: 3
-    opt_depth_increase_factor: 1.050
-    min_top_inserted_cloud_OD: 0.005
-    cloud_overlap_correlation: 0.33
-    num_cloud_overlap_blocks: 6
-    num_wavelength_bins: 18
-    use_H2O_UV_absorption: true
+    cloud-j:
+      num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
+      cloud_scheme_flag: 3
+      opt_depth_increase_factor: 1.050
+      min_top_inserted_cloud_OD: 0.005
+      cloud_overlap_correlation: 0.33
+      num_cloud_overlap_blocks: 6
+      sphere_correction: 1
+      num_wavelength_bins: 18
+      use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05/
       cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -89,9 +89,16 @@ operations:
   photolysis:
     activate: true
     num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
+    cloud_scheme_flag: 3
+    opt_depth_increase_factor: 1.050
+    min_top_inserted_cloud_OD: 0.005
+    cloud_overlap_correlation: 0.33
+    num_cloud_overlap_blocks: 6
+    num_wavelength_bins: 18
+    use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05/
-      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2023-05/
+      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/
     overhead_O3:
       use_online_O3_from_model: ${RUNDIR_USE_ONLINE_O3}
       use_column_O3_from_met: true

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -100,7 +100,7 @@ operations:
       use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05/
-      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/
+      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-09/
     overhead_O3:
       use_online_O3_from_model: ${RUNDIR_USE_ONLINE_O3}
       use_column_O3_from_met: true

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -88,14 +88,16 @@ operations:
 
   photolysis:
     activate: true
-    num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
-    cloud_scheme_flag: 3
-    opt_depth_increase_factor: 1.050
-    min_top_inserted_cloud_OD: 0.005
-    cloud_overlap_correlation: 0.33
-    num_cloud_overlap_blocks: 6
-    num_wavelength_bins: 18
-    use_H2O_UV_absorption: true
+    cloud-j:
+      num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
+      cloud_scheme_flag: 3
+      opt_depth_increase_factor: 1.050
+      min_top_inserted_cloud_OD: 0.005
+      cloud_overlap_correlation: 0.33
+      num_cloud_overlap_blocks: 6
+      sphere_correction: 1
+      num_wavelength_bins: 18
+      use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05/
       cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -72,9 +72,16 @@ operations:
   photolysis:
     activate: true
     num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
+    cloud_scheme_flag: 3
+    opt_depth_increase_factor: 1.050
+    min_top_inserted_cloud_OD: 0.005
+    cloud_overlap_correlation: 0.33
+    num_cloud_overlap_blocks: 6
+    num_wavelength_bins: 18
+    use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05/
-      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2023-05/
+      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/
     overhead_O3:
       use_online_O3_from_model: ${RUNDIR_USE_ONLINE_O3}
       use_column_O3_from_met: true

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -71,14 +71,16 @@ operations:
 
   photolysis:
     activate: true
-    num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
-    cloud_scheme_flag: 3
-    opt_depth_increase_factor: 1.050
-    min_top_inserted_cloud_OD: 0.005
-    cloud_overlap_correlation: 0.33
-    num_cloud_overlap_blocks: 6
-    num_wavelength_bins: 18
-    use_H2O_UV_absorption: true
+    cloud-j:
+      num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
+      cloud_scheme_flag: 3
+      opt_depth_increase_factor: 1.050
+      min_top_inserted_cloud_OD: 0.005
+      cloud_overlap_correlation: 0.33
+      num_cloud_overlap_blocks: 6
+      sphere_correction: 1
+      num_wavelength_bins: 18
+      use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05/
       cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -83,7 +83,7 @@ operations:
       use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/FAST_JX/v2024-05/
-      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-08/
+      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2024-09/
     overhead_O3:
       use_online_O3_from_model: ${RUNDIR_USE_ONLINE_O3}
       use_column_O3_from_met: true

--- a/run/GEOS/geoschem_config.yml
+++ b/run/GEOS/geoschem_config.yml
@@ -60,9 +60,16 @@ operations:
   photolysis:
     activate: true
     num_levs_with_cloud: 34
+    cloud_scheme_flag: 3
+    opt_depth_increase_factor: 1.050
+    min_top_inserted_cloud_OD: 0.005
+    cloud_overlap_correlation: 0.33
+    num_cloud_overlap_blocks: 6
+    num_wavelength_bins: 18
+    use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/FAST_JX/v2023-10/
-      cloudj_input_dir: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/CLOUD_J/v2023-05/
+      cloudj_input_dir: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/CLOUD_J/v2024-08/
     overhead_O3:
       use_online_O3_from_model: true
       use_column_O3_from_met: true

--- a/run/GEOS/geoschem_config.yml
+++ b/run/GEOS/geoschem_config.yml
@@ -59,14 +59,16 @@ operations:
 
   photolysis:
     activate: true
-    num_levs_with_cloud: 34
-    cloud_scheme_flag: 3
-    opt_depth_increase_factor: 1.050
-    min_top_inserted_cloud_OD: 0.005
-    cloud_overlap_correlation: 0.33
-    num_cloud_overlap_blocks: 6
-    num_wavelength_bins: 18
-    use_H2O_UV_absorption: true
+    cloud-j:
+      num_levs_with_cloud: 34
+      cloud_scheme_flag: 3
+      opt_depth_increase_factor: 1.050
+      min_top_inserted_cloud_OD: 0.005
+      cloud_overlap_correlation: 0.33
+      num_cloud_overlap_blocks: 6
+      sphere_correction: 1
+      num_wavelength_bins: 18
+      use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/FAST_JX/v2023-10/
       cloudj_input_dir: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/CLOUD_J/v2024-08/

--- a/run/GEOS/geoschem_config.yml
+++ b/run/GEOS/geoschem_config.yml
@@ -71,7 +71,7 @@ operations:
       use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/FAST_JX/v2023-10/
-      cloudj_input_dir: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/CLOUD_J/v2024-08/
+      cloudj_input_dir: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/CLOUD_J/v2024-09/
     overhead_O3:
       use_online_O3_from_model: true
       use_column_O3_from_met: true

--- a/run/WRF/fullchem/geoschem_config.yml
+++ b/run/WRF/fullchem/geoschem_config.yml
@@ -67,14 +67,16 @@ operations:
 
   photolysis:
     activate: true
-    num_levs_with_cloud: 20
-    cloud_scheme_flag: 3
-    opt_depth_increase_factor: 1.050
-    min_top_inserted_cloud_OD: 0.005
-    cloud_overlap_correlation: 0.33
-    num_cloud_overlap_blocks: 6
-    num_wavelength_bins: 18
-    use_H2O_UV_absorption: true
+    cloud-j:
+      num_levs_with_cloud: 20
+      cloud_scheme_flag: 3
+      opt_depth_increase_factor: 1.050
+      min_top_inserted_cloud_OD: 0.005
+      cloud_overlap_correlation: 0.33
+      num_cloud_overlap_blocks: 6
+      sphere_correction: 1
+      num_wavelength_bins: 18
+      use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/FAST_JX/v2024-05/
       cloudj_input_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/CLOUD_J/v2024-08/

--- a/run/WRF/fullchem/geoschem_config.yml
+++ b/run/WRF/fullchem/geoschem_config.yml
@@ -66,8 +66,18 @@ operations:
      use_non_local_pbl: true 
 
   photolysis:
-    input_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/FAST_JX/v2021-10/
+    activate: true
     num_levs_with_cloud: 20
+    cloud_scheme_flag: 3
+    opt_depth_increase_factor: 1.050
+    min_top_inserted_cloud_OD: 0.005
+    cloud_overlap_correlation: 0.33
+    num_cloud_overlap_blocks: 6
+    num_wavelength_bins: 18
+    use_H2O_UV_absorption: true
+    input_directories:
+      fastjx_input_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/FAST_JX/v2024-05/
+      cloudj_input_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/CLOUD_J/v2024-08/
     overhead_O3:
       use_online_O3_from_model: true 
       use_column_O3_from_met: true

--- a/run/WRF/fullchem/geoschem_config.yml
+++ b/run/WRF/fullchem/geoschem_config.yml
@@ -79,7 +79,7 @@ operations:
       use_H2O_UV_absorption: true
     input_directories:
       fastjx_input_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/FAST_JX/v2024-05/
-      cloudj_input_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/CLOUD_J/v2024-08/
+      cloudj_input_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/CLOUD_J/v2024-09/
     overhead_O3:
       use_online_O3_from_model: true 
       use_column_O3_from_met: true


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This pull request brings in updates for compatibility with Cloud-J version 8.0.0. The primary change is expanding the photolysis menu in configuration file `geoschem_config.yml` to allow easy run-time configuration of Cloud-J from GEOS-Chem run directories. Previously these settings were configured in an input file stored in external data directories.

Also in this update is the inclusion of the option to turn off the UV absorption by water vapor. H2O UV absorption is the main update in Cloud-J v8 and some GEOS-Chem users may want to experiment with it. It is turned on by default but can be toggled off in the photolysis menu of `geoschem_config.yml`.

This PR requires updating the Cloud-J submodule at the same time as merge. The Cloud-J PR that accompanies this PR is https://github.com/geoschem/Cloud-J/pull/24.

### Expected changes

We expect the mean OH will decrease and CH4 lifetime will increase due to the absorption of UV by H2O. If the UV absorption is turned off then this becomes a no diff update relative to Cloud-J 7.7.

### Reference(s)

Prather, Michael (2023). An updated cloud-overlap photolysis module for atmospheric chemistry models, UCI Cloud-J v8.0, with near-UV H2O absorption [Dataset]. Dryad. [https://doi.org/10.7280/D1Q398](https://doi.org/10.7280/D1Q398)

### Related Github Issues

https://github.com/geoschem/Cloud-J/issues/12
closes https://github.com/geoschem/geos-chem/issues/2386
