### PR TITLE
Implement GRPI CH4 rice emissions to replace EDGAR in CH4 and carbon simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added Australian Hg emissions for 2000-2019 from MacFarlane et. al. [2022], plus corresponding mask file
 - Added comments in GEOS-Chem Classic `HISTORY.rc` template files advising users not to change the `BoundaryConditions.frequency` setting
+- Implemented the Global Rice Patty Inventory (GRPI) for CH4 and carbon simulations to replace EDGAR rice emissions
 
 ### Fixed
 - Reverted CH4 livestock emissions to EDGAR v7 to avoid hotspots and to apply seasonality

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
@@ -63,6 +63,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> Scarpelli_Mexico       :       true     # 2015
 # ----- GLOBAL INVENTORIES ----------------------------------------------------
     --> GFEIv2                 :       true     # 2019
+    --> GRPI                   :       true     # 2022
     --> EDGARv8                :       true     # 2010-2022
     --> QFED2                  :       false    # 2009-2015
     --> JPL_WETCHARTS          :       true     # 2009-2017
@@ -365,6 +366,15 @@ VerboseOnCores:              root       # Accepted values: root all
 0 GFEI_CH4_GAS  $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Gas_All.nc  emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  2 5
 0 GFEI_CH4_COAL $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Coal.nc     emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  3 5
 )))GFEIv2
+
+#==============================================================================
+# --- Global Rice Patty Inventory (GRPI, Zichong Chen et al., 2025) ---
+#
+# This inventory will replace EDGAR (rice)
+#==============================================================================
+(((GRPI
+0 GRPI_CH4_RICE $ROOT/CH4/v2025-01/GRPI/GRPI_01x01.nc emi_ch4 2022/1-12/1/0 C xy kg/m2/s CH4 -  7 5
+)))GRPI
 
 #==============================================================================
 # --- EDGAR v8.0 emissions ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -70,6 +70,7 @@ Mask fractions:              false
     --> Scarpelli_Mexico       :       true     # 2015
 # ..... Global Inventories ...........
     --> GFEIv2                 :       true     # 2019
+    --> GRPI                   :       true     # 2022
     --> EDGARv8                :       true     # 2010-2022
     --> QFED2                  :       false    # 2009-2015
     --> JPL_WETCHARTS          :       true     # 2009-2017
@@ -408,6 +409,15 @@ Mask fractions:              false
 0 GFEI_CH4_GAS  $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Gas_All.nc  emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  2 5
 0 GFEI_CH4_COAL $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Coal.nc     emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  3 5
 )))GFEIv2
+
+#==============================================================================
+# --- Global Rice Patty Inventory (GRPI, Zichong Chen et al., 2025) ---
+#
+# This inventory will replace EDGAR (rice)
+#==============================================================================
+(((GRPI
+0 GRPI_CH4_RICE $ROOT/CH4/v2025-01/GRPI/GRPI_01x01.nc emi_ch4 2022/1-12/1/0 C xy kg/m2/s CH4 -  7 5
+)))GRPI
 
 #==============================================================================
 # --- CH4: EDGAR v8.0 emissions ---

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -195,6 +195,9 @@ GFEI_CH4_OIL  kg/m2/s N Y - none 2.66350462E-22 emis_ch4  ./HcoDir/CH4/v2022-01/
 GFEI_CH4_GAS  kg/m2/s N Y - none 2.66350462E-22 emis_ch4  ./HcoDir/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Gas_All.nc
 GFEI_CH4_COAL kg/m2/s N Y - none 2.66350462E-22 emis_ch4  ./HcoDir/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Coal.nc
 
+# --- GRPI ---
+GRPI_CH4_RICE kg/m2/s N Y F2022-%m2-01T00:00:00  none none emi_ch4 ./HcoDir/CH4/v2025-01/GRPI/GRPI_01x01.nc
+
 # --- EDGAR v8.0 ---
 EDGAR8_CH4_PRO_OIL             kg/m2/s N Y F%y4-%m2-01T00:00:00  none none emi_ch4 ./HcoDir/CH4/v2024-02/EDGARv8/%y4/v8.0_FT2022_GHG_CH4_%y4_PRO_OIL_flx.nc         
 EDGAR8_CH4_REF_TRF             kg/m2/s N Y F%y4-%m2-01T00:00:00  none none emi_ch4 ./HcoDir/CH4/v2024-02/EDGARv8/%y4/v8.0_FT2022_GHG_CH4_%y4_REF_TRF_flx.nc         

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -70,6 +70,7 @@ Mask fractions:              false
     --> Scarpelli_Mexico       :       true     # 2015
 # ..... Global Inventories ...........
     --> GFEIv2                 :       true     # 2019
+    --> GRPI                   :       true     # 2022
     --> EDGARv8                :       true     # 2010-2022
     --> QFED2                  :       false    # 2009-2015
     --> JPL_WETCHARTS          :       true     # 2009-2017
@@ -408,6 +409,15 @@ Mask fractions:              false
 0 GFEI_CH4_GAS  $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Gas_All.nc  emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  2 5
 0 GFEI_CH4_COAL $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Coal.nc     emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  3 5
 )))GFEIv2
+
+#==============================================================================
+# --- Global Rice Patty Inventory (GRPI, Zichong Chen et al., 2025) ---
+#
+# This inventory will replace EDGAR (rice)
+#==============================================================================
+(((GRPI
+0 GRPI_CH4_RICE $ROOT/CH4/v2025-01/GRPI/GRPI_01x01.nc emi_ch4 2022/1-12/1/0 C xy kg/m2/s CH4 -  7 5
+)))GRPI
 
 #==============================================================================
 # --- CH4: EDGAR v8.0 emissions ---


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The Global Rice Patty Inventory (GRPI) as documented in Z. Chen et al. (2025) is added as the default global rice emissions inventory in CH4 and carbon simulations. The GHGI_v2 (US) and Scarpelli_Mexico rice emissions will still be used over the US and Mexico. GRPI emissions are monthly and provided at 0.1x0.1 resolution. They are based on Landsat satellite inundation data.

Tagging developers @zichongchen and @eastjames 

### Expected changes

This is a zero-difference update with respect to the fullchem benchmark simulations. In CH4 and carbon simulations it will increase CH4 rice emissions. From Chen et al. (2025):

>Our global emission of 39.3 ± 4.7 Tg a-1 is higher than previous inventories that use outdated rice maps and IPCC-recommended emission factors now considered too low. 

<img width="743" alt="Screenshot 2025-01-08 at 9 37 02 AM" src="https://github.com/user-attachments/assets/19bc9d10-2026-4509-9884-37e329bfb696" />


### Reference(s)

- Chen, Z., Lin, H., Balasus, N., Hardy, A., East. J.D., Zhang, Y., Runkle, B.R.K., Hancock, S.E., Taylor, C.A., Du, X., Sander, B.O., Jacob, D. J. , Global Rice Paddy Inventory (GRPI): a  high-resolution inventory of methane emissions from rice agriculture based on Landsat satellite inundation data, submitted to Earth's Future, https://doi.org/10.31223/X5941Z, 2025.

### Related Github Issue

Closes #2637 
