### PR TITLE
Add RxnRate, RxnConst and KppDiags diagnostics to the carbon and Hg simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `#InvCEDSshipALK6`, `#InvCEDS_TMB`, and `#InvCEDSship_TMB` (commented out by default) to `HEMCO_Diagn*` and GCHP `HISTORY.rc.fullchem` files
 - Added `EmisOCs*` diagnostics to `run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.carbon` (these were missing)
 - Added entry for GFAS methanol for ExtData
-- Added `RxnConst` and `RxnRates` History collections to the carbon gases simulation
+- Added `RxnConst` and `RxnRates` History collections to `HISTORY.rc.carbon` and `HISTORY.rc.Hg` template files
 
 ### Changed
 - Updated GCHP template files `HEMCO_Diagn.rc.fullchem` and `HISTORY.rc.fullchem` so that the same emission diagnostics are requested in both
 - Changed `ALD2_PLANTDECAY` emissions category (for GEOS-Chem in NASA-GEOS ESM only) from 3 to 99 to not conflict with the anthropogenic transport sector
 - Abstracted diagnostic code out of `Chem_Carbon_Gases` and into PRIVATE subroutines in `GeosCore/carbon_gases_mod.F90`
+- Abstracted diagnostic code out of `ChemMercury` and into PRIVATE subroutines in `GeosCore/mercury_mod.F90`
 - Modified logic in `Init_State_Diag` so `KppDiags` diagnostic fields can be registered when using fullchem, Hg, or carbon mechanisms
 - Modified logic in `Init_State_Diag` so that `JValues` and `UVFlux` diagnostic fields can be registered when using fullchem or Hg simulations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated GCHP template files `HEMCO_Diagn.rc.fullchem` and `HISTORY.rc.fullchem` so that the same emission diagnostics are requested in both
 - Changed `ALD2_PLANTDECAY` emissions category (for GEOS-Chem in NASA-GEOS ESM only) from 3 to 99 to not conflict with the anthropogenic transport sector
 - Abstracted diagnostic code out of `Chem_Carbon_Gases` and into PRIVATE subroutines in `GeosCore/carbon_gases_mod.F90`
+- Modified logic in `Init_State_Diag` so `KppDiags` diagnostic fields can be registered when using fullchem, Hg, or carbon mechanisms
+- Modified logic in `Init_State_Diag` so that `JValues` and `UVFlux` diagnostic fields can be registered when using fullchem or Hg simulations
 
 ### Fixed
 - Restored the `UVFlux` diagnostic collection to the GCHP `fullchem_alldiags` integration test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `EmisOCs*` diagnostics to `run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.carbon` (these were missing)
 - Added entry for GFAS methanol for ExtData
 - Added `RxnConst` and `RxnRates` History collections to `HISTORY.rc.carbon` and `HISTORY.rc.Hg` template files
+- Added routine `Hg_UpdateKppDiags` to update the `KppDiags` history diagnostic arrays in `mercury_mod.F90`
 
 ### Changed
 - Updated GCHP template files `HEMCO_Diagn.rc.fullchem` and `HISTORY.rc.fullchem` so that the same emission diagnostics are requested in both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,24 @@
 This file documents all notable changes to the GEOS-Chem repository starting in version 14.0.0, including all GEOS-Chem Classic and GCHP run directory updates.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased] - TBD
 ### Added
 - Added `#InvCEDSshipALK6`, `#InvCEDS_TMB`, and `#InvCEDSship_TMB` (commented out by default) to `HEMCO_Diagn*` and GCHP `HISTORY.rc.fullchem` files
 - Added `EmisOCs*` diagnostics to `run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.carbon` (these were missing)
 - Added entry for GFAS methanol for ExtData
+- Added `RxnConst` and `RxnRates` History collections to the carbon gases simulation
 
 ### Changed
 - Updated GCHP template files `HEMCO_Diagn.rc.fullchem` and `HISTORY.rc.fullchem` so that the same emission diagnostics are requested in both
 - Changed `ALD2_PLANTDECAY` emissions category (for GEOS-Chem in NASA-GEOS ESM only) from 3 to 99 to not conflict with the anthropogenic transport sector
+- Abstracted diagnostic code out of `Chem_Carbon_Gases` and into PRIVATE subroutines in `GeosCore/carbon_gases_mod.F90`
 
 ### Fixed
 - Restored the `UVFlux` diagnostic collection to the GCHP `fullchem_alldiags` integration test
 - Fixed outdated path for GFED4 daily fraction
 - Fixed entries for GEOS-IT preprocessed cubed-sphere wind in GCHP
+- Fixed the `KppTime` diagnostic in `Chem_Carbon_Gases`; it was not being updated properly
 
 ## [Unreleased] - TBD
 ### Added

--- a/GeosCore/mercury_mod.F90
+++ b/GeosCore/mercury_mod.F90
@@ -653,7 +653,6 @@ CONTAINS
     USE GcKpp_Monitor,      ONLY : SPC_NAMES, FAM_NAMES
     USE GcKpp_Parameters
     USE GcKpp_Integrator,   ONLY : Integrate
-    USE GcKpp_Function
     USE GcKpp_Model
     USE Gckpp_Global
     USE GcKpp_Rates,        ONLY : UPDATE_RCONST, RCONST
@@ -728,8 +727,6 @@ CONTAINS
     INTEGER                :: ISTATUS(20)
     REAL(dp)               :: RCNTRL(20)
     REAL(dp)               :: RSTATE(20)
-    REAL(dp)               :: Vloc(NVAR)
-    REAL(dp)               :: Aout(NREACT)
     REAL(dp)               :: C_before_integrate(NSPEC)
 
     ! Pointers
@@ -861,32 +858,7 @@ CONTAINS
 
     ! Zero diagnostic archival arrays to make sure that we don't have any
     ! leftover values from the last timestep near the top of the chemgrid
-    IF (State_Diag%Archive_Loss           ) State_Diag%Loss           = 0.0_f4
-    IF (State_Diag%Archive_Prod           ) State_Diag%Prod           = 0.0_f4
-    IF (State_Diag%Archive_SatDiagnLoss   ) State_Diag%SatDiagnLoss   = 0.0_f4
-    IF (State_Diag%Archive_SatDiagnProd   ) State_Diag%SatDiagnProd   = 0.0_f4
-    IF (State_Diag%Archive_JVal           ) State_Diag%JVal           = 0.0_f4
-    IF (State_Diag%Archive_SatDiagnJVal   ) State_Diag%SatDiagnJVal   = 0.0_f4
-    IF (State_Diag%Archive_JNoon          ) State_Diag%JNoon          = 0.0_f4
-    IF (State_Diag%Archive_OHreactivity   ) State_Diag%OHreactivity   = 0.0_f4
-    IF (State_Diag%Archive_RxnRate        ) State_Diag%RxnRate        = 0.0_f4
-    IF (State_Diag%Archive_RxnConst       ) State_Diag%RxnConst       = 0.0_f4
-    IF (State_Diag%Archive_HgBrAfterChem  ) State_Diag%HgBrAfterChem  = 0.0_f4
-    IF (State_Diag%Archive_HgClAfterChem  ) State_Diag%HgClAfterChem  = 0.0_f4
-    IF (State_Diag%Archive_HgOHAfterChem  ) State_Diag%HgOHAfterChem  = 0.0_f4
-    IF (State_Diag%Archive_HgBrOAfterChem ) State_Diag%HgBrOAfterChem = 0.0_f4
-    IF (State_Diag%Archive_HgClOAfterChem ) State_Diag%HgClOAfterChem = 0.0_f4
-    IF (State_Diag%Archive_HgOHOAfterChem ) State_Diag%HgOHOAfterChem = 0.0_f4
-    IF (State_Diag%Archive_KppDiags) THEN
-       IF (State_Diag%Archive_KppIntCounts) State_Diag%KppIntCounts   = 0.0_f4
-       IF (State_Diag%Archive_KppJacCounts) State_Diag%KppJacCounts   = 0.0_f4
-       IF (State_Diag%Archive_KppTotSteps ) State_Diag%KppTotSteps    = 0.0_f4
-       IF (State_Diag%Archive_KppAccSteps ) State_Diag%KppAccSteps    = 0.0_f4
-       IF (State_Diag%Archive_KppRejSteps ) State_Diag%KppRejSteps    = 0.0_f4
-       IF (State_Diag%Archive_KppLuDecomps) State_Diag%KppLuDecomps   = 0.0_f4
-       IF (State_Diag%Archive_KppSubsts   ) State_Diag%KppSubsts      = 0.0_f4
-       IF (State_Diag%Archive_KppSmDecomps) State_Diag%KppSmDecomps   = 0.0_f4
-    ENDIF
+    CALL Hg_ZeroDiagArrays( State_Diag )
 
     !======================================================================
     ! Convert species to [molec/cm3] (ewl, 8/16/16)
@@ -1018,8 +990,8 @@ CONTAINS
     !$OMP DEFAULT( SHARED                                                   )&
     !$OMP PRIVATE( I,        J,        L,        N                          )&
     !$OMP PRIVATE( IERR,     RCNTRL,   ISTATUS,  RSTATE                     )&
-    !$OMP PRIVATE( SpcID,    KppID,    F,        P                          )&
-    !$OMP PRIVATE( Vloc,     Aout,     NN,       C_before_integrate         )&
+    !$OMP PRIVATE( SpcID,    KppID,    F,        C_before_integrate         )&
+    !$OMP PRIVATE( P,        NN                                             )&
     !$OMP COLLAPSE( 3                                                       )&
     !$OMP SCHEDULE ( DYNAMIC,  24                                           )&
     !$OMP REDUCTION( +:errorCount                                           )
@@ -1133,44 +1105,8 @@ CONTAINS
        ! Update the array of rate constants
        CALL Update_RCONST( )
 
-       !---------------------------------------------------------------------
-       ! HISTORY (aka netCDF diagnostics)
-       !
-       ! Archive KPP equation rates (Aout).  For GEOS-Chem in GEOS, also
-       ! archive the time derivative of variable species (Vdot).
-       !
-       ! NOTE: Replace VAR with C(1:NVAR) and FIX with C(NVAR+1:NSPEC),
-       ! because VAR and FIX are now local to the integrator
-       !  -- Bob Yantosca (03 May 2022)
-       !---------------------------------------------------------------------
-       IF ( State_Diag%Archive_RxnRate ) THEN
-
-          ! Get the reaction rates as Aout
-          CALL Fun ( V       = C(1:NVAR),                                    &
-                     F       = C(NVAR+1:NSPEC),                              &
-                     RCT     = RCONST,                                       &
-                     Vdot    = Vloc,                                         &
-                     Aout    = Aout                                         )
-
-          ! Only save requested equation rates
-          DO S = 1, State_Diag%Map_RxnRate%nSlots
-             N = State_Diag%Map_RxnRate%slot2Id(S)
-             State_Diag%RxnRate(I,J,L,S) = Aout(N)
-          ENDDO
-
-       ENDIF
-
-       ! Archive KPP reaction rate constants (RCONST). The units vary.
-       ! They are already updated in Update_RCONST, and do not require
-       ! a call of Fun(). (hplin, 3/28/23)
-       IF ( State_Diag%Archive_RxnConst ) THEN
-
-          DO S = 1, State_Diag%Map_RxnConst%nSlots
-             N = State_Diag%Map_RxnConst%slot2Id(S)
-             State_Diag%RxnConst(I,J,L,S) = RCONST(N)
-          ENDDO
-
-       ENDIF
+       ! HISTORY: Update RxnRates, RxnConst collections
+       CALL Hg_UpdateRxnDiags( I, J, L, State_Diag )
 
        !=====================================================================
        ! Set options for the KPP Integrator (M. J. Evans)
@@ -4402,5 +4338,264 @@ CONTAINS
     ENDIF
 
   END SUBROUTINE Set_Kpp_GridBox_Values
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Hg_ZeroDiagArrays
+!
+! !DESCRIPTION: Zeroes diagnostic archival arrays to make sure that we
+!  don't have any leftover values from the last timestep near the top of
+!  the chemistry grid.  This was abstracted out of ChemMercury
+!  in order to reduce clutter.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE Hg_ZeroDiagArrays( State_Diag )
+!
+! !USES:
+!
+    USE State_Diag_Mod, ONLY : DgnState
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(DgnState), INTENT(INOUT) :: State_Diag   ! Diagnostic State object
+!
+! !REVISION HISTORY:
+!  07 May 2025 - R. Yantosca - Initial version
+!  See the subsequent Git history with the gitk browser!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+    !========================================================================
+    ! Hg_ZeroDiagArrays begins here!
+    !========================================================================
+
+    !------------------------------------------
+    ! %%%%% Prod & loss diagnostics %%%%%
+    !------------------------------------------
+
+    IF ( State_Diag%Archive_Loss ) THEN
+       State_Diag%Loss = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_Prod ) THEN
+       State_Diag%Prod = 0.0_f4
+    ENDIF
+
+    IF (State_Diag%Archive_SatDiagnLoss ) THEN
+       State_Diag%SatDiagnLoss = 0.0_f4
+    ENDIF
+
+    IF (State_Diag%Archive_SatDiagnProd ) THEN
+       State_Diag%SatDiagnProd = 0.0_f4
+    ENDIF
+
+    !------------------------------------------
+    ! %%%%% J-value diagnostics %%%%%
+    !------------------------------------------
+
+    IF ( State_Diag%Archive_JVal ) THEN
+       State_Diag%JVal = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_SatDiagnJVal ) THEN
+       State_Diag%SatDiagnJVal = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_JNoon ) THEN
+       State_Diag%JNoon = 0.0_f4
+    ENDIF
+
+    !------------------------------------------
+    ! %%%%% Reaction rate diagnostics %%%%%
+    !------------------------------------------
+
+    IF ( State_Diag%Archive_RxnRate ) THEN
+       State_Diag%RxnRate = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_RxnConst ) THEN
+       State_Diag%RxnConst = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_SatDiagnRxnRate ) THEN
+       State_Diag%SatDiagnRxnRate = 0.0_f4
+    ENDIF
+
+    !------------------------------------------
+    ! %%%%% Chemistry diagnostics %%%%%
+    !------------------------------------------
+
+    IF ( State_Diag%Archive_OHreactivity ) THEN
+       State_Diag%OHreactivity = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_HgBrAfterChem ) THEN
+       State_Diag%HgBrAfterChem = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_HgClAfterChem ) THEN
+       State_Diag%HgClAfterChem = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_HgOHAfterChem ) THEN
+       State_Diag%HgOHAfterChem = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_HgBrOAfterChem ) THEN
+       State_Diag%HgBrOAfterChem = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_HgClOAfterChem ) THEN
+       State_Diag%HgClOAfterChem = 0.0_f4
+    ENDIF
+
+    IF ( State_Diag%Archive_HgOHOAfterChem ) THEN
+       State_Diag%HgOHOAfterChem = 0.0_f4
+    ENDIF
+
+    !------------------------------------------
+    ! %%%%% KPP solver statistics  %%%%%
+    !------------------------------------------
+
+    IF ( State_Diag%Archive_KppDiags ) THEN
+
+       IF (State_Diag%Archive_KppIntCounts ) THEN
+          State_Diag%KppIntCounts = 0.0_f4
+       ENDIF
+
+       IF ( State_Diag%Archive_KppJacCounts ) THEN
+          State_Diag%KppJacCounts = 0.0_f4
+       ENDIF
+
+       IF ( State_Diag%Archive_KppTotSteps ) THEN
+          State_Diag%KppTotSteps = 0.0_f4
+       ENDIF
+
+       IF ( State_Diag%Archive_KppAccSteps ) THEN
+          State_Diag%KppAccSteps = 0.0_f4
+       ENDIF
+
+       IF ( State_Diag%Archive_KppRejSteps ) THEN
+          State_Diag%KppRejSteps = 0.0_f4
+       ENDIF
+
+       IF ( State_Diag%Archive_KppLuDecomps) THEN
+          State_Diag%KppLuDecomps = 0.0_f4
+       ENDIF
+
+       IF ( State_Diag%Archive_KppSubsts ) THEN
+          State_Diag%KppSubsts = 0.0_f4
+       ENDIF
+
+       IF ( State_Diag%Archive_KppSmDecomps) THEN
+          State_Diag%KppSmDecomps = 0.0_f4
+       ENDIF
+
+    ENDIF
+
+  END SUBROUTINE Hg_ZeroDiagArrays
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Hg_UpdateRxnDiags
+!
+! !DESCRIPTION: Updates History diagnostic arrays for KPP reaction rates,
+!  rate constants, and solver statistics.  This was abstracted out of
+!  routine Chem_Carbon_gases to reduce clutter.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE Hg_UpdateRxnDiags( I, J, L, State_Diag )
+!
+! !USES:
+!
+    USE gckpp_Global,     ONLY : C,      RCONST
+    USE gckpp_Function,   ONLY : Fun
+    USE gckpp_Parameters, ONLY : NREACT, NSPEC,  NVAR
+    USE gckpp_Precision
+    USE State_Diag_Mod,   ONLY : DgnState
+!
+! !INPUT PARAMETERS:
+!
+    INTEGER,        INTENT(IN)    :: I, J, L      ! Grid box indices
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(DgnState), INTENT(INOUT) :: State_Diag   ! Diagnostic State object
+!
+! !REVISION HISTORY:
+!  06 May 2025 - R. Yantosca - Initial version
+!  See the subsequent Git history with the gitk browser!
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+
+    ! Scalars
+    INTEGER  :: N, S
+
+    ! Arrays
+    REAL(dp) :: Aout(NREACT)
+    REAL(dp) :: Vloc(NVAR)
+
+    !========================================================================
+    ! HISTORY: Archive KPP reaction rates [molec cm-3 s-1]
+    !
+    ! See gckpp_Monitor.F90 for a list of chemical reactions
+    !========================================================================
+    IF ( State_Diag%Archive_RxnRate                                     .or. &
+         State_Diag%Archive_SatDiagnRxnRate                           ) THEN
+
+       ! Get equation rates (Aout)
+       CALL Fun( V    = C(1:NVAR),                                           &
+                 F    = C(NVAR+1:NSPEC),                                     &
+                 RCT  = RCONST,                                              &
+                 Vdot = Vloc,                                                &
+                 Aout = Aout                                                )
+
+       ! Archive the RxnRate diagnostic collection
+       IF ( State_Diag%Archive_RxnRate ) THEN
+          DO S = 1, State_Diag%Map_RxnRate%nSlots
+             N = State_Diag%Map_RxnRate%slot2Id(S)
+             State_Diag%RxnRate(I,J,L,S) = Aout(N)
+          ENDDO
+       ENDIF
+
+       ! Archive the SatDiagnRxnRate diagnostic collection
+       IF ( State_Diag%Archive_SatDiagnRxnRate ) THEN
+          DO S = 1, State_Diag%Map_SatDiagnRxnRate%nSlots
+             N = State_Diag%Map_SatDiagnRxnRate%slot2Id(S)
+             State_Diag%SatDiagnRxnRate(I,J,L,S) = Aout(N)
+          ENDDO
+       ENDIF
+    ENDIF
+
+    !========================================================================
+    ! HISTORY: Archive KPP reaction rate constants (RCONST).
+    !
+    ! The units vary.  They are already updated in Update_RCONST,
+    ! and do not require a call of Fun(). (hplin, 3/28/23)
+    !
+    ! See gckpp_Monitor.F90 for a list of chemical reactions
+    !========================================================================
+    IF ( State_Diag%Archive_RxnConst ) THEN
+       DO S = 1, State_Diag%Map_RxnConst%nSlots
+          N = State_Diag%Map_RxnConst%slot2Id(S)
+          State_Diag%RxnConst(I,J,L,S) = RCONST(N)
+       ENDDO
+    ENDIF
+
+  END SUBROUTINE Hg_UpdateRxnDiags
 !EOC
 END MODULE Mercury_Mod

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -5900,12 +5900,16 @@ CONTAINS
     ENDIF
 
     !=======================================================================
-    ! The following diagnostic quantities are only relevant for:
+    ! The following diagnostic quantities are only relevant for
+    ! simulations using KPP-generated mechanism code, that is:
     !
     ! ALL FULL-CHEMISTRY SIMULATIONS
-    ! (benchmark, standard, tropchem, *SOA*, aciduptake, marinePOA)
+    ! MERCURY SIMULATION
+    ! CARBON GASES SIMULATION
     !=======================================================================
-    IF ( Input_Opt%ITS_A_FULLCHEM_SIM .OR. Input_Opt%ITS_A_MERCURY_SIM ) THEN
+    IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or.                                   &
+         Input_Opt%ITS_A_MERCURY_SIM  .or.                                   &
+         Input_Opt%ITS_A_CARBON_SIM        ) THEN
 
        !--------------------------------------------------------------------
        ! KPP Reaction Rates
@@ -5979,6 +5983,383 @@ CONTAINS
           RETURN
        ENDIF
 
+       !-------------------------------------------------------------------
+       ! Number of KPP Integrations per grid box
+       !-------------------------------------------------------------------
+       diagID  = 'KppIntCounts'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppIntCounts,                        &
+            archiveData    = State_Diag%Archive_KppIntCounts,                &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! Number of times KPP updated the Jacobian per grid box
+       !-------------------------------------------------------------------
+       diagID  = 'KppJacCounts'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppJacCounts,                        &
+            archiveData    = State_Diag%Archive_KppJacCounts,                &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+       !-------------------------------------------------------------------
+       ! Number of KPP total internal integration time steps
+       !-------------------------------------------------------------------
+       diagID  = 'KppTotSteps'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppTotSteps,                         &
+            archiveData    = State_Diag%Archive_KppTotSteps,                 &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! Number of KPP accepted internal integration time steps
+       !-------------------------------------------------------------------
+       diagID  = 'KppAccSteps'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppAccSteps,                         &
+            archiveData    = State_Diag%Archive_KppAccSteps,                 &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! Number of KPP rejected internal integration time steps
+       !-------------------------------------------------------------------
+       diagID  = 'KppRejSteps'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppRejSteps,                         &
+            archiveData    = State_Diag%Archive_KppRejSteps,                 &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! Number of KPP LU Decompositions
+       !-------------------------------------------------------------------
+       diagID  = 'KppLuDecomps'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppLuDecomps,                        &
+            archiveData    = State_Diag%Archive_KppLuDecomps,                &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! Number of KPP substitutions (forward and backward)
+       !-------------------------------------------------------------------
+       diagID  = 'KppSubsts'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppSubsts,                           &
+            archiveData    = State_Diag%Archive_KppSubsts,                   &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! Number of KPP singular matrix decompositions
+       !-------------------------------------------------------------------
+       diagID  = 'KppSmDecomps'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppSmDecomps,                        &
+            archiveData    = State_Diag%Archive_KppsmDecomps,                &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! Number of negative concentrations after KPP integration
+       !-------------------------------------------------------------------
+       diagID  = 'KppNegatives'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppNegatives,                        &
+            archiveData    = State_Diag%Archive_KppNegatives,                &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! Number of negative concentrations after first KPP integration try
+       !-------------------------------------------------------------------
+       diagID  = 'KppNegatives0'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppNegatives0,                       &
+            archiveData    = State_Diag%Archive_KppNegatives0,               &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! AR only -- Number of species in reduced mechanism (NVAR - NRMV)
+       !-------------------------------------------------------------------
+       diagID = 'KppAutoReducerNVAR'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppAutoReducerNVAR,                  &
+            archiveData    = State_Diag%Archive_KppAutoReducerNVAR,          &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! AR only -- Computed reduction threshold (molec cm-3 s-1)
+       !-------------------------------------------------------------------
+       diagID = 'KppAutoReduceThres'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppAutoReduceThres,                  &
+            archiveData    = State_Diag%Archive_KppAutoReduceThres,          &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! AR only -- Number of nonzero entries in LU decomp (cNONZERO)
+       !-------------------------------------------------------------------
+       diagID = 'KppcNONZERO'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppcNONZERO,                         &
+            archiveData    = State_Diag%Archive_KppcNONZERO,                 &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !-------------------------------------------------------------------
+       ! CPU time spent in grid box for KPP
+       !-------------------------------------------------------------------
+       diagID = 'KppTime'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%KppTime,                             &
+            archiveData    = State_Diag%Archive_KppTime,                     &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+    ELSE
+
+       !-------------------------------------------------------------------
+       ! Halt with an error message if any of the following quantities
+       ! have been requested as diagnostics in simulations other than
+       ! full-chemistry simulations.
+       !
+       ! This will prevent potential errors caused by the quantities
+       ! being requested as diagnostic output when the corresponding
+       ! array has not been allocated.
+       !-------------------------------------------------------------------
+       DO N = 1, 17
+          ! Select the diagnostic ID
+          SELECT CASE( N )
+             CASE( 1  )
+                diagID = 'RxnRate'
+             CASE( 2  )
+                diagID = 'SatDiagnRxnRate'
+             CASE( 3  )
+                diagID = 'RxnConst'
+             CASE( 4 )
+                diagID = 'KppIntCounts'
+             CASE( 5 )
+                diagID = 'KppJacCounts'
+             CASE( 6  )
+                diagID = 'KppTotSteps'
+             CASE( 7 )
+                diagID = 'KppAccSteps'
+             CASE( 8 )
+                diagID = 'KppRejSteps'
+             CASE( 9 )
+                diagID = 'KppLuDecomps'
+             CASE( 10 )
+                diagID = 'KppSubsts'
+             CASE( 11 )
+                diagID = 'KppSmDecomps'
+             CASE( 12 )
+                diagID = 'KppNegatives'
+             CASE( 13 )
+                diagID = 'KppNegatives0'
+             CASE( 14 )
+                diagID = 'KppAutoReducerNVAR'
+             CASE( 15 )
+                diagID = 'KppAutoReduceThres'
+             CASE( 16 )
+                diagID = 'KppcNONZERO'
+             CASE( 17 )
+                diagID = 'KppTime'
+          END SELECT
+
+          ! Exit if any of the above are in the diagnostic list
+          CALL Check_DiagList( am_I_Root, Diag_List, diagID, Found, RC )
+          IF ( Found ) THEN
+             ErrMsg = TRIM( diagId ) // ' is a requested diagnostic, '    // &
+                      'but this is only appropriate for full-chemistry, ' // &
+                      'Hg, or carbon gases simulations.'
+             CALL GC_Error( ErrMsg, RC, ThisLoc )
+             RETURN
+          ENDIF
+       ENDDO
+    ENDIF
+
+    !=======================================================================
+    ! The following diagnostic quantities are only relevant for:
+    !
+    ! ALL FULL-CHEMISTRY SIMULATIONS
+    ! MERCURY SIMULATION
+    !=======================================================================
+    IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or. Input_Opt%ITS_A_MERCURY_SIM ) THEN
+
        !--------------------------------------------------------------------
        ! OH reactivity
        !--------------------------------------------------------------------
@@ -6000,6 +6381,28 @@ CONTAINS
           CALL GC_Error( errMsg, RC, thisLoc )
           RETURN
        ENDIF
+
+       !--------------------------------------------------------------------
+       ! Satellite Diagnostic: OH reactivity
+       !--------------------------------------------------------------------
+       diagID  = 'SatDiagnOHreactivity'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%SatDiagnOHreactivity,                &
+            archiveData    = State_Diag%Archive_SatDiagnOHreactivity,        &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF       
 
 #ifdef MODEL_GEOS
        !--------------------------------------------------------------------
@@ -6044,28 +6447,6 @@ CONTAINS
           RETURN
        ENDIF
 #endif
-
-       !--------------------------------------------------------------------
-       ! Satellite Diagnostic: OH reactivity
-       !--------------------------------------------------------------------
-       diagID  = 'SatDiagnOHreactivity'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%SatDiagnOHreactivity,                &
-            archiveData    = State_Diag%Archive_SatDiagnOHreactivity,        &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF       
 
        !--------------------------------------------------------------------
        ! J-Values (instantaneous values)
@@ -6364,6 +6745,75 @@ CONTAINS
           CALL GC_Error( errMsg, RC, thisLoc )
           RETURN
        ENDIF
+
+    ELSE
+
+       !-------------------------------------------------------------------
+       ! Halt with an error message if any of the following quantities
+       ! have been requested as diagnostics in simulations other than
+       ! full-chemistry simulations.
+       !
+       ! This will prevent potential errors caused by the quantities
+       ! being requested as diagnostic output when the corresponding
+       ! array has not been allocated.
+       !-------------------------------------------------------------------
+       DO N = 1, 17
+          ! Select the diagnostic ID
+          SELECT CASE( N )
+             CASE( 1  )
+                diagID = 'OHreactivity'
+             CASE( 2  )
+                diagID = 'SatDiagnOHreactivity'
+             CASE( 3 )
+                diagID = 'NOxTau'
+             CASE( 4 )
+                diagID = 'TropNOxTau'
+             CASE( 5  )
+                diagID = 'Jval'
+             CASE( 6  )
+                diagID = 'JvalO3O1D'
+             CASE( 7 )
+                diagID = 'JvalO3O3P'
+             CASE( 8 )
+                diagID = 'SatDiagnJval'
+             CASE( 9 )
+                diagID = 'SatDiagnJvalO3O1D'
+             CASE( 10 )
+                diagID = 'SatDiagnJvalO3O3P'
+             CASE( 11 )
+                diagID = 'JNoon'
+             CASE( 12 )
+                diagID = 'JNoonFrac'
+             CASE( 13 )
+                diagID = 'UvFluxDiffuse'
+             CASE( 14 )
+                diagID = 'UVFluxDirect'
+             CASE( 15 )
+                diagID = 'UVFluxNet'
+             CASE( 16 )
+                diagID = 'OD600'
+             CASE( 17 )
+                diagID = 'TCOD600'
+          END SELECT
+
+          ! Exit if any of the above are in the diagnostic list
+          CALL Check_DiagList( am_I_Root, Diag_List, diagID, Found, RC )
+          IF ( Found ) THEN
+             ErrMsg = TRIM( diagId ) // ' is a requested diagnostic, '    // &
+                      'but this is only appropriate for full-chemistry '  // &
+                      'simulations.'
+             CALL GC_Error( ErrMsg, RC, ThisLoc )
+             RETURN
+          ENDIF
+       ENDDO
+    ENDIF
+
+    !=======================================================================
+    ! The following diagnostic quantities are only relevant for:
+    !
+    ! ALL FULL-CHEMISTRY SIMULATIONS
+    !=======================================================================
+    IF ( Input_Opt%ITS_A_FULLCHEM_SIM ) THEN
 
        !--------------------------------------------------------------------
        ! HO2 concentration upon exiting the FlexChem solver
@@ -6740,313 +7190,6 @@ CONTAINS
           RETURN
        ENDIF
 
-       !-------------------------------------------------------------------
-       ! Number of KPP Integrations per grid box
-       !-------------------------------------------------------------------
-       diagID  = 'KppIntCounts'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppIntCounts,                        &
-            archiveData    = State_Diag%Archive_KppIntCounts,                &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! Number of times KPP updated the Jacobian per grid box
-       !-------------------------------------------------------------------
-       diagID  = 'KppJacCounts'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppJacCounts,                        &
-            archiveData    = State_Diag%Archive_KppJacCounts,                &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-       !-------------------------------------------------------------------
-       ! Number of KPP total internal integration time steps
-       !-------------------------------------------------------------------
-       diagID  = 'KppTotSteps'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppTotSteps,                         &
-            archiveData    = State_Diag%Archive_KppTotSteps,                 &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! Number of KPP accepted internal integration time steps
-       !-------------------------------------------------------------------
-       diagID  = 'KppAccSteps'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppAccSteps,                         &
-            archiveData    = State_Diag%Archive_KppAccSteps,                 &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! Number of KPP rejected internal integration time steps
-       !-------------------------------------------------------------------
-       diagID  = 'KppRejSteps'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppRejSteps,                         &
-            archiveData    = State_Diag%Archive_KppRejSteps,                 &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! Number of KPP LU Decompositions
-       !-------------------------------------------------------------------
-       diagID  = 'KppLuDecomps'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppLuDecomps,                        &
-            archiveData    = State_Diag%Archive_KppLuDecomps,                &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! Number of KPP substitutions (forward and backward)
-       !-------------------------------------------------------------------
-       diagID  = 'KppSubsts'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppSubsts,                           &
-            archiveData    = State_Diag%Archive_KppSubsts,                   &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! Number of KPP singular matrix decompositions
-       !-------------------------------------------------------------------
-       diagID  = 'KppSmDecomps'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppSmDecomps,                        &
-            archiveData    = State_Diag%Archive_KppsmDecomps,                &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! Number of negative concentrations after KPP integration 
-       !-------------------------------------------------------------------
-       diagID  = 'KppNegatives'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppNegatives,                        &
-            archiveData    = State_Diag%Archive_KppNegatives,                &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! Number of negative concentrations after first KPP integration try
-       !-------------------------------------------------------------------
-       diagID  = 'KppNegatives0'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppNegatives0,                       &
-            archiveData    = State_Diag%Archive_KppNegatives0,               &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! AR only -- Number of species in reduced mechanism (NVAR - NRMV)
-       !-------------------------------------------------------------------
-       diagID = 'KppAutoReducerNVAR'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppAutoReducerNVAR,                  &
-            archiveData    = State_Diag%Archive_KppAutoReducerNVAR,          &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! AR only -- Computed reduction threshold (molec cm-3 s-1)
-       !-------------------------------------------------------------------
-       diagID = 'KppAutoReduceThres'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppAutoReduceThres,                  &
-            archiveData    = State_Diag%Archive_KppAutoReduceThres,          &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! AR only -- Number of nonzero entries in LU decomp (cNONZERO)
-       !-------------------------------------------------------------------
-       diagID = 'KppcNONZERO'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppcNONZERO,                         &
-            archiveData    = State_Diag%Archive_KppcNONZERO,                 &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
-       !-------------------------------------------------------------------
-       ! CPU time spent in grid box for KPP
-       !-------------------------------------------------------------------
-       diagID = 'KppTime'
-       CALL Init_and_Register(                                               &
-            Input_Opt      = Input_Opt,                                      &
-            State_Chm      = State_Chm,                                      &
-            State_Diag     = State_Diag,                                     &
-            State_Grid     = State_Grid,                                     &
-            DiagList       = Diag_List,                                      &
-            TaggedDiagList = TaggedDiag_List,                                &
-            Ptr2Data       = State_Diag%KppTime,                             &
-            archiveData    = State_Diag%Archive_KppTime,                     &
-            diagId         = diagId,                                         &
-            RC             = RC                                             )
-
-       IF ( RC /= GC_SUCCESS ) THEN
-          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
-          CALL GC_Error( errMsg, RC, thisLoc )
-          RETURN
-       ENDIF
-
 #if defined( MODEL_GEOS ) || defined( MODEL_WRF ) || defined( MODEL_CESM )
        !--------------------------------------------------------------------
        ! KPP error flag
@@ -7082,91 +7225,46 @@ CONTAINS
        ! being requested as diagnostic output when the corresponding
        ! array has not been allocated.
        !-------------------------------------------------------------------
-       DO N = 1, 41
+       DO N = 1, 18
+
           ! Select the diagnostic ID
           SELECT CASE( N )
              CASE( 1  )
-                diagID = 'RxnRate'
-!             CASE( 2  )
-!                diagID = 'Jval'
-             CASE( 3  )
-                diagID = 'JNoon'
-             CASE( 4  )
-                diagID = 'JNoonFrac'
-             CASE( 5  )
-                diagID = 'UvFluxDiffuse'
-             CASE( 6  )
-                diagID = 'UvFluxDirect'
-             CASE( 7  )
-                diagID = 'UvFluxNet'
-             CASE( 8  )
                 diagID = 'HO2concAfterChem'
-             CASE( 9  )
+             CASE( 2  )
                 diagID = 'O1DconcAfterChem'
-             CASE( 10 )
+             CASE( 3 )
                 diagID = 'O3PconcAfterChem'
-             CASE( 11 )
+             CASE( 4 )
+                diagID = 'CH4pseudoFlux'
+             CASE( 5  )
                 diagID = 'ProdSO4fromHOBrInCloud'
-             CASE( 12 )
+             CASE( 6  )
                 diagID = 'ProdSO4fromSRHOBr'
-             CASE( 13 )
+             CASE( 7 )
                 diagID = 'AerMassASOA'
-             CASE( 14 )
+             CASE( 8 )
                 diagID = 'AerMassINDIOL'
-             CASE( 15 )
+             CASE( 9 )
                 diagID = 'AerMassISN1OA'
-             CASE( 16 )
+             CASE( 10 )
                 diagID = 'AerMassLVOCOA'
-             CASE( 17 )
+             CASE( 11 )
                 diagID = 'AerMassOPOA'
-             CASE( 18 )
+             CASE( 12 )
                 diagID = 'AerMassPOA'
-             CASE( 19 )
+             CASE( 13 )
                 diagID = 'AerMassSOAGX'
-             CASE( 20 )
+             CASE( 14 )
                 diagID = 'AerMassSOAIE'
-             CASE( 21 )
+             CASE( 15 )
                 diagID = 'AerMassTSOA'
-             CASE( 22 )
+             CASE( 16 )
                 diagID = 'BetaNO'
-             CASE( 23 )
+             CASE( 17 )
                 diagID = 'TotalBiogenicOA'
-             CASE( 24 )
-                diagID = 'OHreactivity'
-             CASE( 25 )
-                diagID = 'KppIntCounts'
-             CASE( 26 )
-                diagID = 'KppJacCounts'
-             CASE( 27 )
-                diagID = 'KppTotSteps'
-             CASE( 28 )
-                diagID = 'KppAccSteps'
-             CASE( 29 )
-                diagID = 'KppRejSteps'
-             CASE( 30 )
-                diagID = 'KppLuDecomps'
-             CASE( 31 )
-                diagID = 'KppSubsts'
-             CASE( 32 )
-                diagID = 'KppSmDecomps'
-             CASE( 33 )
-                diagID = 'NOxTau'
-             CASE( 34 )
-                diagID = 'TropNOxTau'
-             CASE( 35 )
-                diagID = 'KppAutoReducerNVAR'
-             CASE( 36 )
-                diagID = 'KppTime'
-             CASE( 37 )
-                diagID = 'KppcNONZERO'
-             CASE( 38 )
-                diagID = 'KppAutoReduceThres'
-             CASE( 39 )
-                diagID = 'RxnConst'
-             CASE( 40 )
-                diagID = 'KppNegatives'
-             CASE( 41 )
-                diagID = 'KppNegatives0'
+             CASE( 18 )
+                diagID = 'KppError'
           END SELECT
 
           ! Exit if any of the above are in the diagnostic list

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
@@ -36,7 +36,10 @@ COLLECTIONS: 'Restart',
              #'CloudConvFlux',
              #'DryDep',
              #'LevelEdgeDiags',
+	     #'KppDiags',
              #'ProdLoss',
+	     #'RxnConst',
+	     #'RxnRates',
              #'SatDiagn',
              #'SatDiagnEdge',
              #'StateMet',
@@ -250,6 +253,66 @@ COLLECTIONS: 'Restart',
   ProdLoss.duration:          ${RUNDIR_HIST_TIME_AVG_DUR}
   ProdLoss.mode:              'time-averaged'
   ProdLoss.fields:            'Prod_?PRD?                    ',
+::
+#==============================================================================
+# %%%%% THE KppDiags COLLECTION %%%%%
+#
+# Diagnostics from the KPP solver.
+#
+# Available for fullchem, carbon, Hg simulations.
+#==============================================================================
+  KppDiags.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  KppDiags.frequency:         ${RUNDIR_HIST_TIME_AVG_FREQ}
+  KppDiags.duration:          ${RUNDIR_HIST_TIME_AVG_DUR}
+  KppDiags.mode:              'time-averaged'
+  KppDiags.fields:            'KppIntCounts                  ',
+                              'KppJacCounts                  ',
+                              'KppTotSteps                   ',
+                              'KppAccSteps                   ',
+                              'KppRejSteps                   ',
+                              'KppLuDecomps                  ',
+                              'KppSubsts                     ',
+                              'KppSmDecomps                  ',
+                              'KppTime                       ',
+::
+#==============================================================================
+# %%%%% THE RxnConst COLLECTION %%%%%
+#
+# Archives chemical reaction rates constants from the KPP solver.
+# It is best to list individual reactions to avoid using too much memory.
+# Reactions should be listed as "RxnConst_EQnnnn", where nnnn is the reaction
+# index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
+#
+# The units of reaction rate constants vary according to the number of
+# reactants in the reaction.
+#
+# Available for fullchem, carbon, Hg simulations.
+#==============================================================================
+  RxnConst.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  RxnConst.frequency:         ${RUNDIR_HIST_TIME_AVG_FREQ}
+  RxnConst.duration:          ${RUNDIR_HIST_TIME_AVG_DUR}
+  RxnConst.mode:              'time-averaged'
+  RxnConst.fields:            'RxnConst_EQ0001                ',
+                              'RxnConst_EQ0002                ',
+                              # ... add others as needed ...
+::
+#==============================================================================
+# %%%%% THE RxnRates COLLECTION %%%%%
+#
+# Archives chemical reaction rates from the KPP solver.
+# It is best to list individual reactions to avoid using too much memory.
+# Reactions should be listed as "RxnRate_EQnnnn", where nnnn is the reaction
+# index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
+#
+# Available for the fullchem, carbon, Hg simulations.
+#==============================================================================
+  RxnRates.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  RxnRates.frequency:         ${RUNDIR_HIST_TIME_AVG_FREQ}
+  RxnRates.duration:          ${RUNDIR_HIST_TIME_AVG_DUR}
+  RxnRates.mode:              'time-averaged'
+  RxnRates.fields:            'RxnRate_EQ0001                 ',
+                              'RxnRate_EQ0002                 ',
+                              # ... add others as needed ...
 ::
 #==============================================================================
 # %%%%% THE SatDiagn COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -34,7 +34,10 @@ COLLECTIONS: 'Restart',
 	     #'Carbon',
              #'CloudConvFlux',
              #'ConcAfterChem',
+	     #'KppDiags',
              #'LevelEdgeDiags',
+	     #'RxnConst',
+	     #'RxnRates',
              #'SatDiagn',
              #'SatDiagnEdge',
              'StateMet',
@@ -116,40 +119,40 @@ COLLECTIONS: 'Restart',
   Budget.frequency:           ${RUNDIR_HIST_TIME_AVG_FREQ}
   Budget.duration:            ${RUNDIR_HIST_TIME_AVG_DUR}
   Budget.mode:                'time-averaged'
-  Budget.fields:              'BudgetEmisDryDepFull_?ADV?           ',
-                              'BudgetEmisDryDepTrop_?ADV?           ',
-                              'BudgetEmisDryDepPBL_?ADV?            ',
-                              'BudgetEmisDryDepLevs1to35_?ADV?      ',
-                              'BudgetChemistryFull_?ADV?            ',
-                              'BudgetChemistryTrop_?ADV?            ',
-                              'BudgetChemistryPBL_?ADV?             ',
-                              'BudgetChemistryLevs1to35_?ADV?       ',
-                              'BudgetTransportFull_?ADV?            ',
-                              'BudgetTransportTrop_?ADV?            ',
-                              'BudgetTransportPBL_?ADV?             ',
-                              'BudgetTransportLevs1to35_?ADV?       ',
-                              'BudgetMixingFull_?ADV?               ',
-                              'BudgetMixingTrop_?ADV?               ',
-                              'BudgetMixingPBL_?ADV?                ',
-                              'BudgetMixingLevs1to35_?ADV?          ',
-                              'BudgetConvectionFull_?ADV?           ',
-                              'BudgetConvectionTrop_?ADV?           ',
-                              'BudgetConvectionPBL_?ADV?            ',
-                              'BudgetConvectionLevs1to35_?ADV?      ',
+  Budget.fields:              'BudgetEmisDryDepFull_?ADV?     ',
+                              'BudgetEmisDryDepTrop_?ADV?     ',
+                              'BudgetEmisDryDepPBL_?ADV?      ',
+                              'BudgetEmisDryDepLevs1to35_?ADV?',
+                              'BudgetChemistryFull_?ADV?      ',
+                              'BudgetChemistryTrop_?ADV?      ',
+                              'BudgetChemistryPBL_?ADV?       ',
+                              'BudgetChemistryLevs1to35_?ADV? ',
+                              'BudgetTransportFull_?ADV?      ',
+                              'BudgetTransportTrop_?ADV?      ',
+                              'BudgetTransportPBL_?ADV?       ',
+                              'BudgetTransportLevs1to35_?ADV? ',
+                              'BudgetMixingFull_?ADV?         ',
+                              'BudgetMixingTrop_?ADV?         ',
+                              'BudgetMixingPBL_?ADV?          ',
+                              'BudgetMixingLevs1to35_?ADV?    ',
+                              'BudgetConvectionFull_?ADV?     ',
+                              'BudgetConvectionTrop_?ADV?     ',
+                              'BudgetConvectionPBL_?ADV?      ',
+                              'BudgetConvectionLevs1to35_?ADV?',
 ::
 #==============================================================================
 # %%%%% THE Carbon COLLECTION %%%%%
 #
 # Production and loss fields from the carbon simulation via KPP
 #==============================================================================
-  Carbon.template:       '%y4%m2%d2_%h2%n2z.nc4',
-  Carbon.frequency:      ${RUNDIR_HIST_TIME_AVG_FREQ}
-  Carbon.duration:       ${RUNDIR_HIST_TIME_AVG_DUR}
-  Carbon.mode:           'time-averaged'
-  Carbon.fields:         'OHconcAfterChem               ',
-                         'ProdCOfromCH4                 ',
-                         'ProdCOfromNMVOC               ',
-                         'ProdCO2fromCO                 ',
+  Carbon.template:            '%y4%m2%d2_%h2%n2z.nc4',
+  Carbon.frequency:           ${RUNDIR_HIST_TIME_AVG_FREQ}
+  Carbon.duration:            ${RUNDIR_HIST_TIME_AVG_DUR}
+  Carbon.mode:                'time-averaged'
+  Carbon.fields:              'OHconcAfterChem                ',
+                              'ProdCOfromCH4                  ',
+                              'ProdCOfromNMVOC                ',
+                              'ProdCO2fromCO                  ',
 ::
 #==============================================================================
 # %%%%% THE CloudConvFlux COLLECTION %%%%%
@@ -170,7 +173,7 @@ COLLECTIONS: 'Restart',
 # Concentrations of OH, HO2, O1D, O3P immediately after exiting the KPP solver
 # or OH after the CH4 specialty-simulation chemistry routine.
 #
-# OH:       Available for all full-chemistry simulations and CH4 specialty sim
+# OH: Available for all full-chemistry simulations and carbon/CH4 simulations
 #==============================================================================
   ConcAfterChem.template:     '%y4%m2%d2_%h2%n2z.nc4',
   ConcAfterChem.frequency:    ${RUNDIR_HIST_TIME_AVG_FREQ}
@@ -196,6 +199,79 @@ COLLECTIONS: 'Restart',
                               'Met_PFILSAN                   ',
                               'Met_PFLCU                     ',
                               'Met_PFLLSAN                   ',
+::
+#==============================================================================
+# %%%%% THE KppDiags COLLECTION %%%%%
+#
+# Diagnostics from the KPP solver.
+#
+# NOTE: The carbon simulation uses the Forward Euler (feuler) solver, which
+# has no internal timestepping loop.  Therefore many of these diagnostics
+# will have little or no variation across grid boxes.  If using another
+# integrator
+#==============================================================================
+  KppDiags.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  KppDiags.frequency:         ${RUNDIR_HIST_TIME_AVG_FREQ}
+  KppDiags.duration:          ${RUNDIR_HIST_TIME_AVG_DUR}
+  KppDiags.mode:              'time-averaged'
+  KppDiags.fields:            'KppIntCounts                  ',
+                              'KppJacCounts                  ',
+                              'KppTotSteps                   ',
+                              'KppAccSteps                   ',
+                              'KppRejSteps                   ',
+                              'KppLuDecomps                  ',
+                              'KppSubsts                     ',
+                              'KppSmDecomps                  ',
+                              'KppTime                       ',
+::
+#==============================================================================
+# %%%%% THE RxnConst COLLECTION %%%%%
+#
+# Archives chemical reaction rates constants from the KPP solver.
+# It is best to list individual reactions to avoid using too much memory.
+# Reactions should be listed as "RxnConst_EQnnnn", where nnnn is the reaction
+# index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
+#
+# The units of reaction rate constants vary according to the number of
+# reactants in the reaction.
+#
+# Available for fullchem, carbon, Hg simulations.
+#==============================================================================
+  RxnConst.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  RxnConst.frequency:         ${RUNDIR_HIST_TIME_AVG_FREQ}
+  RxnConst.duration:          ${RUNDIR_HIST_TIME_AVG_DUR}
+  RxnConst.mode:              'time-averaged'
+  RxnConst.fields:            'RxnConst_EQ0001                ',
+                              'RxnConst_EQ0002                ',
+                              'RxnConst_EQ0003                ',
+                              'RxnConst_EQ0004                ',
+                              'RxnConst_EQ0005                ',
+                              'RxnConst_EQ0006                ',
+                              'RxnConst_EQ0007                ',
+                              'RxnConst_EQ0008                ',
+::
+#==============================================================================
+# %%%%% THE RxnRates COLLECTION %%%%%
+#
+# Archives chemical reaction rates from the KPP solver.
+# It is best to list individual reactions to avoid using too much memory.
+# Reactions should be listed as "RxnRate_EQnnnn", where nnnn is the reaction
+# index as listed in KPP/fullchem/gckpp_Monitor.F90 (pad zeroes as needed).
+#
+# Available for the fullchem, carbon, Hg simulations.
+#==============================================================================
+  RxnRates.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  RxnRates.frequency:         ${RUNDIR_HIST_TIME_AVG_FREQ}
+  RxnRates.duration:          ${RUNDIR_HIST_TIME_AVG_DUR}
+  RxnRates.mode:              'time-averaged'
+  RxnRates.fields:            'RxnRate_EQ0001                 ',
+                              'RxnRate_EQ0002                 ',
+                              'RxnRate_EQ0003                 ',
+                              'RxnRate_EQ0004                 ',
+                              'RxnRate_EQ0005                 ',
+                              'RxnRate_EQ0006                 ',
+                              'RxnRate_EQ0007                 ',
+                              'RxnRate_EQ0008                 ',
 ::
 #==============================================================================
 # %%%%% THE SatDiagn COLLECTION %%%%%

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -365,7 +365,7 @@ COLLECTIONS: 'Emissions',
   RxnRates.mode:              'time-averaged'
   RxnRates.fields:            'RxnRate_EQ0001                  ',
                               'RxnRate_EQ0002                  ',
-			      # ... add others as needed ...   
+			      # ... add others as needed ...
 ::
 #==============================================================================
   RxnConst.template:          '%y4%m2%d2_%h2%n2z.nc4',
@@ -376,7 +376,7 @@ COLLECTIONS: 'Emissions',
   RxnConst.mode:              'time-averaged'
   RxnConst.fields:            'RxnConst_EQ0001                ',
                               'RxnConst_EQ0002                ',
-			      # ... add others as needed ...   
+			      # ... add others as needed ...
 ::
 #==============================================================================
   StateMet.template:       '%y4%m2%d2_%h2%n2z.nc4',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -62,7 +62,10 @@ COLLECTIONS: 'Emissions',
              #'FV3Dynamics',
              #'GCHPctmEnvLevCenter',
              #'GCHPctmEnvLevEdge',
+             #'KppDiags',
              #'LevelEdgeDiags',
+             #'RxnConst',
+             #'RxnRates',
              'StateMet',
 ::
 #==============================================================================
@@ -335,6 +338,45 @@ COLLECTIONS: 'Emissions',
                                  'Met_PFILSAN ', 'GCHPchem',
                                  'Met_PFLCU   ', 'GCHPchem',
                                  'Met_PFLLSAN ', 'GCHPchem',
+::
+#==============================================================================
+  KppDiags.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  KppDiags.format:            'CFIO',
+  KppDiags.monthly:           1
+  KppDiags.frequency:         010000
+  KppDiags.duration:          010000
+  KppDiags.mode:              'time-averaged'
+  KppDiags.fields:            'KppIntCounts                  ',
+                              'KppJacCounts                  ',
+                              'KppTotSteps                   ',
+                              'KppAccSteps                   ',
+                              'KppRejSteps                   ',
+                              'KppLuDecomps                  ',
+                              'KppSubsts                     ',
+                              'KppSmDecomps                  ',
+                              'KppTime                       ',
+::
+#==============================================================================
+  RxnRates.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  RxnRates.format:            'CFIO',
+  RxnRates.monthly:           1
+  RxnRates.frequency:         010000
+  RxnRates.duration:          010000
+  RxnRates.mode:              'time-averaged'
+  RxnRates.fields:            'RxnRate_EQ0001                  ',
+                              'RxnRate_EQ0002                  ',
+			      # ... add others as needed ...   
+::
+#==============================================================================
+  RxnConst.template:          '%y4%m2%d2_%h2%n2z.nc4',
+  RxnConst.format:            'CFIO',
+  RxnConst.monthly:           1
+  RxnConst.frequency:         010000
+  RxnConst.duration:          010000
+  RxnConst.mode:              'time-averaged'
+  RxnConst.fields:            'RxnConst_EQ0001                ',
+                              'RxnConst_EQ0002                ',
+			      # ... add others as needed ...   
 ::
 #==============================================================================
   StateMet.template:       '%y4%m2%d2_%h2%n2z.nc4',


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #2844.  The `fullchem`, `Hg`, and `carbon` simulations use KPP-based solver code.  But in GEOS-Chem 14,6.0, the History collections for KPP-based diagnostic quantities (`KppDiags`, `RxnRates`, `RxnConst`) only work for the `fullchem` simulation.  In this PR we do the following:

1. Updated the IF-block logic in `Headers/state_diag_mod.F90` so that fields of the `KppDiags`, `RxnRates`, `RxnConst` collections can be registered for the `carbon` and `Hg` simulations without throwing an error.

2. Added code to update the `KppDiags`, `RxnRates`, and `RxnConst` collections in `GeosCore/carbon_gases_mod.F90` and `GeosCore/mercury_mod.F90`.

3. Added the `KppDiags`, `RxnRates`, and `RxnConst` diagnostic collection entries to the `HISTORY.rc.carbon` and `HISTORY.rc.Hg` template files.

### Expected changes
GEOS-Chem simulations using either `carbon` or `Hg` mechanisms will be able to archive diagnostic fields of the `KppDiags`, `RxnRates`, and `RxnConst` collections.

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue
- Closes #2844

Integration tests on the branch are currently running.  I will make this PR ready for review once they finish.
