### PR TITLE
Add ozonesonde observation locations to the kpp_standalone_interface.yml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated start date and restart file for CO2 and tagCO simulations for consistency with carbon simulations
 - Allocated `State_Diag%SatDiagnPEDGE` ffield with vertical dimension `State_Grid%NZ+1`
 - Modified `run/GCClassic/cleanRunDir.sh` to skip removing bpch files, as well as now removing `fort.*` and `OutputDir/*.txt` files
+- Edited `run/shared/kpp_standalone_interface.yml` to include additional entries under `active cells` and `locations`
 
 ### Fixed
 - Added a fix to skip the call to KPP when only CO2 is defined in the carbon simulation

--- a/run/shared/kpp_standalone_interface.yml
+++ b/run/shared/kpp_standalone_interface.yml
@@ -1,9 +1,9 @@
 ---
 # ============================================================================
-# Configuration file for KPP standalone interface
+# Configuration file for the KPP-Standalone Interface.
 #
 # This file specifies at which locations we will archive the model
-# state so that we can initialize KPP standalone box model simulations.
+# state so that we can initialize KPP-Standalone Box Model simulations.
 # ============================================================================
 
 # ------------------------------------
@@ -22,78 +22,177 @@ settings:
     - 35
     - 48
     - 56
-  timestep: 15                         # Timestep (mins) for KPP standalone
 
 # ------------------------------------
 # Where to archive model state?
 # ------------------------------------
 active_cells:
-   - LosAngeles
-   - McMurdo
-   - Paris
-   - Beijing
-   - Kinshasa
-   - Kennaook
-   - Graciosa
-   - Utqiagvik
-   - Ozarks
-   - Amazon
-   - Congo
-   - Borneo
-   - IndianOcean
-   - AtlanticOcean
-   - PacificOcean
-   - ElDjouf
+  - Alert
+  - Amazon
+  - AtlanticOcean
+  - Beijing
+  - Borneo
+  - Boulder
+  - Broadmeadows
+  - Congo
+  - DeBilt
+  - Edmonton
+  - ElDjouf
+  - Eureka
+  - Graciosa
+  - GooseBay
+  - HiloHawaii
+  - Hohenpeissenberg
+  - Kennaook
+  - Kinshasa
+  - IndianOcean
+  - Lauder
+  - Legionowo
+  - Lindenberg
+  - LosAngeles
+  - MacquarieIsland
+  - McMurdo
+  - NahaOkinawa
+  - Nairobi
+  - Ozarks
+  - PacificOcean
+  - Paramibo
+  - Paris
+  - Payerne
+  - Reunion
+  - Sapporo
+  - Sodankyla
+  - Syowa
+  - TatenoTsukuba
+  - TrinidadHead
+  - Uccle
+  - Utqiagvik
+  - WallopsIsland
 
 # ------------------------------------
 # Active cell geographic coordinates
 # ------------------------------------
 locations:
-  LosAngeles:
-    longitude: -118.243
-    latitude: 34.0522
-  Paris:
-    longitude: 2.3522
-    latitude: 48.8566
-  Beijing:
-    longitude: 116.4074
-    latitude: 39.9042
-  Kinshasa:
-    longitude: 15.3105
-    latitude: -4.3033
-  Kennaook:
-    longitude: 144.6833
-    latitude: -40.6833
-  Graciosa:
-    longitude: -28.0069
-    latitude: 39.0525
-  McMurdo:
-    longitude: 166.6698
-    latitude: -77.8455
-  Utqiagvik:
-    longitude: -156.7886
-    latitude: 71.2906
-  Ozarks:
-    longitude: -91.259
-    latitude: 37.502
+  Alert:
+    latitude: 82.5
+    longitude: -62.3
   Amazon:
-    longitude: -62.2159
     latitude: -3.4653
-  Congo:
-    longitude: 12.5484
-    latitude: -5.9175
-  Borneo:
-    longitude: 114.0
-    latitude: 0.0
-  IndianOcean:
-    longitude: 87.2
-    latitude: 23.0
+    longitude: -62.2159
   AtlanticOcean:
-    longitude: -41.574755
     latitude: 34.707874
-  PacificOcean:
-    longitude: -121.964508
+    longitude: -41.574755
+  Beijing:
+    latitude: 39.9042
+    longitude: 116.4074
+  Borneo:
     latitude: 0.0
+    longitude: 114.0
+  Boulder:
+    latitude: 39.99
+    longitude: -105.26
+  Broadmeadows:
+    latitude: -37.69
+    longitude: 114.95
+  Congo:
+    latitude: -5.9175
+    longitude: 12.5484
+  DeBilt:
+    latitude: 52.1
+    longitude: 5.18
+  Edmonton:
+    latitude: 53.55
+    longitude: -114.1
   ElDjouf:
-    longitude: -6.6661
     latitude: 21.5008
+    longitude: -6.6661
+  Eureka:
+    latitude: 80.05
+    longitude: -86.42
+  Graciosa:
+    latitude: 39.0525
+    longitude: -28.0069
+  GooseBay:
+    latitude: 53.29:
+    longitude: -60.39:
+  HiloHawaii:
+    latitude: 19.58
+    longitude: -155.07
+  Hohenpeissenberg:
+    latitude: 47.8
+    longitude: 11.0
+  Kennaook:
+    latitude: -40.6833
+    longitude: 144.6833
+  Kinshasa:
+    latitude: -4.3033
+    longitude: 15.3105
+  IndianOcean:
+    latitude: 23.0
+    longitude: 87.2
+  Lauder:
+    latitude: -45.05
+    longitude: 169.68
+  Legionowo:
+    latitude: 52.4
+    longitude: 20.97
+  Lindenberg:
+    latitude: 52.22
+    longitude: 14.12
+  LosAngeles:
+    latitude: 34.0522
+    longitude: -118.243
+  MacquarieIsland:
+    latitude: -54.5
+    longitude: 158.94
+  McMurdo:
+    latitude: -77.8455
+    longitude: 166.6698
+  NahaOkinawa:
+    latitude: 26.21
+    longitude: 127.69
+  Nairobi:
+    latitude: -1.3
+    longitude: 36.8
+  Ozarks:
+    latitude: 37.502
+    longitude: -91.259
+  PacificOcean:
+    latitude: 0.0
+    longitude: -121.964508
+  Paramibo:
+    latitude: 5.806
+    longitude: -55.214
+  Paris:
+    latitude: 48.8566
+    longitude: 2.3522
+  Payerne:
+    latitude: 46.81
+    longitude: 6.94
+  Reunion:
+    latitude: -21.1
+    longitude: 55.5
+  Sapporo:
+    latitude: 43.06
+    longitude: 141.33
+  Sodankyla:
+    latitude: 67.36
+    longitude: 26.63
+  Syowa:
+    latitude: -69.0
+    longitude: 39.58
+  TatenoTsukuba:
+    latitude: 36.06
+    longitude: 140.13
+  TrinidadHead:
+    latitude: 41.05
+    longitude: -124.15
+  Uccle:
+    latitude: 50.8
+    longitude: 4.36
+  Utqiagvik:
+    latitude: 71.2906
+    longitude: -156.7886
+  WallopsIsland:
+    latitude: 37.94
+    longitude: -75.46


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This update adds several additional sites (to the `run/shared/kpp_standalone_interface.yml` file. which determines the locations where the KPP-Standalone Interface will archive model state to disk.   The new sites are the locations of the ozonesonde data that we use for validating GEOS-Chem 1-year benchmark output.

The timestep YAML tag has also been removed since the model timestep is now written to the KPP-Standalone box model output files.

### Expected changes
This PR changes the `run/shared/kpp_standalone_interface.yml` file from:
```yaml
---
# ============================================================================
# Configuration file for KPP standalone interface
#
# This file specifies at which locations we will archive the model
# state so that we can initialize KPP standalone box model simulations.
# ============================================================================

# ------------------------------------
# General settngs
# ------------------------------------
settings:
  activate: false                      # Main on/off switch
  start_output_at: [19000101, 000000]  # Save model state for KPP standalone
  stop_output_at:  [21000101, 000000]  # ... if between these 2 datetimes
  output_directory: "./OutputDir/"     # This directory should already exist
  levels:                              # Model levels to archive
    - 1
    - 2
    - 10
    - 23
    - 35
    - 48
    - 56
  timestep: 15                         # Timestep (mins) for KPP standalone

# ------------------------------------
# Where to archive model state?
# ------------------------------------
active_cells:
   - LosAngeles
   - McMurdo
   - Paris
   - Beijing
   - Kinshasa
   - Kennaook
   - Graciosa
   - Utqiagvik
   - Ozarks
   - Amazon
   - Congo
   - Borneo
   - IndianOcean
   - AtlanticOcean
   - PacificOcean
   - ElDjouf

# ------------------------------------
# Active cell geographic coordinates
# ------------------------------------
locations:
  LosAngeles:
    longitude: -118.243
    latitude: 34.0522
  Paris:
    longitude: 2.3522
    latitude: 48.8566
  ...etc..
```
to
```yaml
# ============================================================================
# Configuration file for the KPP-Standalone Interface.
#
# This file specifies at which locations we will archive the model
# state so that we can initialize KPP-Standalone Box Model simulations.
# ============================================================================

# ------------------------------------
# General settngs
# ------------------------------------
settings:
  activate: false                      # Main on/off switch
  start_output_at: [19000101, 000000]  # Save model state for KPP standalone
  stop_output_at:  [21000101, 000000]  # ... if between these 2 datetimes
  output_directory: "./OutputDir/"     # This directory should already exist
  levels:                              # Model levels to archive
    - 1
    - 2
    - 10
    - 23
    - 35
    - 48
    - 56

# ------------------------------------
# Where to archive model state?
# ------------------------------------
active_cells:
  - Alert
  - Amazon
  - AtlanticOcean
  - Beijing
  - Borneo
  - Boulder
  - Broadmeadows
  - Congo
  - DeBilt
  - Edmonton
  - ElDjouf
  - Eureka
  - Graciosa
  - GooseBay
  - HiloHawaii
  - Hohenpeissenberg
  - Kennaook
  - Kinshasa
  - IndianOcean
  - Lauder
  - Legionowo
  - Lindenberg
  - LosAngeles
  - MacquarieIsland
  - McMurdo
  - NahaOkinawa
  - Nairobi
  - Ozarks
  - PacificOcean
  - Paramibo
  - Paris
  - Payerne
  - Reunion
  - Sapporo
  - Sodankyla
  - Syowa
  - TatenoTsukuba
  - TrinidadHead
  - Uccle
  - Utqiagvik
  - WallopsIsland

# ------------------------------------
# Active cell geographic coordinates
# ------------------------------------
locations:
  Alert:
    latitude: 82.5
    longitude: -62.3
  Amazon:
    latitude: -3.4653
    longitude: -62.2159
... etc ...
```
### Related Github Issue
- https://github.com/geoschem/GCClassic/pull/73
- https://github.com/geoschem/GCHP/pull/463
- https://github.com/geoschem/geos-chem/pull/2588