### PR TITLE
Fixes towards achieving bit-for-bit reproducibility in GC-Classic upon restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added met-field dependent dust tuning factors for GCHP C24 resolution in `setCommonRunSettings.sh`.  Others to be added later.
 - Added placeholder values for dust mass tuning factors in `HEMCO_Config.rc.GEOS`
 - Added dust scale factors for MERRA-2, GEOS-IT, and GEOS-FP when using USTAR for Dust DEAD extension
+- Added utility subroutine Print_Species_Min_Max_Sum to print_mod.F90
 
 ### Changed
 - Updated default CEDS from CEDSv2 (0.5 deg x 0.5 de) to new CEDS (0.1 deg x 0.1 deg)
 - Added the `KPP_INTEGRATOR_AUTOREDUCE` C-preprocessor switch integrator-specific handling
 - Added code to `KPP/*/CMakeLists.txt` to read the integrator name from the `*.kpp` file
 - Replaced `GOTO` statements with `IF/THEN/ELSE` blocks in `GeosCore/drydep_mod.F90`
+- Changed several diagnostic subroutines to expect species concentrations in mol/mol rather than kg/kg
+- Added precision when registering State_Met and State_Chm arrays to change output file precision to match precision in the model
+- Changed GEOS-Chem Classic restart file precision of species concentrations (State_Chm%SpcRestart) from REAL4 to REAL8 to match precision in the model
+- Moved GEOS-Chem Classic retrieval of restart variable DELPDRY from HEMCO to GC_Get_Restart for consistency with handling of all other restart variables
 
 ### Fixed
 - Fixed CEDS `HEMCO_Config.rc` entries to emit TMB into the TMB species (and not HCOOH)
 - Added C6H14 emissions into the ALK6 species for CMIP6 & HTAPv3 inventories
 - Fixed the ocean landcover type for dry deposition of O3 to oceans (cf issue #2707)
+- Moved where prescribed CH4 is applied in GEOS-Chem Classic to after emissions application so that updated PBL heights are used
+- Moved species concentration unit conversions between mol/mol and kg/kg to start and end of every timestep in GEOS-Chem Classic to remove differences introduced when reading and writing restart files
+- Fixed bug in restart file entry for ORVCSESQ in GEOS-Chem Classic fullchem HEMCO_Config.rc that resulted in initializing to all zeros
+- Fixed parallelization issue when computing State_Chm%DryDepNitrogren used in HEMCO soil NOx extension
 
 ### Removed
 - `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files
+- Remove unused level argument passed to SOIL_DRYDEP and SOIL_WETDEP
 
 ## [14.5.1] - 2025-01-10
 ### Added

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -26,6 +26,7 @@ MODULE Diagnostics_mod
 !
   PUBLIC :: Set_AerMass_Diagnostic
   PUBLIC :: Set_Diagnostics_EndofTimestep
+  PUBLIC :: Set_SpcConc_Diags_VVDry
   PUBLIC :: Zero_Diagnostics_StartofTimestep
   PUBLIC :: Compute_Budget_Diagnostics
 #ifdef ADJOINT
@@ -34,7 +35,6 @@ MODULE Diagnostics_mod
 !
 ! !PRIVATE MEMBER FUNCTIONS
 !
-  PRIVATE :: Set_SpcConc_Diags_VVDry
   PRIVATE :: Set_SpcConc_Diags_MND
 !
 ! !REVISION HISTORY:
@@ -120,20 +120,6 @@ CONTAINS
     ErrMsg  = ''
     ThisLoc = &
       ' -> at Set_Diagnostics_EndofTimestep (in GeosCore/diagnostics_mod.F90)'
-
-    !------------------------------------------------------------------------
-    ! Set species concentration for diagnostics in units of
-    ! v/v dry air = mol/mol dry air
-    !------------------------------------------------------------------------
-    CALL Set_SpcConc_Diags_VVDry( Input_Opt,  State_Chm, State_Diag,         &
-                                  State_Grid, State_Met, RC                 )
-
-    ! Trap potential errors
-    IF ( RC /= GC_SUCCESS ) THEN
-       ErrMsg = 'Error encountered setting SpeciesConcVV diagnostic'
-       CALL GC_ERROR( ErrMsg, RC, ThisLoc )
-       RETURN
-    ENDIF
 
     !-----------------------------------------------------------------------
     ! Set species concentration for diagnostics in units of
@@ -487,7 +473,6 @@ CONTAINS
 
     ! Assume success
     RC      =  GC_SUCCESS
-    Found   = .FALSE.
     ThisLoc = ' -> Set_SpcAdj_Diagnostic (in GeosCore/diagnostics_mod.F90)'
 
     ! Make sure all units are in kg/kg dry
@@ -588,14 +573,13 @@ CONTAINS
 ! !USES:
 !
     USE Input_Opt_Mod,  ONLY : OptInput
-    USE PhysConstants,  ONLY : AIRMW
     USE State_Met_Mod,  ONLY : MetState
     USE State_Chm_Mod,  ONLY : ChmState
     USE State_Diag_Mod, ONLY : DgnMap
     USE State_Diag_Mod, ONLY : DgnState
     USE State_Grid_Mod, ONLY : GrdState
     USE Time_Mod,       ONLY : Get_LocalTime
-    USE UnitConv_Mod,   ONLY : Check_Units, KG_SPECIES_PER_KG_DRY_AIR
+    USE UnitConv_Mod,   ONLY : Check_Units, MOLES_SPECIES_PER_MOLES_DRY_AIR
 !
 ! !INPUT PARAMETERS:
 !
@@ -622,7 +606,6 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    LOGICAL               :: Found
     INTEGER               :: D, I, J, L, N, S
     REAL(fp)              :: TmpVal, Conv, LT, GOOD
 
@@ -632,50 +615,20 @@ CONTAINS
     ! Objects
     TYPE(DgnMap), POINTER :: mapData
 
-    ! Arrays
-    REAL(fp)              :: TmpSpcArr(State_Grid%NX,State_Grid%NY, &
-                                       State_Grid%NZ,State_Chm%nSpecies)
-
     !====================================================================
     ! Set_SpcConc_Diags_VVDry begins here!
     !====================================================================
 
     ! Assume success
     RC      =  GC_SUCCESS
-    Found   = .FALSE.
     ThisLoc = &
          ' -> at Set_SpcConc_Diags_VVDry (in GeosCore/diagnostics_mod.F90)'
 
-    ! Verify that incoming State_Chm%Species units are kg/kg dry air.
-    IF ( .not. Check_Units( State_Chm, KG_SPECIES_PER_KG_DRY_AIR ) ) THEN
-       ErrMsg = 'Not all species are in "kg/kg dry" units!'
+    ! Verify that incoming State_Chm%Species units are mol/mol dry air.
+    IF ( .not. Check_Units( State_Chm, MOLES_SPECIES_PER_MOLES_DRY_AIR ) ) THEN
+       ErrMsg = 'Not all species are in "mol/mol dry" units!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
        RETURN
-    ENDIF
-
-    ! Store species in v/v dry as temporary variable if diagnostics on
-    IF ( State_Diag%Archive_SpeciesConcVV                               .or. &
-         State_Diag%Archive_SpeciesBC                                   .or. &
-         State_Diag%Archive_SpeciesRst                                  .or. &
-         State_Diag%Archive_ConcAboveSfc                                .or. & 
-         State_Diag%Archive_SatDiagnConc                              ) THEN
-
-       !$OMP PARALLEL DO                                                     &
-       !$OMP DEFAULT( SHARED                                                )&
-       !$OMP PRIVATE( I, J, L, N                                            )&
-       !$OMP COLLAPSE( 4                                                    )
-       DO N = 1, State_Chm%nSpecies
-       DO L = 1, State_Grid%NZ
-       DO J = 1, State_Grid%NY
-       DO I = 1, State_Grid%NX
-          TmpSpcArr(I,J,L,N) = State_Chm%Species(N)%Conc(I,J,L) *            &
-                               ( AIRMW / State_Chm%SpcData(N)%Info%MW_g )
-       ENDDO
-       ENDDO
-       ENDDO
-       ENDDO
-       !$OMP END PARALLEL DO
-
     ENDIF
 
     !=======================================================================
@@ -691,7 +644,7 @@ CONTAINS
        !$OMP PRIVATE( N, S   )
        DO S = 1, mapData%nSlots
           N = mapData%slot2id(S)
-          State_Diag%SpeciesConcVV(:,:,:,S) = TmpSpcArr(:,:,:,N)
+          State_Diag%SpeciesConcVV(:,:,:,S) = State_Chm%Species(N)%Conc(:,:,:)
        ENDDO
        !$OMP END PARALLEL DO
 
@@ -724,7 +677,8 @@ CONTAINS
           ! Archie into SatDiagnConc diagnostic array
           DO S = 1, State_Diag%Map_SatDiagnConc%nSlots
              N = State_Diag%Map_SatDiagnConc%slot2id(S)
-             State_Diag%SatDiagnConc(I,:,:,S) = TmpSpcArr(I,:,:,N) * GOOD
+             State_Diag%SatDiagnConc(I,:,:,S) =      &
+                  State_Chm%Species(N)%Conc(I,:,:) * GOOD
           ENDDO
        ENDDO
        !$OMP END PARALLEL DO
@@ -743,7 +697,7 @@ CONTAINS
        !$OMP PRIVATE( N, S   )
        DO S = 1, mapData%nSlots
           N = mapData%slot2id(S)
-          State_Diag%SpeciesBC(:,:,:,S) = TmpSpcArr(:,:,:,N)
+          State_Diag%SpeciesBC(:,:,:,S) = State_Chm%Species(N)%Conc(:,:,:)
        ENDDO
        !$OMP END PARALLEL DO
 
@@ -756,8 +710,14 @@ CONTAINS
     ! Copy species to SpeciesRst (restart file output) [v/v dry]
     !=======================================================================
     IF ( State_Diag%Archive_SpeciesRst ) THEN
-       State_Diag%SpeciesRst(:,:,:,:) = TmpSpcArr(:,:,:,:)
-    ENDIF
+       !$OMP PARALLEL DO       &
+       !$OMP DEFAULT( SHARED ) &
+       !$OMP PRIVATE( N      )
+       DO N = 1, State_Chm%nSpecies
+          State_Diag%SpeciesRst(:,:,:,N) = State_Chm%Species(N)%Conc(:,:,:)
+       ENDDO
+       !$OMP END PARALLEL DO
+   ENDIF
 
     !=======================================================================
     ! Diagnostic for correcting species concentrations from the height
@@ -792,9 +752,9 @@ CONTAINS
 
        ! Loop over the number of drydep species that we wish
        ! to save at a user-specified altitude above the surface
-       !$OMP PARALLEL DO                         &
-       !$OMP DEFAULT( SHARED                   ) &
-       !$OMP PRIVATE( D, N, I, J, TmpVal, Conv )
+       !$OMP PARALLEL DO                 &
+       !$OMP DEFAULT( SHARED           ) &
+       !$OMP PRIVATE( D, N, I, J, Conv )
        DO D = 1, State_Chm%nDryAlt
 
           ! Get the corresponding species index and drydep index
@@ -803,9 +763,6 @@ CONTAINS
           ! Loop over surface locations
           DO J = 1, State_Grid%NY
           DO I = 1, State_Grid%NX
-
-             ! Species concentration [v/v dry]
-             TmpVal = TmpSpcArr(I,J,1,N)
 
              ! Conversion factor used to translate from
              ! lowest model layer (~60m) to the surface
@@ -818,7 +775,8 @@ CONTAINS
 
              ! Save concentration at the user-defined altitude
              ! as defined in geoschem_config.yml (usually 10m).
-             State_Diag%SpeciesConcALT1(I,J,D) = TmpVal * Conv
+             State_Diag%SpeciesConcALT1(I,J,D) =            &
+                  State_Chm%Species(N)%Conc(I,J,1) * Conv
 
           ENDDO
           ENDDO
@@ -838,7 +796,7 @@ CONTAINS
 !
 ! !DESCRIPTION: Subroutine Set_SpcConc\_Diags\_MND sets several species
 !  concentration diagnostic arrays stored in State_Diag to the instantaneous
-!  State_Chm%Species values (in units of "v/v, dry air").
+!  State_Chm%Species values (in units of "molecules/cm3 air").
 !\\
 !\\
 ! !INTERFACE:

--- a/GeosCore/get_ndep_mod.F90
+++ b/GeosCore/get_ndep_mod.F90
@@ -77,7 +77,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE SOIL_DRYDEP( I, J, L, NN, TDRYFX, State_Chm )
+  SUBROUTINE SOIL_DRYDEP( I, J, NN, TDRYFX, State_Chm )
 !
 ! !USES:
 !
@@ -87,7 +87,6 @@ CONTAINS
 !
     INTEGER,  INTENT(IN)  :: I          ! I
     INTEGER,  INTENT(IN)  :: J          ! J
-    INTEGER,  INTENT(IN)  :: L          ! Level
     INTEGER,  INTENT(IN)  :: NN         ! Dry Dep Tracer #
     REAL(fp), INTENT(IN)  :: TDRYFX     ! Dry dep flux [molec/cm2/s]
 !
@@ -126,7 +125,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE SOIL_WETDEP( I, J, L, NN, TWETFX, State_Chm )
+  SUBROUTINE SOIL_WETDEP( I, J, NN, TWETFX, State_Chm )
 !
 ! !USES:
 !
@@ -136,7 +135,6 @@ CONTAINS
 !
     INTEGER,  INTENT(IN) :: I          ! I
     INTEGER,  INTENT(IN) :: J          ! J
-    INTEGER,  INTENT(IN) :: L          ! Level
     INTEGER,  INTENT(IN) :: NN         ! Wet Dep Tracer #
     REAL(fp), INTENT(IN) :: TWETFX     ! Wet dep flux [kg/s]
 !

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -4385,22 +4385,6 @@ CONTAINS
       D = GET_FIRST_I3_TIME()
       CALL FlexGrid_Read_I3_1( D(1), D(2), Input_Opt, State_Grid, State_Met )
 
-      ! Get delta pressure per grid box stored in restart file to allow
-      ! mass conservation across consecutive runs.
-      v_name = 'DELPDRY'
-      CALL HCO_GC_GetPtr( Input_Opt, State_Grid, TRIM(v_name), Ptr3D, RC, FOUND=FOUND )
-      IF ( FOUND ) THEN
-         State_Met%DELP_DRY = Ptr3D
-         IF ( Input_Opt%amIRoot ) THEN
-            WRITE(6,*) 'Initialize DELP_DRY from restart file'
-         ENDIF
-      ELSE
-         IF ( Input_Opt%amIRoot ) THEN
-            WRITE(6,*) 'DELP_DRY not found in restart, set to zero'
-         ENDIF
-      ENDIF
-      Ptr3D => NULL()
-
       ! Set dry surface pressure (PS1_DRY) from State_Met%PS1_WET
       ! and compute avg dry pressure near polar caps
       CALL Set_Dry_Surface_Pressure( State_Grid, State_Met, 1 )

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -4991,7 +4991,8 @@ CONTAINS
              tmpFlx = 0.0_fp
              !$OMP PARALLEL DO            &
              !$OMP DEFAULT( SHARED       )&
-             !$OMP PRIVATE( I, J, tmpFlx )
+             !$OMP PRIVATE( I, J, tmpFlx )&
+             !$OMP COLLAPSE( 2 )
              DO J = 1, State_Grid%NY
              DO I = 1, State_Grid%NX
                 tmpFlx = dflx(I,J,N) / MW_kg * AVO * 1.e-4_fp                &

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -4943,9 +4943,6 @@ CONTAINS
 
        ! Loop over only the drydep species
        ! If drydep is turned off, nDryDep=0 and the loop won't execute
-       !$OMP PARALLEL DO                                                     &
-       !$OMP DEFAULT( SHARED                                                )&
-       !$OMP PRIVATE( ND, N, ThisSpc, MW_kg, tmpFlx, S                      )
        DO ND = 1, State_Chm%nDryDep
 
           ! Get the species ID from the drydep ID
@@ -4992,22 +4989,24 @@ CONTAINS
           !-----------------------------------------------------------------
           IF ( Input_Opt%LSOILNOX ) THEN
              tmpFlx = 0.0_fp
+             !$OMP PARALLEL DO            &
+             !$OMP DEFAULT( SHARED       )&
+             !$OMP PRIVATE( I, J, tmpFlx )
              DO J = 1, State_Grid%NY
              DO I = 1, State_Grid%NX
-                tmpFlx = dflx(I,J,N)                                         &
-                       / MW_kg                                               &
-                       * AVO           * 1.e-4_fp                            &
+                tmpFlx = dflx(I,J,N) / MW_kg * AVO * 1.e-4_fp                &
                        * GET_TS_CONV() / GET_TS_EMIS()
-
                 CALL Soil_DryDep( I, J, 1, N, tmpFlx, State_Chm )
              ENDDO
              ENDDO
+             !$OMP END PARALLEL DO
           ENDIF
 
           ! Free species database pointer
           ThisSpc => NULL()
+
        ENDDO
-       !$OMP END PARALLEL DO
+
     ENDIF
 
     !=======================================================================

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -4996,7 +4996,7 @@ CONTAINS
              DO I = 1, State_Grid%NX
                 tmpFlx = dflx(I,J,N) / MW_kg * AVO * 1.e-4_fp                &
                        * GET_TS_CONV() / GET_TS_EMIS()
-                CALL Soil_DryDep( I, J, 1, N, tmpFlx, State_Chm )
+                CALL Soil_DryDep( I, J, N, tmpFlx, State_Chm )
              ENDDO
              ENDDO
              !$OMP END PARALLEL DO

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -1663,8 +1663,9 @@ CONTAINS
    ! FORMAT strings
 500   FORMAT( a                                                              )
 510   FORMAT( a21, ': Min = ', es15.9, '  Max = ', es15.9, '  Sum = ',es15.9 )
-520   FORMAT( a21, ': not found in GEOS-Chem restart file, setting to zero'
+520   FORMAT( a21, ': not found in GEOS-Chem restart file, setting to zero'  )
 530   FORMAT( 'Species ', i3, ', ', a9, ': Min = ', es15.9, ', Max = ', es15.9, '  Sum = ',es15.9 )
+540   FORMAT( 'Species ', i3, ', ', a9, ': not found in restart, setting to background = ', es15.9)
 
    !=================================================================
    ! Open GEOS-Chem restart file
@@ -1721,10 +1722,8 @@ CONTAINS
          ! Print the min, max, and sum of each species as it is read from
          ! the restart file in mol/mol
          IF ( Input_Opt%amIRoot ) THEN
-            WRITE( 6, 120 ) N, TRIM( SpcInfo%Name ), &
+            WRITE( 6, 530 ) N, TRIM( SpcInfo%Name ), &
                             MINVAL( Ptr3D ), MAXVAL( Ptr3D ), SUM ( Ptr3D(:,:,1:State_Grid%NZ) )
-120         FORMAT( 'Species ', i3, ', ', a8, ': Min = ', es15.9, &
-                    '  Max = ',es15.9, '  Sum = ',es15.9)
          ENDIF
 
          !$OMP PARALLEL DO       &
@@ -1766,9 +1765,7 @@ CONTAINS
                ! Print to log a warning that background values will be used
                IF ( Input_Opt%amIRoot .AND. &
                     I == 1 .AND. J == 1 .AND. L == 1 ) THEN
-                  WRITE( 6, 140 ) N, TRIM( SpcInfo%Name ), SpcInfo%BackgroundVV
-140               FORMAT('Species ', i3, ', ', a9, &
-                         ': Use background = ', es15.9)
+                  WRITE( 6, 540 ) N, TRIM( SpcInfo%Name ), SpcInfo%BackgroundVV
                ENDIF
 
 

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -1977,6 +1977,32 @@ CONTAINS
    ENDIF
 
    !=========================================================================
+   ! Get delta pressure per grid box stored in restart file to allow mass
+   ! conservation across consecutive runs
+   !========================================================================
+   v_name = 'DELPDRY'
+
+   ! Get variable from HEMCO and store in local array
+   CALL HCO_GC_GetPtr( Input_Opt, State_Grid, TRIM( v_name ),  &
+        Ptr3D,     RC,         FOUND=FOUND )
+
+   IF ( FOUND ) THEN
+      State_Met%DELP_DRY = Ptr3D
+      IF ( Input_Opt%amIRoot ) THEN
+         WRITE( 6, 510 ) ADJUSTL( v_name   ),                 &
+              MINVAL(  State_Met%DELP_DRY ),                  &
+              MAXVAL(  State_Met%DELP_DRY ),                  &
+              SUM(     State_Met%DELP_DRY )
+      ENDIF
+   ELSE
+      State_Met%DELP_DRY = 0.0_fp
+      IF ( Input_Opt%amIRoot ) WRITE( 6, 520 ) ADJUSTL( v_name )
+   ENDIF
+
+   ! Nullify pointer
+   Ptr3D => NULL()
+
+   !=========================================================================
    ! Get variables for KPP mechanisms (right now just fullchem and Hg)
    !=========================================================================
    IF ( ( Input_Opt%ITS_A_FULLCHEM_SIM .or.                                  &

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -1723,12 +1723,13 @@ CONTAINS
          ! the restart file in mol/mol
          IF ( Input_Opt%amIRoot ) THEN
             WRITE( 6, 530 ) N, TRIM( SpcInfo%Name ), &
-                            MINVAL( Ptr3D ), MAXVAL( Ptr3D ), SUM ( Ptr3D(:,:,1:State_Grid%NZ) )
+                            MINVAL( Ptr3D ), MAXVAL( Ptr3D ), SUM ( Ptr3D )
          ENDIF
 
          !$OMP PARALLEL DO       &
-         !$OMP DEFAULT( SHARED ) &
-         !$OMP PRIVATE( I, J, L )
+         !$OMP DEFAULT( SHARED  )&
+         !$OMP PRIVATE( I, J, L )&
+         !$OMP COLLAPSE( 3 )
          DO L = 1, State_Grid%NZ
          DO J = 1, State_Grid%NY
          DO I = 1, State_Grid%NX

--- a/GeosCore/mixing_mod.F90
+++ b/GeosCore/mixing_mod.F90
@@ -713,7 +713,7 @@ CONTAINS
 
                    ! Eventually add to SOIL_DRYDEP
                    IF ( Input_Opt%LSOILNOX ) THEN
-                      CALL SOIL_DRYDEP( I, J, L, N, FLUX, State_Chm )
+                      CALL SOIL_DRYDEP( I, J, N, FLUX, State_Chm )
                    ENDIF
 
                    !--------------------------------------------------------

--- a/GeosCore/tccon_ch4_mod.F90
+++ b/GeosCore/tccon_ch4_mod.F90
@@ -741,10 +741,8 @@ CONTAINS
        GC_CH4_NATIVE(:) = 0.0_fp
        GC_H2O_NATIVE(:) = 0.0_fp
 
-       ! Get species concentrations
-       ! Convert from [kg/box] --> [v/v]
-       GC_CH4_NATIVE(:) = State_Chm%Species(id_CH4)%Conc(I,J,:) * ( AIRMW / &
-                          State_Chm%SpcData(id_CH4)%Info%MW_g )
+       ! Get species concentrations [v/v]
+       GC_CH4_NATIVE(:) = State_Chm%Species(id_CH4)%Conc(I,J,:)
 
        GC_H2O_NATIVE(:) = State_Met%AVGW(I,J,:)
 

--- a/GeosCore/ucx_mod.F90
+++ b/GeosCore/ucx_mod.F90
@@ -622,7 +622,6 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER                               :: IOS
     INTEGER                               :: ILEV
     INTEGER                               :: I, J, L, ITRAC
     INTEGER                               :: JJNOX
@@ -630,10 +629,7 @@ CONTAINS
     REAL(fp)                              :: CURRVAL
     INTEGER                               :: VERTCOUNT, AS
     LOGICAL                               :: FOUNDLEV,EXTRAP
-    INTEGER                               :: IU_FILE, fId
-    INTEGER                               :: st3d(3), ct3d(3) ! Start/count
     LOGICAL                               :: ISRATE
-    CHARACTER(LEN=255)                    :: NOX_FILE
     CHARACTER(LEN=255)                    :: TARG_TRAC
     CHARACTER(LEN=255)                    :: DBGMSG
     REAL(fp), DIMENSION(:,:,:), POINTER   :: NOXDATA2D => NULL()

--- a/GeosCore/wetscav_mod.F90
+++ b/GeosCore/wetscav_mod.F90
@@ -4202,7 +4202,7 @@ CONTAINS
 
        ! Archive wet loss in kg/m2/s
        IF ( LSOILNOX ) THEN
-          CALL SOIL_WETDEP ( I, J, L, N, WETLOSS / DT, State_Chm )
+          CALL SOIL_WETDEP ( I, J, N, WETLOSS / DT, State_Chm )
        ENDIF
 
        !---------------------------------------------------------------------
@@ -4761,7 +4761,7 @@ CONTAINS
 
        ! Archive wet loss in kg/m2/s
        IF ( LSOILNOX ) THEN
-          CALL SOIL_WETDEP ( I, J, L, N, WETLOSS / DT, State_Chm )
+          CALL SOIL_WETDEP ( I, J, N, WETLOSS / DT, State_Chm )
        ENDIF
 
        !---------------------------------------------------------------------
@@ -5035,7 +5035,7 @@ CONTAINS
 
        ! Archive wet loss in kg/m2/s
        IF ( LSOILNOX ) THEN
-          CALL SOIL_WETDEP ( I, J, L, N, WETLOSS / DT, State_Chm )
+          CALL SOIL_WETDEP ( I, J, N, WETLOSS / DT, State_Chm )
        ENDIF
 
        !--------------------------------------------------------------------
@@ -5319,10 +5319,10 @@ CONTAINS
        ENDIF
 
 
-       ! Archive wet loss in kg/m2/s (check source code for this routine - ewl )
-       !IF ( LSOILNOX ) THEN
-       CALL SOIL_WETDEP ( I, J, L, N, WETLOSS / DT, State_Chm )
-       !ENDIF
+       ! Archive wet loss in kg/m2/s
+       IF ( LSOILNOX ) THEN
+          CALL SOIL_WETDEP ( I, J, N, WETLOSS / DT, State_Chm )
+       ENDIF
 
        !--------------------------------------------------------------------
        ! Dirty kludge to prevent wet deposition from removing

--- a/GeosUtil/CMakeLists.txt
+++ b/GeosUtil/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(GeosUtil STATIC EXCLUDE_FROM_ALL
         henry_mod.F90
 	ifort_errmsg.F90
 	pressure_mod.F90
+	print_mod.F90
 	regrid_a2a_mod.F90
 	time_mod.F90
 	timers_mod.F90

--- a/GeosUtil/print_mod.F90
+++ b/GeosUtil/print_mod.F90
@@ -1,0 +1,128 @@
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !MODULE: print_mod.F90
+!
+! !DESCRIPTION: Module PRINT\_MOD contains routines which are used as a
+!  general utility to print various quantities to log for debugging
+!  or informational purposes.
+!\\
+!\\
+! !INTERFACE:
+!
+MODULE Print_Mod
+!
+! !USES:
+!
+  USE ErrCode_Mod
+  USE Error_Mod
+  USE PhysConstants
+  USE Precision_Mod
+  USE Input_Opt_Mod,  ONLY : OptInput
+  USE State_Chm_Mod,  ONLY : ChmState
+  USE State_Chm_Mod,  ONLY : Ind_
+  USE State_Grid_Mod, ONLY : GrdState
+  USE State_Met_Mod,  ONLY : MetState
+  USE UnitConv_Mod
+
+  IMPLICIT NONE
+  PRIVATE
+!
+! !PUBLIC MEMBER FUNCTIONS:
+!
+  PUBLIC :: Print_Species_Min_Max_Sum
+!
+! !REMARKS:
+!
+!
+! !REVISION HISTORY:
+!  15 Oct 20324 - E. Lundgren - Initial version
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+CONTAINS
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Print_Species_Min_Max_Sum
+!
+! !DESCRIPTION: Subroutine Print\_Species\_Min\_Max\_Sum prints the
+!   minimum, maximum, and sum of species concentrations on the root thread
+!   to log. The default is to write all species. Arguments can be passed to
+!   to specify start index and stop index of State_Chm%Species array to
+!   limit species to one species or a consecutive sequence.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE Print_Species_Min_Max_Sum( msg, Input_Opt, State_Chm,  &
+                                        RC,  nStart,    nStop        )
+!
+! !INPUT PARAMETERS:
+!
+
+    CHARACTER(LEN=*), INTENT(IN)           :: msg       ! Message to print
+    TYPE(OptInput),   INTENT(IN)           :: Input_Opt ! Input Options object
+    TYPE(ChmState),   INTENT(IN)           :: State_Chm ! Chemistry State object
+    INTEGER,          INTENT(IN), OPTIONAL :: nStart    ! Index of 1st species to print
+    INTEGER,          INTENT(IN), OPTIONAL :: nStop     ! Index of last species to print
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,          INTENT(OUT)   :: RC     ! Success or failure?
+!
+! !REMARKS:
+!
+! !REVISION HISTORY:
+!  07 Oct 2024 - E. Lundgren - Initial version
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! Scalars
+    INTEGER            :: N, N_Start, N_Stop
+
+    ! Strings
+    CHARACTER(LEN=255) :: errMsg, errLoc, units
+
+    !========================================================================
+    ! Print_Species_Min_Max_Sum begins here!
+    !========================================================================
+
+    RC     = GC_SUCCESS
+    errMsg = ''
+    errLoc = ' -> at Print_Species_Min_Max_Sum (in GeosUtil/print_mod.F90)'
+
+    ! Set defaults
+    N_START = 1
+    N_STOP = State_Chm%nSpecies
+
+    ! Override with optional args
+    IF ( PRESENT(nStart) ) N_START = nStart
+    IF ( PRESENT(nStop ) ) N_STOP  = nStop
+
+    ! Write to log
+    IF ( Input_Opt%amIRoot ) THEN
+       WRITE(6,*) TRIM(msg) // ' (' // TRIM(UNIT_STR(State_Chm%Species(1)%Units)) // ')'
+       DO N = N_START, N_STOP
+          WRITE( 6, 120 ) N, TRIM( State_Chm%SpcData(N)%Info%Name ), &
+               MINVAL( State_Chm%Species(N)%Conc(:,:,:) ), &
+               MAXVAL( State_Chm%Species(N)%Conc(:,:,:) ), &
+               SUM ( State_Chm%Species(N)%Conc(:,:,:) )
+       ENDDO
+    ENDIF
+120 FORMAT( '   Species ', i3, ', ', a8, ': Min = ', es15.9, &
+         '  Max = ',es15.9, '  Sum = ',es15.9)
+
+  END SUBROUTINE Print_Species_Min_Max_Sum
+!EOC
+END MODULE Print_Mod

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -2534,12 +2534,12 @@ CONTAINS
 
        ! 
        ALLOCATE( State_Chm%KPP_AbsTol( N ), STAT=RC )
-       CALL GC_CheckVar( 'State_Chm%KppAbsTol', 0, RC )
+       CALL GC_CheckVar( 'State_Chm%Kpp_AbsTol', 0, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
        State_Chm%KPP_AbsTol = 0.0_f8
 
        ALLOCATE( State_Chm%KPP_RelTol( N ), STAT=RC )
-       CALL GC_CheckVar( 'State_Chm%KppRelTol', 0, RC )
+       CALL GC_CheckVar( 'State_Chm%Kpp_RelTol', 0, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
        State_Chm%KPP_RelTol = 0.0_f8
     ENDIF

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -4514,6 +4514,7 @@ CONTAINS
                                 // ' et al 2011, GMD)'
           IF ( isUnits ) Units = 'count'
           IF ( isRank  ) Rank  = 3
+          IF ( isType ) Type = KINDVAL_F4
 
        CASE ( 'KHETISLAN2O5H2O' )
           IF ( isDesc  ) Desc  = 'Sticking coefficient for N2O5 + H2O reaction'
@@ -4774,6 +4775,7 @@ CONTAINS
           IF ( isUnits   ) Units  = 'm s-1'
           IF ( isRank    ) Rank   = 2
           IF ( isSpc     ) perSpc = 'DRY'
+          IF ( isType    ) type   = KINDVAL_F8
 
 #ifdef MODEL_GEOS
        CASE( 'DRYDEPRA2M' )
@@ -5744,6 +5746,7 @@ CONTAINS
             Description  = TRIM( desc       ),                               &
             Units        = TRIM( units      ),                               &
             Data2d_4     = Ptr2Data,                                         &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -5883,6 +5886,7 @@ CONTAINS
             Units        = TRIM( units      ),                               &
             OnLevelEdges = onEdges,                                          &
             Data2d_4     = Ptr2Data(:,:,nCat),                               &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -5932,6 +5936,7 @@ CONTAINS
                Units        = TRIM( units       ),                           &
                OnLevelEdges = onEdges,                                       &
                Data2d_4     = Ptr2Data(:,:,N),                               &
+               Output_KindVal = type,                                        &
                RC           = RC                                            )
 
           ! Trap potential errors
@@ -5970,6 +5975,7 @@ CONTAINS
             Units        = TRIM( units      ),                               &
             Data3d_4     = Ptr2Data,                                         &
             OnLevelEdges = onEdges,                                          &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -6114,6 +6120,7 @@ CONTAINS
             Units        = TRIM( units      ),                               &
             OnLevelEdges = onEdges,                                          &
             Data3d_4     = Ptr2Data(:,:,:,Ncat),                             &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -6163,6 +6170,7 @@ CONTAINS
                Units        = TRIM( units       ),                           &
                OnLevelEdges = onEdges,                                       &
                Data3d_4     = Ptr2Data(:,:,:,N),                             &
+               Output_KindVal = type,                                        &
                RC           = RC                                            )
 
           ! Trap potential errors
@@ -6305,6 +6313,7 @@ CONTAINS
             Description  = TRIM( desc       ),                               &
             Units        = TRIM( units      ),                               &
             Data2d_8     = Ptr2Data,                                         &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -6447,6 +6456,7 @@ CONTAINS
             Units        = TRIM( units      ),                               &
             OnLevelEdges = onEdges,                                          &
             Data2d_8     = Ptr2Data(:,:,nCat),                               &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -6496,6 +6506,7 @@ CONTAINS
                Units        = TRIM( units       ),                           &
                OnLevelEdges = onEdges,                                       &
                Data2d_8     = Ptr2Data(:,:,N),                               &
+               Output_KindVal = type,                                        &
                RC           = RC                                            )
 
           ! Trap potential errors
@@ -6534,6 +6545,7 @@ CONTAINS
             Units        = TRIM( units      ),                               &
             Data3d_8     = Ptr2Data,                                         &
             OnLevelEdges = onEdges,                                          &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -6676,6 +6688,7 @@ CONTAINS
             Units        = TRIM( units      ),                               &
             OnLevelEdges = onEdges,                                          &
             Data3d_8     = Ptr2Data(:,:,:,Ncat),                             &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -6717,6 +6730,7 @@ CONTAINS
                Units        = TRIM( units       ),                           &
                OnLevelEdges = onEdges,                                       &
                Data3d_8     = Ptr2Data(:,:,:,N),                             &
+               Output_KindVal = type,                                        &
                RC           = RC                                            )
 
           ! Trap potential errors

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -14583,12 +14583,7 @@ CONTAINS
        IF ( isRank    ) Rank  = 3
        IF ( isTagged  ) TagId = 'ALL'
        IF ( isSrcType ) SrcType  = KINDVAL_F8
-       !--------------------------------------------------------------------
-       ! NOTE: We will eventually want restart file variables to be written
-       ! to netCDF as REAL*8, but HEMCO cannot yet read this.  For now
-       ! we will keep writing out restart files as REAL*4. (bmy, 8/14/20)
-       IF ( isOutType ) OutType  = KINDVAL_F4
-       !--------------------------------------------------------------------
+       IF ( isOutType ) OutType  = KINDVAL_F8
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'SPECIESBC' ) THEN
        IF ( isDesc    ) Desc  = 'Dry mixing ratio of species'

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -6343,6 +6343,7 @@ CONTAINS
          Units       = TRIM( Units      ),                                   &
          Description = TRIM( Desc       ),                                   &
          Data2d_4    = Ptr2Data,                                             &
+         Output_KindVal = type,                                              &
          RC          = RC                                                   )
 
     ! Trap potential errors
@@ -6476,6 +6477,7 @@ CONTAINS
                Description  = TRIM( thisDesc   ),                            &
                Units        = TRIM( Units      ),                            &
                Data2d_4     = Ptr2Data(:,:,N),                               &
+               Output_KindVal = type,                                        &
                RC           = RC                                            )
        ENDDO
 
@@ -6502,6 +6504,7 @@ CONTAINS
             Units        = TRIM( Units      ),                               &
             OnLevelEdges = onEdges,                                          &
             Data3d_4     = Ptr2Data,                                         &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -6616,6 +6619,7 @@ CONTAINS
          Description = TRIM( Desc       ),                                   &
          Units       = TRIM( Units      ),                                   &
          Data2d_8    = Ptr2Data,                                             &
+         Output_KindVal = type,                                              &
          RC          = RC                                                   )
 
     ! Trap potential errors
@@ -6749,6 +6753,7 @@ CONTAINS
                Description  = TRIM( thisDesc   ),                            &
                Units        = TRIM( units      ),                            &
                Data2d_8     = Ptr2Data(:,:,N),                               &
+               Output_KindVal = type,                                        &
                RC           = RC                                            )
 
        ENDDO
@@ -6776,6 +6781,7 @@ CONTAINS
             Units        = TRIM( Units      ),                               &
             OnLevelEdges = onEdges,                                          &
             Data3d_8     = Ptr2Data,                                         &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors
@@ -6890,6 +6896,7 @@ CONTAINS
          Description = TRIM( Desc       ),                                   &
          Units       = TRIM( Units      ),                                   &
          Data2d_I    = Ptr2Data,                                             &
+         Output_KindVal = type,                                              &
          RC          = RC                                                   )
 
     ! Trap potential errors
@@ -7019,6 +7026,7 @@ CONTAINS
                Description  = TRIM( thisDesc   ),                            &
                Units        = TRIM( Units      ),                            &
                Data2d_I     = Ptr2Data(:,:,N),                               &
+               Output_KindVal = type,                                        &
                RC           = RC                                            )
 
        ENDDO
@@ -7046,6 +7054,7 @@ CONTAINS
             Units        = TRIM( Units      ),                               &
             OnLevelEdges = onEdges,                                          &
             Data3d_I     = Ptr2Data,                                         &
+            Output_KindVal = type,                                           &
             RC           = RC                                               )
 
        ! Trap potential errors

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -1117,26 +1117,6 @@ PROGRAM GEOS_Chem
           ENDIF
        ENDIF
 
-       ! Prescribe methane surface concentrations throughout PBL
-       IF ( Input_Opt%ITS_A_FULLCHEM_SIM   .and.                             &
-            id_CH4 > 0                     .and.                             &
-            notDryRun                     ) THEN
-
-          IF ( VerboseAndRoot ) THEN
-             CALL DEBUG_MSG( '### MAIN: Setting PBL CH4 conc')
-          ENDIF
-
-          ! Set CH4 concentrations
-          CALL SET_CH4( Input_Opt, State_Chm, State_Diag, State_Grid, &
-                        State_Met, RC )
-
-          ! Trap potential errors
-          IF ( RC /= GC_SUCCESS ) THEN
-             ErrMsg = 'Error encountered in call to "SET_CH4"!'
-             CALL Error_Stop( ErrMsg, ThisLoc )
-          ENDIF
-       ENDIF
-
        !=====================================================================
        !                  ***** T R A N S P O R T *****
        !=====================================================================
@@ -1364,6 +1344,27 @@ PROGRAM GEOS_Chem
 
           IF ( Input_Opt%useTimers ) THEN
              CALL Timer_End( "HEMCO", RC )
+          ENDIF
+       ENDIF
+
+       ! Also prescribe methane surface concentrations throughout PBL
+       ! (currently done outside emissions)
+       IF ( Input_Opt%ITS_A_FULLCHEM_SIM   .and.                             &
+            id_CH4 > 0                     .and.                             &
+            notDryRun                     ) THEN
+
+          IF ( VerboseAndRoot ) THEN
+             CALL DEBUG_MSG( '### MAIN: Setting PBL CH4 conc')
+          ENDIF
+
+          ! Set CH4 concentrations
+          CALL SET_CH4( Input_Opt, State_Chm, State_Diag, State_Grid, &
+                        State_Met, RC )
+
+          ! Trap potential errors
+          IF ( RC /= GC_SUCCESS ) THEN
+             ErrMsg = 'Error encountered in call to "SET_CH4"!'
+             CALL Error_Stop( ErrMsg, ThisLoc )
           ENDIF
        ENDIF
 

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -205,6 +205,7 @@ PROGRAM GEOS_Chem
   INTEGER                  :: ELAPSED_SEC,   NHMSb,       RC
   INTEGER                  :: ELAPSED_TODAY, HOUR,        MINUTE,  SECOND
   INTEGER                  :: id_H2O,        id_CH4,      id_CLOCK
+  INTEGER                  :: previous_units
 
   ! Reals
   REAL(f8)                 :: TAU,           TAUb
@@ -661,7 +662,9 @@ PROGRAM GEOS_Chem
   ENDIF
 
   ! Run HEMCO phase 0 as simplfied phase 1 to get initial met fields
-  ! and restart file fields
+  ! and restart file fields. State_Chm%Species fields are populated in
+  ! this step and set to either values from file or background values
+  ! in mol/mol dry air.
   TimeForEmis = .FALSE.
   CALL Emissions_Run( Input_Opt, State_Chm,   State_Diag, State_Grid,  &
                       State_Met, TimeForEmis, 0,          RC )
@@ -882,6 +885,20 @@ PROGRAM GEOS_Chem
              CALL Timer_End( "Diagnostics", RC )
           ENDIF
        ENDIF
+
+       !---------------------------------------------------------------------
+       ! Convert species concentrations from v/v dry to kg/kg dry so that
+       ! the State_Chm%Species(:)%Conc unit is the same for most of the dynamic
+       ! timestep as the unit used in GCHP/GEOS GEOS-Chem Run method.
+       !---------------------------------------------------------------------
+       CALL Convert_Spc_Units(                                                  &
+            Input_Opt      = Input_Opt,                                         &
+            State_Chm      = State_Chm,                                         &
+            State_Grid     = State_Grid,                                        &
+            State_Met      = State_Met,                                         &
+            new_units      = KG_SPECIES_PER_KG_DRY_AIR,                         &
+            previous_units = previous_units,                                    &
+            RC             = RC                                                )
 
        !=====================================================================
        !       ***** R U N   H E M C O   P H A S E   1 *****
@@ -1705,6 +1722,35 @@ PROGRAM GEOS_Chem
              ErrMsg = 'Error encountered in "Set_AerMass_Diagnostic"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
           ENDIF
+
+          !------------------------------------------------------------------------
+          ! Set species concentration back to v/v dry air (mol/mol dry air)
+          ! prior to setting restart file arrays. Doing this conversion every
+          ! timestep is required for bit-for-bit reproducibility when breaking up
+          ! runs in time.
+          !------------------------------------------------------------------------
+          ! Turn off diagnostics timer
+          IF ( Input_Opt%useTimers ) THEN
+             CALL Timer_End( "Diagnostics", RC )
+          ENDIF
+
+          ! Convert units
+          CALL Convert_Spc_Units(                                                  &
+               Input_Opt  = Input_Opt,                                             &
+               State_Chm  = State_Chm,                                             &
+               State_Grid = State_Grid,                                            &
+               State_Met  = State_Met,                                             &
+               new_units  = previous_units,                                        &
+               RC         = RC                                                    )
+
+          ! Turn timer back on
+          IF ( Input_Opt%useTimers ) THEN
+             CALL Timer_Start( "Diagnostics", RC )
+          ENDIF
+
+          ! Set diagnostics arrays in State_Diag that are in mol/mol
+          CALL Set_SpcConc_Diags_VVDry( Input_Opt,  State_Chm, State_Diag,         &
+               State_Grid, State_Met, RC                 )
 
           ! Increment the timestep values by the heartbeat time
           ! This is because we need to write out data with the timestamp

--- a/ObsPack/obspack_mod.F90
+++ b/ObsPack/obspack_mod.F90
@@ -1296,7 +1296,7 @@ CONTAINS
     USE State_Met_Mod,  ONLY : MetState
     USE Time_Mod,       ONLY : Ymd_Extract
     USE Timers_Mod,     ONLY : Timer_End, Timer_Start
-    USE UnitConv_Mod
+    USE UnitConv_Mod,   ONLY : Check_Units, MOLES_SPECIES_PER_MOLES_DRY_AIR
 !
 ! !INPUT PARAMETERS:
 !
@@ -1334,7 +1334,6 @@ CONTAINS
     LOGICAL             :: prtLog,  doSample
     INTEGER             :: I,       J,        L,  N,  R,  S
     INTEGER             :: Yr,      Mo,       Da, Hr, Mn, Sc
-    INTEGER             :: previous_units
     REAL(f8)            :: TsStart, TsEnd
 
     ! Strings
@@ -1363,24 +1362,9 @@ CONTAINS
        CALL Timer_End( "Diagnostics", RC )
     ENDIF
 
-    ! Ensure that units of species are [v/v dry], which is dry air mole 
-    ! fraction, aka [mol/mol dry].  Capture the InUnit value, this is what 
-    ! the units are prior to this call.  After we sample the species, we'll 
-    ! call this again requesting that the species are converted back to the 
-    ! InUnit values.
-    CALL Convert_Spc_Units(                                                  &
-         Input_Opt      = Input_Opt,                                         &
-         State_Chm      = State_Chm,                                         &
-         State_Grid     = State_Grid,                                        &
-         State_Met      = State_Met,                                         &
-         mapping        = State_Chm%Map_Advect,                              &
-         new_units      = MOLES_SPECIES_PER_MOLES_DRY_AIR,                   &
-         previous_units = previous_units,                                    &
-         RC             = RC                                                )
-
-    ! Trap potential errors
-    IF ( RC /= GC_SUCCESS ) THEN
-       ErrMsg = 'Error encountered in "Convert_Units"!'
+    ! Verify that incoming State_Chm%Species units are mol/mol dry air.
+    IF ( .not. Check_Units( State_Chm, MOLES_SPECIES_PER_MOLES_DRY_AIR ) ) THEN
+       ErrMsg = 'Not all species are in "mol/mol dry" units!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
@@ -1475,9 +1459,6 @@ CONTAINS
              S = State_Diag%ObsPack_Species_Ind(R)
 
              ! Add the species concentration
-             !%%% TODO: Maybe do an in-line unit conversion to avoid
-             !%%% converting units for all species if we are only saving
-             !%%% out a few.
              State_Diag%ObsPack_Species(N,R) =                               &
              State_Diag%ObsPack_Species(N,R) + State_Chm%Species(S)%Conc(I,J,L)
           ENDDO
@@ -1518,24 +1499,6 @@ CONTAINS
     ! Halt diags timer (so that unit conv can be timed separately)
     IF ( Input_Opt%useTimers ) THEN
        CALL Timer_End( "Diagnostics", RC )
-    ENDIF
-
-    ! Return State_Chm%Species(:)%Conc to whatever units they had
-    ! coming into this routine
-    CALL Convert_Spc_Units(                                                  &
-         Input_Opt  = Input_Opt,                                             &
-         State_Chm  = State_Chm,                                             &
-         State_Grid = State_Grid,                                            &
-         State_Met  = State_Met,                                             &
-         mapping    = State_Chm%Map_Advect,                                  &
-         new_units  = previous_units,                                        &
-         RC         = RC                                                    )
-
-    ! Trap potential errors
-    IF ( RC /= GC_SUCCESS ) THEN
-       ErrMsg = 'Error encountered in "Convert_Units"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc )
-       RETURN
     ENDIF
 
     ! Start diags timer again

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3462,7 +3462,7 @@ VerboseOnCores:              root       # Accepted values: root all
 * SO2_AFTERCHEM  ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_SO2AfterChem   $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
 * H2O2_AFTERCHEM ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_H2O2AfterChem  $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
 * AEROH2O_SNA    ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_AeroH2OSNA     $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
-* ORVCSESQ       ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_ORVCSESQ       $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
+* ORVCSESQ       ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_ORVCsesq       $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
 * JOH            ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_JOH            $YYYY/$MM/$DD/$HH EY   xy  1 * - 1 1
 * JNO2           ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_JNO2           $YYYY/$MM/$DD/$HH EY   xy  1 * - 1 1
 * STATE_PSC      ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_StatePSC       $YYYY/$MM/$DD/$HH EY   xyz count * - 1 1

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -3452,7 +3452,7 @@ VerboseOnCores:              root       # Accepted values: root all
 * SO2_AFTERCHEM  ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_SO2AfterChem   $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
 * H2O2_AFTERCHEM ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_H2O2AfterChem  $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
 * AEROH2O_SNA    ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_AeroH2OSNA     $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
-* ORVCSESQ       ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_ORVCSESQ       $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
+* ORVCSESQ       ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_ORVCsesq       $YYYY/$MM/$DD/$HH EY   xyz 1 * - 1 1
 * JOH            ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_JOH            $YYYY/$MM/$DD/$HH EY   xy  1 * - 1 1
 * JNO2           ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_JNO2           $YYYY/$MM/$DD/$HH EY   xy  1 * - 1 1
 * STATE_PSC      ./Restarts/GEOSChem.Restart.$YYYY$MM$DD_$HH$MNz.nc4 Chem_StatePSC       $YYYY/$MM/$DD/$HH EY   xyz count * - 1 1


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR applies changes in GC-Classic needed to achieve bit-for-bit reproducibility when breaking up a run in time. Please note that with these updates out-of-the-box GC-Classic will still not have reproducibility upon restart due to a limitation of HEMCO. HEMCO reads inputs, including GEOS-Chem restart file variables, as single precision when most of these fields in GEOS-Chem are double precision.

Separately I implemented an update that reads the GEOS-Chem restart file locally, preserving native precision found in the file. With this PR and that update on top of it I am able to achieve bit-for-bit reproducibility in GC-Classic full chemistry benchmark simulation when breaking up the run in time. We are not going to bring in the update to read the restart file locally because we need to use HEMCO for its flexgrid capability. However, I will make that update available as a dev branch should anyone want to use it (see [here](https://github.com/geoschem/geos-chem/tree/feature/bypass_hemco_to_read_gcclassic_restart_as_real8)). An update to HEMCO to read native precision will come later.

Updates within GEOS-Chem that change benchmark output:
1. Fix a parallelization issue in GEOS-Chem's computation of `State_Chm%DryDepNitrogen` used in the HEMCO soil NOx extension and saved out to the GEOS-Chem restart file. I believe this was previously undetected because the differences are at the level of double precision numerical noise and thus were previously obscured by outputting to file as single precision. This update includes writing to the restart and diagnostic files using native precision which exposed the issue.
2. Fix bug in `Chem_ORVCsesq` restart file entry in GC-Classic fullchem `HEMCO_Config.rc`.
3. Register `State_Met` and `State_Chm` arrays in GC-Classic History using the native precision used in the model. Previously the precision was unspecified and outputs thus used the default of single precision.
4. Specify `REAL*8` as the output precision of `State_Diag%SpeciesRst` which is the species concentration array written to the restart file GC-Classic. Previously it was set to `REAL*4`.
5. Convert species concentration units of mol/mol <-> kg/kg in main.F90. This update ensures error is not introduced due to unit conversions used for saving species to the restart file in mol/mol. Conversion to mol/mol must occur every timestep as part of updating diagnostics used for restart variables so that GEOS-Chem Classic can achieve bit-for-bit reproducibility upon breaking up runs. We still use kg/kg dry air throughout main.F90. Conversion from mol/mol to kg/kg occurs at the start of every timestep. This also means that mol/mol is not converted to kg/kg in the subroutine that retrieves restart variables from HEMCO during initialization since it will occur later.
6.   Move setting prescribed CH4 to just after emissions in GC-Classic. It is necessary to move where prescribed CH4 is set because it is dependent on PBL height and previously PBL height was not updated until after Set_CH4 was called. This introduced small differences in GC-Classic when breaking up runs. CH4 is now set using updated PBL height and is grouped with emissions where other prescribed surface VMRs are applied. It is still applied outside of emissions.

This PR also contains several no-diff updates:
- Fix minor error in checking variables after `State_Chm` array allocation
- Remove unused local variables in `ucx_mod`
- Move getting restart var `DELPDRY` to subroutine `GC_Get_Restart`. This is a no diff update but now allows print of min, max, sum of restart variable `Met_DELPDRY` to be included with all of the other restart variables retrieved from HEMCO into GEOS-Chem for use upon startup.
- Add `GeosUtil/print_mod.F90` for specialized model print options. This module currently has one subroutine only, to print min, max, and mean of species concentrations to log. It currently only prints if root thread and does not convert units. Optional arguments allow printing one species or a consecutive sequence of species indexes. The current units are printed to the log.
- Clean up prints in `Get_GC_Restart` subroutine so that all species initial concentrations are printed to log, including if background values are used (with note about that), as well as initial concentrations of other arrays in the restart file that are read into the model.
- No diff fixes to `SOIL_WETDEP` and `SOIL_DRYDEP` subroutines used to update `State_Chm%WetDepNitrogen` and `State_Chm%DryDepNitrogen` used in the Soil NOx extension in HEMCO. Changes include removing the unused level argument and uncommenting a commented out Soil NOx extension logical used to determine whether to call `SOIL_WETDEP` in `Do_Washout_as_Sfc`.

### Expected changes

This update will cause small differences in all GEOS-Chem Classic simulations.

### Reference(s)

None

### Related Github Issue

https://github.com/geoschem/HEMCO/issues/18
https://github.com/geoschem/geos-chem/issues/111
https://github.com/geoschem/geos-chem/issues/2014
