### PR TITLE
Remove setting DELP_DRY to zero when not found in restart file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased - tbd
+### Removed
+- Removed setting `DELP_DRY` to zero in `hco_utilities_gc_mod.F90` when not found in the restart file to avoid negative concentrations
+
 ## [14.6.0] - 2025-04-18
 ### Added
 - Added CEDS 0.1 x 0.1 degree emissions (in `HEMCO/CEDS/v2024-06`)

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -1923,9 +1923,6 @@ CONTAINS
               MAXVAL(  State_Met%DELP_DRY ),                  &
               SUM(     State_Met%DELP_DRY )
       ENDIF
-   ELSE
-      State_Met%DELP_DRY = 0.0_fp
-      IF ( Input_Opt%amIRoot ) WRITE( 6, 520 ) ADJUSTL( v_name_in_file )
    ENDIF
 
    ! Nullify pointer


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The code for initializing `DELP_DRY` was moved from `hco_interface_gc_mod.F90` to `hco_utilities_gc_mod.F90` in PR #2521. This inadvertently led to negative concentrations in simulations where `DELP_DRY` was not found in the restart file. This is because `DELP_DRY` is updated in the first call to `AirQnt` in `hco_interfaces_gc_mod.F90`. When it is not found in the restart file, it is reset to zero which causes issues later in the simulation (manifesting as negative values in mixing). To avoid these issues, we remove the ELSE statement setting DELP_DRY to zero when it's not found in the restart file.

### Expected changes

This is a zero difference update for simulations where `DELP_DRY` is included in the restart file. This is the case for simulations in GCClassic integration testing. It does not impact GCHP.

### Related Github Issue

- https://github.com/geoschem/geos-chem/issues/2865
