### PR TITLE
Add .zenodo.json to auto-populate DOI fields upon version releases

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,22 @@
+{
+    "access_right": "open",
+    "creators": [
+	{
+	    "name": "The International GEOS-Chem User Community"
+	}
+    ],
+    "description": "GEOS-Chem (science codebase)",
+    "keywords": [
+	"atmospheric-chemistry",
+	"atmospheric-composition",
+	"atmospheric-modeling",
+	"aws",
+	"climate-modeling",
+	"cloud-computing",
+	"geos-chem",
+	"atmospheric-computing",
+	"scientific-computing"
+    ],
+    "license": "mit-license",
+    "upload_type": "software"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added Australian Hg emissions for 2000-2019 from MacFarlane et. al. [2022], plus corresponding mask file
 - Added comments in GEOS-Chem Classic `HISTORY.rc` template files advising users not to change the `BoundaryConditions.frequency` setting
+- Added `.zenodo.json` for auto-DOI generation upon version releases
 
 ### Fixed
 - Reverted CH4 livestock emissions to EDGAR v7 to avoid hotspots and to apply seasonality


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
In this PR we have added a `.zenodo.json` file, which will auto-populate fields when a DOI is triggered by each GEOS-Chem (science codebase) release.

### Expected changes
These are zero-diff updates and can be merged alongside another GEOS-Chem PR.