### PR TITLE
Fix bugs in GCHP species diagnostics and metric.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Modified the carbon mechanism in KPP to separate tropospheric CH4 loss by OH from CO production by CH4 to remove dependency of CH4 and CO on each other and eliminate differences between CH4/tagCO simulations and the carbon simulation
 - Renamed several dummy species in the carbon mechanism for clarity
 - Fixed precision calculations within `co2_mod.F90` and `tagged_co_mod.F90` to eliminate differences with the carbon simulation
+- Fixed simulation date information printed by metrics.py for GCHP
 
 ### Removed
 - Removed `CEDSv2`, `CEDS_GBDMAPS`, `CEDS_GBDMAPSbyFuelType` emissions entries from HEMCO and ExtData template files

--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -1696,6 +1696,7 @@ CONTAINS
     ! Set diagnostics arrays in State_Diag that are in mol/mol
     CALL Set_SpcConc_Diags_VVDry( Input_Opt,  State_Chm, State_Diag,         &
          State_Grid, State_Met, RC )
+    _ASSERT(RC==GC_SUCCESS, 'Error calling Set_SpcConc_Diags_VVDry')
 #endif
 
     !=======================================================================

--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -656,6 +656,7 @@ CONTAINS
     USE Diagnostics_Mod,    ONLY : Zero_Diagnostics_StartofTimestep
     USE Diagnostics_Mod,    ONLY : Set_Diagnostics_EndofTimestep
     USE Diagnostics_Mod,    ONLY : Set_AerMass_Diagnostic
+    USE Diagnostics_Mod,    ONLY : Set_SpcConc_Diags_VVDry
 #ifdef ADJOINT
     USE PhysConstants,      ONLY : AIRMW
     USE Diagnostics_Mod,    ONLY :  Set_SpcAdj_Diagnostic
@@ -1680,7 +1681,7 @@ CONTAINS
     if(Input_Opt%AmIRoot.and.NCALLS<10) write(*,*) ' --- Diagnostics done!'
 
     !=======================================================================
-    ! Convert State_Chm%Species units
+    ! Convert State_Chm%Species units back to original units
     !=======================================================================
     CALL Convert_Spc_Units(                                                  &
          Input_Opt  = Input_Opt,                                             &
@@ -1690,6 +1691,12 @@ CONTAINS
          new_units  = previous_units,                                        &
          RC         = RC                                                    )
     _ASSERT(RC==GC_SUCCESS, 'Error calling CONVERT_SPC_UNITS')
+
+#ifndef MODEL_GEOS
+    ! Set diagnostics arrays in State_Diag that are in mol/mol
+    CALL Set_SpcConc_Diags_VVDry( Input_Opt,  State_Chm, State_Diag,         &
+         State_Grid, State_Met, RC )
+#endif
 
     !=======================================================================
     ! Clean up


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes a bug introduced earlier in 14.6.0 development that omitted a new call to set species diagnostics in GCHP. It also update the metrics.py script in run directories to fix the incorrect start and end dates printed for GCHP. Simulation duration and end are printed instead.

### Expected changes

This update will restore GCHP species diagnostics that have been zero since 14.6.0-alpha.9. When these updates are applied to 14.6.0-alpha.9 then GCHP is zero-diff with respect to 14.6.0-alpha.8.

The metrics.py will have different dates shown in the printed header for GCHP.

### Reference(s)

None

### Related Github Issue

https://github.com/geoschem/geos-chem/pull/252
