### PR TITLE
Fix GEOS-Chem 14.5.0 build in CESM by excluding hard dependencies on HEMCO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Moved calls to `RD_AOD` and `CALC_AOD` from `Init_Aerosol` rather than `Init_Photolysis`
 - Updated ResME CH4 reservoir emissions to apply seasonality via mask file
 - Changed fullchem restart file folder from `GC_14.3.0` to `GC_14.5.0`
+- Excluded HEMCO interface and ExtState fields from `MODEL_CESM` in `hco_interface_gc_mod.F90` for compatibility with CESM, which runs HEMCO separately
 
 ### Fixed
 - Simplified SOA representations and fixed related AOD and TotalOA/OC calculations in benchmark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed metals simulation name in config file template comments
 - Fixed bug in `download_data.py` which caused script to fail if log filename contained uppercase characters.
 - Fixed the satellite diagnostics counters from being inadvertently being reset
+- Fixed segmentation fault in qfyaml when running with certain compilers without debug flags on
 
 ### Removed
 - Removed duplicate `WD_RetFactor` tag for HgClHO2 in `species_database.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Added
 - Added allocate guards for arrays in `pressure_mod`
+- Added `State_Diag%SatDiagnEdgeCount` counter for the `SatDiagnEdge` collection
+- Added `State_Diag%Archive_SatDiagnEdgeCount` field
+- Added `State_Diag%Archive_SatDiagnEdge` field
+- Added routine `SatDiagn_or_SatDiagnEdge` in `History/history_utils_mod.F90`
 
 ### Changed
 - Renamed `Emiss_Carbon_Gases` to `CO2_Production` in `carbon_gases_mod.F90`
 - Updated start date and restart file for CO2 and tagCO simulations for consistency with carbon simulations
+- Allocated `State_Diag%SatDiagnPEDGE` ffield with vertical dimension `State_Grid%NZ+1`
 
 ### Fixed
 - Added a fix to skip the call to KPP when only CO2 is defined in the carbon simulation
@@ -19,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed entries for CO2 emissions in `ExtData.rc.carbon`
 - Fixed metals simulation name in config file template comments
 - Fixed bug in `download_data.py` which caused script to fail if log filename contained uppercase characters.
+- Fixed the satellite diagnostics counters from being inadvertently being reset
 
 ## [14.5.0] - 2024-11-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `HEMCO_Config.rc` for carbon simulation to read data based on carbon species used
 - Fixed entries for CO2 emissions in `ExtData.rc.carbon`
 - Fixed metals simulation name in config file template comments
+- Fixed bug in `download_data.py` which caused script to fail if log filename contained uppercase characters.
 
 ## [14.5.0] - 2024-11-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug in `download_data.py` which caused script to fail if log filename contained uppercase characters.
 - Fixed the satellite diagnostics counters from being inadvertently being reset
 
+### Removed
+- Removed duplicate `WD_RetFactor` tag for HgClHO2 in `species_database.yml`
+
 ## [14.5.0] - 2024-11-07
 ### Added
 - Added vectors `State_Chm%KPP_AbsTol` and `State_Chm%KPP_RelTol`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- Added allocate guards for arrays in `pressure_mod`
+
 ### Changed
 - Renamed `Emiss_Carbon_Gases` to `CO2_Production` in `carbon_gases_mod.F90`
 - Updated start date and restart file for CO2 and tagCO simulations for consistency with carbon simulations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added fix to turn on ship emissions for CO2 in the carbon simulation
 - Updated `HEMCO_Config.rc` for carbon simulation to read data based on carbon species used
 - Fixed entries for CO2 emissions in `ExtData.rc.carbon`
+- Fixed metals simulation name in config file template comments
 
 ## [14.5.0] - 2024-11-07
 ### Added

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1466,11 +1466,16 @@ CONTAINS
             locTime <= State_Diag%SatDiagn_EndHr   ) good = 1.0_fp
 
        !---------------------------------------------------------------------
-       ! SatDiagnCount: Count number of local times
+       ! SatDiagnCount and SatDiagnEdgeCount: Count number of local times
        !---------------------------------------------------------------------
        IF ( State_Diag%Archive_SatDiagnCount ) THEN
           State_Diag%SatDiagnCount(I,:,:) = &
           State_Diag%SatDiagnCount(I,:,:) + good
+       ENDIF
+
+       IF ( State_Diag%Archive_SatDiagnEdgeCount ) THEN
+          State_Diag%SatDiagnEdgeCount(I,:,:) = &
+          State_Diag%SatDiagnEdgeCount(I,:,:) + good
        ENDIF
 
        !---------------------------------------------------------------------
@@ -1510,8 +1515,7 @@ CONTAINS
        ! Pressure edges [hPa]:
        !---------------------------------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPEdge ) THEN
-          State_Diag%SatDiagnPEdge(I,:,:) = &
-               State_Met%PEDGE(I,:,1:State_Grid%NZ) * good
+          State_Diag%SatDiagnPEdge(I,:,:) = State_Met%PEDGE(I,:,:) * good
        ENDIF
 
        !---------------------------------------------------------------------

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -46,18 +46,23 @@ MODULE HCO_Interface_GC_Mod
 !
 ! !PUBLIC MEMBER FUNCTIONS:
 !
+#if !defined( MODEL_CESM )
   PUBLIC  :: HCOI_GC_Init
   PUBLIC  :: HCOI_GC_Run
   PUBLIC  :: HCOI_GC_Final
+#endif
+
   PUBLIC  :: HCOI_GC_WriteDiagn
 
   PUBLIC  :: Compute_Sflx_For_Vdiff
 !
 ! !PRIVATE MEMBER FUNCTIONS:
 !
+#if !defined( MODEL_CESM )
   PRIVATE :: ExtState_InitTargets
   PRIVATE :: ExtState_SetFields
   PRIVATE :: ExtState_UpdateFields
+#endif
   PRIVATE :: Get_SzaFact
   PRIVATE :: GridEdge_Set
   PRIVATE :: CheckSettings
@@ -162,6 +167,7 @@ MODULE HCO_Interface_GC_Mod
   LOGICAL,  PARAMETER :: DoDiagn = .TRUE.
 
 CONTAINS
+#if !defined( MODEL_CESM )
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -1293,115 +1299,6 @@ CONTAINS
 #endif
 
   END SUBROUTINE HCOI_GC_Final
-!EOC
-!------------------------------------------------------------------------------
-!                  GEOS-Chem Global Chemical Transport Model                  !
-!------------------------------------------------------------------------------
-!BOP
-!
-! !IROUTINE: HCOI_GC_WriteDiagn
-!
-! !DESCRIPTION: Subroutine HCOI\_GC\_WriteDiagn is the wrapper routine to
-! write the HEMCO diagnostics. This will only write the diagnostics of
-! diagnostics collection 1.
-!\\
-!\\
-! !INTERFACE:
-!
-  SUBROUTINE HCOI_GC_WriteDiagn( Input_Opt, Restart, RC )
-!
-! !USES:
-!
-    USE ErrCode_Mod
-    USE HCOIO_Diagn_Mod, ONLY : HcoDiagn_Write
-    USE Input_Opt_Mod,   ONLY : OptInput
-
-    USE Time_Mod,        ONLY : Get_Year, Get_Month, Get_Day, GET_DAY_OF_YEAR
-    USE Time_Mod,        ONLY : GET_HOUR, GET_MINUTE, GET_SECOND
-#if defined( ADJOINT )
-    USE MAPL_CommsMod,   ONLY : MAPL_AM_I_ROOT
-#endif
-!
-! !INPUT/OUTPUT PARAMETERS:
-!
-    TYPE(OptInput), INTENT(IN   ) :: Input_Opt    ! Input options
-    LOGICAL,        INTENT(IN   ) :: Restart      ! write restart (enforced)?
-!
-! !INPUT/OUTPUT PARAMETERS:
-!
-    INTEGER,        INTENT(INOUT) :: RC           ! Success or failure?
-!
-! !REVISION HISTORY:
-!  01 Apr 2015 - C. Keller   - Initial version
-!  See https://github.com/geoschem/geos-chem for complete history
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-!
-! !LOCAL VARIABLES:
-!
-    ! Scalars
-    INTEGER             :: HMRC
-    INTEGER             :: year, month, day, dayOfYr, hour, minute, second
-
-    ! Strings
-    CHARACTER(LEN=255)  :: ThisLoc, Instr
-    CHARACTER(LEN=512)  :: ErrMsg
-
-    !=======================================================================
-    ! HCOI_GC_WriteDiagn begins here!
-    !=======================================================================
-
-    ! Initialize
-    RC       = GC_SUCCESS
-    HMRC     = HCO_SUCCESS
-    ErrMsg   = ''
-    ThisLoc  = &
-       ' -> at HCOI_GC_WriteDiagn (in module GeosCore/hco_interface_gc_mod.F90)'
-    Instr    = 'THIS ERROR ORIGINATED IN HEMCO!  Please check the '       // &
-               'HEMCO log file for additional error messages!'
-
-    !-----------------------------------------------------------------------
-    ! Make sure HEMCO time is in sync
-    !-----------------------------------------------------------------------
-
-    ! Now done through a universal function in HCO_Interface_Common
-    ! (hplin, 3/12/20)
-    year      = GET_YEAR()
-    month     = GET_MONTH()
-    day       = GET_DAY()
-    dayOfYr   = GET_DAY_OF_YEAR()
-    hour      = GET_HOUR()
-    minute    = GET_MINUTE()
-    second    = GET_SECOND()
-
-    CALL SetHcoTime( HcoState, ExtState, year,   month,   day, dayOfYr, &
-                     hour,     minute,   second, .FALSE., HMRC         )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "SetHcoTime"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       CALL Flush( HcoState%Config%Err%Lun )
-       RETURN
-    ENDIF
-
-    !-----------------------------------------------------------------------
-    ! Write diagnostics
-    !-----------------------------------------------------------------------
-    CALL HcoDiagn_Write( HcoState, RESTART, HMRC )
-
-    ! Trap potential errors
-    IF ( HMRC /= HCO_SUCCESS ) THEN
-       RC     = HMRC
-       ErrMsg = 'Error encountered in "HcoDiagn_Write"!'
-       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
-       CALL Flush( HcoState%Config%Err%Lun )
-       RETURN
-    ENDIF
-
-  END SUBROUTINE HCOI_GC_WriteDiagn
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !
@@ -3245,6 +3142,116 @@ CONTAINS
 #endif
 
   END SUBROUTINE ExtState_UpdateFields
+#endif ! MODEL_CESM exclude
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: HCOI_GC_WriteDiagn
+!
+! !DESCRIPTION: Subroutine HCOI\_GC\_WriteDiagn is the wrapper routine to
+! write the HEMCO diagnostics. This will only write the diagnostics of
+! diagnostics collection 1.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE HCOI_GC_WriteDiagn( Input_Opt, Restart, RC )
+!
+! !USES:
+!
+    USE ErrCode_Mod
+    USE HCOIO_Diagn_Mod, ONLY : HcoDiagn_Write
+    USE Input_Opt_Mod,   ONLY : OptInput
+
+    USE Time_Mod,        ONLY : Get_Year, Get_Month, Get_Day, GET_DAY_OF_YEAR
+    USE Time_Mod,        ONLY : GET_HOUR, GET_MINUTE, GET_SECOND
+#if defined( ADJOINT )
+    USE MAPL_CommsMod,   ONLY : MAPL_AM_I_ROOT
+#endif
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(OptInput), INTENT(IN   ) :: Input_Opt    ! Input options
+    LOGICAL,        INTENT(IN   ) :: Restart      ! write restart (enforced)?
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    INTEGER,        INTENT(INOUT) :: RC           ! Success or failure?
+!
+! !REVISION HISTORY:
+!  01 Apr 2015 - C. Keller   - Initial version
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! Scalars
+    INTEGER             :: HMRC
+    INTEGER             :: year, month, day, dayOfYr, hour, minute, second
+
+    ! Strings
+    CHARACTER(LEN=255)  :: ThisLoc, Instr
+    CHARACTER(LEN=512)  :: ErrMsg
+
+    !=======================================================================
+    ! HCOI_GC_WriteDiagn begins here!
+    !=======================================================================
+
+    ! Initialize
+    RC       = GC_SUCCESS
+    HMRC     = HCO_SUCCESS
+    ErrMsg   = ''
+    ThisLoc  = &
+       ' -> at HCOI_GC_WriteDiagn (in module GeosCore/hco_interface_gc_mod.F90)'
+    Instr    = 'THIS ERROR ORIGINATED IN HEMCO!  Please check the '       // &
+               'HEMCO log file for additional error messages!'
+
+    !-----------------------------------------------------------------------
+    ! Make sure HEMCO time is in sync
+    !-----------------------------------------------------------------------
+
+    ! Now done through a universal function in HCO_Interface_Common
+    ! (hplin, 3/12/20)
+    year      = GET_YEAR()
+    month     = GET_MONTH()
+    day       = GET_DAY()
+    dayOfYr   = GET_DAY_OF_YEAR()
+    hour      = GET_HOUR()
+    minute    = GET_MINUTE()
+    second    = GET_SECOND()
+
+    CALL SetHcoTime( HcoState, ExtState, year,   month,   day, dayOfYr, &
+                     hour,     minute,   second, .FALSE., HMRC         )
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "SetHcoTime"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       CALL Flush( HcoState%Config%Err%Lun )
+       RETURN
+    ENDIF
+
+    !-----------------------------------------------------------------------
+    ! Write diagnostics
+    !-----------------------------------------------------------------------
+    CALL HcoDiagn_Write( HcoState, RESTART, HMRC )
+
+    ! Trap potential errors
+    IF ( HMRC /= HCO_SUCCESS ) THEN
+       RC     = HMRC
+       ErrMsg = 'Error encountered in "HcoDiagn_Write"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc, Instr )
+       CALL Flush( HcoState%Config%Err%Lun )
+       RETURN
+    ENDIF
+
+  END SUBROUTINE HCOI_GC_WriteDiagn
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !

--- a/GeosUtil/pressure_mod.F90
+++ b/GeosUtil/pressure_mod.F90
@@ -517,42 +517,57 @@ CONTAINS
     RC      = GC_SUCCESS
     ThisLoc = ' -> at Init_Pressure (in GeosUtil/pressure_mod.F90)'
 
-    ALLOCATE( PFLT_DRY( State_Grid%NX, State_Grid%NY ), STAT=RC )
-    CALL GC_CheckVar( 'vdiff_mod.F90:PFLT_DRY', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    PFLT_DRY = 0e+0_fp
+    IF (.NOT. ALLOCATED( PFLT_DRY )) THEN
+      ALLOCATE( PFLT_DRY( State_Grid%NX, State_Grid%NY ), STAT=RC )
+      CALL GC_CheckVar( 'vdiff_mod.F90:PFLT_DRY', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      PFLT_DRY = 0e+0_fp
+    END IF
 
-    ALLOCATE( PFLT_WET( State_Grid%NX, State_Grid%NY ), STAT=RC )
-    CALL GC_CheckVar( 'vdiff_mod.F90:PFLT_WET', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    PFLT_WET = 0e+0_fp
+    IF (.NOT. ALLOCATED( PFLT_WET )) THEN
+      ALLOCATE( PFLT_WET( State_Grid%NX, State_Grid%NY ), STAT=RC )
+      CALL GC_CheckVar( 'vdiff_mod.F90:PFLT_WET', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      PFLT_WET = 0e+0_fp
+    END IF
 
-    ALLOCATE( AP( State_Grid%NZ+1 ), STAT=RC )
-    CALL GC_CheckVar( 'vdiff_mod.F90:AP', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    AP = 1e+0_fp
+    IF (.NOT. ALLOCATED( AP )) THEN
+      ALLOCATE( AP( State_Grid%NZ+1 ), STAT=RC )
+      CALL GC_CheckVar( 'vdiff_mod.F90:AP', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      AP = 1e+0_fp
+    END IF
 
-    ALLOCATE( BP( State_Grid%NZ+1 ), STAT=RC )
-    CALL GC_CheckVar( 'vdiff_mod.F90:BP', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    BP = 0e+0_fp
+    IF (.NOT. ALLOCATED( BP )) THEN
+      ALLOCATE( BP( State_Grid%NZ+1 ), STAT=RC )
+      CALL GC_CheckVar( 'vdiff_mod.F90:BP', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      BP = 0e+0_fp
+    END IF
 
-    ALLOCATE( AP_FULLGRID( State_Grid%NativeNZ+1 ), STAT=RC )
-    CALL GC_CheckVar( 'vdiff_mod.F90:AP_FULLGRID', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    AP = 1e+0_fp
+    IF (.NOT. ALLOCATED( AP_FULLGRID )) THEN
+      ALLOCATE( AP_FULLGRID( State_Grid%NativeNZ+1 ), STAT=RC )
+      CALL GC_CheckVar( 'vdiff_mod.F90:AP_FULLGRID', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      AP = 1e+0_fp
+    END IF
 
-    ALLOCATE( BP_FULLGRID( State_Grid%NativeNZ+1 ), STAT=RC )
-    CALL GC_CheckVar( 'vdiff_mod.F90:BP_FULLGRID', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    BP = 0e+0_fp
+    IF (.NOT. ALLOCATED( BP_FULLGRID )) THEN
+      ALLOCATE( BP_FULLGRID( State_Grid%NativeNZ+1 ), STAT=RC )
+      CALL GC_CheckVar( 'vdiff_mod.F90:BP_FULLGRID', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      BP = 0e+0_fp
+    END IF
 
 #if defined( ESMF_ ) || defined( MODEL_ )
-    ALLOCATE( EXTERNAL_PEDGE( State_Grid%NX, State_Grid%NY, State_Grid%NZ+1 ), &
-              STAT=RC )
-    CALL GC_CheckVar( 'vdiff_mod.F90:EXTERNAL_PEDGE', 2, RC )
-    IF ( RC /= GC_SUCCESS ) RETURN
-    EXTERNAL_PEDGE = 0e+0_fp
+    IF (.NOT. ALLOCATED( EXTERNAL_PEDGE )) THEN
+      ALLOCATE( EXTERNAL_PEDGE( State_Grid%NX, State_Grid%NY, &
+                                State_Grid%NZ+1 ), &
+                STAT=RC )
+      CALL GC_CheckVar( 'vdiff_mod.F90:EXTERNAL_PEDGE', 2, RC )
+      IF ( RC /= GC_SUCCESS ) RETURN
+      EXTERNAL_PEDGE = 0e+0_fp
+    END IF
 #endif
 
     IF ( State_Grid%NZ == 47 ) THEN

--- a/Headers/qfyaml_mod.F90
+++ b/Headers/qfyaml_mod.F90
@@ -2272,7 +2272,8 @@ CONTAINS
 
     ! Take the middle element as pivot
     pivot_ix    = SIZE( list ) / 2
-    pivot_value = list(pivot_ix)%var_name
+    temp        = list(pivot_ix)
+    pivot_value = temp%var_name
 
     DO WHILE ( left < right )
 

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -2880,6 +2880,8 @@ CONTAINS
     LOGICAL                          :: DoWrite
     LOGICAL                          :: isBndCond
     LOGICAL                          :: isRestart
+    LOGICAL                          :: isSatDiagn
+    LOGICAL                          :: isSatDiagnEdge
     INTEGER                          :: S, N
 
     ! Strings
@@ -3083,6 +3085,29 @@ CONTAINS
                 RETURN
              ENDIF
           ENDIF
+
+          !-----------------------------------------------------------------
+          ! SPECIAL HANDLING FOR SATELLITE DIAGNOSTIC COLLECTIONS
+          !
+          ! If we have called History_Netcdf_Write (i.e. DoWrite == T),
+          ! then reset the satellite diagnostics counters, as we have now
+          ! entered the next diagnostic interval.  We need to do this here
+          ! instead of in History_Netcdf_Write as there are multiple
+          ! satellite diagnostic collections (SatDiagn, SatDiagnEdge).
+          !-----------------------------------------------------------------
+
+          ! Test container name
+          CALL SatDiagn_or_SatDiagnEdge( cName, isSatDiagn, isSatDiagnEdge )
+
+          ! Zero SatDiagn counter
+          IF ( isSatDiagn .and. State_Diag%Archive_SatDiagnCount ) THEN
+             State_Diag%SatDiagnCount = 0.0_f8
+          ENDIF
+
+          ! Zero SatDiagnEdge counter
+          IF ( isSatDiagnEdge .and. State_Diag%Archive_SatDiagnEdgeCount ) THEN
+             State_Diag%SatDiagnEdgeCount = 0.0_f8
+          ENDIF
        ENDIF
 
        ! Skip to the next collection
@@ -3094,15 +3119,6 @@ CONTAINS
     !=======================================================================
     ! Cleanup & quit
     !=======================================================================
-
-    ! If we have called History_Netcdf_Write (i.e. DoWrite == T), then
-    ! reset the satellite diagnostics counter, as we have now entered the
-    ! next diagnostic interval.  We need to do this here instead of in
-    ! History_Netcdf_Write as there are multiple satellite diagnostic
-    ! collections (SatDiagn, SatDiagnEdge).
-    IF ( State_Diag%Archive_SatDiagnCount .and. DoWrite ) THEN
-       State_Diag%SatDiagnCount = 0.0_f8
-    ENDIF
 
     ! Free pointers
     Container  => NULL()

--- a/History/history_netcdf_mod.F90
+++ b/History/history_netcdf_mod.F90
@@ -715,7 +715,8 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    LOGICAL                     :: output4Bytes,     isSatDiagn
+    LOGICAL                     :: output4Bytes
+    LOGICAL                     :: isSatDiagnEdge,   isSatDiagn
     INTEGER                     :: NcFileId,         NcVarId
     INTEGER                     :: Dim1,             Dim2,       Dim3
 
@@ -765,8 +766,8 @@ CONTAINS
     ThisLoc   =  &
          ' -> at History_Netcdf_Write (in History/history_netcdf_mod.F90)'
 
-    ! Test if this is the SatDiagn or SatDiagnEdge container
-    isSatDiagn = (INDEX(To_UpperCase(TRIM(Container%Name)), 'SATDIAGN' ) > 0)
+    ! Test if this is the SatDiagn or SatDiagnEdge collection
+    CALL SatDiagn_or_SatDiagnEdge( Container%Name, isSatDiagn, isSatDiagnEdge )
 
     !========================================================================
     ! Compute time elapsed since the reference time
@@ -856,10 +857,20 @@ CONTAINS
              Dim2 = SIZE( Item%Data_3d, 2 )
              Dim3 = SIZE( Item%Data_3d, 3 )
 
-             ! Get average for satellite diagnostic:
+             ! Get average for satellite diagnostic (vertical centers)
              IF ( isSatDiagn ) THEN
                 WHERE ( State_Diag%SatDiagnCount > 0.0_f8 )
                    Item%Data_3d = Item%Data_3d / State_Diag%SatDiagnCount
+                ELSEWHERE
+                   Item%Data_3d = MISSING_DBLE
+                ENDWHERE
+                Item%nUpdates   = 1.0_f8
+             ENDIF
+
+             ! Get average for satellite diagnostic (vertical edges)
+             IF ( isSatDiagnEdge ) THEN
+                WHERE ( State_Diag%SatDiagnEdgeCount > 0.0_f8 )
+                   Item%Data_3d = Item%Data_3d / State_Diag%SatDiagnEdgeCount
                 ELSEWHERE
                    Item%Data_3d = MISSING_DBLE
                 ENDWHERE

--- a/History/history_util_mod.F90
+++ b/History/history_util_mod.F90
@@ -25,6 +25,7 @@ MODULE History_Util_Mod
   PUBLIC :: Compute_Julian_Date
   PUBLIC :: Compute_Elapsed_Time
   PUBLIC :: Compute_DeltaYmdHms_For_End
+  PUBLIC :: SatDiagn_or_SatDiagnEdge
 !
 ! !DEFINED PARAMETERS:
 !
@@ -298,5 +299,51 @@ CONTAINS
     deltaHms = ( dHour * 10000 ) + ( dMinute * 100 ) + dSecond
 
   END SUBROUTINE Compute_DeltaYmdHms_For_End
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Is_SatDiagn_or_SatDiagnEdge
+!
+! !DESCRIPTION: Tests a container name to determine if it is one of the
+!  satellite diagnostic collections (SatDiagn, SatDiagnEdge)
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE SatDiagn_or_SatDiagnEdge( cName, isSatDiagn, isSatDiagnEdge )
+!
+! !USES:
+!
+    USE CharPak_Mod, ONLY : To_Uppercase
+!
+! !INPUT PARAMETERS:
+!
+    CHARACTER(LEN=*), INTENT(IN)  :: cName   ! Container name
+!
+! !OUTPUT PARAMETERS:
+!
+    LOGICAL,          INTENT(OUT) :: isSatDiagn
+    LOGICAL,          INTENT(OUT) :: isSatDiagnEdge
+!
+! !REVISION HISTORY:
+!  31 Oct 2024 - R. Yantosca - Initial version
+!  See the subsequent Git history with the gitk browser!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+
+    ! Test if this is the SatDiagnEdge container
+    isSatDiagnEdge = (                                                       &
+       INDEX( To_UpperCase( TRIM( cName) ), 'SATDIAGNEDGE' ) > 0            )
+
+    ! Test if this is the SatDiagn container
+    isSatDiagn = (                                                           &
+      .not. isSatDiagnEdge .and.                                             &
+       INDEX( To_UpperCase( TRIM( cName ) ), 'SATDIAGN'    ) > 0            )
+
+  END SUBROUTINE SatDiagn_or_SatDiagnEdge
 !EOC
 END MODULE History_Util_Mod

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.metals
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.metals
@@ -13,7 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the Transport Tracers simulation.
+#  This file has been customized for the trace metals simulation.
 #  See The HEMCO User's Guide for file details:
 #    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
 #

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
@@ -1,5 +1,5 @@
 ###############################################################################
-###  HISTORY.rc file for GEOS-Chem Transport Tracers simulations            ###
+###  HISTORY.rc file for GEOS-Chem trace metals simulations                 ###
 ###  Contact: GEOS-Chem Support Team (geos-chem-support@g.harvard.edu)      ###
 ###############################################################################
 

--- a/run/shared/download_data.py
+++ b/run/shared/download_data.py
@@ -726,13 +726,15 @@ def parse_args():
 
     # Parse command-line arguments (argument 0 is the program name)
     for i in range(1, len(sys.argv)):
-        arg = sys.argv[i].lower()
-        arg = arg.lstrip('-')
+        arg = sys.argv[i]
 
         if not dryrun_found:
             dryrun_log = arg
             dryrun_found = True
             continue
+
+        # Normalize arguments other than dryrun_log
+        arg = arg.lower().lstrip('-')
 
         if not portal_found:
             for mir in portal_list:

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -2167,7 +2167,6 @@ HgClNO2:
   Formula: ClHgONO
   MW_g: 282.00
 HgClHO2:
-  WD_RetFactor: 1.0
   << : *HgChemProperties
   Fullname: HgClHO2
   Formula: ClHgOOH


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: Harvard Univ.

### Describe the update

In the CESM model, emissions through HEMCO are provided to GEOS-Chem through the physics buffer and not through the HEMCO subroutine calls. A side-effect of this implementation is that HEMCO versions and GEOS-Chem versions in CESM can be decoupled, and thus hard-dependencies on HEMCO data structures should not apply.

In this particular case, additional ExtState fields in HEMCO are causing CESM build failures in the latest GEOS-Chem version. Most (but not all) subroutines in hco_interface_gc_mod.F90 are unused in CESM and are now blocked off from MODEL_CESM to avoid this hard dependency.

Note: `HCOI_GC_WriteDiagn` was rearranged in the module but otherwise unchanged, in order to use one `#if !defined( MODEL_CESM )`

### Expected changes

None

### Reference(s)

N/A

### Related Github Issue

Building CESM with latest GEOS-Chem tag `14.5.0-rc.0`
