### PR TITLE
Fix error in download_data.py causing data to be downloaded one directory level too high

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed incorrect description metadata for `FluxHg0FromAirToOcean` and `FluxHg0FromOceanToAir` diagnostics
 - Placed call to `Convert_Spc_Units` in `main.F90` within an `IF ( notDryrun )` block to avoid executing unit conversions in dryrun simulations
 - Modified CH4 reservoir timestamps in HEMCO_Config.rc to use months 1-12 to ensure HEMCO recalculates those fields monthly and properly applies the seasonal mask
+- Fixed path error `download_data.py` when downloading from `geoschem+http` or `nested+http` portals
 
 ### Removed
 - `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files

--- a/run/shared/download_data.py
+++ b/run/shared/download_data.py
@@ -105,6 +105,8 @@ def extract_pathnames_from_log(
     data_found = set()
     data_missing = set()
     dryrun_log = args["dryrun_log"]
+    portal = args["portal"]
+    remote = args["config"]["portals"][portal]["remote"]
 
     # Open file (or die with error)
     with open(dryrun_log, "r", encoding="UTF-8") as ifile:
@@ -156,6 +158,14 @@ def extract_pathnames_from_log(
             if "ExtData" in path:
                 index = path.find("ExtData")
                 local_prefix = path[:index]
+                #
+                # Data stored at these portals do not have an Extdata/
+                # folder, so we must add "/ExtData" to the path manually:
+                # - https://geos-chem.s3-us-west-2.amazonaws.com
+                # - https://gcgrid.s3.amazonaws.com/
+                #
+                if ".amazonaws.com" in remote:
+                    local_prefix = f"{local_prefix}/ExtData".replace('//', '/')
                 break
 
         # Exit if the local path does not contain ExtData


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
 
This is the companion PR to #2771.

The data portals https://geos-chem.s3-us-west-2.amazonaws.com (aka `geoschem+http`) and  https://gcgrid.s3.amazonaws.com (aka `nested+http`) do not have an ExtData folder.  This was causing the `download_data.py` script to incorrectly define the path to the local `ExtData` folder.  The result was that the data was being downloaded into the local path one directory level higher than it should have been. 

NOTE: Data download via AWSCLI (`aws s3 cp`) is not affected by the bug described in #2771.

### Expected changes
The `download_data.py` script will now download data from `https://geos-chem.s3-us-west-2.amazonaws.com` and  `https://gcgrid.s3.amazonaws.com` into the proper local paths.

### Related Github Issue
- #2771