### PR TITLE
Modify ObsPack I/O to look for "middle" or "midpoint" in the "time:comment" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Abstracted diagnostic code out of `ChemMercury` and into PRIVATE subroutines in `GeosCore/mercury_mod.F90`
 - Modified logic in `Init_State_Diag` so `KppDiags` diagnostic fields can be registered when using fullchem, Hg, or carbon mechanisms
 - Modified logic in `Init_State_Diag` so that `JValues` and `UVFlux` diagnostic fields can be registered when using fullchem or Hg simulations
+- Modified `Obspack_Read_Input` routine to look for `middle of the averaging interval` and `midpoint of the averaging interval` in the `time:comment` string
 
 ### Fixed
 - Restored the `UVFlux` diagnostic collection to the GCHP `fullchem_alldiags` integration test

--- a/ObsPack/obspack_mod.F90
+++ b/ObsPack/obspack_mod.F90
@@ -459,7 +459,7 @@ CONTAINS
        CALL NcRd( State_Diag%ObsPack_Strategy,  fId, TRIM(varName), st1d, ct1d)
     ELSE
        ErrMsg = 'Could not find "CT_sampling_strategy" in file: '         // &
-                TRIM( State_Diag%ObsPack_InFile  )                        // &
+                TRIM( State_Diag%ObsPack_InFile )                         // &
                 '.  Will use hourly sampling by default.'
        CALL GC_Warning( ErrMsg, RC, ThisLoc )
        State_Diag%ObsPack_Strategy = 2
@@ -478,8 +478,13 @@ CONTAINS
     RC = NF90_Inq_Varid( fId, varName, vId )
     RC = NF90_Get_Att( fId, vId, "comment", comment )
     IF ( RC == NF90_NOERR ) THEN
-       N = INDEX( comment, 'midpoint of the averaging interval' )
-       IF ( N > 0 ) Window_Start_Time = .FALSE.
+       N = INDEX( comment, 'middle of the averaging interval' )
+       IF ( N > 0 ) THEN
+          Window_Start_Time = .FALSE.
+       ELSE
+          N = INDEX( comment, 'midpoint of the averaging interval' )
+          IF ( N > 0 ) Window_Start_Time = .FALSE.
+       ENDIF
     ENDIF
 
     ! Assign the values from "time" to the proper tracking array


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #2849 by @aschuh.  In that issue we determined that ObsPack data points near the end of the day were zero, e.g:

Mine:
```console
 - OBSPACK: "time" indicates start of sample window   # INCORRECT
...
SF6 = 0.0004059939, 0.000406291, 0.0004060344, 0.0004063734, 0.0004060753,
0.0004064472, 0.0004061221, 0.0004063239, 0.0004048612, 0.0004061704,
0.0004061492, 0.0004062199, 0.0004064505, 0.0004062964, 0.000405833,
0.0004037992, 0.0004064215, 0.0004063799, 0.0004056979, 0.0004037454,
0.0004063925, 0.000406462, 0.0004055712, 0.0004036944, 0.0004065366,
0.0004065114, 0.0004056366, 0.0004036465, 0.0004068088, 0.0004065524,
0.000405752, 0.0004035985, 0.0004065963, 0.0004058661, 0.0004035936,
0.000406711, 0.0004059482, 0.0004036317, 0.0004068442, 0.000406022,
0.0004036698, 0.000406978, 0.0004060852, 0.000403696, 0.000407125,
0.0004059069, 0.0004037082, 0.0004072757, 0.0004056457, 0.0004037204,
0.0004074234, 0.0004054212, 0.0004036718, 0.000407503, 0.0004053434,
0.0004035721, 0.000407565, 0.0004052983, 0.0004034802, 0.00040763,
0.0004052651, 0.0004034745, 0.0004077661, 0.00040534, 0.0004035119,
0.000407921, 0.0004054388, 0.0004035494, 0.0004070153, 0.0004080631,
0.0004055212, 0, 0 ;
```
This was caused by the code in this IF block:

https://github.com/geoschem/geos-chem/blob/80bc0746b336e1160ef58e351d1c0535e7824739/ObsPack/obspack_mod.F90#L475-L483

The code looks for the text "midpoint of the averaging interval" in the `time:comment` field in order to determine if the timestamp is at the start of the averaging interval or at the middle of the averaging interval.  The problem is that most ObsPack data files use the text "middle of the averaging interval" in the `time:comment` field.  Therefore, the GEOS-Chem
ObsPack diagnostic's averaging interval was skewed incorrectly.

### Expected changes

The IF block has been modified to search for either "middle of the averaging interval" or "midpoint of the averaging interval" in the `time:comment` field of ObsPack data files.

https://github.com/geoschem/geos-chem/blob/ca341c7ebf9e7380808efd2a7079daa893387fc9/ObsPack/obspack_mod.F90#L475-L489

This now results in the proper computation of the averaging window, and eliminates the zero values near the end of the day.

```console
 - OBSPACK: "time" indicates midpoint of sample window   # CORRECT
...
SF6 = 0.0004059769, 0.0004062567, 0.0004060141, 0.0004063322, 0.0004060547,
0.0004064146, 0.0004060979, 0.0004064113, 0.0004049634, 0.0004061462,
0.0004062365, 0.0004061946, 0.0004065007, 0.0004062547, 0.0004059006,
0.0004038261, 0.0004064361, 0.0004063382, 0.0004057654, 0.0004037723,
0.000406407, 0.0004064216, 0.0004056304, 0.000403719, 0.0004064257,
0.000406491, 0.0004055789, 0.0004036704, 0.0004066726, 0.0004065319,
0.0004056943, 0.0004036225, 0.0004065728, 0.0004058098, 0.0004035831,
0.0004066445, 0.0004059114, 0.0004036126, 0.0004067776, 0.0004059851,
0.0004036507, 0.0004069108, 0.0004060589, 0.0004036878, 0.0004070498,
0.0004060275, 0.0004037021, 0.0004072004, 0.0004057662, 0.0004037143,
0.0004073509, 0.0004055252, 0.0004037091, 0.0004074721, 0.000405366,
0.0004036181, 0.000407534, 0.0004053209, 0.0004035262, 0.0004075959,
0.0004052757, 0.0004034601, 0.0004076888, 0.0004052906, 0.0004034932,
0.0004078436, 0.0004053894, 0.0004035307, 0.0004068354, 0.0004079985,
0.0004054883, 0.0004035588, 0.0004071053 ;
```

### Related Github Issue

- Closes #2849

Tagging our ObsPack & IMI users: @msulprizio @eastjames @jhaskinsPHD @aschuh