### PR TITLE
Fix CO2 weekly scale factors entry in GCHP ExtData.rc for carbon simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [14.5.2] - TBD
 
 ### Fixed
+- Fixed GCHP refresh time for CO2_WEEKLY scale factors so updated daily 
+
 ## [14.5.1] - 2025-01-10
 ### Added
 - Added Australian Hg emissions for 2000-2019 from MacFarlane et. al. [2022], plus corresponding mask file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.5.2] - TBD
+
+### Fixed
 ## [14.5.1] - 2025-01-10
 ### Added
 - Added Australian Hg emissions for 2000-2019 from MacFarlane et. al. [2022], plus corresponding mask file

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -419,7 +419,7 @@ SHIP_LEVS     1 N Y - none none cmv_c3     ./HcoDir/VerticalScaleFactors/v2021-0
 
 # --- National fossil fuel CO2 scale factors (Nassar et al, 2013) ---
 CO2_DIURNAL 1 N Y F2006-01-01T%h2:00:00 none none diurnal_scale_factors ./HcoDir/CO2/v2015-04/FOSSIL/TIMES_diurnal_scale_factors.nc
-CO2_WEEKLY  1 D Y F2006-01-01T00:00:00   none none weekly_scale_factors  ./HcoDir/CO2/v2015-04/FOSSIL/TIMES_weekly_scale_factors.nc
+CO2_WEEKLY  1 D Y F2006-01-%d2T00:00:00 none none weekly_scale_factors  ./HcoDir/CO2/v2015-04/FOSSIL/TIMES_weekly_scale_factors.nc
 
 # --- Domestic aviation surface correction factor ---
 AVIATION_SURF_CORR      1       Y  Y F2004-01-01T00:00:00  none none CO2 ./HcoDir/CO2/v2022-11/FOSSIL/Aviation_SurfCorr_SclFac.1x1.nc


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes a bug in the GCHP carbon simulation where the CO2 weekly scale factors were incorrectly updated only once. The update changes the time refresh in `ExtData.rc` to update daily.

This PR also updates the changelog to add a new section for 14.5.2.

### Expected changes

CO2 weekly scale factors will be correctly applied. This causes minor differences.

### Reference(s)

None

### Related Github Issue

closes https://github.com/geoschem/GCHP/issues/429
