### PR TITLE
Apply retuned dust scale factors for MERRA2 C24, GEOSFP C24, and GEOSIT C24 grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Added
 - Added CEDS 0.1 x 0.1 degree emissions (in `HEMCO/CEDS/v2024-06`)
-- Added met-field dependent dust tuning factors for GCHP C24 and C30 resolution in `setCommonRunSettings.sh`.  Others to be added later.
+- Added met-field dependent dust tuning factors for GCHP C24 resolution in `setCommonRunSettings.sh`.  Others to be added later.
+- Added placeholder values for dust mass tuning factors in `HEMCO_Config.rc.GEOS`
 
 ### Changed
 - Updated default CEDS from CEDSv2 (0.5 deg x 0.5 de) to new CEDS (0.1 deg x 0.1 deg)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Added
 - Added CEDS 0.1 x 0.1 degree emissions (in `HEMCO/CEDS/v2024-06`)
+- Added met-field dependent dust tuning factors for GCHP C24 and C30 resolution in `setCommonRunSettings.sh`.  Others to be added later.
 
 ### Changed
 - Updated default CEDS from CEDSv2 (0.5 deg x 0.5 de) to new CEDS (0.1 deg x 0.1 deg)

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -211,6 +211,21 @@ RRTMG_Timestep_sec=10800
 # Mass tuning factor is used in the HEMCO DustDead extenstion for GEOS-Chem
 # benchmarking and is resolution-dependent. We recommend using offline dust
 # instead of the online extension for GCHP science runs.
+#
+# NOTE: We have retuned the dust scaling factors to account for the fact
+# that the HEMCO DustDead extension uses USTAR from the meteorology
+# instead of computing it from U10M and V10M.  For now we have computed
+# new scale factors for C24 and C30 to allow benchmarks to proceed.
+# Other resolution/met field combinations will be added later.
+#   -- Bob Yantosca (05 Feb 2025)
+
+metField=$(grep "met_field:" geoschem_config.yml)
+metField=${metField/met_field\:/}
+metField=${metField// /}
+
+errorMsg="Dust scale factor not defined for ${CS_RES} with met field "
+errorMsg+="${metField}. Please add the tuning factor you wish to use "
+errorMsg+="for the target resolution above."
 
 dustEntry=$(grep "105.*DustDead" HEMCO_Config.rc || echo "missing")
 if [[ ${dustEntry} != "missing" ]]; then
@@ -220,10 +235,21 @@ if [[ ${dustEntry} != "missing" ]]; then
             echo "WARNING: Online dust (DustDead) is not recommended for stretched-grid simulation. Consider using OFFLINE_DUST."
         fi
         if [[ $CS_RES -eq 24 ]]; then
-            Dust_SF=6.0e-4
-        elif [[ $CS_RES -eq 30 ]]; then
-            Dust_SF=5.76e-4 # approximated as linear interpolation between 24 and 48. use for testing only!
-        elif [[ $CS_RES -eq 48 ]]; then
+	    if [[ "x${metField}" == "xMERRA2" ]]; then
+		Dust_SF=5.4856e-5
+	    elif [[ "x${metField}" == "xGEOSFP" ]]; then
+		Dust_SF=4.6495e-5
+	    else
+		echo "${errorMsg}"
+		exit 1
+	    fi
+        elif [[ $CS_RES -eq 30 ]]; then	    
+	    if [[ "x${metField}" == "xGEOSIT" ]]; then
+		Dust_SF=3.7410e-5
+	    else
+		echo "${errorMsg}"
+	    fi
+	elif [[ $CS_RES -eq 48 ]]; then
             Dust_SF=5.0416e-4
         elif [[ $CS_RES -eq 90 ]]; then
             Dust_SF=4.0e-4
@@ -245,6 +271,13 @@ fi
 # Mass tuning factor is used in the HEMCO DustDead extenstion for GEOS-Chem
 # benchmarking and is resolution-dependent. We recommend using offline dust
 # instead of the online extension for GCHP science runs.
+#
+# NOTE: We have retuned the dust scaling factors to account for the fact
+# that the HEMCO DustDead extension uses USTAR from the meteorology
+# instead of computing it from U10M and V10M.  For now we have computed
+# new scale factors for C24 and C30 to allow benchmarks to proceed.
+# Other resolution/met field combinations will be added later.
+#   -- Bob Yantosca (05 Feb 2025)
 
 TomasDustEntry=$(grep "131.*TOMAS_DustDead" HEMCO_Config.rc || echo "missing")
 if [[ ${TomasDustEntry} != "missing" ]]; then
@@ -254,7 +287,21 @@ if [[ ${TomasDustEntry} != "missing" ]]; then
             echo "WARNING: Online dust (TOMAS_DustDead) is not recommended for stretched-grid simulation. Consider using OFFLINE_DUST."
         fi
         if [[ $CS_RES -eq 24 ]]; then
-            TomasDust_SF=6.0e-4
+	    if [[ "x${metField}" == "xMERRA2" ]]; then
+		TomasDust_SF=5.4856e-5
+	    elif [[ "x${metField}" == "xGEOSFP" ]]; then
+		TomasDust_SF=4.6495e-5
+	    else
+		echo "${errorMsg}"
+		exit 1
+	    fi
+        elif [[ $CS_RES -eq 30 ]]; then	    
+	    if [[ "x${metField}" == "xGEOSIT" ]]; then
+		TomasDust_SF=3.7410e-5
+	    else
+		echo "${errorMsg}"
+		exit 1
+	    fi
         elif [[ $CS_RES -eq 48 ]]; then
             TomasDust_SF=5.0416e-4
         elif [[ $CS_RES -eq 90 ]]; then

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -212,10 +212,10 @@ RRTMG_Timestep_sec=10800
 # benchmarking and is resolution-dependent. We recommend using offline dust
 # instead of the online extension for GCHP science runs.
 #
-# NOTE: We have retuned the dust scaling factors to account for the fact
-# that the HEMCO DustDead extension uses USTAR from the meteorology
-# instead of computing it from U10M and V10M.  For now we have computed
-# new scale factors for C24 and C30 to allow benchmarks to proceed.
+# NOTE: We have retuned the dust scaling factors to account for the
+# fact that the HEMCO DustDead extension uses USTAR directly from the
+# meteorology instead of computing it from U10M and V10M.  For now we
+# have computed new scale factors for C24 to allow benchmarks to proceed.
 # Other resolution/met field combinations will be added later.
 #   -- Bob Yantosca (05 Feb 2025)
 
@@ -239,16 +239,14 @@ if [[ ${dustEntry} != "missing" ]]; then
 		Dust_SF=5.4856e-5
 	    elif [[ "x${metField}" == "xGEOSFP" ]]; then
 		Dust_SF=4.6495e-5
+	    elif [[ "x${metField}" == "xGEOSIT" ]]; then
+		Dust_SF=3.7410e-5
 	    else
 		echo "${errorMsg}"
 		exit 1
 	    fi
         elif [[ $CS_RES -eq 30 ]]; then	    
-	    if [[ "x${metField}" == "xGEOSIT" ]]; then
-		Dust_SF=3.7410e-5
-	    else
-		echo "${errorMsg}"
-	    fi
+	    Dust_SF=5.76e-4 # approximated as linear interpolation between 24 and 48. use for testing only!
 	elif [[ $CS_RES -eq 48 ]]; then
             Dust_SF=5.0416e-4
         elif [[ $CS_RES -eq 90 ]]; then
@@ -272,10 +270,10 @@ fi
 # benchmarking and is resolution-dependent. We recommend using offline dust
 # instead of the online extension for GCHP science runs.
 #
-# NOTE: We have retuned the dust scaling factors to account for the fact
-# that the HEMCO DustDead extension uses USTAR from the meteorology
-# instead of computing it from U10M and V10M.  For now we have computed
-# new scale factors for C24 and C30 to allow benchmarks to proceed.
+# NOTE: We have retuned the dust scaling factors to account for the
+# fact that the HEMCO DustDead extension uses USTAR directly from the
+# meteorology instead of computing it from U10M and V10M.  For now we
+# have computed new scale factors for C24 to allow benchmarks to proceed.
 # Other resolution/met field combinations will be added later.
 #   -- Bob Yantosca (05 Feb 2025)
 
@@ -291,12 +289,7 @@ if [[ ${TomasDustEntry} != "missing" ]]; then
 		TomasDust_SF=5.4856e-5
 	    elif [[ "x${metField}" == "xGEOSFP" ]]; then
 		TomasDust_SF=4.6495e-5
-	    else
-		echo "${errorMsg}"
-		exit 1
-	    fi
-        elif [[ $CS_RES -eq 30 ]]; then	    
-	    if [[ "x${metField}" == "xGEOSIT" ]]; then
+	    elif [[ "x${metField}" == "xGEOSIT" ]]; then
 		TomasDust_SF=3.7410e-5
 	    else
 		echo "${errorMsg}"

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -209,106 +209,62 @@ RRTMG_Timestep_sec=10800
 #    ONLINE DUST MASS TUNING FACTOR
 #------------------------------------------------------------------
 # Mass tuning factor is used in the HEMCO DustDead extenstion for GEOS-Chem
-# benchmarking and is resolution-dependent. We recommend using offline dust
-# instead of the online extension for GCHP science runs.
-#
-# NOTE: We have retuned the dust scaling factors to account for the
-# fact that the HEMCO DustDead extension uses USTAR directly from the
-# meteorology instead of computing it from U10M and V10M.  For now we
-# have computed new scale factors for C24 to allow benchmarks to proceed.
-# Other resolution/met field combinations will be added later.
-#   -- Bob Yantosca (05 Feb 2025)
+# benchmarking and is resolution and met-source dependent. We recommend
+# using offline dust instead of the online extension for GCHP science runs.
 
-metField=$(grep "met_field:" geoschem_config.yml)
-metField=${metField/met_field\:/}
-metField=${metField// /}
-
-errorMsg="Dust scale factor not defined for ${CS_RES} with met field "
-errorMsg+="${metField}. Please add the tuning factor you wish to use "
-errorMsg+="for the target resolution above."
-
-dustEntry=$(grep "105.*DustDead" HEMCO_Config.rc || echo "missing")
-if [[ ${dustEntry} != "missing" ]]; then
-    dustSetting=(${dustEntry// / })
-    if [[ ${dustSetting[3]} = "on" ]]; then
-        if [[ ${STRETCH_GRID} == 'ON' ]]; then
-            echo "WARNING: Online dust (DustDead) is not recommended for stretched-grid simulation. Consider using OFFLINE_DUST."
-        fi
-        if [[ $CS_RES -eq 24 ]]; then
-	    if [[ "x${metField}" == "xMERRA2" ]]; then
-		Dust_SF=5.4856e-5
-	    elif [[ "x${metField}" == "xGEOSFP" ]]; then
-		Dust_SF=4.6495e-5
-	    elif [[ "x${metField}" == "xGEOSIT" ]]; then
-		Dust_SF=3.7410e-5
-	    else
-		echo "${errorMsg}"
-		exit 1
-	    fi
-        elif [[ $CS_RES -eq 30 ]]; then	    
-	    Dust_SF=5.76e-4 # approximated as linear interpolation between 24 and 48. use for testing only!
-	elif [[ $CS_RES -eq 48 ]]; then
-            Dust_SF=5.0416e-4
-        elif [[ $CS_RES -eq 90 ]]; then
-            Dust_SF=4.0e-4
-        elif [[ $CS_RES -eq 180 ]]; then
-            Dust_SF=3.23e-4
-        elif [[ $CS_RES -eq 360 ]]; then
-            Dust_SF=2.35e-4
-        elif [[ $CS_RES -eq 720 ]]; then
-            Dust_SF=2.3e-4
-        else
-            echo "Dust scale factor not defined for this resolution. Please add the tuning factor you wish to use for the target resolution above."
-            exit 1
-        fi
-    fi
+result=$(grep "105.*DustDead" HEMCO_Config.rc || echo "missing")
+if [[ "x${result}" != "xmissing" ]]; then
+    array=(${result// / })
+    dustDead=${array[3]}
 fi
-#------------------------------------------------------------------
-#    ONLINE DUST MASS TUNING FACTOR (for TOMAS)
-#------------------------------------------------------------------
-# Mass tuning factor is used in the HEMCO DustDead extenstion for GEOS-Chem
-# benchmarking and is resolution-dependent. We recommend using offline dust
-# instead of the online extension for GCHP science runs.
-#
-# NOTE: We have retuned the dust scaling factors to account for the
-# fact that the HEMCO DustDead extension uses USTAR directly from the
-# meteorology instead of computing it from U10M and V10M.  For now we
-# have computed new scale factors for C24 to allow benchmarks to proceed.
-# Other resolution/met field combinations will be added later.
-#   -- Bob Yantosca (05 Feb 2025)
+result=$(grep "131.*TOMAS_DustDead" HEMCO_Config.rc || echo "missing")
+if [[ "x${result}" != "xmissing" ]]; then
+    array=(${result// / })
+    tomasDustDead=${array[3]}
+fi
 
-TomasDustEntry=$(grep "131.*TOMAS_DustDead" HEMCO_Config.rc || echo "missing")
-if [[ ${TomasDustEntry} != "missing" ]]; then
-    TomasDustSetting=(${TomasDustEntry// / })
-    if [[ ${TomasDustSetting[3]} = "on" ]]; then
-        if [[ ${STRETCH_GRID} == 'ON' ]]; then
-            echo "WARNING: Online dust (TOMAS_DustDead) is not recommended for stretched-grid simulation. Consider using OFFLINE_DUST."
-        fi
-        if [[ $CS_RES -eq 24 ]]; then
-	    if [[ "x${metField}" == "xMERRA2" ]]; then
-		TomasDust_SF=5.4856e-5
-	    elif [[ "x${metField}" == "xGEOSFP" ]]; then
-		TomasDust_SF=4.6495e-5
-	    elif [[ "x${metField}" == "xGEOSIT" ]]; then
-		TomasDust_SF=3.7410e-5
-	    else
-		echo "${errorMsg}"
-		exit 1
-	    fi
-        elif [[ $CS_RES -eq 48 ]]; then
-            TomasDust_SF=5.0416e-4
-        elif [[ $CS_RES -eq 90 ]]; then
-            TomasDust_SF=4.0e-4
-        elif [[ $CS_RES -eq 180 ]]; then
-            TomasDust_SF=3.23e-4
-        elif [[ $CS_RES -eq 360 ]]; then
-            TomasDust_SF=2.35e-4
-        elif [[ $CS_RES -eq 720 ]]; then
-            TomasDust_SF=2.3e-4
-        else
-            echo "Dust scale factor not defined for this resolution. Please add the tuning factor you wish to use for the target resolution above."
-            exit 1
-        fi
+if [[ "x${dustDead}" == "xon" || "x${tomasDustDead}" == "xon" ]]; then
+    metField=$(grep "met_field:" geoschem_config.yml)
+    metField=${metField/met_field\:/}
+    metField=${metField// /}
+
+    if [[ "x${STRETCH_GRID}" == "xON" ]]; then
+	msg="WARNING: Online dust is not recommended for stretched-grid "
+	msg+="simulations. Consider using OFFLINE_DUST instead."
+	echo "${msg}"
+    fi
+
+    if [[ $CS_RES -eq 24 ]]; then
+	if [[ "x${metField}" == "xMERRA2" ]]; then
+	    Dust_SF=5.4856e-5
+	elif [[ "x${metField}" == "xGEOSFP" ]]; then
+	    Dust_SF=4.6495e-5
+	elif [[ "x${metField}" == "xGEOSIT" ]]; then
+	    Dust_SF=3.7410e-5
+	else
+	    msg="Dust scale factors are currenlty only available for C24. "
+	    msg+="with MERRA-2, GEOSFP, or GEOSIT."
+	    echo "${msg}"
+	    exit 1
+	fi
+    elif [[ $CS_RES -eq 30 ]]; then
+	Dust_SF=5.76e-4 # approximated as linear interpolation between 24 and 48. use for testing only!
+    elif [[ $CS_RES -eq 48 ]]; then
+        Dust_SF=5.0416e-4
+    elif [[ $CS_RES -eq 90 ]]; then
+        Dust_SF=4.0e-4
+    elif [[ $CS_RES -eq 180 ]]; then
+        Dust_SF=3.23e-4
+    elif [[ $CS_RES -eq 360 ]]; then
+        Dust_SF=2.35e-4
+    elif [[ $CS_RES -eq 720 ]]; then
+        Dust_SF=2.3e-4
+    else
+	msg="Dust scale factor not defined for this resolution. Please add "
+	msg+="the tuning factor you wish to use for the target resolution "
+	msg+="above."
+	echo "${msg}"
+        exit 1
     fi
 fi
 
@@ -717,11 +673,8 @@ replace_val      "AdvCore_Advection" "${ADVCORE_ADVECTION}" GCHP.rc
 print_msg ""
 print_msg "HEMCO settings:"
 print_msg "---------------"
-if [[ ${dustSetting[3]} = "on" ]]; then
+if [[ "x${dustDead}" ==  "xon" || "x${tomasDustDead}" == "xon" ]]; then
     replace_val "--> Mass tuning factor" ${Dust_SF} HEMCO_Config.rc
-fi
-if [[ ${TomasDustSetting[3]} = "on" ]]; then
-    replace_val "--> Mass tuning factor" ${TomasDust_SF} HEMCO_Config.rc
 fi
 
 ###  Set initial restart file options

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -247,6 +247,10 @@ if [[ "x${dustDead}" == "xon" || "x${tomasDustDead}" == "xon" ]]; then
 	    echo "${msg}"
 	    exit 1
 	fi
+    #
+    # NOTE: Met-field dependent mass tuning factors for the grid resolutions
+    # listed below will be added later.  Leave the prior values for now.
+    #
     elif [[ $CS_RES -eq 30 ]]; then
 	Dust_SF=5.76e-4 # approximated as linear interpolation between 24 and 48. use for testing only!
     elif [[ $CS_RES -eq 48 ]]; then

--- a/run/GEOS/HEMCO_Config.rc
+++ b/run/GEOS/HEMCO_Config.rc
@@ -107,11 +107,16 @@ VerboseOnCores:              root       # Accepted values: root all
     --> Use fertilizer NOx:       true
 105     DustDead          : on    DST1/DST2/DST3/DST4
     --> Mass tuning factor:       2.454e-4 
-####    --> Mass tuning factor:       4.0e-4 
-####    --> Mass tuning factor:       5.0416e-4
-#C48    --> Mass tuning factor:       5.0416e-4
-#C720   --> Mass tuning factor:       2.3e-4
-#C180   --> Mass tuning factor:       3.23e-4
+##################################################################
+# Mass tuning factors are resolution and met-source dependent
+#    --> Mass tuning factor:       3.7410e-5  # C24  GEOS-IT
+#    --> Mass tuning factor:       X.XXXXe-5  # C30  GEOS-IT
+#    --> Mass tuning factor:       X.XXXXe-5  # C48  GEOS-IT
+#    --> Mass tuning factor:       X.XXXXe-5  # C90  GEOS-IT
+#    --> Mass tuning factor:       X.XXXXe-5  # C180 GEOS-IT
+#    --> Mass tuning factor:       X.XXXXe-5  # C360 GEOS-IT
+#    --> Mass tuning factor:       X.XXXXe-5  # C720 GEOS-IT
+##################################################################
 107     SeaSalt                : on    SALA/SALC/SALACL/SALCCL/SALAAL/SALCAL/BrSALA/BrSALC/MOPO/MOPI
     --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR applies re-tuned dust scaling factors to the `run/GCHP/setCommonRunSettings.sh`, in order to account for the fact that the HEMCO DustDead extension now uses USTAR directly from the meteorology.

Dust scaling factors were computed by @yuanjianz.

| Grid | Met field | Dust tuning factor  |
| ---- | ----------| ------------------- |
| C24  | MERRA2    | 5.4856e-5           |
| C24  | GEOS-FP   | 4.6495e-5           |
| C24  | GEOS-IT   | 3.7410e-5           |

### Expected changes
This PR should fix the over-production of dust as previously noted in this issue: https://github.com/geoschem/HEMCO/issues/278#issuecomment-2616415681

### Related Github Issue
- https://github.com/geoschem/HEMCO/issues/278
- https://github.com/geoschem/HEMCO/pull/279
- #2512