### PR TITLE
Fix tagged CO simulation in dev branch

### DIFF
--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -79,8 +79,8 @@ restarts:
     remote: v2020-02/GEOSChem.Restart.POPs_BaP.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   tagco:
-    remote: v2020-02/GEOSChem.Restart.tagCO.20190701_0000z.nc4
-    local:  GEOSChem.Restart.20190701_0000z.nc4
+    remote: v2020-02/GEOSChem.Restart.carbon.20190101_0000z.nc4
+    local:  GEOSChem.Restart.20190101_0000z.nc4
   tago3:
     remote: GC_14.5.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes a bug introduced to the dev/no-diff-to-benchmark branch when 14.5.0 was merged in. That merge reverted an
update to change the start date and restart file for tagged CO simulations. With this updates the tagged CO integration tests will no longer fail.

Note that there is no need for a changelog update because the issue is only in the dev/no-diff-to-benchmark branch and is not in any official releases.

### Expected changes

Tagged CO simulations will use the carbon restart file and start on Jan 1 by default. This returns functionality introduced in the CO2 updates in the dev/no-diff-to-benchmark branch.

### Reference(s)

None

### Related Github Issue

None needed since bug is not in any releases.
