### PR TITLE
Add allocate guards for arrays in `pressure_mod`

### DIFF
--- a/GeosUtil/pressure_mod.F90
+++ b/GeosUtil/pressure_mod.F90
@@ -517,39 +517,47 @@ CONTAINS
     RC      = GC_SUCCESS
     ThisLoc = ' -> at Init_Pressure (in GeosUtil/pressure_mod.F90)'
 
-    ALLOCATE( PFLT_DRY( State_Grid%NX, State_Grid%NY ), STAT=RC )
+    IF (.NOT. ALLOCATED( PFLT_DRY ))
+      ALLOCATE( PFLT_DRY( State_Grid%NX, State_Grid%NY ), STAT=RC )
     CALL GC_CheckVar( 'vdiff_mod.F90:PFLT_DRY', 2, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PFLT_DRY = 0e+0_fp
 
-    ALLOCATE( PFLT_WET( State_Grid%NX, State_Grid%NY ), STAT=RC )
+    IF (.NOT. ALLOCATED( PFLT_WET ))
+      ALLOCATE( PFLT_WET( State_Grid%NX, State_Grid%NY ), STAT=RC )
     CALL GC_CheckVar( 'vdiff_mod.F90:PFLT_WET', 2, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PFLT_WET = 0e+0_fp
 
-    ALLOCATE( AP( State_Grid%NZ+1 ), STAT=RC )
+    IF (.NOT. ALLOCATED( AP ))
+      ALLOCATE( AP( State_Grid%NZ+1 ), STAT=RC )
     CALL GC_CheckVar( 'vdiff_mod.F90:AP', 2, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     AP = 1e+0_fp
 
-    ALLOCATE( BP( State_Grid%NZ+1 ), STAT=RC )
+    IF (.NOT. ALLOCATED( BP ))
+      ALLOCATE( BP( State_Grid%NZ+1 ), STAT=RC )
     CALL GC_CheckVar( 'vdiff_mod.F90:BP', 2, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     BP = 0e+0_fp
 
-    ALLOCATE( AP_FULLGRID( State_Grid%NativeNZ+1 ), STAT=RC )
+    IF (.NOT. ALLOCATED( AP_FULLGRID ))
+      ALLOCATE( AP_FULLGRID( State_Grid%NativeNZ+1 ), STAT=RC )
     CALL GC_CheckVar( 'vdiff_mod.F90:AP_FULLGRID', 2, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     AP = 1e+0_fp
 
-    ALLOCATE( BP_FULLGRID( State_Grid%NativeNZ+1 ), STAT=RC )
+    IF (.NOT. ALLOCATED( BP_FULLGRID ))
+      ALLOCATE( BP_FULLGRID( State_Grid%NativeNZ+1 ), STAT=RC )
     CALL GC_CheckVar( 'vdiff_mod.F90:BP_FULLGRID', 2, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     BP = 0e+0_fp
 
 #if defined( ESMF_ ) || defined( MODEL_ )
-    ALLOCATE( EXTERNAL_PEDGE( State_Grid%NX, State_Grid%NY, State_Grid%NZ+1 ), &
-              STAT=RC )
+    IF (.NOT. ALLOCATED( EXTERNAL_PEDGE ))
+      ALLOCATE( EXTERNAL_PEDGE( State_Grid%NX, State_Grid%NY, &
+                                State_Grid%NZ+1 ), &
+                STAT=RC )
     CALL GC_CheckVar( 'vdiff_mod.F90:EXTERNAL_PEDGE', 2, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     EXTERNAL_PEDGE = 0e+0_fp


### PR DESCRIPTION
### Name and Institution (Required)

Name: Joe Wallwork
Institution: University of Cambridge

### Describe the update

I noticed that arrays in `GeosUtil/pressure_mod.F90` have `IF (ALLOCATED(...))` guards before they are deallocated but do not have `IF (.NOT. ALLOCATED(...))` guards before they are allocated.

### Expected changes

None.

### Reference(s)

N/A

### Related Github Issue

This fixes a bug that we noticed in the coupling effort for GISS Model E and GEOS-Chem (https://github.com/fetch4/GISS-GC). (See https://github.com/fetch4/geos-chem/pull/7.)

Without these changes, calling `INIT_PRESSURE` twice will mean arrays are allocated twice, which can cause errors.