### PR TITLE
Fix TOMAS species indexing

### DIFF
--- a/GeosCore/tomas_mod.F90
+++ b/GeosCore/tomas_mod.F90
@@ -6451,7 +6451,6 @@ CONTAINS
     id_SO4    = Ind_('SO4'  )
     id_NH3    = Ind_('NH3'  )
     id_NH4    = Ind_('NH4'  )
-    id_SF01   = Ind_('SF01'  )
     id_SS01   = Ind_('SS01'  )
     id_ECIL01 = Ind_('ECIL01')
     id_ECOB01 = Ind_('ECOB01')
@@ -6461,6 +6460,18 @@ CONTAINS
 
     ! Number of size bins
     IBINS = State_Chm%nTomasBins
+
+    ! Check to make sure TOMAS species are in the expected order
+    IF (.NOT. (id_SF01   + IBINS == id_SS01   .AND. &
+               id_SS01   + IBINS == id_ECOB01 .AND. &
+               id_ECOB01 + IBINS == id_ECIL01 .AND. &
+               id_ECIL01 + IBINS == id_OCOB01 .AND. &
+               id_OCOB01 + IBINS == id_OCIL01 .AND. &
+               id_OCIL01 + IBINS == id_DUST01) ) THEN
+      MSG = 'TOMAS species are not in the expected order!'
+      LOC = 'Routine INIT_TOMAS in tomas_mod.F90'
+      ERROR_STOP( MSG, LOC )
+    ENDIF
 
     ! Now read large TOMAS input files from a common disk directory
     ! (bmy, 1/30/14)

--- a/GeosCore/tomas_mod.F90
+++ b/GeosCore/tomas_mod.F90
@@ -106,10 +106,10 @@ MODULE TOMAS_MOD
 !
   INTEGER, PARAMETER   :: SRTSO4  = 1
   INTEGER, PARAMETER   :: SRTNACL = 2
-  INTEGER, PARAMETER   :: SRTECIL = 3
-  INTEGER, PARAMETER   :: SRTECOB = 4
-  INTEGER, PARAMETER   :: SRTOCIL = 5
-  INTEGER, PARAMETER   :: SRTOCOB = 6
+  INTEGER, PARAMETER   :: SRTECOB = 3
+  INTEGER, PARAMETER   :: SRTECIL = 4
+  INTEGER, PARAMETER   :: SRTOCOB = 5
+  INTEGER, PARAMETER   :: SRTOCIL = 6
   INTEGER, PARAMETER   :: SRTDUST = 7
   INTEGER, PARAMETER   :: SRTNH4  = 8
   INTEGER, PARAMETER   :: SRTH2O  = 9
@@ -6431,6 +6431,7 @@ CONTAINS
     CHARACTER(LEN=255)   :: filename
     CHARACTER(LEN=255)   :: fname(4)
     CHARACTER(LEN=255)   :: DATA_DIR
+    CHARACTER(LEN=255)   :: MSG, LOC
 
     !=================================================================
     ! INIT_TOMAS begins here!
@@ -6470,7 +6471,7 @@ CONTAINS
                id_OCIL01 + IBINS == id_DUST01) ) THEN
       MSG = 'TOMAS species are not in the expected order!'
       LOC = 'Routine INIT_TOMAS in tomas_mod.F90'
-      ERROR_STOP( MSG, LOC )
+      CALL ERROR_STOP( MSG, LOC )
     ENDIF
 
     ! Now read large TOMAS input files from a common disk directory


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard University

### Describe the update

I fixed the indexing for OCIL/OCOB and ECIL/ECOB and added a check to make sure there is an error if the ordering is not as expected. Previously, hydrophobic and hydrophilic species of organic and elemental carbon were mixed up for TOMAS. I will wait to add a CHANGELOG.md update until @theloniuspunk and @BettyCroft review. This only impacts TOMAS.

### Expected changes

I ran GCHP at C24 resolution (TOMAS-15, MERRA-2) for one month, starting at 20190701 with the default restart file. On the last day of the simulation, 20190731,  I archived the 24-hour average species concentrations of the TOMAS species in each of the 15 size bins.

Here are before and after the fix for the number concentrations and mass concentrations for all 8 species. These are global averages at the lowest vertical level.
[number_distribution.pdf](https://github.com/user-attachments/files/19860408/number_distribution.pdf)
[mass_distribution_AW.pdf](https://github.com/user-attachments/files/19860400/mass_distribution_AW.pdf)
[mass_distribution_DUST.pdf](https://github.com/user-attachments/files/19860401/mass_distribution_DUST.pdf)
[mass_distribution_ECIL.pdf](https://github.com/user-attachments/files/19860402/mass_distribution_ECIL.pdf)
[mass_distribution_ECOB.pdf](https://github.com/user-attachments/files/19860403/mass_distribution_ECOB.pdf)
[mass_distribution_OCIL.pdf](https://github.com/user-attachments/files/19860404/mass_distribution_OCIL.pdf)
[mass_distribution_OCOB.pdf](https://github.com/user-attachments/files/19860405/mass_distribution_OCOB.pdf)
[mass_distribution_SF.pdf](https://github.com/user-attachments/files/19860406/mass_distribution_SF.pdf)
[mass_distribution_SS.pdf](https://github.com/user-attachments/files/19860407/mass_distribution_SS.pdf)

Here are before and after the fix for the spatial maps of total number concentrations and mass concentrations for all 8 species. These are also at the lowest vertical level.
[map_number.pdf](https://github.com/user-attachments/files/19860414/map_number.pdf)
[map_AW.pdf](https://github.com/user-attachments/files/19860410/map_AW.pdf)
[map_DUST.pdf](https://github.com/user-attachments/files/19860411/map_DUST.pdf)
[map_ECIL.pdf](https://github.com/user-attachments/files/19860412/map_ECIL.pdf)
[map_ECOB.pdf](https://github.com/user-attachments/files/19860413/map_ECOB.pdf)
[map_OCIL.pdf](https://github.com/user-attachments/files/19860415/map_OCIL.pdf)
[map_OCOB.pdf](https://github.com/user-attachments/files/19860416/map_OCOB.pdf)
[map_SF.pdf](https://github.com/user-attachments/files/19860417/map_SF.pdf)
[map_SS.pdf](https://github.com/user-attachments/files/19860419/map_SS.pdf)

The biggest differences are between OCIL/OCOB.

### Reference(s)

n/a

### Related Github Issue

https://github.com/geoschem/geos-chem/issues/2822
