### PR TITLE
Fix issues causing fullchem_alldiags integration tests to differ; Fix incorrect file paths in download_data.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Moved Cloud-J and Fast-JX input directories to Cloud-J and new Fast-JX menus respectively in `geoschem_config.yml`
 - Updated photolysis and aerosol optics input directories to use new mineral dust values in `FJX_scat-aer.dat` and `dust.dat` based on spheroidal shapes
 - Set `State_Diag%Archive_SatDiagn` to true if `State_Diag%Archive_SatDiagnPMID` is true
+- Disabled the `KppTime` diagnostic output the `fullchem_alldiags` integration tests; this will vary from run to run causing difference tests to fail
 
 ### Fixed
 - Fixed PDOWN definition to lower rather than upper edge
@@ -45,12 +46,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Modified CH4 reservoir timestamps in HEMCO_Config.rc to use months 1-12 to ensure HEMCO recalculates those fields monthly and properly applies the seasonal mask
 - Fixed path error `download_data.py` when downloading from `geoschem+http` or `nested+http` portals
 - Retrieve UV flux arrays from Cloud-J used to set UV flux diagnostics
+- Fixed issue in `download_data.py` that was adding an extra `ExtData` to file paths
+- Restored `UVFlux` diagnostic output in the `fullchem_alldiags` integration test
 
 ### Removed
 - `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files
 - Removed re-evaporation requirement for washout
 - Removed unused level argument passed to `SOIL_DRYDEP` and `SOIL_WETDEP`
 - Removed Fast-JX input directory from geoschem_config.yml files except for Hg simulation
+- Removed `History` attribute from ObsPack output netCDF files; the date info was causing difference tests to fail
 
 ## [14.5.3] - 2025-03-04
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Moved Cloud-J and Fast-JX input directories to Cloud-J and new Fast-JX menus respectively in `geoschem_config.yml`
 - Updated photolysis and aerosol optics input directories to use new mineral dust values in `FJX_scat-aer.dat` and `dust.dat` based on spheroidal shapes
 - Set `State_Diag%Archive_SatDiagn` to true if `State_Diag%Archive_SatDiagnPMID` is true
-- Disabled the `KppTime` diagnostic output the in `fullchem_alldiags` integration tests; this will vary from run to run causing difference tests to fail
+- Disabled the `KppTime` diagnostic output in the `fullchem_alldiags` integration tests; this will vary from run to run causing difference tests to fail
 
 ### Fixed
 - Fixed PDOWN definition to lower rather than upper edge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Moved Cloud-J and Fast-JX input directories to Cloud-J and new Fast-JX menus respectively in `geoschem_config.yml`
 - Updated photolysis and aerosol optics input directories to use new mineral dust values in `FJX_scat-aer.dat` and `dust.dat` based on spheroidal shapes
 - Set `State_Diag%Archive_SatDiagn` to true if `State_Diag%Archive_SatDiagnPMID` is true
-- Disabled the `KppTime` diagnostic output the `fullchem_alldiags` integration tests; this will vary from run to run causing difference tests to fail
+- Disabled the `KppTime` diagnostic output the in `fullchem_alldiags` integration tests; this will vary from run to run causing difference tests to fail
 
 ### Fixed
 - Fixed PDOWN definition to lower rather than upper edge

--- a/ObsPack/obspack_mod.F90
+++ b/ObsPack/obspack_mod.F90
@@ -905,7 +905,6 @@ CONTAINS
     REAL(f4), POINTER     :: ptr1d(:)
 
     ! Strings
-    CHARACTER(LEN=16)     :: stamp
     CHARACTER(LEN=31)     :: varName
     CHARACTER(LEN=255)    :: attVal
     CHARACTER(LEN=255)    :: ThisLoc
@@ -1029,8 +1028,7 @@ CONTAINS
     !=======================================================================
 
     ! History
-    stamp   = SYSTEM_TIMESTAMP()
-    attVal = 'GEOS-Chem simulation at ' // stamp
+    attVal = 'GEOS-Chem simulation'
     CALL NcDef_Glob_Attributes( fId, 'history', TRIM(attVal) )
 
     ! Conventions

--- a/run/shared/download_data.py
+++ b/run/shared/download_data.py
@@ -163,9 +163,10 @@ def extract_pathnames_from_log(
                 # folder, so we must add "/ExtData" to the path manually:
                 # - https://geos-chem.s3-us-west-2.amazonaws.com
                 # - https://gcgrid.s3.amazonaws.com/
-                #
-                if ".amazonaws.com" in remote:
-                    local_prefix = f"{local_prefix}/ExtData".replace('//', '/')
+                if "ExtData" not in local_prefix:
+                    if ".amazonaws.com" in remote:
+                        local_prefix = \
+                            f"{local_prefix}/ExtData".replace('//', '/')
                 break
 
         # Exit if the local path does not contain ExtData
@@ -178,6 +179,8 @@ def extract_pathnames_from_log(
         # The "sorted" command will return unique values
         ifile.close()
 
+        # Error check!  If ExtData appears more than once in
+        #if local_prefix.count("ExtData") > 1:
         paths = {
             "comments": comments,
             "found": found,
@@ -644,7 +647,11 @@ def create_download_script(
 
         # Kludge: Create a ExtData/CHEM_INPUTS folder if it
         # does not exist. This will prevent abnormal exits.
-        chem_dir = paths["local_prefix"] + 'ExtData/CHEM_INPUTS'
+        if "ExtData" in paths["local_prefix"]:
+            chem_dir = paths["local_prefix"] + '/CHEM_INPUTS'
+        else:
+            chem_dir = paths["local_prefix"] + '/ExtData/CHEM_INPUTS'
+          
         cmd = f"if [[ ! -d {chem_dir} ]]; then mkdir {chem_dir}; fi"
         print(cmd, file=ofile)
         print(file=ofile)
@@ -690,6 +697,8 @@ def download_the_data(
     create_download_script(paths, args)
 
     #### DEBUG: Uncomment this if you wish to see the download script
+    #### and also comment out the previous 'if args["skip_download"]'
+    #### statement above
     #if args["skip_download"]:
     #    return
 

--- a/test/integration/GCClassic/integrationTestCreate.sh
+++ b/test/integration/GCClassic/integrationTestCreate.sh
@@ -309,13 +309,14 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
 
     # Turn on all collections except RRTMG and Tomas collections (which
     # Make sure to activate these in the RRTMG and TOMAS integration tests.
-    # Also note; there is a floating point error in the UVFlux diagnostic,
-    # so temporarily comment that out.
     sed_ie "s|#'|'|"               "HISTORY.rc"
     sed_ie "s|'RRTMG'|#'RRTMG'|"   "HISTORY.rc"
     sed_ie "s|'Tomas'|#'Tomas'|"   "HISTORY.rc"
     sed_ie "s|'DynHeat|#'DynHeat|" "HISTORY.rc"
-    sed_ie "s|'UVFlux'|#'UVFlux'|" "HISTORY.rc"
+
+    # Disable the KppTime diagnostic (time spent in integrator) as
+    # this will vary due to local conditions on the cluster/node
+    sed_ie "s|'KppTime'|#'KppTime'|" "HISTORY.rc"
 
     # Activate the planeflight diagnostic
     cp -r "${pfDat}" .


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR does the following:

1. Fixes minor issues that were causing the `fullchem_alldiags` integration tests to show differences in diagnostic outputs.
    - Commented out `KppTime` (time spent in the KPP integrator) during `fullchem_alldiags` integration tests.  This metric is rarely the same between 2 successive tests due to local cluster/node conditions.
    - Removed the timestamp from the netCDF `history` attribute in the ObsPack diagnostic output.  The timestamps were causing netCDF files to show as differing even if they contain otherwise identical data.

2. Updated program logic in the `download_data.py` script to avoid having `ExtData` placed twice in file paths. 
    - See #2785 for more details.

### Expected changes
1. The `fullchem_alldiags` integration tests should no longer show any differences
2. `download_data.py` will no longer produce incorrect data paths

### Related Github Issue
- Closes #2785

Tagging @msulprizio @lizziel.  Integration tests are running.