### PR TITLE
Now allow RxnRate and RxnConst to use four-digit reaction numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added precision when registering `State_Met` and `State_Chm` arrays to change output file precision to match precision in the model
 - Changed GEOS-Chem Classic restart file precision of species concentrations (`State_Chm%SpcRestart`) from `REAL*4` to `REAL*8` to match precision in the model
 - Moved GEOS-Chem Classic retrieval of restart variable DELPDRY from HEMCO to `GC_Get_Restart` for consistency with handling of all other restart variables
+- Updated `RxnRates` and `RxnConst` diagnostic fields to use 4-digit reaction numbers.
   
 ### Fixed
 - Fixed PDOWN definition to lower rather than upper edge

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -17156,7 +17156,7 @@ CONTAINS
 
        ! KPP equation reaction rates
        CASE( 'RXN' )
-          WRITE ( Nstr, "(I3.3)" ) D
+          WRITE ( Nstr, "(I4.4)" ) D
           tagName = 'EQ' // TRIM(Nstr)
 
        ! UVFlux requested output fluxes
@@ -18962,7 +18962,7 @@ CONTAINS
     INTEGER                   :: S
 
     ! Strings
-    CHARACTER(LEN=3  )        :: rxnStr
+    CHARACTER(LEN=4  )        :: rxnStr
     CHARACTER(LEN=255)        :: mapName
     CHARACTER(LEN=255)        :: mapName2
     CHARACTER(LEN=255)        :: tagName
@@ -19146,10 +19146,10 @@ CONTAINS
 
           ELSE IF ( isRxnRate ) THEN
 
-             ! RxnRate: the last 3 characters is the index #
+             ! RxnRate: the last 4 characters is the index #
              S      = LEN_TRIM( TagItem%name )
-             rxnStr = TagItem%name(S-2:S)
-             READ( rxnstr, '(I3.3) ' ) index
+             rxnStr = TagItem%name(S-3:S)
+             READ( rxnstr, '(I4.4) ' ) index
              mapData%slot2id(TagItem%index) = index
 
           ELSE IF ( isUvFlx ) THEN

--- a/run/CESM/HISTORY.rc
+++ b/run/CESM/HISTORY.rc
@@ -636,7 +636,7 @@ COLLECTIONS: 'Metrics',
 #
 # Archives chemical reaction rates from the KPP solver.
 # It is best to list individual reactions to avoid using too much memory.
-# Reactions should be listed as "RxnRate_EQnnn", where nnn is the reaction
+# Reactions should be listed as "RxnRate_EQnnnn", where nnnn is the reaction
 # index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
 #
 # Available for the fullchem simulations.
@@ -645,15 +645,15 @@ COLLECTIONS: 'Metrics',
   RxnRates.frequency:  {FREQUENCY}
   RxnRates.duration:   {DURATION}
   RxnRates.mode:       'time-averaged'
-  RxnRates.fields:     'RxnRate_EQ001                           ',
-                       'RxnRate_EQ002                           ',
+  RxnRates.fields:     'RxnRate_EQ0001                           ',
+                       'RxnRate_EQ0002                           ',
 ::
 #==============================================================================
 # %%%%% RxnConst %%%%%
 #
 # Archives chemical reaction rates constants from the KPP solver.
 # It is best to list individual reactions to avoid using too much memory.
-# Reactions should be listed as "RxnConst_EQnnn", where nnn is the reaction
+# Reactions should be listed as "RxnConst_EQnnnn", where nnnn is the reaction
 # index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
 #
 # The units of reaction rate constants vary according to the number of reactants
@@ -665,8 +665,8 @@ COLLECTIONS: 'Metrics',
   RxnConst.frequency:  {FREQUENCY}
   RxnConst.duration:   {DURATION}
   RxnConst.mode:       'time-averaged'
-  RxnConst.fields:     'RxnConst_EQ001                          ',
-                       'RxnConst_EQ002                          ',
+  RxnConst.fields:     'RxnConst_EQ0001                          ',
+                       'RxnConst_EQ0002                          ',
 ::
 #==============================================================================
 # %%%%% StateChm %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -564,7 +564,7 @@ COLLECTIONS: 'Restart',
 #
 # Archives chemical reaction rates from the KPP solver.
 # It is best to list individual reactions to avoid using too much memory.
-# Reactions should be listed as "RxnRate_EQnnn", where nnn is the reaction
+# Reactions should be listed as "RxnRate_EQnnnn", where nnnn is the reaction
 # index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
 #
 # Available for the fullchem simulations.
@@ -573,15 +573,15 @@ COLLECTIONS: 'Restart',
   RxnRates.frequency:  ${RUNDIR_HIST_TIME_AVG_FREQ}
   RxnRates.duration:   ${RUNDIR_HIST_TIME_AVG_DUR}
   RxnRates.mode:       'time-averaged'
-  RxnRates.fields:     'RxnRate_EQ001                           ',
-                       'RxnRate_EQ002                           ',
+  RxnRates.fields:     'RxnRate_EQ0001                           ',
+                       'RxnRate_EQ0002                           ',
 ::
 #==============================================================================
 # %%%%% THE RxnConst COLLECTION %%%%%
 #
 # Archives chemical reaction rates constants from the KPP solver.
 # It is best to list individual reactions to avoid using too much memory.
-# Reactions should be listed as "RxnConst_EQnnn", where nnn is the reaction
+# Reactions should be listed as "RxnConst_EQnnnn", where nnnn is the reaction
 # index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
 #
 # The units of reaction rate constants vary according to the number of reactants
@@ -593,8 +593,8 @@ COLLECTIONS: 'Restart',
   RxnConst.frequency:  ${RUNDIR_HIST_TIME_AVG_FREQ}
   RxnConst.duration:   ${RUNDIR_HIST_TIME_AVG_DUR}
   RxnConst.mode:       'time-averaged'
-  RxnConst.fields:     'RxnConst_EQ001                          ',
-                       'RxnConst_EQ002                          ',
+  RxnConst.fields:     'RxnConst_EQ0001                          ',
+                       'RxnConst_EQ0002                          ',
 ::
 #==============================================================================
 # %%%%% THE SatDiagn COLLECTION %%%%%
@@ -661,10 +661,10 @@ COLLECTIONS: 'Restart',
                               'SatDiagnSurfFlux_NO            ',
                               'SatDiagnProd_?PRD?             ',
                               'SatDiagnLoss_?LOS?             ',
-                              'SatDiagnRxnRate_EQ385          ',
-                              'SatDiagnRxnRate_EQ386          ',
-                              'SatDiagnRxnRate_EQ387          ',
-                              'SatDiagnRxnRate_EQ388          ',
+                              'SatDiagnRxnRate_EQ0385         ',
+                              'SatDiagnRxnRate_EQ0386         ',
+                              'SatDiagnRxnRate_EQ0387         ',
+                              'SatDiagnRxnRate_EQ0388         ',
 ::
 #==============================================================================
 # %%%%% THE SatDiagnEdge COLLECTION %%%%%

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -1760,7 +1760,7 @@ COLLECTIONS: @#'DefaultCollection',
 #
 # Archives chemical reaction rates from the KPP solver.
 # It is best to list individual reactions to avoid using too much memory.
-# Reactions should be listed as "RxnRate_EQnnn", where nnn is the reaction
+# Reactions should be listed as "RxnRate_EQnnnn", where nnnn is the reaction
 # index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
 #
 # Available for the fullchem simulations.
@@ -1772,15 +1772,15 @@ COLLECTIONS: @#'DefaultCollection',
   RxnRates.frequency:      010000
   RxnRates.duration:       010000
   RxnRates.mode:           'time-averaged'
-  RxnRates.fields:         'RxnRate_EQ001     ', 'GCHPchem',
-                           'RxnRate_EQ002     ', 'GCHPchem',
+  RxnRates.fields:         'RxnRate_EQ0001     ', 'GCHPchem',
+                           'RxnRate_EQ0002     ', 'GCHPchem',
 ::
 #==============================================================================
 # %%%%% THE RxnConst COLLECTION %%%%%
 #
 # Archives chemical reaction rates constants from the KPP solver.
 # It is best to list individual reactions to avoid using too much memory.
-# Reactions should be listed as "RxnConst_EQnnn", where nnn is the reaction
+# Reactions should be listed as "RxnConst_EQnnnn", where nnnn is the reaction
 # index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
 #
 # The units of reaction rate constants vary according to the number of reactants
@@ -1795,8 +1795,8 @@ COLLECTIONS: @#'DefaultCollection',
   RxnConst.frequency:      010000
   RxnConst.duration:       010000
   RxnConst.mode:           'time-averaged'
-  RxnConst.fields:         'RxnConst_EQ001    ', 'GCHPchem',
-                           'RxnConst_EQ002    ', 'GCHPchem',
+  RxnConst.fields:         'RxnConst_EQ0001    ', 'GCHPchem',
+                           'RxnConst_EQ0002    ', 'GCHPchem',
 ::
 #==============================================================================
 # %%%%% THE SpeciesConc COLLECTION %%%%%


### PR DESCRIPTION
### Name and Institution (Required)

Name: Alfred Mayhew
Institution: University of Utah

### Describe the update
References to the KPP reacttion numbers in `HISTORY.rc` expect a 3-digit 0-padded number. Given that the GEOS-Chem fullchem mechanism now includes over 1000 reactions, this causes errors when trying to reference reaction numbers with 4 digits or when using the `?RXN?` wildcard.
I have changed `rxnStr` variable in `Headers/state_diag_mod.F90` to accept 4 characters. I have also adjusted the template `HISTORY.rc` files to provide 4-digit reaction numbers. I haven't tested this with CESM or GCHP, but have used this as a fix for the issue in my GCClassic runs.

