### PR TITLE
Now define the dry deposition land cover type properly for O3 deposition to oceans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed CEDS `HEMCO_Config.rc` entries to emit TMB into the TMB species (and not HCOOH)
 - Added C6H14 emissions into the ALK6 species for CMIP6 & HTAPv3 inventories
+- Fixed the ocean landcover type for dry deposition of O3 to oceans (cf issue #2707)
 
 ### Removed
 - `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files

--- a/GeosCore/drydep_mod.F90
+++ b/GeosCore/drydep_mod.F90
@@ -1478,9 +1478,7 @@ CONTAINS
              ! 11 in GEOS-Chem dry dep; 73 in Olson landcover type
              II     = IDEP(IOLSON)
              
-             ! If the surface is snow or ice, set dry deposition
-             ! landcover type to 1.
-             !
+             ! Over snow or ice, set drydep landcover type to 1
              IF ((State_Met%isSnow(I,J)).OR.(State_Met%isIce(I,J))) II=1
 
              !* Read the internal resistance RI (minimum stomatal resistance for
@@ -1904,8 +1902,21 @@ CONTAINS
              DO LDT = 1, IREG(I,J)
                 IF ( IUSE(I,J,LDT) > 0 ) THEN
 
-                   ! because of high resistance values, different rule applied for
-                   ! ocean ozone
+                   ! Because of high resistance values, a different rule
+                   ! is applied for deposition of O3 to ocean.
+                   ! Recompute the drydep landcover value II here,
+                   ! which had been missing prior to 14.5.1.
+                   !  -- Eloise Marais (07 Feb 2025)
+
+                   ! Olson land type index + 1
+                   IOLSON = ILAND(I,J,LDT) + 1
+
+                   ! Equivalent dry deposition land type
+                   II     = IDEP(IOLSON)
+
+                   ! Over snow or ice, set drydep land cover type to 1
+                   IF ( State_Met%isSnow(I,J) .OR. State_Met%isIce(I,J) ) II=1
+
                    N_SPC = State_Chm%Map_DryDep(K)
                    IF ((N_SPC .EQ. ID_O3) .AND. (II .EQ. 11)) THEN
                       RSURFC(K,LDT)= MAX(1.e+0_f8, MIN(RSURFC(K,LDT),999999.e+0_f8))


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #2707.  We recompute the drydep landcover type variable (`II`) in the IF block starting at line 1903 in `GeosCore/drydep_mod.F90`, which had been inadvertently omitted.

### Expected changes
See discussion by @eamarais in #2707

### Related Github Issue
- Closes #2707 

