### PR TITLE
Do not build KPP-Standalone executable unless specifically requested at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [14.5.2] - TBD
-### Fixed
-- Fixed GCHP refresh time for CO2_WEEKLY scale factors so updated daily
-- Fixed bug in GCHP GEOS-IT run directory using raw lat-lon fields on NASA discover cluster
-
 ### Added
 - Implemented the Global Rice Patty Inventory (GRPI) for CH4 and carbon simulations to replace EDGAR rice emissions
 - Added run directory creation for processed cubed-sphere GEOS-IT meteorology
@@ -16,6 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Updated GC-Classic and GCHP environment files, build scripts, and run scripts for NASA discover cluster
+- Updated rundir scripts to ask for confirmation before building the KPP-Standalone executable
+- Updated rundir scripts to print a reminder to compile with `-DKPPSA=y` to build the KPP-Standalone executable
+- Updated `integrationTestCreate.sh` and `parallelTestCreate.sh` scripts to decline building the KPP-Standalone.
+
+### Fixed
+- Fixed GCHP refresh time for `CO2_WEEKLY` scale factors so updated daily
+- Fixed bug in GCHP GEOS-IT run directory using raw lat-lon fields on NASA discover cluster
 
 ## [14.5.1] - 2025-01-10
 ### Added

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -898,12 +898,6 @@ if [[ "x${sim_name}" == "xfullchem" || "x${sim_name}" == "xCH4" ]]; then
     chmod 744 ${rundir}/metrics.py
 fi
 
-# Copy the KPP standalone interface config file to ther rundir (fullchem only)
-if [[ "x${sim_name}" == "xfullchem"  ]]; then
-    cp -r ${gcdir}/run/shared/kpp_standalone_interface.yml ${rundir}
-    chmod 644 ${rundir}/kpp_standalone_interface.yml
-fi
-
 # Set permissions
 chmod 744 ${rundir}/cleanRunDir.sh
 chmod 744 ${rundir}/archiveRun.sh
@@ -1202,21 +1196,42 @@ while [ "$valid_response" -eq 0 ]; do
     fi
 done
 
+#-----------------------------------------------------------------
+# Ask user whether to build the KPP-standalone box model
+#-----------------------------------------------------------------
+enable_kppsa=""
+if [[ "x${sim_name}" == "xfullchem" ]]; then
+    printf "${thinline}Do you want to build the KPP-Standalone Box Model? (y/n)${thinline}"
+    valid_response=0
+    while [ "$valid_response" -eq 0 ]; do
+	read -p "${USER_PROMPT}" enable_kppsa
+	if [[ "x${enable_kppsa}" == "xy" ]]; then
+	    cp -r ${gcdir}/run/shared/kpp_standalone_interface.yml  ${rundir}
+	    chmod 644 ${rundir}/kpp_standalone_interface.yml
+	    valid_response=1
+	elif [[ "x${enable_kppsa}" = "xn" ]]; then
+	    valid_response=1
+	else
+	    printf "Input not recognized. Try again.\n"
+	fi
+    done
+fi
+
 #---------------------------------------------------------------------------
 # Add reminders to compile with CMake options for simulations that need them
 #---------------------------------------------------------------------------
 hdr="\n>>>> REMINDER: You must compile with options:"
 ftr="<<<<\n"
-
 EXTRA_CMAKE_OPTIONS=""
-[[ "x${sim_name}" == "xcarbon" ]] && EXTRA_CMAKE_OPTIONS="-DMECH=carbon"
-[[ "x${sim_name}" == "xHg"     ]] && EXTRA_CMAKE_OPTIONS="-DMECH=Hg -DFASTJX=y"
+[[ "x${sim_name}" == "xcarbon" ]] && EXTRA_CMAKE_OPTIONS="-DMECH=carbon "
+[[ "x${sim_name}" == "xHg"     ]] && EXTRA_CMAKE_OPTIONS="-DMECH=Hg -DFASTJX=y "
 if [[ "x${sim_name}" == "xfullchem" ]]; then
-    [[ "x${sim_extra_option}" == "xAPM"     ]] && EXTRA_CMAKE_OPTIONS="-DAPM=y"
-    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && EXTRA_CMAKE_OPTIONS="-DRRTMG=y"
-    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=15"
-    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=40"
+    [[ "x${sim_extra_option}" == "xAPM"     ]] && EXTRA_CMAKE_OPTIONS="-DAPM=y "
+    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && EXTRA_CMAKE_OPTIONS="-DRRTMG=y "
+    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=15 "
+    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=40 "
 fi
+[[ "x${enable_kppsa}" == "xy" ]] && EXTRA_CMAKE_OPTIONS+="-DKPPSA=y"
 
 # Add to RUNDIR_VARS
 RUNDIR_VARS+="EXTRA_CMAKE_OPTIONS=${EXTRA_CMAKE_OPTIONS}"

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -905,6 +905,27 @@ printf "\n  -- Example run scripts are in the runScriptSamples subdirectory"
 printf "\n  -- For more information visit the GCHP user guide at"
 printf "\n     https://readthedocs.org/projects/gchp/\n\n"
 
+#-----------------------------------------------------------------
+# Ask user whether to build the KPP-standalone box model
+#-----------------------------------------------------------------
+enable_kppsa=""
+if [[ "x${sim_name}" == "xfullchem" ]]; then
+    printf "${thinline}Do you want to build the KPP-Standalone Box Model? (y/n)${thinline}"
+    valid_response=0
+    while [ "$valid_response" -eq 0 ]; do
+	read -p "${USER_PROMPT}" enable_kppsa
+	if [[ "x${enable_kppsa}" == "xy" ]]; then
+	    cp -r ${gcdir}/run/shared/kpp_standalone_interface.yml  ${rundir}
+	    chmod 644 ${rundir}/kpp_standalone_interface.yml
+	    valid_response=1
+	elif [[ "x${enable_kppsa}" = "xn" ]]; then
+	    valid_response=1
+	else
+	    printf "Input not recognized. Try again.\n"
+	fi
+    done
+fi
+
 #---------------------------------------------------------------------------
 # Add reminders to compile with CMake options for simulations that need them
 #---------------------------------------------------------------------------
@@ -912,14 +933,15 @@ hdr="\n>>>> REMINDER: You must compile with options:"
 ftr="<<<<\n"
 
 EXTRA_CMAKE_OPTIONS=""
-[[ "x${sim_name}" == "xcarbon" ]] && EXTRA_CMAKE_OPTIONS="-DMECH=carbon"
-[[ "x${sim_name}" == "xHg"     ]] && EXTRA_CMAKE_OPTIONS="-DMECH=Hg -DFASTJX=y"
+[[ "x${sim_name}" == "xcarbon" ]] && EXTRA_CMAKE_OPTIONS="-DMECH=carbon "
+[[ "x${sim_name}" == "xHg"     ]] && EXTRA_CMAKE_OPTIONS="-DMECH=Hg -DFASTJX=y "
 if [[ "x${sim_name}" == "xfullchem" ]]; then
-    [[ "x${sim_extra_option}" == "xAPM"     ]] && EXTRA_CMAKE_OPTIONS="-DAPM=y"
-    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && EXTRA_CMAKE_OPTIONS="-DRRTMG=y"
-    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=15"
-    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=40"
+    [[ "x${sim_extra_option}" == "xAPM"     ]] && EXTRA_CMAKE_OPTIONS="-DAPM=y "
+    [[ "x${sim_extra_option}" == "xRRTMG"   ]] && EXTRA_CMAKE_OPTIONS="-DRRTMG=y "
+    [[ "x${sim_extra_option}" == "xTOMAS15" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=15 "
+    [[ "x${sim_extra_option}" == "xTOMAS40" ]] && EXTRA_CMAKE_OPTIONS="-DTOMAS=y -DTOMAS_BINS=40 "
 fi
+[[ "x${enable_kppsa}" == "xy" ]] && EXTRA_CMAKE_OPTIONS+="-DKPPSA=y"
 
 # Add to RUNDIR_VARS
 RUNDIR_VARS+="EXTRA_CMAKE_OPTIONS=${EXTRA_CMAKE_OPTIONS}"

--- a/test/integration/GCClassic/integrationTestCreate.sh
+++ b/test/integration/GCClassic/integrationTestCreate.sh
@@ -203,7 +203,7 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     create_rundir "3\n5\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
 
     # 4x5 merra2 fullchem
-    create_rundir "1\n1\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n1\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # Exit after creating a couple of rundirsDirs if $quick is "yes"
     if [[ "X${quick}" == "XYES" ]]; then
@@ -213,31 +213,31 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
 
     # 4x5 merra2 fullchem_LuoWd
     dir="gc_4x5_merra2_fullchem_LuoWd"
-    create_rundir "1\n1\n1\n1\n1\n${rundirsDir}\n${dir}\nn\n" "${log}"
+    create_rundir "1\n1\n1\n1\n1\n${rundirsDir}\n${dir}\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_aciduptake
-    create_rundir "1\n5\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n5\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_APM
-    create_rundir "1\n7\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n7\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_benchmark
-    create_rundir "1\n2\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n2\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_complexSOA
-    create_rundir "1\n3\n1\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n3\n1\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_complexSOA_SVPOA
-    create_rundir "1\n3\n2\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n3\n2\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_marinePOA
-    create_rundir "1\n4\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n4\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_RRTMG
-    create_rundir "1\n8\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n8\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_TOMAS15_47L
-    create_rundir "1\n6\n1\n1\n1\n2\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n6\n1\n1\n1\n2\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 Hg
     create_rundir "4\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
@@ -272,14 +272,14 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     #=========================================================================
 
     # 4x5 merra2 fullchem_47L
-    create_rundir "1\n1\n1\n1\n2\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n1\n1\n1\n2\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     #=========================================================================
     # GCAP 2.0 simulations
     #=========================================================================
 
     # 2x2.5 ModelE2.1 fullchem (scenario SSP2-4.5, option 6)
-    create_rundir "1\n1\n4\n6\n2\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n1\n4\n6\n2\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     #=========================================================================
     # Nested-grid simulations
@@ -289,7 +289,7 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     create_rundir "9\n1\n3\n4\n2\n${rundirsDir}\n\nn\n" "${log}"
 
     # 05x0625 merra2 fullchem_47L_na
-    create_rundir "1\n1\n1\n3\n4\n2\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n1\n1\n3\n4\n2\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     #=========================================================================
     # Simulation with all diagnostics on

--- a/test/integration/GCHP/integrationTestCreate.sh
+++ b/test/integration/GCHP/integrationTestCreate.sh
@@ -213,16 +213,16 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     fi
 
     # c24 merra2 fullchem_standard
-    create_rundir "1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # c24 merra2 fullchem_benchmark
-    create_rundir "1\n2\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n2\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # c24 merra2 fullchem_RRTMG
-    create_rundir "1\n8\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n8\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # c24 merra2 fullchem_TOMAS15
-    create_rundir "1\n6\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n6\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     #=========================================================================
     # Simulation with all diagnostics on

--- a/test/parallel/GCClassic/parallelTestCreate.sh
+++ b/test/parallel/GCClassic/parallelTestCreate.sh
@@ -200,7 +200,7 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     create_rundir "3\n1\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
 
     # 4x5 merra2 fullchem
-    create_rundir "1\n1\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n1\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # DEBUG: Exit after creating a couple of rundirs if $quick is "yes"
     if [[ "X${quick}" == "XYES" ]]; then
@@ -210,31 +210,31 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
 
     # 4x5 merra2 fullchem_LuoWd
     dir="gc_4x5_merra2_fullchem_LuoWd"
-    create_rundir "1\n1\n1\n1\n1\n${rundirsDir}\n${dir}\nn\n" "${log}"
+    create_rundir "1\n1\n1\n1\n1\n${rundirsDir}\n${dir}\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_aciduptake
-    create_rundir "1\n5\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n5\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_APM
-    create_rundir "1\n7\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n7\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_benchmark
-    create_rundir "1\n2\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n2\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_complexSOA
-    create_rundir "1\n3\n1\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n3\n1\n1\n1\n1\n${rundirsDir}\n\nn\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_complexSOA_SVPOA
-    create_rundir "1\n3\n2\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n3\n2\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_marinePOA
-    create_rundir "1\n4\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n4\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_RRTMG
-    create_rundir "1\n8\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n8\n1\n1\n1\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 fullchem_TOMAS15_47L
-    create_rundir "1\n6\n1\n1\n1\n2\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n6\n1\n1\n1\n2\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     # 4x5 merra2 Hg
     create_rundir "4\n1\n1\n1\n${rundirsDir}\n\nn\n" "${log}"
@@ -269,7 +269,7 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     #=========================================================================
 
     # 4x5 merra2 fullchem_47L"
-    create_rundir "1\n1\n1\n1\n2\n${rundirsDir}\n\nn\n" "${log}"
+    create_rundir "1\n1\n1\n1\n2\n${rundirsDir}\n\nn\nn\n" "${log}"
 
     #=========================================================================
     # Nested-grid simulations


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR does the following:

- During run directory creation,:
  - If the simulation is fullchem, then ask user (after asking whether to backup the rundir with Git) if they wish to build the KPP-Standalone executable.
  - If the answer is yes, then copy `run/shared/kpp_standalone_interface.yml` to the run directory and print a reminder to use `-DKPPSA=y` when configuring and building.

Integration and parallel test scripts have been updated accordingly to answer "no" to building the KPP-Standalone executable.

### Expected changes
The KPP-Standalone executable will only be built if the user requests it.

### Related Github Issue
- https://github.com/geoschem/GCClassic/pull/82
- https://github.com/geoschem/GCHP/pull/473
- #2483 
- #2482 