### PR TITLE
Fix a bug in coarse-mode seasalt Ca, Mg, and K

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Copy values from `State_Chm%KPP_AbsTol` to `ATOL` and `State_Chm%KPP_RelTol` to `RTOL` for fullchem and Hg simulations
-- Changed previously zero Ca2, K, and Mg cation values passed to HETP to scaled SALA species concentrations and updated Na:seasalt mass fraction accordingly
+- Introduced seasalt Ca, K, Mg back to aerosol thermodynamics via HETP.
 - Updated `HEMCO_Config.rc.fullchem` (GCClassic + GCHP) and `ExtData.rc` to add emissons of new species from Travis et al 2023
 - Activate the `DryDep` collection for GCClassic & GCHP fullchem benchmarks
 - Reduce the GCHP `DryDep` collection to only the necessary species for benchmarks

--- a/GeosCore/aerosol_thermodynamics_mod.F90
+++ b/GeosCore/aerosol_thermodynamics_mod.F90
@@ -676,17 +676,35 @@ CONTAINS
           ! Total Cl- [mole/m3]
           TCL = ACL + GCL
 
-          ! Total Ca2+ (1.16% by weight of seasalt) [mole/m3]
-          TCA      = Spc(id_SALA)%Conc(I,J,L) * 0.0116e+0_fp * 1.d3 / &
-                                     ( 40.08e+0_fp  * VOL  )
+          ! Assume all Ca2+, K+, and Mg+ originate from seasalt aerosols
+          IF (N == 1) THEN
 
-          ! Total K+   (1.1% by weight of seasalt)  [mole/m3]
-          TK       = Spc(id_SALA)%Conc(I,J,L) * 0.0110e+0_fp * 1.d3 / &
-                                     ( 39.102e+0_fp * VOL  )
+             ! Total Ca2+ (1.16% by weight of fine-mode seasalt) [mole/m3]
+             TCA      = Spc(id_SALA)%Conc(I,J,L) * 0.0116e+0_fp * 1.0e+3_fp * AlkR / &
+                        ( 40.08e+0_fp  * VOL  )
 
-          ! Total Mg+  (3.69% by weight of seasalt) [mole/m3]
-          TMG      = Spc(id_SALA)%Conc(I,J,L) * 0.0369e+0_fp * 1.d3 / &
-                                     ( 24.312e+0_fp * VOL  )
+             ! Total K+   (1.1% by weight of fine-mode seasalt)  [mole/m3]
+             TK       = Spc(id_SALA)%Conc(I,J,L) * 0.0110e+0_fp * 1.0e+3_fp * AlkR / &
+                        ( 39.102e+0_fp * VOL  )
+
+             ! Total Mg+  (3.69% by weight of fine-mode seasalt) [mole/m3]
+             TMG      = Spc(id_SALA)%Conc(I,J,L) * 0.0369e+0_fp * 1.0e+3_fp * AlkR / &
+                        ( 24.312e+0_fp * VOL  )
+          ELSE
+
+             ! Total Ca2+ (1.16% by weight of coarse-mode seasalt) [mole/m3]
+             TCA      = Spc(id_SALC)%Conc(I,J,L) * 0.0116e+0_fp * 1.0e+3_fp * AlkR / &
+                        ( 40.08e+0_fp  * VOL  )
+
+             ! Total K+   (1.1% by weight of coarse-mode seasalt)  [mole/m3]
+             TK       = Spc(id_SALC)%Conc(I,J,L) * 0.0110e+0_fp * 1.0e+3_fp * AlkR / &
+                        ( 39.102e+0_fp * VOL  )
+
+             ! Total Mg+  (3.69% by weight of coarse-mode seasalt) [mole/m3]
+             TMG      = Spc(id_SALC)%Conc(I,J,L) * 0.0369e+0_fp * 1.0e+3_fp * AlkR / &
+                        ( 24.312e+0_fp * VOL  )
+
+          ENDIF
 
           ! Compute gas-phase NO3
           IF ( id_HNO3 > 0 ) THEN


### PR DESCRIPTION

### Name and Institution (Required)

Yuk Chun Chan (UW) and Becky Alexander (UW)

### Describe the update

In the past, GC only called ISORROPIA for doing fine-mode-aerosol calculations, so it assumed all the Ca, Mg, and K in aerosols are from fine-mode seasalt. However, DO_ATE is now used for coarse-mode-aerosol calculations as well so we have to update the code for that.

After this bug fix, GC will use SALC instead of SALA to calculate the contribution of seasalt to coarse-mode Ca, Mg, and K. Note that the alkalinity factor AlkR is now included in the formulas to make sure these cations are treated the same way as Na.


### Expected changes

Without this fix, I expect that GC will likely underestimate cation abundance in coarse-mode aerosols in marine boundary layer, especially after [the previous correction to Na-to-seasalt mass ratio](https://github.com/geoschem/geos-chem/pull/2467).

### Related Github Issue

[Comment back in Ca, Mg, and K cations in aerosol thermodynamics #2391
](https://github.com/geoschem/geos-chem/issues/2391)