### PR TITLE
Restore UVFlux collection in the GCHP fullchem_alldiags int test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Restored the `UVFlux` diagnostic collection to the GCHP `fullchem_alldiags` integration test
+
 ## [14.6.0] - 2025-04-18
 ### Added
 - Added CEDS 0.1 x 0.1 degree emissions (in `HEMCO/CEDS/v2024-06`)

--- a/test/integration/GCHP/integrationTestCreate.sh
+++ b/test/integration/GCHP/integrationTestCreate.sh
@@ -242,7 +242,6 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     sed_ie "s|'RRTMG'|#'RRTMG'|"     gchp_merra2_fullchem_alldiags/HISTORY.rc
     sed_ie "s|'Tomas'|#'Tomas'|"     gchp_merra2_fullchem_alldiags/HISTORY.rc
     sed_ie "s|'DynHeat|#'DynHeat|"   gchp_merra2_fullchem_alldiags/HISTORY.rc
-    sed_ie "s|'UVFlux'|#'UVFlux'|"   gchp_merra2_fullchem_alldiags/HISTORY.rc
 
     # Switch back to the present directory
     cd "${thisDir}"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR restores the `UVFlux` diagnostic collection in the GCHP `fullchem_alldiags` integration test.  The `UVFlux` collection had previously been commented out prior to Cloud-J 8.0.2 but for some reason we never removed the line of code that commented `UVFlux` out after Cloud-J 8.0.2 was added to GEOS-Chem.

### Expected changes
The `UVFlux` diagnostic collection file (`GEOSChem.UVFlux.20190701_0000z.nc4`) will now be generated in the `fullchem_alldiags` integration test.  Otherwise this is a no-diff-to-benchmark update.

### Related Github Issue
- See https://github.com/geoschem/Cloud-J/releases/tag/8.0.2
