### PR TITLE
Fix dry-run simulation issues in 14.6.0 development version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `RxnRates` and `RxnConst` diagnostic fields to use 4-digit reaction numbers.
 - Moved dry dep velocity diagnostic outputs for sea flux and satellite diagnostic species into the `DryDep` collection
 - Moved computation of the `DryDepVelForAlt1` diagnostic into routine `Set_DryDepVel_Diagnostics` 
+- Updated `run/shared/download_data.yml` to use `--no-sign-request` for S3 downloads via anonymous login
  
 ### Fixed
 - Fixed PDOWN definition to lower rather than upper edge
@@ -34,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed parallelization issue when computing `State_Chm%DryDepNitrogren` used in HEMCO soil NOx extension
 - Fixed bugs in column mass array affecting budget diagnostics for fixed level and PBL
 - Updated `SatDiagnColEmis` and `SatDiagnSurfFlux` arrays in `hco_interface_gc_mod.F90`, with `(I,J,S)` instead of `(:,:,S)`
+- Placed call to `Convert_Spc_Units` in `main.F90` within an `IF ( notDryrun )` block to avoid executing unit conversions in dryrun simulations
 
 ### Removed
 - `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files

--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -13,7 +13,7 @@ portals:
     short_name: ga
     s3_bucket: True
     remote: s3://geos-chem
-    command: 'aws s3 cp '
+    command: 'aws s3 cp --no-sign-request '
     quote: ""
 
   # GEOS-Chem Input Data portal, download via HTTP/wget
@@ -31,7 +31,7 @@ portals:
     short_name: na
     s3_bucket: True
     remote: s3://gcgrid
-    command: 'aws s3 cp '
+    command: 'aws s3 cp --no-sign-request '
     quote: ""
 
   # GEOS-Chem Nested Input Data portal, download via HTTP/wget


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR fixes a few issues with GEOS-Chem Classic dry-run simulations that were discovered in the 14.6.0-alpha.10 tag.

- Placed the first call to `Convert_Spc_Units` in the `IF ( notDryRun )` block that precedes it.  This will make sure that the unit conversions are not done during dry-run simulations (which will cause an out-of-bounds error).  This came in with the PR #2521.
- Added `--no-sign-request` to `aws s3 cp` commands in `run/shared/download_data.yml`.  This will allow for S3 data download via anonymous login (for users without AWS accounts).
- Added cosmetic changes (comments, updated column alignments, etc).

### Expected changes
The updates in this PR will allow dry-run simulations to proceed to completion (avoiding an out-of-bounds error).

### Related Github Issue

- See #2521 