### PR TITLE
Update KPP/CMakeLists.txt to only compile KPP-Standalone if configured with -DKPPSA=y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated rundir scripts to print a reminder to compile with `-DKPPSA=y` to build the KPP-Standalone executable
 - Updated `integrationTestCreate.sh` and `parallelTestCreate.sh` scripts to decline building the KPP-Standalone.
 - Changed CESM HEMCO_Config.rc to read 3D AEIC emissions every timestep to avoid differences upon restart
+- Changed `KPP/CMakeLists.txt` to not call `add_directory(standalone)` unless we have configured with `-DKPPSA=y`
 
 ### Fixed
 - Fixed GCHP refresh time for `CO2_WEEKLY` scale factors so updated daily

--- a/KPP/CMakeLists.txt
+++ b/KPP/CMakeLists.txt
@@ -1,12 +1,14 @@
 # KPP/CMakeLists.txt
 
 #-----------------------------------------------------------------------------
-# Build the fullchem mechanism and the KPP standalone executable
-# if configured with -DMECH=fullchem  (This is the default option)
+# Build the fullchem mechanism if configured with -DMECH=fullchem
+# Also build the KPP-Standalone if configured with -DKPPSA=y
 #-----------------------------------------------------------------------------
 if("${MECH}" STREQUAL fullchem)
   add_subdirectory(fullchem)
-  add_subdirectory(standalone)
+  if(KPPSA)
+    add_subdirectory(standalone)
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------
@@ -17,12 +19,14 @@ if("${MECH}" STREQUAL carbon)
 endif()
 
 #-----------------------------------------------------------------------------
-# Build the custom mechanism and the KPP standalone executable
-# if configured with -DMECH=custom
+# Build the custom mechanism if configured with -DMECH=custom
+# Also build the KPP-Standalone if configured with -DKPPSA=y
 #-----------------------------------------------------------------------------
 if("${MECH}" STREQUAL custom)
   add_subdirectory(custom)
-  add_subdirectory(standalone)
+  if(KPPSA)
+    add_subdirectory(standalone)
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR adds if blocks to the `KPP/CMakeLists.txt` file so that the KPP-Standalone code will only be compiled if GEOS-Chem has been configured with `-DKPPSA=y`.  This fixes a bug where the KPP-Standalone was always being built for fullchem or custom mechanisms.  This could lead to compilation errors when GEOS-Chem is compiled in external models such as CESM.

### Expected changes
This is a no-diff-to-benchmark update.  It should allow GEOS-Chem to be built in e.g. CESM without trying to also build the KPP-Standalone.

### Related Github Issue
- See #2712 