### PR TITLE
Extending Stratospheric Adjustment to GCClassic

### DIFF
--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -4455,6 +4455,24 @@ CONTAINS
       CALL FlexGrid_Read_A3( D(1), D(2), Input_Opt, State_Grid, State_Met )
    ENDIF
 
+   !---------------------------------------------------------
+   ! Read 3-hr time averaged DynHeating data (crb, 15/03/24)
+   !---------------------------------------------------------
+   IF (Input_Opt%RRTMG_FDH .and. Input_Opt%Read_Dyn_Heating) THEN
+      ! We can use the boundary condition time functions 
+      ! as they also have no time adjustment
+      IF ( PHASE == 0 ) THEN
+         D = GET_FIRST_BC_TIME()
+      ELSE
+         D = GET_BC_TIME()
+      ENDIF
+      ! We can use ITS_TIME_FOR_A3 as we are also loading in the data every 3 hrs.
+      IF ( PHASE == 0 .or. ITS_TIME_FOR_A3() .and. &
+         .not. ITS_TIME_FOR_EXIT() ) THEN
+         CALL FlexGrid_Read_Dyn( D(1), D(2), Input_Opt, State_Grid, State_Met )  
+      ENDIF
+   ENDIF
+
    !----------------------------------
    ! Read 3-hr instantanous data
    !----------------------------------

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -2884,13 +2884,6 @@ CONTAINS
        ENDIF
     ENDIF
 
-#ifndef MODEL_GCHPCTM
-    If (Input_Opt%RRTMG_FDH) Then
-       errMsg = 'Fixed dynamical heating in RRTMG is currently only available in GCHP'
-       CALL GC_Error( errMsg, RC, thisLoc )
-    End If
-#endif
-
     If (Input_Opt%RRTMG_SEFDH.and.(.not.Input_Opt%RRTMG_FDH)) Then
        errMsg = 'Cannot have seasonally evolving FDH without enabling FDH!'
        CALL GC_Error( errMsg, RC, thisLoc )

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -1662,11 +1662,11 @@ PROGRAM GEOS_Chem
           If ( Input_Opt%RRTMG_FDH ) THEN
              Allocate(DT_3D(State_Grid%NX,State_Grid%NY,State_Grid%NZ),Stat=RC)
              IF ( RC /= 0 ) Call Error_Stop( 'Error allocating DT_3D', ThisLoc )
-             DT_3D(:,:,:) = 0.0e+0_fp
+             DT_3D(:,:,:) = 0
 
              Allocate(HR_3D(State_Grid%NX,State_Grid%NY,State_Grid%NZ),Stat=RC)
              IF ( RC /= 0 ) Call Error_Stop( 'Error allocating HR_3D', ThisLoc )
-             HR_3D(:,:,:) = 0.0e+0_fp
+             HR_3D(:,:,:) = 0
 
              ! Read in dynamical heating rates if necessary
              IF (Input_Opt%Read_Dyn_Heating) THEN

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -1658,6 +1658,28 @@ PROGRAM GEOS_Chem
              WRITE( 6, '(a)' ) REPEAT( '#', 79 )
           ENDIF
 
+          ! Allocate temperature difference arrays (crb, 14/02/24)
+          If ( Input_Opt%RRTMG_FDH ) THEN
+             Allocate(DT_3D(State_Grid%NX,State_Grid%NY,State_Grid%NZ),Stat=RC)
+             IF ( RC /= 0 ) Call Error_Stop( 'Error allocating DT_3D', ThisLoc )
+             DT_3D(:,:,:) = 0.0e+0_fp
+
+             Allocate(HR_3D(State_Grid%NX,State_Grid%NY,State_Grid%NZ),Stat=RC)
+             IF ( RC /= 0 ) Call Error_Stop( 'Error allocating HR_3D', ThisLoc )
+             HR_3D(:,:,:) = 0.0e+0_fp
+
+             ! Read in dynamical heating rates if necessary
+             IF (Input_Opt%Read_Dyn_Heating) THEN
+                HR_3D(:,:,:) = State_Met%DynHeating(:,:,:)
+             ENDIF
+          ELSE
+             ! Safer
+             Allocate(DT_3D(0,0,0),Stat=RC)
+             IF ( RC /= 0 ) Call Error_Stop( 'Error allocating DT_3D', ThisLoc )
+             Allocate(HR_3D(0,0,0),Stat=RC)
+             IF ( RC /= 0 ) Call Error_Stop( 'Error allocating HR_3D', ThisLoc ) 
+          ENDIF
+
           State_Chm%RRTMG_iSeed = State_Chm%RRTMG_iSeed + 15
 
           !------------------------------------------------------------------
@@ -1676,9 +1698,10 @@ PROGRAM GEOS_Chem
           ! Calculation for each of the potential output types
           ! See: wiki.geos-chem.org/Coupling_GEOS-Chem_with_RRTMG
           !
-          ! RRTMG outputs (scheduled in HISTORY.rc):
-          !  0-BA  1=O3  2=ME  3=SU   4=NI  5=AM
-          !  6=BC  7=OA  8=SS  9=DU  10=PM  11=ST
+          !   0=BASE and then...
+          !   1=O3  2=O3T 3=ME  4=H2O  5=CO2  6=CFC  7=N2O
+          !   8=SU  9=NI 10=AM  11=BC  12=OA  13=SS 14=DU
+          !  15=PM  16=ST
           !
           ! State_Diag%RadOutInd(1) will ALWAYS correspond to BASE due
           ! to how it is populated from HISTORY.rc diaglist_mod.F90.
@@ -1695,13 +1718,9 @@ PROGRAM GEOS_Chem
           ! Generate mask for species in RT
           CALL Set_SpecMask( State_Diag%RadOutInd(N), State_Chm )
 
-          ! Dummy values (FDH not available in GC-Classic)
-          Allocate(DT_3D(0,0,0),Stat=RC)
-          IF ( RC /= 0 ) Call Error_Stop( 'Error allocating DT_3D', ThisLoc )
-          Allocate(HR_3D(0,0,0),Stat=RC)
-          IF ( RC /= 0 ) Call Error_Stop( 'Error allocating HR_3D', ThisLoc )
-
           ! Compute radiative transfer for the given output
+          ! If FDH is used, this step will be used to calculate DT and
+          ! fill out DT_3D. The same will be true for HR_3D
           CALL Do_RRTMG_Rad_Transfer( ThisDay    = Day,                    &
                                       ThisMonth  = Month,                  &
                                       iCld       = State_Chm%RRTMG_iCld,   &
@@ -1727,8 +1746,10 @@ PROGRAM GEOS_Chem
 
           ! Calculate for rest of outputs, if any
           DO N = 2, State_Diag%nRadOut
+             ! This time around, DT_3D is read in but not overwritten
              WRITE( 6, 520 ) State_Diag%RadOutName(N), State_Diag%RadOutInd(N)
              CALL Set_SpecMask( State_Diag%RadOutInd(N), State_Chm )
+             ! This call will NOT update DT_3D, so we can just reuse the array
              CALL Do_RRTMG_Rad_Transfer( ThisDay    = Day,                    &
                                          ThisMonth  = Month,                  &
                                          iCld       = State_Chm%RRTMG_iCld,   &
@@ -1763,8 +1784,23 @@ PROGRAM GEOS_Chem
              CALL Debug_Msg( '### MAIN: a DO_RRTMG_RAD_TRANSFER' )
           ENDIF
 
-          If (Allocated(DT_3D)) Deallocate(DT_3D)
-          If (Allocated(HR_3D)) Deallocate(HR_3D)
+          ! Store temperature change and heating rate from RRTMG in diagnostics (crb, 14/02/24)
+          If (Input_Opt%RRTMG_FDH) Then
+             IF (State_Diag%Archive_DynHeating) THEN
+                State_Diag%DynHeating(:,:,:) = HR_3D(:,:,:)
+             ENDIF
+             ! NB: DT_3D is the temperature adjustment either after equilibration (pure FDH)
+             ! or at the start of the NEXT radiation time step (SEFDH)
+             IF (State_Diag%Archive_DTRad     ) THEN
+                State_Diag%DTRad(:,:,:)      = DT_3D(:,:,:)
+             ENDIF
+             RC = 0 
+          ENDIF
+
+          IF (Allocated(DT_3D)) Deallocate(DT_3D, STAT=RC)
+          IF ( RC /= 0 ) Call Error_Stop( 'Error deallocating DT_3D', ThisLoc )
+          IF (Allocated(HR_3D)) Deallocate(HR_3D, STAT=RC)
+          IF ( RC /= 0 ) Call Error_Stop( 'Error deallocating HR_3D', ThisLoc )
 
           IF ( Input_Opt%useTimers ) THEN
              CALL Timer_End( "RRTMG", RC )

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -255,6 +255,7 @@ PROGRAM GEOS_Chem
 #ifdef RRTMG
   ! For stratospheric adjustment
   REAL(f8), ALLOCATABLE          :: DT_3D(:,:,:)
+  REAL(f8), ALLOCATABLE          :: DT_3D_UPDATE(:,:,:)
   REAL(f8), ALLOCATABLE          :: HR_3D(:,:,:)
 #endif
 
@@ -1662,7 +1663,21 @@ PROGRAM GEOS_Chem
           If ( Input_Opt%RRTMG_FDH ) THEN
              Allocate(DT_3D(State_Grid%NX,State_Grid%NY,State_Grid%NZ),Stat=RC)
              IF ( RC /= 0 ) Call Error_Stop( 'Error allocating DT_3D', ThisLoc )
-             DT_3D(:,:,:) = 0
+
+             ! If using seasonally evolving FDH, need to grab the internal
+             ! state temperature adjustment array
+             IF (Input_Opt%RRTMG_SEFDH) THEN
+                ! DT_3D will be updated by the first call to RRTMG; also need to
+                ! store the "current" value
+                Allocate(DT_3D_UPDATE(State_Grid%NX,State_Grid%NY,State_Grid%NZ),Stat=RC)
+                IF ( RC /= 0 ) Call Error_Stop( 'Error allocating DT_3D_UPDATE', ThisLoc )
+                ! Store the adjustment as previously projected to this time point
+                DT_3D(:,:,:) = State_Chm%TStrat_Adj(:,:,:)
+                ! This will just hold the end-of-step value
+                DT_3D_UPDATE(:,:,:) = 0
+             ELSE
+                DT_3D(:,:,:) = 0
+             END IF
 
              Allocate(HR_3D(State_Grid%NX,State_Grid%NY,State_Grid%NZ),Stat=RC)
              IF ( RC /= 0 ) Call Error_Stop( 'Error allocating HR_3D', ThisLoc )
@@ -1784,7 +1799,12 @@ PROGRAM GEOS_Chem
              CALL Debug_Msg( '### MAIN: a DO_RRTMG_RAD_TRANSFER' )
           ENDIF
 
-          ! Store temperature change and heating rate from RRTMG in diagnostics (crb, 14/02/24)
+          ! Copy the adjustment back to DT_3D as calculated in the baseline calculation
+          IF (Input_Opt%RRTMG_SEFDH) THEN
+              DT_3D(:,:,:) = DT_3D_UPDATE(:,:,:)
+          END IF
+
+          ! Store temperature change THEN heating rate from RRTMG in diagnostics (crb, 14/02/24)
           If (Input_Opt%RRTMG_FDH) Then
              IF (State_Diag%Archive_DynHeating) THEN
                 State_Diag%DynHeating(:,:,:) = HR_3D(:,:,:)
@@ -1794,13 +1814,18 @@ PROGRAM GEOS_Chem
              IF (State_Diag%Archive_DTRad     ) THEN
                 State_Diag%DTRad(:,:,:)      = DT_3D(:,:,:)
              ENDIF
-             RC = 0 
+             IF (Input_Opt%RRTMG_SEFDH) THEN
+                State_Chm%TStrat_Adj(:,:,:) = DT_3D(:,:,:)
+             END IF
           ENDIF
 
+          RC = 0
           IF (Allocated(DT_3D)) Deallocate(DT_3D, STAT=RC)
           IF ( RC /= 0 ) Call Error_Stop( 'Error deallocating DT_3D', ThisLoc )
           IF (Allocated(HR_3D)) Deallocate(HR_3D, STAT=RC)
           IF ( RC /= 0 ) Call Error_Stop( 'Error deallocating HR_3D', ThisLoc )
+          IF (Allocated(DT_3D_UPDATE)) Deallocate(DT_3D_UPDATE, STAT=RC)
+          IF ( RC /= 0 ) Call Error_Stop( 'Error deallocating DT_3D_UPDATE', ThisLoc )
 
           IF ( Input_Opt%useTimers ) THEN
              CALL Timer_End( "RRTMG", RC )


### PR DESCRIPTION
### Name and Institution

Name: Connor Barker, @eamarais
Institution: University College London (UCL)

### Describe the update

This update extends the stratospheric adjustment code added by @sdeastham in GCHP (https://github.com/geoschem/geos-chem/pull/2010) to GCClassic. The commit here simply modifies the main level script for GCClassic, and allows the dynamical heating rates to be read in via the HEMCO meteorology file. No changes are made to the underlying RRTMG source code beyond what Seb already has added to include stratospheric adjustment. For further details see the original pull request.

To include stratospheric adjustments of temperature relative to the baseline simulation in the radiative fluxes, follow these steps:

- Run a baseline simulation with no pertubations.
   - Set the following in geoschem_config.yml (rrmtg must be activated): 
      - fixed_dyn_heating: true
       - read_dyn_heating: false
        - Activate the DynHeating collection in HISTORY.rc (sample file provided below) - this outputs the dynamical heating rates.

- Run a pertubation simulation.
    - Create a symbolic link in the run directory called Heating_Baseline to point to the DynHeating output from the baseline simulation:
        - e.g. ln -s /path/to/reference/rundir/OutputDir Heating_Baseline
    - Set the following in geoschem_config.yml (rrmtg must be activated): 
        - fixed_dyn_heating: true
        - read_dyn_heating: true
    - Add the following to the HEMCO_Config.rc.gmao_metfields file - this loads the dynamical heating rates:
```console
# --- DynHeating field ---
* DynHeating  ./Heating_Baseline/GEOSChem.DynHeating.$YYYY$MM$DD_$HH00z.nc4 DynHeating 2019/1-12/1-31/0-23 I xyz 1 * - 1 1
 ```
[HISTORY.txt](https://github.com/user-attachments/files/17411390/HISTORY.txt)

As described in https://github.com/geoschem/geos-chem/pull/2010, occasionally there will be a warning of "RRTMG FDH routine failed to converge for x of y columns on CPU 0". We find this happens sporadically for our simulations for 1/3312 columns. Failing to converge for >10 columns usually indicates an error somewhere.

The seasonally-evolving fixed dynamical heating approximation has also been extended to GCClassic, but is not yet tested (as stated by Seb in https://github.com/geoschem/geos-chem/pull/2010). The fdh_to_toa flag can be added in geoschem_config.yml to extend the stratospheric adjustment calculations to the top of the model.

### Expected changes

This code can be tested by simulating a single day with and without an increase of 100 ppmv CO2 (see https://github.com/geoschem/geos-chem/pull/2010).
```console
    - 20190701 - 20190702, no spinup, default restart file.
    - 4 simulations:
        - baseline   (co2_ppmv: 390.0, read_dyn_heating: false)
        - without_sa (co2_ppmv: 490.0, read_dyn_heating: false)
        - sa_strat   (co2_ppmv: 490.0, read_dyn_heating: true, fdh_to_toa: false)
        - sa_toa     (co2_ppmv: 490.0, read_dyn_heating: true, fdh_to_toa: true)
    - If successful, you should get the following results.  
        -           Sim  TOA RF / W m-2  Trop CO2 RF / W m-2  TOA RF - Trop RF / W m-2
         0        No SA            0.64                 1.25                     -0.61
         1  SA in strat            1.10                 1.24                     -0.09
         2    SA to TOA            1.16                 1.24                     -0.02
        - The expected changes are an increase in the TOA RF, and a small decrease in the Trop CO2 RF. 
```
### References

- See #2010 