### PR TITLE
Update version number to 14.5.0 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - TBD
+## [14.5.0] - 2024-11-07
 ### Added
 - Added vectors `State_Chm%KPP_AbsTol` and `State_Chm%KPP_RelTol`
 - Added setting `KPP_AbsTol` to 1e5 for dummy species in `species_database.yml` and `species_database_hg.yml`


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR changes the version number in `CHANGELOG.md` from 14.4.3 to 14.5.0.

NOTE: The latest version number in `KPP/fullchem/CHANGELOG.md` version number has already been updated

### Expected changes
None, this is a purely documentation change

### Related Github Issue

- https://github.com/geoschem/GCClassic/pull/68
- https://github.com/geoschem/GCHP/pull/448
- https://github.com/geoschem/HEMCO/pull/292