### PR TITLE
Fixed incorrect description metadata for FluxHg0FromOceanToAir and FluxHg0FromAirToOcean diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug in restart file entry for `ORVCSESQ` in GEOS-Chem Classic fullchem HEMCO_Config.rc that resulted in initializing to all zeros
 - Fixed parallelization issue when computing `State_Chm%DryDepNitrogren` used in HEMCO soil NOx extension
 - Fixed bugs in column mass array affecting budget diagnostics for fixed level and PBL
+- Fixed incorrect description metadata for `FluxHg0FromAirToOcean` and `FluxHg0FromOceanToAir` diagnostics
 
 ### Removed
 - `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -16496,13 +16496,13 @@ CONTAINS
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'FLUXHG0FROMAIRTOOCEAN' ) THEN
        IF ( isDesc    ) Desc  = &
-            'Volatization flux of Hg0 from the ocean to the atmosphere'
+            'Volatization flux of Hg0 from the atmosphere to the ocean'
        IF ( isUnits   ) Units = 'kg s-1'
        IF ( isRank    ) Rank  =  2
 
     ELSE IF ( TRIM( Name_AllCaps ) == 'FLUXHG0FROMOCEANTOAIR' ) THEN
        IF ( isDesc    ) Desc  = &
-            'Deposition flux of Hg0 from the atmosphere to the ocean'
+            'Deposition flux of Hg0 from the ocean to the atmosphere'
        IF ( isUnits   ) Units = 'kg s-1'
        IF ( isRank    ) Rank  =  2
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This is the companion PR to #2745 by @bgeyman.  We have fixed the `description` metadata for History diagnostic fields `FluxHg0FromOceanToAir` and `FluxHg0FromAirToOcean`.  These descriptions are used to define the netCDF `long_name` variable attribute.

### Expected changes
The descriptions (and thus the netCDF `long_name` attributes) for the affected diagnostics will now be correct.

### Related Github Issue
- Closes #2745