### PR TITLE
Updated soil NOx scheme from Yi Wang et al. (2021) as an option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - TBD
 ### Added
-- Set `KPP_AbsTol` to 1e5 for dummy species in `species_database.yml` and `species_database_hg.yml`
-- Vectors `State_Chm%KPP_AbsTol` and `State_Chm%KPP_RelTol`
-- Four new species ALK4N1, ALK4N2, ALK4O2, and ALK4P to address issues in ALK4 and R4N2 chemistry following Brewer et al. (2023, JGR)
-- ALK4N1 and ALK4N2 to Ox family in KPP
+- Added setting `KPP_AbsTol` to 1e5 for dummy species in `species_database.yml` and `species_database_hg.yml`
+- Added Vectors `State_Chm%KPP_AbsTol` and `State_Chm%KPP_RelTol`
+- Added ALK4N1 and ALK4N2 to Ox family in KPP
 - PPN photolysis from Horner et al (2024)
 - Added vectors `State_Chm%KPP_AbsTol` and `State_Chm%KPP_RelTol`
 - Added four new species ALK4N1, ALK4N2, ALK4O2, and ALK4P to address issues in ALK4 and R4N2 chemistry following Brewer et al. (2023, JGR)
@@ -17,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added Cloud-J input parameters to geoschem_config.yml in new photolysis sub-menu called cloud-j
 - Added computation of water concentration to use in photolysis for application of UV absorption by water in Cloud-J v8
 - Added ACO3, ACR, ACRO2, ALK4N{1,2,O}2, ALK4P, ALK7, APAN, APINN, APINO2, APINP, AROCMCHO, AROMCO3, AROMPN, BPINN, BPINO2, BPINON, BPINOO2, BPINOOH, BPINP, BUTN, BUTO2, C4H6, C96N, C96O2, C9602H, EBZ, GCO3, HACTA, LIMAL, LIMKB, LIMKET, LIMKO2, LIMN, LIMNB, LIMO2H, LIMO3, LIMO3H, LIMPAN, MEKCO3, MEKPN, MYRCO, PHAN, PIN, PINAL, PINO3, PINONIC, PINPAN, R7N{1,2}, R7O2, R7P, RNO3, STYR, TLFUO2, TLFUONE, TMB, ZRO2 to `species_database.yml` following Travis et  al. 2024.
+- Added TSOIL1 field to `State_Met` for use in HEMCO soil NOx extension. This should only be read in when the `UseSoilTemperature` option is true in HEMCO config.
 
 ### Changed
 - Copy values from `State_Chm%KPP_AbsTol` to `ATOL` and `State_Chm%KPP_RelTol` to `RTOL` for fullchem and Hg simulations

--- a/GeosCore/flexgrid_read_mod.F90
+++ b/GeosCore/flexgrid_read_mod.F90
@@ -500,6 +500,18 @@ CONTAINS
     CALL Get_Met_2D( Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index )
     State_Met%Z0 = Q
 
+    !======================================================================
+    ! Get fields for soil NOX extension only when needed
+    !======================================================================
+    IF ( Input_Opt%LSOILNOX .and. Input_Opt%UseSoilTemp ) THEN
+
+       ! Read TSOIL1
+       v_name = "TSOIL1"
+       CALL Get_Met_2D(Input_Opt, State_Grid, Q, TRIM(v_name), t_index=t_index)
+       State_Met%TSOIL1 = Q
+
+    ENDIF
+
     ! Echo info
     stamp = TimeStamp_String( YYYYMMDD, HHMMSS )
     WRITE( 6, 10 ) stamp

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -674,6 +674,7 @@ CONTAINS
 
     ! Soil NOx
     Input_Opt%LSOILNOX      = ( ExtState%SoilNOx > 0 )
+    Input_Opt%UseSoilTemp   = ExtState%TSOIL1%DoUse
 
     ! Ginoux dust emissions
     IF ( ExtState%DustGinoux > 0 ) THEN
@@ -2282,6 +2283,23 @@ CONTAINS
     IF ( HMRC /= HCO_SUCCESS ) THEN
        RC     = HMRC
        ErrMsg = 'Error encountered in "ExtDat_Set( TSKIN_FOR_EMIS )"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       RETURN
+    ENDIF
+
+    ! TSOIL1
+#if defined( MODEL_CLASSIC )
+    CALL ExtDat_Set( HcoState, ExtState%TSOIL1, 'TSOIL', &
+                    HMRC,      FIRST )
+#else
+    CALL ExtDat_Set( HcoState, ExtState%TSOIL1, 'TSOIL1_FOR_EMIS', &
+                     HMRC,     FIRST,           State_Met%TSOIL1 )
+#endif
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "ExtDat_Set( TSOIL1_FOR_EMIS )"!'
        CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
        RETURN
     ENDIF

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -136,6 +136,7 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: LHCodedOrgHal
      LOGICAL                     :: LCMIP6OrgHal
      LOGICAL                     :: DoLightNOx ! Shadow for LightNOX extension
+     LOGICAL                     :: UseSoilTemp
 
      ! For HEMCO "intermediate" grid (hplin, 6/2/20)
      LOGICAL                     :: LIMGRID    ! Use different grid resolution for HEMCO?
@@ -636,6 +637,7 @@ CONTAINS
     Input_Opt%LHCodedOrgHal          = .FALSE.
     Input_Opt%LCMIP6OrgHal           = .FALSE.
     Input_Opt%DoLightNOx             = .FALSE.
+    Input_Opt%UseSoilTemp            = .FALSE.
     Input_Opt%LIMGRID                = .FALSE.
     Input_Opt%IMGRID_XSCALE          = 1
     Input_Opt%IMGRID_YSCALE          = 1

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -145,6 +145,7 @@ MODULE State_Met_Mod
      REAL(fp), POINTER :: TropHt        (:,:  ) ! Tropopause height [km]
      REAL(fp), POINTER :: TS            (:,:  ) ! Surface temperature [K]
      REAL(fp), POINTER :: TSKIN         (:,:  ) ! Surface skin temperature [K]
+     REAL(fp), POINTER :: TSOIL1        (:,:  ) ! Soil temperature [K]
      REAL(fp), POINTER :: U10M          (:,:  ) ! E/W wind speed @ 10m ht [m/s]
      REAL(fp), POINTER :: USTAR         (:,:  ) ! Friction velocity [m/s]
      REAL(fp), POINTER :: UVALBEDO      (:,:  ) ! UV surface albedo [1]
@@ -435,6 +436,7 @@ CONTAINS
     State_Met%TropHt         => NULL()
     State_Met%TS             => NULL()
     State_Met%TSKIN          => NULL()
+    State_Met%TSOIL1         => NULL()
     State_Met%U10M           => NULL()
     State_Met%USTAR          => NULL()
     State_Met%UVALBEDO       => NULL()
@@ -1829,6 +1831,24 @@ CONTAINS
          State_Grid = State_Grid,                                            &
          metId      = metId,                                                 &
          Ptr2Data   = State_Met%TSKIN,                                       &
+         RC         = RC                                                    )
+
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = TRIM( errMsg_ir ) // TRIM( metId )
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    !------------------------------------------------------------------------
+    ! TSOIL1 [K]
+    !------------------------------------------------------------------------
+    metId = 'TSOIL1'
+    CALL Init_and_Register(                                                  &
+         Input_Opt  = Input_Opt,                                             &
+         State_Met  = State_Met,                                             &
+         State_Grid = State_Grid,                                            &
+         metId      = metId,                                                 &
+         Ptr2Data   = State_Met%TSOIL1,                                      &
          RC         = RC                                                    )
 
     IF ( RC /= GC_SUCCESS ) THEN
@@ -3700,6 +3720,13 @@ CONTAINS
        State_Met%TSKIN => NULL()
     ENDIF
 
+    IF ( ASSOCIATED( State_Met%TSOIL1 ) ) THEN
+       DEALLOCATE( State_Met%TSOIL1, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%TSOIL1', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%TSOIL1 => NULL()
+    ENDIF
+
     IF ( ASSOCIATED( State_Met%TO3 ) ) THEN
        DEALLOCATE( State_Met%TO3, STAT=RC  )
        CALL GC_CheckVar( 'State_Met%TO3', 2, RC )
@@ -4841,6 +4868,11 @@ CONTAINS
 
        CASE ( 'TSKIN' )
           IF ( isDesc  ) Desc  = 'Surface skin temperature'
+          IF ( isUnits ) Units = 'K'
+          IF ( isRank  ) Rank  = 2
+
+       CASE ( 'TSOIL1' )
+          IF ( isDesc  ) Desc  = 'Soil temperature'
           IF ( isUnits ) Units = 'K'
           IF ( isRank  ) Rank  = 2
 

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -174,6 +174,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> LightningClimatology   :       ${RUNDIR_LIGHTNOX_CLIM}
     --> CDF table              :       $ROOT/LIGHTNOX/v2014-07/light_dist.ott2010.dat
 104     SoilNOx                : ${RUNDIR_SOILNOX_EXT}   NO
+    --> UseSoilTemperature     :       false
     --> Use fertilizer NOx     :       true
 105     DustDead               : ${RUNDIR_DUSTDEAD_EXT}   DST1/DST2/DST3/DST4
     --> Mass tuning factor     :       ${RUNDIR_DUSTDEAD_TF}

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.gmao_metfields
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.gmao_metfields
@@ -144,6 +144,15 @@ METDIR:   ${RUNDIR_MET_DIR}
 )))LightningClimatology
 )))LightNOx
 
+#==============================================================================
+# --- Fields for soil NOx emissions (Extension 104) ---
+#==============================================================================
+(((SoilNOx
+(((UseSoilTemperature
+* TSOIL1    $METDIR/$YYYY/$MM/$MET.$YYYY$MM$DD.A1soil.$RES.$NC     TSOIL1   1980-2100/1-12/1-31/*/+30minute RFY xy  1  * -  1 1
+)))UseSoilTemperature
+)))SoilNOx
+
 ### END SECTION BASE EMISSIONS ###
 
 ### END OF HEMCO INPUT FILE ###

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -43,6 +43,13 @@ FLASH_DENS 1 Y Y F1980-%m2-01T00:00:00 none none LDENS ./HcoDir/OFFLINE_LIGHTNIN
 CONV_DEPTH 1 Y Y F1980-%m2-01T00:00:00 none none CTH   ./HcoDir/OFFLINE_LIGHTNING/v2020-03/${RUNDIR_METLIGHTNING}/CLIM/FLASH_CTH_${RUNDIR_METLIGHTNING}_${RUNDIR_METLIGHTNING_RES}_${RUNDIR_MET_LCLIM}.ymonmean.nc4
 #
 #==============================================================================
+# --- Fields for soil NOx emissions (Extension 104) ---
+# These fields are stored in State_Met, along with the other met fields
+# Manually uncomment this line is UseSoilTemperature is true in HEMCO config.
+#==============================================================================
+#TSOIL1 1 N Y F0;003000 none none TSOIL1   ./MetDir/%y4/%m2/GEOSFP.%y4%m2%d2.A1soil.025x03125.nc
+#
+#==============================================================================
 # --- Fields for RRTMG ---
 # Dynamical heating data is only read in when RRTMG FDH/SEFDH is used and
 # must be generated in a reference (companion) run. The time after P at

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -173,6 +173,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> LightningClimatology   :       ${RUNDIR_LIGHTNOX_CLIM}
     --> CDF table              :       $ROOT/LIGHTNOX/v2014-07/light_dist.ott2010.dat
 104     SoilNOx                : ${RUNDIR_SOILNOX_EXT}   NO
+    --> UseSoilTemperature     :       false
     --> Use fertilizer NOx     :       true
 105     DustDead               : ${RUNDIR_DUSTDEAD_EXT}   DST1/DST2/DST3/DST4
     --> Mass tuning factor     :       ${RUNDIR_DUSTDEAD_TF}


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

This is the corresponding pull request for https://github.com/geoschem/geos-chem/issues/1288 and should be merged alongside https://github.com/geoschem/HEMCO/pull/287.

Yi Wang (@ywang37) updated the soil NOx algorithm in HEMCO to utilize soil temperature as described in Yi Wang et al. (ERL, 2021). Those updates require the addition of a new meteorology field, TSOIL1, for the soil temperature in layer 1. This field has been added to State_Met. 

A new option `UseSoilTemperature` has been added to the SoilNOx extension section in HEMCO_Config.rc. It is set to false by default. This option needs to be evaluated further before it can be made the default in the soil NOx extension. Additionally, the full archive of TSOIL1 fields needs to be processed and made available for GEOS-Chem. This updated algorithm will also require generating a new set of offline soil NOx emissions at native GEOS-FP and MERRA-2 resolutions.

### Expected changes

This is a zero-difference change with respect to the full-chemistry benchmark because this updated scheme is off by default. To view the expected changes when the algorithm is used, see [these plots](https://github.com/geoschem/geos-chem/issues/1288#issuecomment-1254031284) in the original Github issue.

### Reference(s)

- Wang, Y., C. Ge, L. Castro Garcia, G. D. Jenerette, P. Y. Oikawa, J. Wang, [Improved modelling of soil NOx emissions in a high temperature agricultural region: role of background emissions on NO2 trend over the US](https://iopscience.iop.org/article/10.1088/1748-9326/ac16a3), Environmental Research Letter, 16, 084061, 2021.

### Related Github Issue

- https://github.com/geoschem/geos-chem/issues/1288
- https://github.com/geoschem/HEMCO/pull/287
