### PR TITLE
Bug fix: Update paths to CEDS_CO_25 emissions in ExtData.rc.TransportTracers.

### DIFF
--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.TransportTracers
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.TransportTracers
@@ -156,14 +156,14 @@ EDGAR_CO_25_FFF  kg/m2/s N Y F%y4-01-01T00:00:00 none none emi_co  ./HcoDir/EDGA
 #==============================================================================
 # --- CEDS (CEDS_01x01) ---
 #==============================================================================
-CEDS_CO_25_AGR    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_agr   ./HcoDir/CEDS/v2023-04/%y4/CEDS_CO_0.1x0.1_%y4.nc
-CEDS_CO_25_ENE    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_ene   ./HcoDir/CEDS/v2023-04/%y4/CEDS_CO_0.1x0.1_%y4.nc
-CEDS_CO_25_IND    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_ind   ./HcoDir/CEDS/v2023-04/%y4/CEDS_CO_0.1x0.1_%y4.nc
-CEDS_CO_25_TRA    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_tra   ./HcoDir/CEDS/v2023-04/%y4/CEDS_CO_0.1x0.1_%y4.nc
-CEDS_CO_25_RCO    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_rco   ./HcoDir/CEDS/v2023-04/%y4/CEDS_CO_0.1x0.1_%y4.nc
-CEDS_CO_25_SLV    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_slv   ./HcoDir/CEDS/v2023-04/%y4/CEDS_CO_0.1x0.1_%y4.nc
-CEDS_CO_25_WST    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_wst   ./HcoDir/CEDS/v2023-04/%y4/CEDS_CO_0.1x0.1_%y4.nc
-CEDS_CO_25_SHP    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_shp   ./HcoDir/CEDS/v2023-04/%y4/CEDS_CO_0.1x0.1_%y4.nc
+CEDS_CO_25_AGR    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_agr   ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
+CEDS_CO_25_ENE    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_ene   ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
+CEDS_CO_25_IND    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_ind   ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
+CEDS_CO_25_TRA    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_tra   ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
+CEDS_CO_25_RCO    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_rco   ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
+CEDS_CO_25_SLV    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_slv   ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
+CEDS_CO_25_WST    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_wst   ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
+CEDS_CO_25_SHP    kg/m2/s N Y F%y4-%m2-01T00:00:00 none none CO_shp   ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
 
 #
 ###############################################################################


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
Update data paths to the CEDS_CO_25 emissions from the `CEDS/v2023-04` to the `CEDS/v2024-06` folder.  This edit was made in the HEMCO_Config.rc template file but apparently not in ExtData.rc.TransportTracers.

### Expected changes
This fix will now prevent GCHP TransportTracers simulations from exiting with error on Harvard Cannon, where the `CEDS/v2023-04` data has since been deleted.

### Related Github Issue
- See #2171 
