### PR TITLE
Fix typo: KPP_INTEGERATOR_AUTOREDUCE -> KPP_INTEGRATOR_AUTOREDUCE (bug from PR #2689)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed CEDS `HEMCO_Config.rc` entries to emit TMB into the TMB species (and not HCOOH)
 - Added C6H14 emissions into the ALK6 species for CMIP6 & HTAPv3 inventories
-- Fixed typo: `KPP_INTEGERATOR_AUTOREDUCE` -> `KPP_INTEGRATOR_AUTOREDUCE`
 
 ### Removed
 - `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-### Added
-- Added dust scale factors for MERRA-2, GEOS-IT, and GEOS-FP when using USTAR for Dust DEAD extension
-
 # Changelog
 
 This file documents all notable changes to the GEOS-Chem repository starting in version 14.0.0, including all GEOS-Chem Classic and GCHP run directory updates.
@@ -12,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added CEDS 0.1 x 0.1 degree emissions (in `HEMCO/CEDS/v2024-06`)
 - Added met-field dependent dust tuning factors for GCHP C24 resolution in `setCommonRunSettings.sh`.  Others to be added later.
 - Added placeholder values for dust mass tuning factors in `HEMCO_Config.rc.GEOS`
+- Added dust scale factors for MERRA-2, GEOS-IT, and GEOS-FP when using USTAR for Dust DEAD extension
 
 ### Changed
 - Updated default CEDS from CEDSv2 (0.5 deg x 0.5 de) to new CEDS (0.1 deg x 0.1 deg)
@@ -21,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed CEDS `HEMCO_Config.rc` entries to emit TMB into the TMB species (and not HCOOH)
 - Added C6H14 emissions into the ALK6 species for CMIP6 & HTAPv3 inventories
+- Fixed typo: `KPP_INTEGERATOR_AUTOREDUCE` -> `KPP_INTEGRATOR_AUTOREDUCE`
 
 ### Removed
 - `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -104,7 +104,7 @@ CONTAINS
 !
     USE ErrCode_Mod
     USE ERROR_MOD
-#ifdef KPP_INTEGERATOR_AUTOREDUCE
+#ifdef KPP_INTEGRATOR_AUTOREDUCE
     USE fullchem_AutoReduceFuncs, ONLY : fullchem_AR_KeepHalogensActive
     USE fullchem_AutoReduceFuncs, ONLY : fullchem_AR_SetKeepActive
     USE fullchem_AutoReduceFuncs, ONLY : fullchem_AR_UpdateKppDiags
@@ -507,7 +507,7 @@ CONTAINS
     !------------------------------------------------------------------------
     ! Always consider halogens as "fast" species for auto-reduce
     !------------------------------------------------------------------------
-#ifdef KPP_INTEGERATOR_AUTOREDUCE
+#ifdef KPP_INTEGRATOR_AUTOREDUCE
     IF ( FIRSTCHEM .and. Input_Opt%ITS_A_FULLCHEM_SIM ) THEN
        IF ( Input_Opt%AutoReduce_Is_KeepActive ) THEN
           CALL fullchem_AR_KeepHalogensActive( Input_Opt%amIRoot )
@@ -581,7 +581,7 @@ CONTAINS
 #endif
 #endif
 
-#ifdef KPP_INTEGERATOR_AUTOREDUCE
+#ifdef KPP_INTEGRATOR_AUTOREDUCE
        ! Per discussions for Lin et al., force keepActive throughout the
        ! atmosphere if keepActive option is enabled. (hplin, 2/9/22)
        CALL fullchem_AR_SetKeepActive( option=.TRUE. )
@@ -1003,7 +1003,7 @@ CONTAINS
 
        ENDIF
 
-#ifdef KPP_INTEGERATOR_AUTOREDUCE
+#ifdef KPP_INTEGRATOR_AUTOREDUCE
        !=====================================================================
        ! Set options for the KPP integrator in vectors ICNTRL and RCNTRL
        ! This now needs to be done within the parallel loop
@@ -1123,7 +1123,7 @@ CONTAINS
              State_Diag%KppSmDecomps(I,J,L) = ISTATUS(8)
           ENDIF
 
-#ifdef KPP_INTEGERATOR_AUTOREDUCE
+#ifdef KPP_INTEGRATOR_AUTOREDUCE
           ! Update autoreduce solver statistics
           ! (only if the autoreduction is turned on)
           IF ( Input_Opt%Use_AutoReduce ) THEN


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR fixes a bug in the implementation of PR #2689.  The C-preprocessor switch was named incorrectly in `GeosCore/fullchem_mod.F90` (KPP_INTEGERATOR_AUTOREDUCE -> KPP_INTEGRATOR_AUTOREDUCE).

### Expected changes
This should result in zero-diff output w/r/t 1-hr benchmarks: gcc-4x5-1Hr-14.6.0-alpha.4-2-ge4f279a and gchp-c24-1Hr-14.6.0-alpha.4-4-ga835f7c

### Related Github Issue
- #2689 
