### PR TITLE
Fix miscellanous minor issues (TOMAS sim, aerosol-only sim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Modified logic in `Init_State_Diag` so `KppDiags` diagnostic fields can be registered when using fullchem, Hg, or carbon mechanisms
 - Modified logic in `Init_State_Diag` so that `JValues` and `UVFlux` diagnostic fields can be registered when using fullchem or Hg simulations
 - Modified `Obspack_Read_Input` routine to look for `middle of the averaging interval` and `midpoint of the averaging interval` in the `time:comment` string
+- Wrapped several TOMAS print statements in `IF ( Input_Opt%Verbose )` blocks to avoid excessive printout when using GCHP-TOMAS
 
 ### Fixed
 - Restored the `UVFlux` diagnostic collection to the GCHP `fullchem_alldiags` integration test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added entry for GFAS methanol for ExtData
 - Added `RxnConst` and `RxnRates` History collections to `HISTORY.rc.carbon` and `HISTORY.rc.Hg` template files
 - Added routine `Hg_UpdateKppDiags` to update the `KppDiags` history diagnostic arrays in `mercury_mod.F90`
+- Added `rrtmg_radiative_transfer_model:aod_wavelength_in_nm` to the GCClassic `geoschem_config.yml.aerosol` template file
+- Added an error trap in routine `Init_Aerosol` to make sure at least 1 AOD wavelength is selected for fullchem or aerosol-only simulations
 
 ### Changed
 - Updated GCHP template files `HEMCO_Diagn.rc.fullchem` and `HISTORY.rc.fullchem` so that the same emission diagnostics are requested in both
@@ -21,6 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Modified logic in `Init_State_Diag` so that `JValues` and `UVFlux` diagnostic fields can be registered when using fullchem or Hg simulations
 - Modified `Obspack_Read_Input` routine to look for `middle of the averaging interval` and `midpoint of the averaging interval` in the `time:comment` string
 - Wrapped several TOMAS print statements in `IF ( Input_Opt%Verbose )` blocks to avoid excessive printout when using GCHP-TOMAS
+
+### Removed
+- Removed most entries under the `photolysis` section in `geoschem_config.yml.aerosol` template file, as the aerosol-only simulation doesn't call Cloud-J
 
 ### Fixed
 - Restored the `UVFlux` diagnostic collection to the GCHP `fullchem_alldiags` integration test

--- a/GeosCore/aerosol_mod.F90
+++ b/GeosCore/aerosol_mod.F90
@@ -2356,7 +2356,7 @@ CONTAINS
 !
 ! !IROUTINE: init_aerosol
 !
-! !DESCRIPTION: Subroutine INIT\_AEROSOL initializes module variables
+! !DESCRIPTION: Subroutine INIT\_AEROSOL initializes module variables.
 !\\
 !\\
 ! !INTERFACE:
@@ -2397,8 +2397,9 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
-    INTEGER            :: N, SpcID
-    CHARACTER(LEN=255) :: ErrMsg, ThisLoc
+    INTEGER                :: N, SpcID
+    CHARACTER(LEN=255)     :: ThisLoc
+    CHARACTER(LEN=512)     :: ErrMsg
 
     TYPE(Species), POINTER :: SpcInfo
     
@@ -2504,6 +2505,22 @@ CONTAINS
        SpcInfo => NULL()
 
     ENDDO
+
+    !------------------------------------------------------------------------
+    ! The fullchem and aerosol simulations need at least one AOD wavelength
+    ! to be selected.  Return with an error if this is not the case.
+    !------------------------------------------------------------------------
+    IF ( Input_Opt%NWVSELECT == 0 ) THEN
+       ErrMsg = 'For fullchem and aerosol-only simulations, you must '    // &
+                'specify the wavelength at which the AOD will be '        // &
+                'calculated.  (For fullchem simulations using RRTMG, '    // &
+                'you may specify up to 3 wavelengths.)  Check the '       // &
+                '"aod_wavelength_in_nm" tag (under the '                  // &
+                '"rrtmg_radiative_transfer_model" section) in your '      // &
+                '"geoschem_config.yml" file.'
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
 
     !------------------------------------------------------------------------
     ! Read in AOD data

--- a/GeosCore/tomas_mod.F90
+++ b/GeosCore/tomas_mod.F90
@@ -593,8 +593,10 @@ CONTAINS
           H2SO4rate_o = 0.e+0_fp
        ENDIF
        !
-       IF ( I == 10 .and. J == 10 .and. L == 10 ) THEN
-          Print*, 'Debug TOMAS: H2SO4RATE =', H2SO4rate_o
+       IF ( Input%Opt%Verbose ) THEN
+          IF ( I == 10 .and. J == 10 .and. L == 10 ) THEN
+             Print*, 'Debug TOMAS: H2SO4RATE =', H2SO4rate_o
+          ENDIF
        ENDIF
 
        ! nitrogen and sulfur mass checks
@@ -6528,8 +6530,10 @@ CONTAINS
        ICOMP = ICOMP + 1
        IDIAG = IDIAG + 1
     ENDIF
-    print *, 'In init_TOMAS, ICOMP = ', ICOMP
-    print *, 'In init_TOMAS, IBINS = ', IBINS
+    IF ( Input_Opt%Verbose ) THEN
+       print *, 'In init_TOMAS, ICOMP = ', ICOMP
+       print *, 'In init_TOMAS, IBINS = ', IBINS
+    ENDIF
 
     !=================================================================
     ! Allocate arrays
@@ -6747,9 +6751,11 @@ CONTAINS
     DO J=1,46
     DO I=1,72
        READ( LUN ,'(I5,I5,I5,E10.3)') dum1,dum2,dum3,cosmic_ions(I,J,L)
-       if (I.eq.50.and.J.eq.20.and.L.eq.5)then
-          print*,'ion test',cosmic_ions(I,J,L)
-       endif
+       IF ( Input%Opt%Verbose ) THEN
+          if (I.eq.50.and.J.eq.20.and.L.eq.5)then
+             print*,'ion test',cosmic_ions(I,J,L)
+          endif
+       ENDIF
     ENDDO
     ENDDO
     ENDDO

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
@@ -64,22 +64,14 @@ operations:
      use_non_local_pbl: ${RUNDIR_USE_NLPBL}
 
   photolysis:
-    activate: true
-    cloud-j:
-      cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2025-01/
-      num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
-      cloud_scheme_flag: 3
-      opt_depth_increase_factor: 1.050
-      min_top_inserted_cloud_OD: 0.005
-      cloud_overlap_correlation: 0.33
-      num_cloud_overlap_blocks: 6
-      sphere_correction: 1
-      num_wavelength_bins: 18
-      use_H2O_UV_absorption: true
     overhead_O3:
       use_online_O3_from_model: false
       use_column_O3_from_met: true
       use_TOMS_SBUV_O3: false
+
+  rrtmg_rad_transfer_model:           # This menu is only used to specify the
+    aod_wavelengths_in_nm:            # AOD wavelength.  RRTMG can only be
+      - 550                           # called from a fullchem simulation.
 
   transport:
     gcclassic_tpcore:                 # GEOS-Chem Classic only


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR does the following:

1. Wraps several debug print statements for TOMAS in `IF ( Input_Opt%Verbose )` blocks so that they will only print if they are on the root core and if verbose output is selected.  This fixes the issue raised by @nicholasbalasus in #2821, and reduces the amount of verbose output that will be printed, especially when using TOMAS in GCHP.

2. Adds the `aod_wavelength_in_nm` specification to the GCClassic template file `geoschem_config.yml.aerosol`, for aerosol-only simulations.  Omitting the wavelength at which AOD is to be calculated causes the `AODDust` diagnostics in the aerosol-only simulations to be zero everywhere.  This was reported in issues #2854 and #2857 by @grandeamore333.

3. Adds an error trap in routine `Init_Aerosol` (in `GeosCore/aerosol_mod.F90`) that will halt a fullchem or aerosol-only simulation that does not have at least one AOD wavelength specified in `geoschem_config.yml`.  This will prevent situations such as reported by @grandeamore333 in #2854 and #2857.

4. Removed unnecessary tags from the `photolysis` section of `geoschem_config.yml.aerosol`.  The aerosol-only simulation does not call Cloud-J photolysis.  Only the overhead O3 tags are retained.
 
### Expected changes
1. Printout will only be restricted to the root core
2. The `AODDust` diagnostic fields will be computed properly in aerosol-only simulations
3. Aerosol-only simulations will not be allowed to proceed unless an AOD wavelength is specified
4. No change

### Related Github Issue

- Closes #2821
- Closes #2854
- Closes #2857 