### PR TITLE
Retrieve arrays needed in Cloud-J to correctly set UV Flux diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed parallelization issue when computing `State_Chm%DryDepNitrogren` used in HEMCO soil NOx extension
 - Fixed bugs in column mass array affecting budget diagnostics for fixed level and PBL
 - Updated `SatDiagnColEmis` and `SatDiagnSurfFlux` arrays in `hco_interface_gc_mod.F90`, with `(I,J,S)` instead of `(:,:,S)`
+- Retrieve UV flux arrays from Cloud-J used to set UV flux diagnostics
 
 ### Removed
 - `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -303,7 +303,7 @@ CONTAINS
     REAL(fp) :: FJBOT(W_+W_r)
     REAL(fp) :: FSBOT(W_+W_r)
     REAL(fp) :: FLXD(L1_,W_+W_r)
-    REAL(fp) :: FJFLX(L_,W_+W_r)
+    REAL(fp) :: FJFLX(L1_,W_+W_r)
 
     ! For UVFlux* diagnostics
     REAL(fp) :: FDIRECT (L1_)

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -299,11 +299,11 @@ CONTAINS
     ! Other local variables
     !------------------------------------------------------------------------
 
-    ! These are currently never set. Should they be output from Cloud-J?
-    REAL(fp) :: FJBOT(W_)
-    REAL(fp) :: FSBOT(W_)
-    REAL(fp) :: FLXD(L1_,W_)
-    REAL(fp) :: FJFLX(L_,W_)
+    ! To be retrieved from Cloud-J
+    REAL(fp) :: FJBOT(W_+W_r)
+    REAL(fp) :: FSBOT(W_+W_r)
+    REAL(fp) :: FLXD(L1_,W_+W_r)
+    REAL(fp) :: FJFLX(L_,W_+W_r)
 
     ! For UVFlux* diagnostics
     REAL(fp) :: FDIRECT (L1_)
@@ -945,7 +945,8 @@ CONTAINS
                       REFFL,    REFFI,    CLDF,     CLDCOR,   CLDIW,     &
                       AERSP,    NDXAER,   L1_,      AN_,      JVN_,      &
                       VALJXX,   SKPERD,   SWMSQ,    OD18,     IRAN,      &
-                      NICA,     JCOUNT,   LDARK,    WTQCA,    RC         )
+                      NICA,     JCOUNT,   LDARK,    WTQCA,    FSBOT,     &
+                      FJBOT,    FLXD,     FJFLX,    RC                   )
 
        !-----------------------------------------------------------------
        ! Fill GEOS-Chem array ZPJ with J-values
@@ -994,8 +995,6 @@ CONTAINS
              FDIRECT  = 0.0_fp
              FDIFFUSE = 0.0_fp
        
-             ! ewl: this is messed up. FSBOT and FJBOT aren't set.
-
              ! Direct & diffuse fluxes at each level
              FDIRECT(1)  = FSBOT(K)                    ! surface
              FDIFFUSE(1) = FJBOT(K)                    ! surface

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -300,7 +300,7 @@ CONTAINS
     !------------------------------------------------------------------------
 
     ! To be retrieved from Cloud-J
-    REAL(fp) :: FJBOT(W_+W_r)
+    REAL(fp) :: FJXBOT(W_+W_r)
     REAL(fp) :: FSBOT(W_+W_r)
     REAL(fp) :: FLXD(L1_,W_+W_r)
     REAL(fp) :: FJFLX(L1_,W_+W_r)
@@ -431,7 +431,7 @@ CONTAINS
     !$OMP PRIVATE( CLDIW, CLDF, IWP, LWP, REFFI, REFFL, IWC, LWC, DELTA_P      ) &
     !$OMP PRIVATE( AERSP, RFL, RRR, LPRTJ, IRAN, CLDCOR, HHH, CCC              ) &
     !$OMP PRIVATE( LDARK, NICA, JCOUNT, SWMSQ, OD18, WTQCA, SKPERD, VALJXX     ) &
-    !$OMP PRIVATE( FJBOT, FSBOT, FLXD, FJFLX, FDIRECT, FDIFFUSE, UVX_CONST     ) &
+    !$OMP PRIVATE( FJXBOT, FSBOT, FLXD, FJFLX, FDIRECT, FDIFFUSE, UVX_CONST     ) &
     !$OMP SCHEDULE( DYNAMIC )
 
     ! Loop over all latitudes and all longitudes
@@ -939,14 +939,14 @@ CONTAINS
           print *, " -> IRAN     : ", IRAN
        ENDIF
 
-       CALL Cloud_JX( U0,       SZA,      RFL,      SOLF,     LPRTJ,     &
-                      P_CTM,    Z_CLIM,   T_CLIM,   HHH,      AIR_CLIM,  &
-                      RRR,      O3_CLIM,  CCC,      LWP,      IWP,       &
-                      REFFL,    REFFI,    CLDF,     CLDCOR,   CLDIW,     &
-                      AERSP,    NDXAER,   L1_,      AN_,      JVN_,      &
-                      VALJXX,   SKPERD,   SWMSQ,    OD18,     IRAN,      &
-                      NICA,     JCOUNT,   LDARK,    WTQCA,    FSBOT,     &
-                      FJBOT,    FLXD,     FJFLX,    RC                   )
+       CALL Cloud_JX( U0,       SZA,      RFL,      SOLF,     LPRTJ,       &
+                      P_CTM,    Z_CLIM,   T_CLIM,   HHH,      AIR_CLIM,    &
+                      RRR,      O3_CLIM,  CCC,      LWP,      IWP,         &
+                      REFFL,    REFFI,    CLDF,     CLDCOR,   CLDIW,       &
+                      AERSP,    NDXAER,   L1_,      AN_,      JVN_,        &
+                      VALJXX,   SKPERD,   SWMSQ,    OD18,     IRAN,        &
+                      NICA,     JCOUNT,   LDARK,    WTQCA,    RC,          &
+                      FSBOT=FSBOT, FJXBOT=FJXBOT, FLXD=FLXD, FJFLX=FJFLX    )
 
        !-----------------------------------------------------------------
        ! Fill GEOS-Chem array ZPJ with J-values
@@ -997,7 +997,7 @@ CONTAINS
        
              ! Direct & diffuse fluxes at each level
              FDIRECT(1)  = FSBOT(K)                    ! surface
-             FDIFFUSE(1) = FJBOT(K)                    ! surface
+             FDIFFUSE(1) = FJXBOT(K)                   ! surface
              DO L = 2, State_Grid%NZ
                 FDIRECT(L) = FDIRECT(L-1) + FLXD(L-1,K)
                 FDIFFUSE(L) = FJFLX(L-1,K)

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -300,10 +300,10 @@ CONTAINS
     !------------------------------------------------------------------------
 
     ! To be retrieved from Cloud-J
-    REAL(fp) :: FJXBOT(W_+W_r)
-    REAL(fp) :: FSBOT(W_+W_r)
-    REAL(fp) :: FLXD(L1_,W_+W_r)
-    REAL(fp) :: FJFLX(L1_,W_+W_r)
+    REAL(fp) :: DiffSfcFlux(W_+W_r)
+    REAL(fp) :: DirSfcFlux(W_+W_r)
+    REAL(fp) :: DepFlux(L1_,W_+W_r)
+    REAL(fp) :: DiffTopFlux(L1_,W_+W_r)
 
     ! For UVFlux* diagnostics
     REAL(fp) :: FDIRECT (L1_)
@@ -431,7 +431,8 @@ CONTAINS
     !$OMP PRIVATE( CLDIW, CLDF, IWP, LWP, REFFI, REFFL, IWC, LWC, DELTA_P      ) &
     !$OMP PRIVATE( AERSP, RFL, RRR, LPRTJ, IRAN, CLDCOR, HHH, CCC              ) &
     !$OMP PRIVATE( LDARK, NICA, JCOUNT, SWMSQ, OD18, WTQCA, SKPERD, VALJXX     ) &
-    !$OMP PRIVATE( FJXBOT, FSBOT, FLXD, FJFLX, FDIRECT, FDIFFUSE, UVX_CONST     ) &
+    !$OMP PRIVATE( DiffSfcFlux, DirSfcFlux, DepFlux, DiffTopFlux               ) &
+    !$OMP PRIVATE( FDIRECT, FDIFFUSE, UVX_CONST                                ) &
     !$OMP SCHEDULE( DYNAMIC )
 
     ! Loop over all latitudes and all longitudes
@@ -946,7 +947,8 @@ CONTAINS
                       AERSP,    NDXAER,   L1_,      AN_,      JVN_,        &
                       VALJXX,   SKPERD,   SWMSQ,    OD18,     IRAN,        &
                       NICA,     JCOUNT,   LDARK,    WTQCA,    RC,          &
-                      FSBOT=FSBOT, FJXBOT=FJXBOT, FLXD=FLXD, FJFLX=FJFLX    )
+                      DirSfcFlux=DirSfcFlux, DiffSfcFlux=DiffSfcFlux,      &
+                      DepFlux=DepFlux,       DiffTopFlux=DiffTopFlux      )
 
        !-----------------------------------------------------------------
        ! Fill GEOS-Chem array ZPJ with J-values
@@ -996,11 +998,11 @@ CONTAINS
              FDIFFUSE = 0.0_fp
        
              ! Direct & diffuse fluxes at each level
-             FDIRECT(1)  = FSBOT(K)                    ! surface
-             FDIFFUSE(1) = FJXBOT(K)                   ! surface
+             FDIRECT(1)  = DirSfcFlux(K)                    ! surface
+             FDIFFUSE(1) = DiffSfcFlux(K)                   ! surface
              DO L = 2, State_Grid%NZ
-                FDIRECT(L) = FDIRECT(L-1) + FLXD(L-1,K)
-                FDIFFUSE(L) = FJFLX(L-1,K)
+                FDIRECT(L) = FDIRECT(L-1) + DepFlux(L-1,K)
+                FDIFFUSE(L) = DiffTopFlux(L-1,K)
              ENDDO
        
              ! Constant to multiply UV fluxes at each wavelength bin


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update sets the UV flux diagnostics using fluxes retrieved from Cloud-J. Previously the flux diagnostics were all zeros when using Cloud-J because the needed arrays were not returned by the model.

**This update requires an update to the version of Cloud-J used in GEOS-Chem, specifically a version including https://github.com/geoschem/Cloud-J/pull/29**

### Expected changes

This is a zero diff update for GEOS-Chem Classic and GCHP except for the UV flux diagnostics.

### Reference(s)

None

### Related Github Issues/PRs

closes https://github.com/geoschem/geos-chem/issues/2447

Related to https://github.com/geoschem/Cloud-J/pull/29
