### PR TITLE
Remove duplicate WD_RetFactor tag for HgClHO2 entry in species-database.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Added
 - Added allocate guards for arrays in `pressure_mod`
+- Added `State_Diag%SatDiagnEdgeCount` counter for the `SatDiagnEdge` collection
+- Added `State_Diag%Archive_SatDiagnEdgeCount` field
+- Added `State_Diag%Archive_SatDiagnEdge` field
+- Added routine `SatDiagn_or_SatDiagnEdge` in `History/history_utils_mod.F90`
 
 ### Changed
 - Renamed `Emiss_Carbon_Gases` to `CO2_Production` in `carbon_gases_mod.F90`
 - Updated start date and restart file for CO2 and tagCO simulations for consistency with carbon simulations
+- Allocated `State_Diag%SatDiagnPEDGE` ffield with vertical dimension `State_Grid%NZ+1`
 
 ### Fixed
 - Added a fix to skip the call to KPP when only CO2 is defined in the carbon simulation
@@ -19,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed entries for CO2 emissions in `ExtData.rc.carbon`
 - Fixed metals simulation name in config file template comments
 - Fixed bug in `download_data.py` which caused script to fail if log filename contained uppercase characters.
+- Fixed the satellite diagnostics counters from being inadvertently being reset
 
 ## [14.5.0] - 2024-11-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug in `download_data.py` which caused script to fail if log filename contained uppercase characters.
 - Fixed the satellite diagnostics counters from being inadvertently being reset
 
+### Removed
+- Removed duplicate `WD_RetFactor` tag for HgClHO2 in `species_database.yml`
+
 ## [14.5.0] - 2024-11-07
 ### Added
 - Added vectors `State_Chm%KPP_AbsTol` and `State_Chm%KPP_RelTol`

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1466,11 +1466,16 @@ CONTAINS
             locTime <= State_Diag%SatDiagn_EndHr   ) good = 1.0_fp
 
        !---------------------------------------------------------------------
-       ! SatDiagnCount: Count number of local times
+       ! SatDiagnCount and SatDiagnEdgeCount: Count number of local times
        !---------------------------------------------------------------------
        IF ( State_Diag%Archive_SatDiagnCount ) THEN
           State_Diag%SatDiagnCount(I,:,:) = &
           State_Diag%SatDiagnCount(I,:,:) + good
+       ENDIF
+
+       IF ( State_Diag%Archive_SatDiagnEdgeCount ) THEN
+          State_Diag%SatDiagnEdgeCount(I,:,:) = &
+          State_Diag%SatDiagnEdgeCount(I,:,:) + good
        ENDIF
 
        !---------------------------------------------------------------------
@@ -1510,8 +1515,7 @@ CONTAINS
        ! Pressure edges [hPa]:
        !---------------------------------------------------------------------
        IF ( State_Diag%Archive_SatDiagnPEdge ) THEN
-          State_Diag%SatDiagnPEdge(I,:,:) = &
-               State_Met%PEDGE(I,:,1:State_Grid%NZ) * good
+          State_Diag%SatDiagnPEdge(I,:,:) = State_Met%PEDGE(I,:,:) * good
        ENDIF
 
        !---------------------------------------------------------------------

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -2880,6 +2880,8 @@ CONTAINS
     LOGICAL                          :: DoWrite
     LOGICAL                          :: isBndCond
     LOGICAL                          :: isRestart
+    LOGICAL                          :: isSatDiagn
+    LOGICAL                          :: isSatDiagnEdge
     INTEGER                          :: S, N
 
     ! Strings
@@ -3083,6 +3085,29 @@ CONTAINS
                 RETURN
              ENDIF
           ENDIF
+
+          !-----------------------------------------------------------------
+          ! SPECIAL HANDLING FOR SATELLITE DIAGNOSTIC COLLECTIONS
+          !
+          ! If we have called History_Netcdf_Write (i.e. DoWrite == T),
+          ! then reset the satellite diagnostics counters, as we have now
+          ! entered the next diagnostic interval.  We need to do this here
+          ! instead of in History_Netcdf_Write as there are multiple
+          ! satellite diagnostic collections (SatDiagn, SatDiagnEdge).
+          !-----------------------------------------------------------------
+
+          ! Test container name
+          CALL SatDiagn_or_SatDiagnEdge( cName, isSatDiagn, isSatDiagnEdge )
+
+          ! Zero SatDiagn counter
+          IF ( isSatDiagn .and. State_Diag%Archive_SatDiagnCount ) THEN
+             State_Diag%SatDiagnCount = 0.0_f8
+          ENDIF
+
+          ! Zero SatDiagnEdge counter
+          IF ( isSatDiagnEdge .and. State_Diag%Archive_SatDiagnEdgeCount ) THEN
+             State_Diag%SatDiagnEdgeCount = 0.0_f8
+          ENDIF
        ENDIF
 
        ! Skip to the next collection
@@ -3094,15 +3119,6 @@ CONTAINS
     !=======================================================================
     ! Cleanup & quit
     !=======================================================================
-
-    ! If we have called History_Netcdf_Write (i.e. DoWrite == T), then
-    ! reset the satellite diagnostics counter, as we have now entered the
-    ! next diagnostic interval.  We need to do this here instead of in
-    ! History_Netcdf_Write as there are multiple satellite diagnostic
-    ! collections (SatDiagn, SatDiagnEdge).
-    IF ( State_Diag%Archive_SatDiagnCount .and. DoWrite ) THEN
-       State_Diag%SatDiagnCount = 0.0_f8
-    ENDIF
 
     ! Free pointers
     Container  => NULL()

--- a/History/history_netcdf_mod.F90
+++ b/History/history_netcdf_mod.F90
@@ -715,7 +715,8 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     ! Scalars
-    LOGICAL                     :: output4Bytes,     isSatDiagn
+    LOGICAL                     :: output4Bytes
+    LOGICAL                     :: isSatDiagnEdge,   isSatDiagn
     INTEGER                     :: NcFileId,         NcVarId
     INTEGER                     :: Dim1,             Dim2,       Dim3
 
@@ -765,8 +766,8 @@ CONTAINS
     ThisLoc   =  &
          ' -> at History_Netcdf_Write (in History/history_netcdf_mod.F90)'
 
-    ! Test if this is the SatDiagn or SatDiagnEdge container
-    isSatDiagn = (INDEX(To_UpperCase(TRIM(Container%Name)), 'SATDIAGN' ) > 0)
+    ! Test if this is the SatDiagn or SatDiagnEdge collection
+    CALL SatDiagn_or_SatDiagnEdge( Container%Name, isSatDiagn, isSatDiagnEdge )
 
     !========================================================================
     ! Compute time elapsed since the reference time
@@ -856,10 +857,20 @@ CONTAINS
              Dim2 = SIZE( Item%Data_3d, 2 )
              Dim3 = SIZE( Item%Data_3d, 3 )
 
-             ! Get average for satellite diagnostic:
+             ! Get average for satellite diagnostic (vertical centers)
              IF ( isSatDiagn ) THEN
                 WHERE ( State_Diag%SatDiagnCount > 0.0_f8 )
                    Item%Data_3d = Item%Data_3d / State_Diag%SatDiagnCount
+                ELSEWHERE
+                   Item%Data_3d = MISSING_DBLE
+                ENDWHERE
+                Item%nUpdates   = 1.0_f8
+             ENDIF
+
+             ! Get average for satellite diagnostic (vertical edges)
+             IF ( isSatDiagnEdge ) THEN
+                WHERE ( State_Diag%SatDiagnEdgeCount > 0.0_f8 )
+                   Item%Data_3d = Item%Data_3d / State_Diag%SatDiagnEdgeCount
                 ELSEWHERE
                    Item%Data_3d = MISSING_DBLE
                 ENDWHERE

--- a/History/history_util_mod.F90
+++ b/History/history_util_mod.F90
@@ -25,6 +25,7 @@ MODULE History_Util_Mod
   PUBLIC :: Compute_Julian_Date
   PUBLIC :: Compute_Elapsed_Time
   PUBLIC :: Compute_DeltaYmdHms_For_End
+  PUBLIC :: SatDiagn_or_SatDiagnEdge
 !
 ! !DEFINED PARAMETERS:
 !
@@ -298,5 +299,51 @@ CONTAINS
     deltaHms = ( dHour * 10000 ) + ( dMinute * 100 ) + dSecond
 
   END SUBROUTINE Compute_DeltaYmdHms_For_End
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Is_SatDiagn_or_SatDiagnEdge
+!
+! !DESCRIPTION: Tests a container name to determine if it is one of the
+!  satellite diagnostic collections (SatDiagn, SatDiagnEdge)
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE SatDiagn_or_SatDiagnEdge( cName, isSatDiagn, isSatDiagnEdge )
+!
+! !USES:
+!
+    USE CharPak_Mod, ONLY : To_Uppercase
+!
+! !INPUT PARAMETERS:
+!
+    CHARACTER(LEN=*), INTENT(IN)  :: cName   ! Container name
+!
+! !OUTPUT PARAMETERS:
+!
+    LOGICAL,          INTENT(OUT) :: isSatDiagn
+    LOGICAL,          INTENT(OUT) :: isSatDiagnEdge
+!
+! !REVISION HISTORY:
+!  31 Oct 2024 - R. Yantosca - Initial version
+!  See the subsequent Git history with the gitk browser!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+
+    ! Test if this is the SatDiagnEdge container
+    isSatDiagnEdge = (                                                       &
+       INDEX( To_UpperCase( TRIM( cName) ), 'SATDIAGNEDGE' ) > 0            )
+
+    ! Test if this is the SatDiagn container
+    isSatDiagn = (                                                           &
+      .not. isSatDiagnEdge .and.                                             &
+       INDEX( To_UpperCase( TRIM( cName ) ), 'SATDIAGN'    ) > 0            )
+
+  END SUBROUTINE SatDiagn_or_SatDiagnEdge
 !EOC
 END MODULE History_Util_Mod

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -2167,7 +2167,6 @@ HgClNO2:
   Formula: ClHgONO
   MW_g: 282.00
 HgClHO2:
-  WD_RetFactor: 1.0
   << : *HgChemProperties
   Fullname: HgClHO2
   Formula: ClHgOOH


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR removes a duplicate `WD_RetFactor` YAML tag for species HgClHO2 from the `species_database.yml` file.

### Expected changes
This is a zero-diff update w/r/t the full-chemistry benchmark.  It only affects the Hg simulation.

### Reference(s)
N/A

### Related Github Issue
- Closes #2546