### PR TITLE
Output sea flux species dry deposition velocity with DryDep collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Moved PINO3H to be in alphabetical order in `species_database.yml`
+- Moved dry dep velocity diagnostic outputs for sea flux and satellite diagnostic species into the `DryDep` collection
 
 ### Fixed
 - Fixed CEDS HEMCO_Config.rc entries to emit TMB into the TMB species (and not HCOOH)

--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -610,9 +610,8 @@ CONTAINS
     ENDDO
     !$OMP END PARALLEL DO
 
-    ! Set diagnostics - cnsider moving?
-    IF ( State_Diag%Archive_DryDepVel                                   .or. &
-         State_Diag%Archive_DryDepVelForALT1                            .or. &
+    ! Set diagnostics - consider moving?
+    IF ( State_Diag%Archive_DryDepVelForALT1                            .or. &
          State_Diag%Archive_SatDiagnDryDepVel                         ) THEN 
 
        !$OMP PARALLEL DO                                                     &
@@ -623,15 +622,7 @@ CONTAINS
           ! Point to State_Chm%DryDepVel [m/s]
           NDVZ = NDVZIND(D)
 
-          ! Dry dep velocity [cm/s]
-          IF ( State_Diag%Archive_DryDepVel ) THEN
-             S = State_Diag%Map_DryDepVel%id2slot(D)
-             IF ( S > 0 ) THEN
-                State_Diag%DryDepVel(:,:,S)   =                              &
-                State_Chm%DryDepVel(:,:,NDVZ) * 100.0_f4
-             ENDIF
-          ENDIF
-
+          ! eam: this should also be moved eventually
           ! Satellite diagnostic: Dry dep velocity [cm/s]
           IF ( State_Diag%Archive_SatDiagnDryDepVel ) THEN
              S = State_Diag%Map_SatDiagnDryDepVel%id2slot(D)
@@ -2254,6 +2245,7 @@ CONTAINS
        !** Load array State_Chm%DryDepVel
        DO 550 K=1,NUMDEP
           IF (.NOT.LDEP(K)) GOTO 550
+          
           State_Chm%DryDepVel(I,J,K) = VD(K)
 
           ! Now check for negative deposition velocity before returning to

--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -611,8 +611,7 @@ CONTAINS
     !$OMP END PARALLEL DO
 
     ! Set diagnostics - consider moving?
-    IF ( State_Diag%Archive_DryDepVelForALT1                            .or. &
-         State_Diag%Archive_SatDiagnDryDepVel                         ) THEN 
+    IF ( State_Diag%Archive_DryDepVelForALT1 )   THEN 
 
        !$OMP PARALLEL DO                                                     &
        !$OMP DEFAULT( SHARED                                                )&
@@ -621,16 +620,6 @@ CONTAINS
 
           ! Point to State_Chm%DryDepVel [m/s]
           NDVZ = NDVZIND(D)
-
-          ! eam: this should also be moved eventually
-          ! Satellite diagnostic: Dry dep velocity [cm/s]
-          IF ( State_Diag%Archive_SatDiagnDryDepVel ) THEN
-             S = State_Diag%Map_SatDiagnDryDepVel%id2slot(D)
-             IF ( S > 0 ) THEN
-                State_Diag%SatDiagnDryDepVel(:,:,S)   =                      &
-                State_Chm%DryDepVel(:,:,NDVZ) * 100.0_f4
-             ENDIF
-          ENDIF
 
           ! Dry dep velocity [cm/s] for species at altitude (e.g. 10m)
           IF ( State_Diag%Archive_DryDepVelForALT1 ) THEN

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -4792,7 +4792,7 @@ CONTAINS
 
       ! Free pointers
       ThisSpc => NULL()
-   ENDDO   ! NA
+    ENDDO   ! NA
 
     !=======================================================================
     ! Add emissions & deposition values calculated in HEMCO.
@@ -4871,25 +4871,6 @@ CONTAINS
           
        ENDDO
 
-       ! eam:
-       ! Dry dep velocity [cm/s]
-       !IF ( State_Diag%Archive_DryDepVel ) THEN
-       !   PRINT*, 'YOU ARE HERE'
-       !   PRINT*, 'no. of slots = ', State_Diag%Map_DryDep%nSlots
-          !STOP
-          !DO S = 1, State_Diag%Map_DryDepVel%nSlots
-          
-       !      PRINT*, 'SS = ', SS
-       !      DVZ = dflx(I,J,N) * State_Met%BXHEIGHT(I,J,1) * 1.0e+2_fp
-       !      !State_Diag%DryDepVel(I,J,SS) = DVZ
-       !      PRINT*, 'DVZ: ', DVZ
-       !      STOP
-       !ENDIF
-       ! Before convert dflx from 1/s to kg/m2/s, save dry deposition
-       ! velocity in cm/s:
-       !PRINT*, 'box height: ', State_Met%BXHEIGHT(I,J,1)
-       !PRINT*, 'dflx (1/s): ', dflx(I,J,N)
-       !PRINT*, 'Vel (cm/s): ', dflx(I,J,N) * State_Met%BXHEIGHT(I,J,1) * 1.0e+2_fp
 
        !=====================================================================
        ! Convert DFLX from 1/s to kg/m2/s
@@ -4922,8 +4903,6 @@ CONTAINS
        !=====================================================================
        ! Defining Satellite Diagnostics
        !=====================================================================
-
-       ! eam: shouldn't there be I,J and not :,:, as occur within lat and long loops
        ! Define emission satellite diagnostics
        IF ( State_Diag%Archive_SatDiagnColEmis ) THEN
           DO S = 1, State_Diag%Map_SatDiagnColEmis%nSlots
@@ -5003,7 +4982,8 @@ CONTAINS
     !=======================================================================
     IF ( Input_Opt%LGTMM              .or. Input_Opt%LSOILNOX          .or.  &
          State_Diag%Archive_DryDepMix .or. State_Diag%Archive_DryDep   .or.  &
-         State_Diag%Archive_DryDepVel ) THEN
+         State_Diag%Archive_DryDepVel .or. &
+         State_Diag%Archive_SatDiagnDryDepVel     ) THEN
 
        ! Loop over only the drydep species
        ! If drydep is turned off, nDryDep=0 and the loop won't execute
@@ -5049,10 +5029,19 @@ CONTAINS
              ENDIF
           ENDIF
 
+          ! Dry deposition velocity (cm/s):
           IF ( State_Diag%Archive_DryDepVel ) THEN
              S = State_Diag%Map_DryDepVel%id2slot(ND)
              IF ( S > 0 ) THEN
                 State_Diag%DryDepVel(:,:,S) = dvel(:,:,N)
+             ENDIF
+          ENDIF
+
+          ! Satellite diagnostic dry deposition velocity (cm/s):
+          IF ( State_Diag%Archive_SatDiagnDryDepVel ) THEN
+             S = State_Diag%Map_SatDiagnDryDepVel%id2slot(ND)
+             IF ( S > 0 ) THEN
+                State_Diag%SatDiagnDryDepVel(:,:,S) = dvel(:,:,N)
              ENDIF
           ENDIF
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to issue #2564 by @eamarais.  This moves the dry deposition velocity for HEMCO extension seaflux species and satellite diagnostic species to the DryDep diagnostic collection.

### Expected changes
See: https://github.com/geoschem/geos-chem/issues/2564#issue-2643900822

### Reference(s)
N/A

### Related Github Issue
- Closes #2564 