### PR TITLE
Update CH4 global oil, gas, and coal emissions from GFEIv2 to GFEIv3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed the minimum KPP version to 3.2.0
 - Disabled the `KppTime` diagnostic output in the `fullchem_alldiags` integration tests; this will vary from run to run causing difference tests to fail
 - Updated the `KPP-Standalone` for compatibility with KPP 3.2.0 and to write the proper number of header lines to skip before data begins
+- Updated CH4 global oil, gas, and coal emissions from GFEIv2 to GFEIv3
 
 ### Fixed
 - Fixed PDOWN definition to lower rather than upper edge

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
@@ -363,9 +363,9 @@ VerboseOnCores:              root       # Accepted values: root all
 # This inventory will replace EDGAR (oil, gas, & coal)
 #==============================================================================
 (((GFEIv3
-0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
-0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
-0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  3 5
+0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  Oil_All 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
+0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  Gas_All 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
+0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     Coal    2020/1/1/0 C xy kg/m2/s CH4 -  3 5
 )))GFEIv3
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
@@ -62,7 +62,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> Scarpelli_Canada       :       true     # 2018
     --> Scarpelli_Mexico       :       true     # 2015
 # ----- GLOBAL INVENTORIES ----------------------------------------------------
-    --> GFEIv2                 :       true     # 2019
+    --> GFEIv3                 :       true     # 2020
     --> GRPI                   :       true     # 2022
     --> EDGARv8                :       true     # 2010-2022
     --> QFED2                  :       false    # 2009-2015
@@ -358,15 +358,15 @@ VerboseOnCores:              root       # Accepted values: root all
 )))Scarpelli_Canada
 
 #==============================================================================
-# --- Global Fuel Exploitation Inventory (GFEI v2, Scarpelli et al., 2021) ---
+# --- Global Fuel Exploitation Inventory (GFEI v3, Scarpelli et al., 2025) ---
 #
 # This inventory will replace EDGAR (oil, gas, & coal)
 #==============================================================================
-(((GFEIv2
-0 GFEI_CH4_OIL  $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Oil_All.nc  emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  1 5
-0 GFEI_CH4_GAS  $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Gas_All.nc  emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  2 5
-0 GFEI_CH4_COAL $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Coal.nc     emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  3 5
-)))GFEIv2
+(((GFEIv3
+0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
+0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
+0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  3 5
+)))GFEIv3
 
 #==============================================================================
 # --- Global Rice Patty Inventory (GRPI, Zichong Chen et al., 2025) ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -401,9 +401,9 @@ Mask fractions:              false
 # This inventory will replace EDGAR (oil, gas, & coal)
 #==============================================================================
 (((GFEIv3
-0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
-0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
-0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  3 5
+0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  Oil_All 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
+0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  Gas_All 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
+0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     Coal    2020/1/1/0 C xy kg/m2/s CH4 -  3 5
 )))GFEIv3
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -69,7 +69,7 @@ Mask fractions:              false
     --> Scarpelli_Canada       :       true     # 2018
     --> Scarpelli_Mexico       :       true     # 2015
 # ..... Global Inventories ...........
-    --> GFEIv2                 :       true     # 2019
+    --> GFEIv3                 :       true     # 2020
     --> GRPI                   :       true     # 2022
     --> EDGARv8                :       true     # 2010-2022
     --> QFED2                  :       false    # 2009-2015
@@ -396,15 +396,15 @@ Mask fractions:              false
 )))Scarpelli_Canada
 
 #==============================================================================
-# --- CH4: Global Fuel Exploitation Inventory (GFEI v2, Scarpelli et al., 2021) ---
+# --- CH4: Global Fuel Exploitation Inventory (GFEI v3, Scarpelli et al., 2025) ---
 #
 # This inventory will replace EDGAR (oil, gas, & coal)
 #==============================================================================
-(((GFEIv2
-0 GFEI_CH4_OIL  $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Oil_All.nc  emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  1 5
-0 GFEI_CH4_GAS  $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Gas_All.nc  emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  2 5
-0 GFEI_CH4_COAL $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Coal.nc     emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  3 5
-)))GFEIv2
+(((GFEIv3
+0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
+0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
+0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  3 5
+)))GFEIv3
 
 #==============================================================================
 # --- Global Rice Patty Inventory (GRPI, Zichong Chen et al., 2025) ---

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -190,9 +190,9 @@ CAN_WASTEWATER          kg/m2/s N Y - none none  wastewater_total           ./Hc
 CAN_OTHER               kg/m2/s N Y - none none  other_minor_sources_total  ./HcoDir/CH4/v2022-01/Scarpelli_Canada/can_emis_other_minor_sources_2018.nc
 
 # --- GFEI ---
-GFEI_CH4_OIL  kg/m2/s N Y - none none emis_ch4  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc
-GFEI_CH4_GAS  kg/m2/s N Y - none none emis_ch4  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc
-GFEI_CH4_COAL kg/m2/s N Y - none none emis_ch4  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc
+GFEI_CH4_OIL  kg/m2/s N Y - none none Oil_All  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc
+GFEI_CH4_GAS  kg/m2/s N Y - none none Gas_All  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc
+GFEI_CH4_COAL kg/m2/s N Y - none none Coal     ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc
 
 # --- GRPI ---
 GRPI_CH4_RICE kg/m2/s N Y F2022-%m2-01T00:00:00  none none emi_ch4 ./HcoDir/CH4/v2025-01/GRPI/GRPI_01x01.nc

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -190,10 +190,9 @@ CAN_WASTEWATER          kg/m2/s N Y - none none  wastewater_total           ./Hc
 CAN_OTHER               kg/m2/s N Y - none none  other_minor_sources_total  ./HcoDir/CH4/v2022-01/Scarpelli_Canada/can_emis_other_minor_sources_2018.nc
 
 # --- GFEI ---
-# Include scaling to convert molecules/cm2/s to kg/m2/s
-GFEI_CH4_OIL  kg/m2/s N Y - none 2.66350462E-22 emis_ch4  ./HcoDir/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Oil_All.nc
-GFEI_CH4_GAS  kg/m2/s N Y - none 2.66350462E-22 emis_ch4  ./HcoDir/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Gas_All.nc
-GFEI_CH4_COAL kg/m2/s N Y - none 2.66350462E-22 emis_ch4  ./HcoDir/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Coal.nc
+GFEI_CH4_OIL  kg/m2/s N Y - none none emis_ch4  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc
+GFEI_CH4_GAS  kg/m2/s N Y - none none emis_ch4  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc
+GFEI_CH4_COAL kg/m2/s N Y - none none emis_ch4  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc
 
 # --- GRPI ---
 GRPI_CH4_RICE kg/m2/s N Y F2022-%m2-01T00:00:00  none none emi_ch4 ./HcoDir/CH4/v2025-01/GRPI/GRPI_01x01.nc

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -401,9 +401,9 @@ Mask fractions:              false
 # This inventory will replace EDGAR (oil, gas, & coal)
 #==============================================================================
 (((GFEIv3
-0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
-0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
-0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  3 5
+0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  Oil_All 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
+0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  Gas_All 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
+0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     Coal    2020/1/1/0 C xy kg/m2/s CH4 -  3 5
 )))GFEIv3
 
 #==============================================================================

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -69,7 +69,7 @@ Mask fractions:              false
     --> Scarpelli_Canada       :       true     # 2018
     --> Scarpelli_Mexico       :       true     # 2015
 # ..... Global Inventories ...........
-    --> GFEIv2                 :       true     # 2019
+    --> GFEIv3                 :       true     # 2020
     --> GRPI                   :       true     # 2022
     --> EDGARv8                :       true     # 2010-2022
     --> QFED2                  :       false    # 2009-2015
@@ -396,15 +396,15 @@ Mask fractions:              false
 )))Scarpelli_Canada
 
 #==============================================================================
-# --- CH4: Global Fuel Exploitation Inventory (GFEI v2, Scarpelli et al., 2021) ---
+# --- CH4: Global Fuel Exploitation Inventory (GFEI v3, Scarpelli et al., 2025) ---
 #
 # This inventory will replace EDGAR (oil, gas, & coal)
 #==============================================================================
-(((GFEIv2
-0 GFEI_CH4_OIL  $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Oil_All.nc  emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  1 5
-0 GFEI_CH4_GAS  $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Gas_All.nc  emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  2 5
-0 GFEI_CH4_COAL $ROOT/CH4/v2022-01/GFEIv2/Global_Fuel_Exploitation_Inventory_v2_2019_Coal.nc     emis_ch4 2019/1/1/0 C xy molec/cm2/s CH4 -  3 5
-)))GFEIv2
+(((GFEIv3
+0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
+0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
+0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     emis_ch4 2020/1/1/0 C xy kg/m2/s CH4 -  3 5
+)))GFEIv3
 
 #==============================================================================
 # --- Global Rice Patty Inventory (GRPI, Zichong Chen et al., 2025) ---


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

This update simply swaps out GFEIv3 emission files with GFEIv3 emission files in CH4 and carbon simulation input files.
    
Data files were obtained from https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/HH4EUM. From the README there:
    
> The Global Fuel Exploitation Inventory (GFEI) which provides a 0.1 x 0.1 degree grid of methane emissions of fugitive emissions related to oil, gas, and coal activities (IPCC Sector 1B1 and 1B2). The inventory emissions are based on individual country reports submitted in accordance with the United Nations Framework Convention on Climate Change (UNFCCC). For those countries that do not report we estimate emissions following IPCC methods. Emissions are allocated to infrastructure locations including mines, wells, pipelines, compressor stations, storage facilities, processing plants, and refineries. This version of the inventory (GFEI v3) inventory is for 2020 and presents an update of GFEI v2 and v1 which were for 2019 and 2016, respectively.

### Expected changes

This is a zero difference update with respect to the full-chemistry benchmark simulation. It is expected to modify CH4 emissions of oil, gas, and coal emissions in CH4 and carbon simulations.

### Reference(s)

- Scarpelli, T. R., Roy, E., Jacob, D. J., Sulprizio, M. P., Tate, R. D., and Cusworth, D. H.: Using new geospatial data and 2020 fossil fuel methane emissions for the Global Fuel Exploitation Inventory (GFEI) v3, Earth Syst. Sci. Data Discuss. [preprint], https://doi.org/10.5194/essd-2024-552, in review, 2025.

### Related Github Issue

- https://github.com/geoschem/geos-chem/issues/1043
