### PR TITLE
Add comments to GCClassic HISTORY.rc template files advising users not to change BoundaryConditions.frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- Added comments in GEOS-Chem Classic `HISTORY.rc` template files advising users not to change the `BoundaryConditions.frequency` setting
+
 ### Fixed
 - Reverted CH4 livestock emissions to EDGAR v7 to avoid hotspots and to apply seasonality
 

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
@@ -336,6 +336,10 @@ COLLECTIONS: 'Restart',
 # GEOS-Chem boundary conditions for use in nested grid simulations
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   BoundaryConditions.template:   '%y4%m2%d2_%h2%n2z.nc4',
   BoundaryConditions.frequency:  00000000 030000

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -294,6 +294,10 @@ COLLECTIONS: 'Restart',
 # GEOS-Chem boundary conditions for use in nested grid simulations
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   BoundaryConditions.template:   '%y4%m2%d2_%h2%n2z.nc4',
   BoundaryConditions.frequency:  00000000 030000

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
@@ -426,6 +426,10 @@ COLLECTIONS: 'Restart',
 # GEOS-Chem boundary conditions for use in nested grid simulations
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   BoundaryConditions.template:   '%y4%m2%d2_%h2%n2z.nc4',
   BoundaryConditions.frequency:  00000000 030000

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.POPs
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.POPs
@@ -314,6 +314,10 @@ COLLECTIONS: 'Restart',
 # GEOS-Chem boundary conditions for use in nested grid simulations
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   BoundaryConditions.template:   '%y4%m2%d2_%h2%n2z.nc4',
   BoundaryConditions.frequency:  00000000 030000

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -367,6 +367,10 @@ COLLECTIONS: 'Restart',
 # Diagnostics for evaluating transport, including age of air [s]
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   AdvFluxVert.template:       '%y4%m2%d2_%h2%n2z.nc4',
   AdvFluxVert.frequency:      ${RUNDIR_HIST_TIME_AVG_FREQ}

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
@@ -506,6 +506,10 @@ COLLECTIONS: 'Restart',
 # GEOS-Chem boundary conditions for use in nested grid simulations
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   BoundaryConditions.template:   '%y4%m2%d2_%h2%n2z.nc4',
   BoundaryConditions.frequency:  00000000 030000

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -337,6 +337,10 @@ COLLECTIONS: 'Restart',
 # GEOS-Chem boundary conditions for use in nested grid simulations
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   BoundaryConditions.template:   '%y4%m2%d2_%h2%n2z.nc4',
   BoundaryConditions.frequency:  00000000 030000

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -1349,6 +1349,10 @@ COLLECTIONS: 'Restart',
 # GEOS-Chem boundary conditions for use in nested grid simulations
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   BoundaryConditions.template:   '%y4%m2%d2_%h2%n2z.nc4',
   BoundaryConditions.frequency:  00000000 030000

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
@@ -333,6 +333,10 @@ COLLECTIONS: 'Restart',
 # Diagnostics for evaluating transport, including age of air [s]
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   AdvFluxVert.template:       '%y4%m2%d2_%h2%n2z.nc4',
   AdvFluxVert.frequency:      ${RUNDIR_HIST_TIME_AVG_FREQ}

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
@@ -308,6 +308,10 @@ COLLECTIONS: 'Restart',
 # GEOS-Chem boundary conditions for use in nested grid simulations
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   BoundaryConditions.template:   '%y4%m2%d2_%h2%n2z.nc4',
   BoundaryConditions.frequency:  00000000 030000

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
@@ -335,6 +335,10 @@ COLLECTIONS: 'Restart',
 # GEOS-Chem boundary conditions for use in nested grid simulations
 #
 # Available for all simulations
+#
+# NOTE: Do not change the BoundaryConditions.frequency setting below,
+# because GEOS-Chem nested-grid simulations expect to read boundary
+# condition data at 3 hour intervals.
 #==============================================================================
   BoundaryConditions.template:   '%y4%m2%d2_%h2%n2z.nc4',
   BoundaryConditions.frequency:  00000000 030000


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
Following upon the issue reported by @LittleFeify in #2665, we have now added comments to the `BoundaryConditions` collection in all GEOS-Chem Classic `HISTORY.rc` template files advising users not to change the `BoundaryConditions.frequency` setting.  The frequency must be left at `00000000 030000`, as GEOS-Chem Classic nested-grid simulations expect to read boundary conditions every 3 hours.

### Expected changes
This is a no-diff-to-benchmark update.  The only changes that were made were comments in the `run/GCClassic/HISTORY.rc.templates/HISTORY.rc.*` files.

### Related Github Issue
- Closes #2665 

### Notes
Ideally this can go into 14.5.1, but if it is not possible, it can go into the next Y or Z version.