### PR TITLE
Fix dry mass fraction of seasalt in aerosol thermodynamics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Copy values from `State_Chm%KPP_AbsTol` to `ATOL` and `State_Chm%KPP_RelTol` to `RTOL` for fullchem and Hg simulations
-- Change previously zero Ca2, K, and Mg cation values passed to HETP to scaled SALA species concentrations
+- Changed previously zero Ca2, K, and Mg cation values passed to HETP to scaled SALA species concentrations and updated Na:seasalt mass fraction accordingly
 - Updated `HEMCO_Config.rc.fullchem` (GCClassic + GCHP) and `ExtData.rc` to add emissons of new species from Travis et al 2023
 - Activate the `DryDep` collection for GCClassic & GCHP fullchem benchmarks
 - Reduce the GCHP `DryDep` collection to only the necessary species for benchmarks

--- a/GeosCore/aerosol_thermodynamics_mod.F90
+++ b/GeosCore/aerosol_thermodynamics_mod.F90
@@ -642,7 +642,9 @@ CONTAINS
 
              ! Total Na+ (30.61% by weight of seasalt) [mole/m3]
              ! increase to account for all cations, xnw 11/26/17
-             TNA = Spc(id_SALA)%Conc(I,J,L) * 0.397_fp * 1.0e+3_fp           &
+             ! Reverted Na:SS ratio from 0.397 to 0.3061 since
+             ! cations are no longer excluded (Ca, Mg, K), 9/19/24
+             TNA = Spc(id_SALA)%Conc(I,J,L) * 0.3061_fp * 1.0e+3_fp           &
                    * AlkR / ( 23.0_fp  * VOL  )
 
              ! Total Cl- (55.04% by weight of seasalt) [mole/m3]
@@ -655,7 +657,8 @@ CONTAINS
                    ( 35.45_fp  * VOL  )
           ELSE
 
-             TNA = Spc(id_SALC)%Conc(I,J,L) * 0.378_fp * 1.0e+3_fp           &
+             ! Changed 0.378 to 0.3061 (dry mass fraction of seasalt)
+             TNA = Spc(id_SALC)%Conc(I,J,L) * 0.3061_fp * 1.0e+3_fp           &
                    * AlkR / ( 23.0_fp  * VOL  )
              ACL = Spc(id_SALCCL)%Conc(I,J,L) * 1.0e+3_fp * AlkR /           &
                    ( 35.45_fp  * VOL  )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren (Harvard/GCST), on behalf of Yuk Chun Chan (UW) and Becky Alexander (UW)

### Describe the update

This PR applies two corrections to the dry mass ratio of seasalt that is hard-coded in aerosol thermodynamics. The changes are updates submitted by Yuk Chun Chan (UW) and Becky Alexander (UW):
    
From Yuk Chun Chan:

> To account for the missing Ca, Mg, and K, the Na-to-seasalt mass ratio was artificially increased from 0.3061 (i.e., seawater average) to 0.397 in previous versions. Since we are re-introducing Ca, Mg, and K to the model now, we should adjust the Na-to-SS mass ratio from 0.397 back to 0.3061. Otherwise, we would get excess amount of cations in the model.

    
From Becky Alexander

> The TNA equation needs "to be changed, which deals with coarse-mode sea salt aerosol. The current value is 0.378. I don't know why these values are different for fine and coarse mode. They should both be 0.3061, which is the dry mass fraction of sea salt.

These changes will go into 14.5.0 on top of earlier updates in this version to add back in cations Ca, Mg, and K for aerosol theremodynamics.

### Expected changes

Tagging @yc-chan and @beckyalexander to comment on expected changes.

### Reference(s)

None

### Related Github Issue

closes https://github.com/geoschem/geos-chem/issues/2391