### PR TITLE
Fix bugs in fixed level and PBL budget diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed PDOWN definition to lower rather than upper edge
+- Fixed bugs in column mass array affecting budget diagnostics for fixed level and PBL
 
 ## [14.5.2] - 2025-02-12
 ### Added

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1333,13 +1333,13 @@ CONTAINS
              ! After operation: Compute change in column mass (final-initial),
              ! convert to [kg/s], and store in the diagLevs array.
              IF ( before ) THEN
-                colMass(I,J,N,3) = colSum
+                colMass(I,J,N,4) = colSum
              ELSE
 #ifdef MODEL_GEOS
-                diagLevs(I,J,S) = ( colSum - colMass(I,J,N,3) ) / timeStep &
+                diagLevs(I,J,S) = ( colSum - colMass(I,J,N,4) ) / timeStep &
                                / State_Grid%AREA_M2(I,J)
 #else
-                diagLevs(I,J,S) = ( colSum - colMass(I,J,N,3) ) / timeStep
+                diagLevs(I,J,S) = ( colSum - colMass(I,J,N,4) ) / timeStep
 #endif
              ENDIF
           ENDDO

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -12494,7 +12494,7 @@ CONTAINS
         ALLOCATE( State_Diag%BudgetColumnMass( State_Grid%NX,                &
                                                State_Grid%NY,                &
                                                State_Chm%nAdvect,            &
-                                               3                 ), STAT=RC )
+                                               4                 ), STAT=RC )
        CALL GC_CheckVar( 'State_Diag%BudgetColumnMass', 0, RC )
        IF ( RC /= GC_SUCCESS ) RETURN
     ENDIF


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes an issue with the column mass array used to compute budget diagnostics for fixed level and PBL. The array's 4th dimension was incorrectly allocated with size 3 and both the PBL and fixed level diagnostics used index 3 of the 4th dimension to track column tracer mass. The 4th dimension is now allocated with size 4. The PBL budget diagnostics continue to use index 3 but the fixed level budget diagnostic now uses index 4.

### Expected changes

This update only affected budget diagnostics. PBL and fixed level budget diagnostics will now be correct. Full and Trop budget diagnostics are not affected.

### Reference(s)

None

### Related Github Issue

close https://github.com/geoschem/geos-chem/issues/2738
