### PR TITLE
Change default environment files for integration tests on Harvard Cannon from gnu10 to gnu12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed doing Linoz and Linearized chemistry messages to print only if verbose
 - Updated HEMCO subroutine calls for error and log handling changes in HEMCO 3.9.1
 - Updated configuration files for using GEOS-Chem 14.5 in CESM
+- Changed integration tests to use Harvard Cannon GNU 12 environment files by default
 
 ### Fixed
 - Added a fix to skip the call to KPP when only CO2 is defined in the carbon simulation

--- a/test/shared/commonFunctionsForTests.sh
+++ b/test/shared/commonFunctionsForTests.sh
@@ -778,7 +778,7 @@ function get_default_gcc_env_file() {
     #========================================================================
     # Returns the default environment file for GEOS-Chem Classic
     #========================================================================
-    envFile=$(realpath "../../../run/GCClassic/runScriptSamples/operational_examples/harvard_cannon/gcclassic.gcc10_cannon_rocky.env")
+    envFile=$(realpath "../../../run/GCClassic/runScriptSamples/operational_examples/harvard_cannon/gcclassic.gcc12_cannon_rocky.env")
     echo "$envFile"
     return 0
 }
@@ -788,7 +788,7 @@ function get_default_gchp_env_file() {
     #========================================================================
     # Returns the default environment file for GCHP
     #========================================================================
-    envFile=$(realpath "../../../run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.gcc10_openmpi4_cannon_rocky.env")
+    envFile=$(realpath "../../../run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.gcc12_openmpi4_cannon_rocky.env")
     echo "$envFile"
     return 0
 }


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR changes the `run/shared/commonFunctionsForTests.sh` script as follows:

1. Environment file `run/GCClassic/runScriptSamples/operational_examples/harvard_cannon/gcclassic.gcc12_cannon_rocky.env` will be used for GEOS-Chem Classic integration tests on Harvard Cannon (unless otherwise specified)

2. Environment file `run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.gcc12_openmpi4_cannon_rocky.env` will be used for GCHP integration tests on Harvard Cannon (unless otherwise specified)

### Expected changes
This is a no-diff-to-benchmark update. It only changes the compiler (plus corresponding modules) from GCC 10.2.0 to GCC 12.2.0 for integration tests on Harvard Cannon.  This is because most Harvard Cannon developers are using the GCC 12.2.0 compilers now.

### Related Github Issue
N/A