### PR TITLE
Update for MAPL 2.59 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated the `KPP-Standalone` for compatibility with KPP 3.2.0 and to write the proper number of header lines to skip before data begins
 - Set `use_archived_PCO_from_CH4` and `use_archived_PCO2_from_CO2` to true by default for carbon simulations
 - Updated CH4 global oil, gas, and coal emissions from GFEIv2 to GFEIv3
+- Changed GCHPctmEnv and DYNAMICS diagnostic names in GCHP to include suffix '_R4'
 
 ### Fixed
 - Fixed PDOWN definition to lower rather than upper edge

--- a/run/CESM/HISTORY.rc
+++ b/run/CESM/HISTORY.rc
@@ -75,12 +75,12 @@ COLLECTIONS: 'Metrics',
              'JValues',
              #'KppDiags',
 	     #'KppARDiags',
-             #'LevelEdgeDiags',
              'ProdLoss',
              #'RxnRates',
 	     #'RxnConst',
              'StateChm',
              #'StateMet',
+             #'StateMetLevEdge',
              #'StratBM',
              #'UVFlux',
 ::
@@ -580,26 +580,6 @@ COLLECTIONS: 'Metrics',
                               'KppcNONZERO                   ',
 ::
 #==============================================================================
-# %%%%% LevelEdgeDiags %%%%%
-#
-# Diagnostics that are defined on grid box level edges. Vertical dimension
-# size is one more than 3D fields in the StateMet collection.
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   {FREQUENCY}
-  LevelEdgeDiags.duration:    {DURATION}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% ProdLoss %%%%%
 #
 # Chemical production and loss rates
@@ -705,9 +685,9 @@ COLLECTIONS: 'Metrics',
 #==============================================================================
 # %%%%% StateMet %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection). All
+# Fields of the State_Met object (also see the StateMetLevEdge collection). All
 # 3D fields are centered in the grid box, i.e. not at level edges. Vertical
-# dimension size is one more than 3D fields in the LevelEdgeDiags collection.
+# dimension size is one more than 3D fields in the StateMetLevEdge collection.
 #
 # Available for all simulations
 #==============================================================================
@@ -797,4 +777,24 @@ COLLECTIONS: 'Metrics',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
                               'FracOfTimeInTrop              ',
+::
+#==============================================================================
+# %%%%% StateMetLevEdge %%%%%
+#
+# State_Met arrays that are defined on grid box level edges. Vertical dimension
+# size is one more than 3D fields in the StateMet collection.
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   {FREQUENCY}
+  StateMetLevEdge.duration:    {DURATION}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CH4
@@ -34,10 +34,10 @@ COLLECTIONS: 'Restart',
              #'Budget',
              #'CloudConvFlux',
              #'ConcAfterChem',
-             #'LevelEdgeDiags',
              #'SatDiagn',
              #'SatDiagnEdge',
              'StateMet',
+             #'StateMetLevEdge',
              #'BoundaryConditions',
 ::
 ###############################################################################
@@ -181,25 +181,6 @@ COLLECTIONS: 'Restart',
   ConcAfterChem.fields:       'OHconcAfterChem               ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE SatDiagn COLLECTION %%%%%
 #
 # GEOS-Chem data during satellite overpass
@@ -243,7 +224,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -329,6 +310,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE BoundaryConditions COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -32,10 +32,10 @@ COLLECTIONS: 'Restart',
              'SpeciesConc',
              #'Budget',
              #'CloudConvFlux',
-             #'LevelEdgeDiags',
              #'SatDiagn',
              #'SatDiagnEdge',
              #'StateMet',
+             #'StateMetLevEdge',
              #'BoundaryConditions',
 ::
 ###############################################################################
@@ -140,25 +140,6 @@ COLLECTIONS: 'Restart',
   CloudConvFlux.fields:       'CloudConvFlux_?ADV?           ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE SatDiagn COLLECTION %%%%%
 #
 # GEOS-Chem data during satellite overpass
@@ -202,7 +183,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -288,6 +269,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE BoundaryConditions COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.Hg
@@ -35,7 +35,6 @@ COLLECTIONS: 'Restart',
              #'Budget',
              #'CloudConvFlux',
              #'DryDep',
-             #'LevelEdgeDiags',
 	     #'KppDiags',
              #'ProdLoss',
 	     #'RxnConst',
@@ -43,6 +42,7 @@ COLLECTIONS: 'Restart',
              #'SatDiagn',
              #'SatDiagnEdge',
              #'StateMet',
+             #'StateMetLevEdge',
              #'WetLossConv',
              #'WetLossLS',
              #'BoundaryConditions',
@@ -161,25 +161,6 @@ COLLECTIONS: 'Restart',
                               'DryDep_?DRY?                  ',
                               #'DryDepChm_?DRY?              ',
                               #'DryDepMix_?DRY?              ',
-::
-#==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE MercuryChem COLLECTION %%%%%
@@ -369,7 +350,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -455,6 +436,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE WetLossConv COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.POPs
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.POPs
@@ -33,8 +33,8 @@ COLLECTIONS: 'Restart',
              #'Budget',
              #'CloudConvFlux',
              #'DryDep',
-             #'LevelEdgeDiags',
              #'StateMet',
+             #'StateMetLevEdge',
              #'WetLossConv',
              #'WetLossLS',
              #'BoundaryConditions',
@@ -172,28 +172,9 @@ COLLECTIONS: 'Restart',
                          'ProdPOPPBCPOfromNO3                ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -279,6 +260,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE WetLossConv COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -33,10 +33,10 @@ COLLECTIONS: 'Restart',
              #'Budget',
              'CloudConvFlux',
              'DryDep',
-             'LevelEdgeDiags',
 	     #'SatDiagn',
 	     #'SatDiagnEdge',
              'StateMet',
+             'StateMetLevEdge',
              'WetLossConv',
              'WetLossLS',
              'AdvFluxVert',
@@ -149,25 +149,6 @@ COLLECTIONS: 'Restart',
                               #'DryDepMix_?DRY?              ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE RadioNuclide COLLECTION %%%%%
 #
 # Radioactive production and decay of radionuclide species
@@ -247,7 +228,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -333,6 +314,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE WetLossConv COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.aerosol
@@ -34,12 +34,12 @@ COLLECTIONS: 'Restart',
              #'Aerosols',
              #'CloudConvFlux',
              #'DryDep',
-             #'LevelEdgeDiags',
              #'ProdLoss',
 	     #'SatDiagn',
 	     #'SatDiagnEdge',
              #'StateChm',
              #'StateMet',
+             #'StateMetLevEdge',
              #'WetLossConv',
              #'WetLossLS',
              #'BoundaryConditions',
@@ -252,25 +252,6 @@ COLLECTIONS: 'Restart',
                               #'DryDepMix_?DRY?              ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE ProdLoss COLLECTION %%%%%
 #
 # Chemical production and loss rates
@@ -386,7 +367,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -472,6 +453,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE WetLossConv COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -35,12 +35,12 @@ COLLECTIONS: 'Restart',
              #'CloudConvFlux',
              #'ConcAfterChem',
 	     #'KppDiags',
-             #'LevelEdgeDiags',
 	     #'RxnConst',
 	     #'RxnRates',
              #'SatDiagn',
              #'SatDiagnEdge',
              'StateMet',
+             'StateMetLevEdge',
              #'BoundaryConditions',
 ::
 ###############################################################################
@@ -182,25 +182,6 @@ COLLECTIONS: 'Restart',
   ConcAfterChem.fields:       'OHconcAfterChem               ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE KppDiags COLLECTION %%%%%
 #
 # Diagnostics from the KPP solver.
@@ -321,7 +302,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -407,6 +388,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE BoundaryConditions COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -41,7 +41,6 @@ COLLECTIONS: 'Restart',
              #'JValues',
              ##'KppDiags',
              ##'KppARDiags',
-             ##'LevelEdgeDiags',
              ##'ProdLoss',
              ##'RRTMG',
              ##'RxnRates',
@@ -50,6 +49,7 @@ COLLECTIONS: 'Restart',
              ##'SatDiagnEdge',
              ##'StateChm',
              #'StateMet',
+             ##'StateMetLevEdge',
              ##'StratBM',
              ##'Tomas',
              ##'UVFlux',
@@ -441,25 +441,6 @@ COLLECTIONS: 'Restart',
                               'KppcNONZERO                   ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE ProdLoss COLLECTION %%%%%
 #
 # Chemical production and loss rates
@@ -719,7 +700,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -809,6 +790,25 @@ COLLECTIONS: 'Restart',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
                               'FracOfTimeInTrop              ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE StratBM COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.metals
@@ -32,10 +32,10 @@ COLLECTIONS: 'Restart',
              #'Budget',
              #'CloudConvFlux',
              #'DryDep',
-             #'LevelEdgeDiags',
              #'SatDiagn',
              #'SatDiagnEdge',
              #'StateMet',
+             #'StateMetLevEdge',
              #'WetLossConv',
              #'WetLossLS',
 ::
@@ -147,25 +147,6 @@ COLLECTIONS: 'Restart',
                               #'DryDepMix_?DRY?              ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE SatDiagn COLLECTION %%%%%
 #
 # GEOS-Chem data during satellite overpass
@@ -213,7 +194,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -299,6 +280,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE WetLossConv COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagCO
@@ -32,11 +32,11 @@ COLLECTIONS: 'Restart',
              'SpeciesConc',
              #'Budget',
              #'CloudConvFlux',
-             #'LevelEdgeDiags',
              #'ProdLoss',
              #'SatDiagn',
              #'SatDiagnEdge',
              #'StateMet',
+             #'StateMetLevEdge',
              #'BoundaryConditions',
 ::
 ###############################################################################
@@ -127,25 +127,6 @@ COLLECTIONS: 'Restart',
   CloudConvFlux.fields:       'CloudConvFlux_?ADV?           ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE ProdLoss COLLECTION %%%%%
 #
 # Chemical production and loss rates
@@ -216,7 +197,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -302,6 +283,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE BoundaryConditions COLLECTION %%%%%

--- a/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
+++ b/run/GCClassic/HISTORY.rc.templates/HISTORY.rc.tagO3
@@ -33,11 +33,11 @@ COLLECTIONS: 'Restart',
              #'CloudConvFlux',
              #'ConcAboveSfc',
              #'DryDep',
-             #'LevelEdgeDiags',
              #'ProdLoss',
              #'SatDiagn',
              #'SatDiagnEdge',
              #'StateMet',
+             #'StateMetLevEdge',
              #'BoundaryConditions',
 ::
 ###############################################################################
@@ -164,25 +164,6 @@ COLLECTIONS: 'Restart',
                               #'DryDepMix_?DRY?              ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
-  LevelEdgeDiags.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE ProdLoss COLLECTION %%%%%
 #
 # Chemical production and loss rates
@@ -243,7 +224,7 @@ COLLECTIONS: 'Restart',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -329,6 +310,25 @@ COLLECTIONS: 'Restart',
                               'Met_V                         ',
                               'Met_V10M                      ',
                               'Met_Z0                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   ${RUNDIR_HIST_TIME_AVG_FREQ}
+  StateMetLevEdge.duration:    ${RUNDIR_HIST_TIME_AVG_DUR}
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE BoundaryConditions COLLECTION %%%%%

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -58,13 +58,11 @@ COLLECTIONS: 'Emissions',
              #'FV3Dynamics',
              #'GCHPctmEnvLevCenter',
              #'GCHPctmEnvLevEdge',
-             'LevelEdgeDiags',      
-             'SpeciesConc_avg',
-	     'SpeciesConc_inst',
+             'SpeciesConc',
 	     #'Adjoint',
 	     #'SFEmissions',
-             'StateMet_avg',      
-             'StateMet_inst',      
+             'StateMet',
+             'StateMetLevEdge',
 ::
 #==============================================================================
 # Define collections
@@ -228,23 +226,6 @@ COLLECTIONS: 'Emissions',
                                       'MFY_R4      ', 'GCHPctmEnv',
 ::
 #==============================================================================
-  LevelEdgeDiags.template:       '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.format:         'CFIO',
-  LevelEdgeDiags.timestampStart: .true.
-  LevelEdgeDiags.monthly:        1
-  LevelEdgeDiags.frequency:      010000
-  LevelEdgeDiags.duration:       010000
-  LevelEdgeDiags.mode:           'time-averaged'
-  LevelEdgeDiags.fields:         'Met_CMFMC          ', 'GCHPchem',
-                                 'Met_PEDGE          ', 'GCHPchem',
-                                 'Met_PEDGEDRY       ', 'GCHPchem',
-                                 'Met_PFICU          ', 'GCHPchem',
-                                 'Met_PFILSAN        ', 'GCHPchem',
-                                 'Met_PFLCU          ', 'GCHPchem',
-                                 'Met_PFLLSAN        ', 'GCHPchem',
-                                 'UpwardsMassFlux    ', 'GCHPctmEnv',
-::
-#==============================================================================
   SpeciesConc_avg.template:       '%y4%m2%d2_%h2%n2z.nc4',
   SpeciesConc_avg.format:         'CFIO',
   SpeciesConc_avg.timestampStart: .true.
@@ -363,4 +344,20 @@ COLLECTIONS: 'Emissions',
                            'Met_V              ', 'GCHPchem',
                            'Met_V10M           ', 'GCHPchem',
                            'Met_Z0             ', 'GCHPchem',
+::
+#==============================================================================
+  StateMetLevEdge.template:       '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.format:         'CFIO',
+  StateMetLevEdge.timestampStart: .true.
+  StateMetLevEdge.monthly:        1
+  StateMetLevEdge.frequency:      010000
+  StateMetLevEdge.duration:       010000
+  StateMetLevEdge.mode:           'time-averaged'
+  StateMetLevEdge.fields:         'Met_CMFMC          ', 'GCHPchem',
+                                    'Met_PEDGE          ', 'GCHPchem',
+                                    'Met_PEDGEDRY       ', 'GCHPchem',
+                                    'Met_PFICU          ', 'GCHPchem',
+                                    'Met_PFILSAN        ', 'GCHPchem',
+                                    'Met_PFLCU          ', 'GCHPchem',
+                                    'Met_PFLLSAN        ', 'GCHPchem',
 ::

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.CO2
@@ -195,9 +195,9 @@ COLLECTIONS: 'Emissions',
   FV3Dynamics.frequency:      010000
   FV3Dynamics.duration:       010000
   FV3Dynamics.mode:           'time-averaged'
-  FV3Dynamics.fields:         'PLE    ', 'DYNAMICS',
-                              'DryPLE ', 'DYNAMICS',
-                              'PLEadv ', 'DYNAMICS',
+  FV3Dynamics.fields:         'PLE_R4    ', 'DYNAMICS',
+                              'DryPLE_R4 ', 'DYNAMICS',
+                              'PLEadv_R4 ', 'DYNAMICS',
 ::
 #==============================================================================
   GCHPctmEnvLevEdge.template:       '%y4%m2%d2_%h2%n2z.nc4',
@@ -207,11 +207,11 @@ COLLECTIONS: 'Emissions',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux    ', 'GCHPctmEnv',
-                                    'PLE0               ', 'GCHPctmEnv',
-                                    'PLE1               ', 'GCHPctmEnv',
-                                    'DryPLE0            ', 'GCHPctmEnv',
-                                    'DryPLE1            ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+                                    'PLE0_R4               ', 'GCHPctmEnv',
+                                    'PLE1_R4               ', 'GCHPctmEnv',
+                                    'DryPLE0_R4            ', 'GCHPctmEnv',
+                                    'DryPLE1_R4            ', 'GCHPctmEnv',
 ::
 #==============================================================================
   GCHPctmEnvLevCenter.template:       '%y4%m2%d2_%h2%n2z.nc4',
@@ -221,11 +221,11 @@ COLLECTIONS: 'Emissions',
   GCHPctmEnvLevCenter.frequency:      010000
   GCHPctmEnvLevCenter.duration:       010000
   GCHPctmEnvLevCenter.mode:           'time-averaged'
-  GCHPctmEnvLevCenter.fields:         'SPHU0    ', 'GCHPctmEnv',
-                                      'CX       ', 'GCHPctmEnv',
-                                      'CY       ', 'GCHPctmEnv',
-                                      'MFX      ', 'GCHPctmEnv',
-                                      'MFY      ', 'GCHPctmEnv',
+  GCHPctmEnvLevCenter.fields:         'SPHU0_R4    ', 'GCHPctmEnv',
+                                      'CX_R4       ', 'GCHPctmEnv',
+                                      'CY_R4       ', 'GCHPctmEnv',
+                                      'MFX_R4      ', 'GCHPctmEnv',
+                                      'MFY_R4      ', 'GCHPctmEnv',
 ::
 #==============================================================================
   LevelEdgeDiags.template:       '%y4%m2%d2_%h2%n2z.nc4',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -532,9 +532,9 @@ COLLECTIONS: 'Emissions',
   FV3Dynamics.frequency:      010000
   FV3Dynamics.duration:       010000
   FV3Dynamics.mode:           'time-averaged'
-  FV3Dynamics.fields:         'PLE    ', 'DYNAMICS',
-                              'DryPLE ', 'DYNAMICS',
-                              'PLEadv ', 'DYNAMICS',
+  FV3Dynamics.fields:         'PLE_R4    ', 'DYNAMICS',
+                              'DryPLE_R4 ', 'DYNAMICS',
+                              'PLEadv_R4 ', 'DYNAMICS',
 ::
 #==============================================================================
   GCHPctmEnvLevEdge.template:       '%y4%m2%d2_%h2%n2z.nc4',
@@ -544,11 +544,11 @@ COLLECTIONS: 'Emissions',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux    ', 'GCHPctmEnv',
-                                    'PLE0               ', 'GCHPctmEnv',
-                                    'PLE1               ', 'GCHPctmEnv',
-                                    'DryPLE0            ', 'GCHPctmEnv',
-                                    'DryPLE1            ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+                                    'PLE0_R4               ', 'GCHPctmEnv',
+                                    'PLE1_R4               ', 'GCHPctmEnv',
+                                    'DryPLE0_R4            ', 'GCHPctmEnv',
+                                    'DryPLE1_R4            ', 'GCHPctmEnv',
 ::
 #==============================================================================
   GCHPctmEnvLevCenter.template:       '%y4%m2%d2_%h2%n2z.nc4',
@@ -558,11 +558,11 @@ COLLECTIONS: 'Emissions',
   GCHPctmEnvLevCenter.frequency:      010000
   GCHPctmEnvLevCenter.duration:       010000
   GCHPctmEnvLevCenter.mode:           'time-averaged'
-  GCHPctmEnvLevCenter.fields:         'SPHU0    ', 'GCHPctmEnv',
-                                      'CX       ', 'GCHPctmEnv',
-                                      'CY       ', 'GCHPctmEnv',
-                                      'MFX      ', 'GCHPctmEnv',
-                                      'MFY      ', 'GCHPctmEnv',
+  GCHPctmEnvLevCenter.fields:         'SPHU0_R4    ', 'GCHPctmEnv',
+                                      'CX_R4       ', 'GCHPctmEnv',
+                                      'CY_R4       ', 'GCHPctmEnv',
+                                      'MFX_R4      ', 'GCHPctmEnv',
+                                      'MFY_R4      ', 'GCHPctmEnv',
 ::
 #==============================================================================
   LevelEdgeDiags.template:       '%y4%m2%d2_%h2%n2z.nc4',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -61,10 +61,10 @@ COLLECTIONS: 'Emissions',
              'FV3Dynamics',
              'GCHPctmEnvLevCenter',
              'GCHPctmEnvLevEdge',
-             'LevelEdgeDiags',      
              'RadioNuclide',
              'SpeciesConc',
              'StateMet',
+             'StateMetLevEdge',
              'WetLossConv',
              'WetLossLS',
 ::
@@ -565,23 +565,6 @@ COLLECTIONS: 'Emissions',
                                       'MFY_R4      ', 'GCHPctmEnv',
 ::
 #==============================================================================
-  LevelEdgeDiags.template:       '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.format:         'CFIO',
-  LevelEdgeDiags.timestampStart: .true.
-  LevelEdgeDiags.monthly:        1
-  LevelEdgeDiags.frequency:      010000
-  LevelEdgeDiags.duration:       010000
-  LevelEdgeDiags.mode:           'time-averaged'
-  LevelEdgeDiags.fields:    'Met_CMFMC          ', 'GCHPchem',
-                            'Met_PEDGE          ', 'GCHPchem',
-                            'Met_PEDGEDRY       ', 'GCHPchem',
-                            'Met_PFICU          ', 'GCHPchem',
-                            'Met_PFILSAN        ', 'GCHPchem',
-                            'Met_PFLCU          ', 'GCHPchem',
-                            'Met_PFLLSAN        ', 'GCHPchem',
-                            'UpwardsMassFlux    ', 'GCHPctmEnv',
-::
-#==============================================================================
   RadioNuclide.template:       '%y4%m2%d2_%h2%n2z.nc4',
   RadioNuclide.format:         'CFIO',
   RadioNuclide.timestampStart: .true.
@@ -715,6 +698,22 @@ COLLECTIONS: 'Emissions',
                             'Met_V              ', 'GCHPchem',
                             'Met_V10M           ', 'GCHPchem',
                             'Met_Z0             ', 'GCHPchem',
+::
+#==============================================================================
+  StateMetLevEdge.template:       '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.format:         'CFIO',
+  StateMetLevEdge.timestampStart: .true.
+  StateMetLevEdge.monthly:        1
+  StateMetLevEdge.frequency:      010000
+  StateMetLevEdge.duration:       010000
+  StateMetLevEdge.mode:           'time-averaged'
+  StateMetLevEdge.fields:         'Met_CMFMC          ', 'GCHPchem',
+                                  'Met_PEDGE          ', 'GCHPchem',
+                                  'Met_PEDGEDRY       ', 'GCHPchem',
+                                  'Met_PFICU          ', 'GCHPchem',
+                                  'Met_PFILSAN        ', 'GCHPchem',
+                                  'Met_PFLCU          ', 'GCHPchem',
+                                  'Met_PFLLSAN        ', 'GCHPchem',
 ::
 #==============================================================================
   WetLossConv.template:       '%y4%m2%d2_%h2%n2z.nc4',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -290,9 +290,9 @@ COLLECTIONS: 'Emissions',
   FV3Dynamics.frequency:      010000
   FV3Dynamics.duration:       010000
   FV3Dynamics.mode:           'time-averaged'
-  FV3Dynamics.fields:         'PLE    ', 'DYNAMICS',
-                              'DryPLE ', 'DYNAMICS',
-                              'PLEadv ', 'DYNAMICS',
+  FV3Dynamics.fields:         'PLE_R4    ', 'DYNAMICS',
+                              'DryPLE_R4 ', 'DYNAMICS',
+                              'PLEadv_R4 ', 'DYNAMICS',
 ::
 #==============================================================================
   GCHPctmEnvLevEdge.template:       '%y4%m2%d2_%h2%n2z.nc4',
@@ -302,11 +302,11 @@ COLLECTIONS: 'Emissions',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux    ', 'GCHPctmEnv',
-                                    'PLE0               ', 'GCHPctmEnv',
-                                    'PLE1               ', 'GCHPctmEnv',
-                                    'DryPLE0            ', 'GCHPctmEnv',
-                                    'DryPLE1            ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+                                    'PLE0_R4               ', 'GCHPctmEnv',
+                                    'PLE1_R4               ', 'GCHPctmEnv',
+                                    'DryPLE0_R4            ', 'GCHPctmEnv',
+                                    'DryPLE1_R4            ', 'GCHPctmEnv',
 ::
 #==============================================================================
   GCHPctmEnvLevCenter.template:       '%y4%m2%d2_%h2%n2z.nc4',
@@ -316,11 +316,11 @@ COLLECTIONS: 'Emissions',
   GCHPctmEnvLevCenter.frequency:      010000
   GCHPctmEnvLevCenter.duration:       010000
   GCHPctmEnvLevCenter.mode:           'time-averaged'
-  GCHPctmEnvLevCenter.fields:         'SPHU0    ', 'GCHPctmEnv',
-                                      'CX       ', 'GCHPctmEnv',
-                                      'CY       ', 'GCHPctmEnv',
-                                      'MFX      ', 'GCHPctmEnv',
-                                      'MFY      ', 'GCHPctmEnv',
+  GCHPctmEnvLevCenter.fields:         'SPHU0_R4    ', 'GCHPctmEnv',
+                                      'CX_R4       ', 'GCHPctmEnv',
+                                      'CY_R4       ', 'GCHPctmEnv',
+                                      'MFX_R4      ', 'GCHPctmEnv',
+                                      'MFY_R4      ', 'GCHPctmEnv',
 ::
 #==============================================================================
 # Diagnostics on level edges

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -63,10 +63,10 @@ COLLECTIONS: 'Emissions',
              #'GCHPctmEnvLevCenter',
              #'GCHPctmEnvLevEdge',
              #'KppDiags',
-             #'LevelEdgeDiags',
              #'RxnConst',
              #'RxnRates',
              'StateMet',
+             #'StateMetLevEdge',
 ::
 #==============================================================================
 # Define collections
@@ -323,23 +323,6 @@ COLLECTIONS: 'Emissions',
                                       'MFY_R4      ', 'GCHPctmEnv',
 ::
 #==============================================================================
-# Diagnostics on level edges
-  LevelEdgeDiags.template:       '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.format:         'CFIO',
-  LevelEdgeDiags.timestampStart: .true.
-  LevelEdgeDiags.monthly:        1
-  LevelEdgeDiags.frequency:      010000
-  LevelEdgeDiags.duration:       010000
-  LevelEdgeDiags.mode:           'time-averaged'
-  LevelEdgeDiags.fields:         'Met_CMFMC   ', 'GCHPchem',
-                                 'Met_PEDGE   ', 'GCHPchem',
-                                 'Met_PEDGEDRY', 'GCHPchem',
-                                 'Met_PFICU   ', 'GCHPchem',
-                                 'Met_PFILSAN ', 'GCHPchem',
-                                 'Met_PFLCU   ', 'GCHPchem',
-                                 'Met_PFLLSAN ', 'GCHPchem',
-::
-#==============================================================================
   KppDiags.template:          '%y4%m2%d2_%h2%n2z.nc4',
   KppDiags.format:            'CFIO',
   KppDiags.monthly:           1
@@ -465,4 +448,20 @@ COLLECTIONS: 'Emissions',
                            'Met_V          ', 'GCHPchem',
                            'Met_V10M       ', 'GCHPchem',
                            'Met_Z0         ', 'GCHPchem',
+::
+#==============================================================================
+  StateMetLevEdge.template:       '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.format:         'CFIO',
+  StateMetLevEdge.timestampStart: .true.
+  StateMetLevEdge.monthly:        1
+  StateMetLevEdge.frequency:      010000
+  StateMetLevEdge.duration:       010000
+  StateMetLevEdge.mode:           'time-averaged'
+  StateMetLevEdge.fields:         'Met_CMFMC   ', 'GCHPchem',
+                                 'Met_PEDGE   ', 'GCHPchem',
+                                 'Met_PEDGEDRY', 'GCHPchem',
+                                 'Met_PFICU   ', 'GCHPchem',
+                                 'Met_PFILSAN ', 'GCHPchem',
+                                 'Met_PFLCU   ', 'GCHPchem',
+                                 'Met_PFLLSAN ', 'GCHPchem',
 ::

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -74,7 +74,6 @@ COLLECTIONS: @#'DefaultCollection',
              #'Metrics',
              @#'KppDiags',
              @#'KppARDiags',
-             @#'LevelEdgeDiags',
              @#'ProdLoss',
              @##'RRTMG',
              @##'DynHeating',
@@ -83,6 +82,7 @@ COLLECTIONS: @#'DefaultCollection',
              #'SpeciesConc',
              @#'StateChm',
              #'StateMet',
+             @#'StateMetLevEdge',
              @#'StratBM',
              @##'Tomas',
              @#'UVFlux',
@@ -1448,30 +1448,6 @@ COLLECTIONS: @#'DefaultCollection',
                               'OHwgtByAirMassColumnFull    ', 'GCHPchem',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:       '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.format:         'CFIO',
-  LevelEdgeDiags.timestampStart: .true.
-  LevelEdgeDiags.monthly:        1
-  LevelEdgeDiags.frequency:      010000
-  LevelEdgeDiags.duration:       010000
-  LevelEdgeDiags.mode:           'time-averaged'
-  LevelEdgeDiags.fields:         'Met_CMFMC                     ', 'GCHPchem',
-                                 'Met_PEDGE                     ', 'GCHPchem',
-                                 'Met_PEDGEDRY                  ', 'GCHPchem',
-                                 'Met_PFICU                     ', 'GCHPchem',
-                                 'Met_PFILSAN                   ', 'GCHPchem',
-                                 'Met_PFLCU                     ', 'GCHPchem',
-                                 'Met_PFLLSAN                   ', 'GCHPchem',
-                                 'UpwardsMassFlux               ', 'GCHPctmEnv',
-
-::
-#==============================================================================
 # %%%%% THE ProdLoss COLLECTION %%%%%
 #
 # Chemical production and loss rates
@@ -2188,7 +2164,7 @@ COLLECTIONS: @#'DefaultCollection',
 #==============================================================================
 # %%%%% The StateMet time-averaged COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -2280,6 +2256,28 @@ COLLECTIONS: @#'DefaultCollection',
                       #'Met_V10M            ', 'GCHPchem',
                       #'Met_Z0              ', 'GCHPchem',
                       #'FracOfTimeInTrop    ', 'GCHPchem',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# State_Met arrays that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:       '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.format:         'CFIO',
+  StateMetLevEdge.timestampStart: .true.
+  StateMetLevEdge.monthly:        1
+  StateMetLevEdge.frequency:      010000
+  StateMetLevEdge.duration:       010000
+  StateMetLevEdge.mode:           'time-averaged'
+  StateMetLevEdge.fields:         'Met_CMFMC                     ', 'GCHPchem',
+                                  'Met_PEDGE                     ', 'GCHPchem',
+                                  'Met_PEDGEDRY                  ', 'GCHPchem',
+                                  'Met_PFICU                     ', 'GCHPchem',
+                                  'Met_PFILSAN                   ', 'GCHPchem',
+                                  'Met_PFLCU                     ', 'GCHPchem',
+                                  'Met_PFLLSAN                   ', 'GCHPchem',
 ::
 #==============================================================================
 # %%%%% THE StratBM COLLECTION %%%%%

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -614,9 +614,9 @@ COLLECTIONS: @#'DefaultCollection',
   FV3Dynamics.frequency:      010000
   FV3Dynamics.duration:       010000
   FV3Dynamics.mode:           'time-averaged'
-  FV3Dynamics.fields:         'PLE    ', 'DYNAMICS',
-                              'DryPLE ', 'DYNAMICS',
-                              'PLEadv ', 'DYNAMICS',
+  FV3Dynamics.fields:         'PLE_R4    ', 'DYNAMICS',
+                              'DryPLE_R4 ', 'DYNAMICS',
+                              'PLEadv_R4 ', 'DYNAMICS',
 ::
 #==============================================================================
   GCHPctmEnvLevEdge.template:       '%y4%m2%d2_%h2%n2z.nc4',
@@ -626,11 +626,11 @@ COLLECTIONS: @#'DefaultCollection',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux    ', 'GCHPctmEnv',
-                                    'PLE0               ', 'GCHPctmEnv',
-                                    'PLE1               ', 'GCHPctmEnv',
-                                    'DryPLE0            ', 'GCHPctmEnv',
-                                    'DryPLE1            ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+                                    'PLE0_R4               ', 'GCHPctmEnv',
+                                    'PLE1_R4               ', 'GCHPctmEnv',
+                                    'DryPLE0_R4            ', 'GCHPctmEnv',
+                                    'DryPLE1_R4            ', 'GCHPctmEnv',
 ::
 #==============================================================================
   GCHPctmEnvLevCenter.template:       '%y4%m2%d2_%h2%n2z.nc4',
@@ -640,11 +640,11 @@ COLLECTIONS: @#'DefaultCollection',
   GCHPctmEnvLevCenter.frequency:      010000
   GCHPctmEnvLevCenter.duration:       010000
   GCHPctmEnvLevCenter.mode:           'time-averaged'
-  GCHPctmEnvLevCenter.fields:         'SPHU0    ', 'GCHPctmEnv',
-                                      'CX       ', 'GCHPctmEnv',
-                                      'CY       ', 'GCHPctmEnv',
-                                      'MFX      ', 'GCHPctmEnv',
-                                      'MFY      ', 'GCHPctmEnv',
+  GCHPctmEnvLevCenter.fields:         'SPHU0_R4    ', 'GCHPctmEnv',
+                                      'CX_R4       ', 'GCHPctmEnv',
+                                      'CY_R4       ', 'GCHPctmEnv',
+                                      'MFX_R4      ', 'GCHPctmEnv',
+                                      'MFY_R4      ', 'GCHPctmEnv',
 ::
 #==============================================================================
 # %%%%% THE AerosolMass COLLECTION %%%%%

--- a/run/GCHP/logging.yml
+++ b/run/GCHP/logging.yml
@@ -88,7 +88,13 @@ loggers:
        handlers: [mpi_shared]
        level: WARNING
        root_level: WARNING
-       
+
+   MAPL.profiler:
+       handlers: [mpi_shared]
+       propagate: FALSE
+       level: WARNING
+       root_level: INFO
+
    CAP.EXTDATA:
        handlers: [mpi_shared]
        level: WARNING

--- a/run/GCHP/runScriptSamples/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/gchp.batch_job.sh
@@ -89,11 +89,11 @@
 #
 # ADDITIONAL PRE-RUN CONFIGURATION
 #
-# If a subsequent command fails, treat it as fatal (don't continue)
+# If a subsequent command fails, treat it as fatal (don't continue) (for debugging)
 set -e
 
-# For remainder of script, echo commands to the job's log file
-set -x
+# For remainder of script, echo commands to the job's log file (for debugging)
+#set -x
 
 # Unlimit resources to prevent OS killing GCHP due to resource usage/
 # Alternatively you can put this in your environment file.
@@ -118,6 +118,9 @@ log=gchp.${start_str:0:13}z.log
 source setCommonRunSettings.sh
 source setRestartLink.sh
 source checkRunSettings.sh
+
+# Turn off exit if command fails to allow script to finish if GCHP exits early
+set +e
 
 #################################################################
 #

--- a/run/GCHP/runScriptSamples/gchp.local.run
+++ b/run/GCHP/runScriptSamples/gchp.local.run
@@ -29,6 +29,9 @@ source checkRunSettings.sh 2>&1 | tee ${log}
 # Run GCHP with # processors specified in config file setCommonRunSettings.sh
 nCores=$( grep -oP 'TOTAL_CORES=\s*\K\d+' setCommonRunSettings.sh )
 
+# Turn off exit if command fails to allow script to finish if GCHP exits early
+set +e
+
 #--------------------------------------------------
 # Edit this line to run GCHP on your system
 #--------------------------------------------------

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.run
@@ -55,6 +55,10 @@ planeCount=$(( ${coreCount} / ${SLURM_NNODES} ))
 if [[ $(( ${coreCount} % ${SLURM_NNODES} )) > 0 ]]; then
     planeCount=$(( ${planeCount} + 1 ))
 fi
+
+# Turn off exit if command fails to allow script to finish if GCHP exits early
+set +e
+
 time srun -n ${coreCount} -N ${SLURM_NNODES} -m plane=${planeCount} --mpi=pmix ./gchp >> ${log}
 
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds

--- a/run/GCHP/runScriptSamples/operational_examples/icl_rcshpc/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/icl_rcshpc/gchp.run
@@ -19,8 +19,11 @@ ulimit -u 50000              # maxproc
 ulimit -v unlimited          # vmemoryuse
 ulimit -s unlimited          # stacksize
 
-# Exit if command fails, and log all commands
-set -xe
+# Exit if command fails
+set -e
+
+# Debug option to print all commands executed in this script
+#set -x
 
 # Define log name to include simulation start date
 start_str=$(sed 's/ /_/g' cap_restart)
@@ -32,6 +35,9 @@ source setCommonRunSettings.sh > ${log}
 source setRestartLink.sh >> ${log}
 source gchp.env >> ${log}
 source checkRunSettings.sh >> ${log}
+
+# Turn off exit if command fails to allow script to finish if GCHP exits early
+set +e
 
 # Run the code
 mpirun ./gchp >> $log

--- a/run/GCHP/runScriptSamples/operational_examples/msu_orion/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/msu_orion/gchp.run
@@ -47,6 +47,10 @@ planeCount=$(( ${coreCount} / ${SLURM_NNODES} ))
 if [[ $(( ${coreCount} % ${SLURM_NNODES} )) > 0 ]]; then
     planeCount=$(( ${planeCount} + 1 ))
 fi
+
+# Turn off exit if command fails to allow script to finish if GCHP exits early
+set +e
+
 time srun -n ${coreCount} -N ${SLURM_NNODES} -m plane=${planeCount} ./gchp >> ${log}
 
 # Rename mid-run checkpoint files, if any. Discard file if time corresponds

--- a/run/GCHP/runScriptSamples/operational_examples/nasa_discover/gchp.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nasa_discover/gchp.run
@@ -47,6 +47,9 @@ if [[ $(( ${coreCount} % ${SLURM_NNODES} )) > 0 ]]; then
         ${planeCount}=$(( ${planeCount} + 1 ))
 fi
 
+# Turn off exit if command fails to allow script to finish if GCHP exits early
+set +e
+
 mpirun -np ${coreCount} ./gchp >> ${log}
 
 # If new start time in cap_restart is okay, rename restart file

--- a/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nasa_pleiades/gchp.pleiades.run
@@ -62,6 +62,9 @@ echo "-m plane  : ${planeCount}" >> ${log}
 echo ' ' >> ${log}
 echo '===> Run started at' `date` >> ${log}
 
+# Turn off exit if command fails to allow script to finish if GCHP exits early
+set +e
+
 mpiexec -n $coreCount ./gchp >> $log 2>&1 &
 tail --pid=$! -f $log
 #mpiexec dplace -s1 -c 4-11 ./grinder < run_input > output

--- a/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
+++ b/run/GCHP/runScriptSamples/operational_examples/nci_gadi/gchp.pbs.run
@@ -33,6 +33,9 @@ source setRestartLink.sh >> ${log}
 source gchp.env >> ${log}
 source checkRunSettings.sh >> ${log}
 
+# Turn off exit if command fails to allow script to finish if GCHP exits early
+set +e
+
 # Run the code
 mpirun ./gchp >> $log
 

--- a/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/c360_requeuing.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/c360_requeuing.sh
@@ -31,7 +31,7 @@ function last_checkpoint_date() {
 }
 
 # Set up runtime environment
-set -x                           # Print executed commands
+#set -x                          # Print executed commands (optional debugging)
 ulimit -c 0                      # coredumpsize
 ulimit -l unlimited              # memorylocked
 ulimit -u 50000                  # maxproc

--- a/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/wustl_compute1/gchp.batch_job.sh
@@ -49,6 +49,9 @@ source setCommonRunSettings.sh
 source setRestartLink.sh
 source checkRunSettings.sh
 
+# Turn off exit if command fails to allow script to finish if GCHP exits early
+set +e
+
 #################################################################
 #
 # LAUNCH GCHP 

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -101,13 +101,13 @@ Diag_Collections=(SpeciesConc    \
                   JValues        \
                   KppDiags       \
                   KppARDiags     \
-                  LevelEdgeDiags \
                   Metrics        \
                   ProdLoss       \
                   RadioNuclide   \
                   RRTMG 	 \
                   StateChm	 \
                   StateMet       \
+                  StateMetLevEdge \
                   StratBM        \
                   Tomas          \
                   Transport	 \

--- a/run/GEOS/TransportTracers/HISTORY.rc
+++ b/run/GEOS/TransportTracers/HISTORY.rc
@@ -8,10 +8,10 @@ COLLECTIONS: 'Emissions',
              'Budget',
              'CloudConvFlux',
              'DryDep',
-             #'LevelEdgeDiags',
              'RadioNuclide',
              'SpeciesConc',
              'StateMet',
+             'StateMetLevEdge',
              'WetLossConv',
              'WetLossLS',
              #'geosgcm_prog'
@@ -1741,22 +1741,6 @@ PC360x181-DC.LM: 72
                            'DryDepVel_Be10s  ', 'GEOSCHEMCHEM',
 ::
 #==============================================================================
-  LevelEdgeDiags.template:       '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.format:         'CFIO',
-  LevelEdgeDiags.timestampStart: .true.
-  LevelEdgeDiags.monthly:        1
-  LevelEdgeDiags.frequency:      010000
-  LevelEdgeDiags.duration:       010000
-  LevelEdgeDiags.mode:           'time-averaged'
-  LevelEdgeDiags.fields:    'Met_CMFMC          ', 'GEOSCHEMCHEM',
-                            'Met_PEDGE          ', 'GEOSCHEMCHEM',
-                            'Met_PEDGEDRY       ', 'GEOSCHEMCHEM',
-                            'Met_PFICU          ', 'GEOSCHEMCHEM',
-                            'Met_PFILSAN        ', 'GEOSCHEMCHEM',
-                            'Met_PFLCU          ', 'GEOSCHEMCHEM',
-                            'Met_PFLLSAN        ', 'GEOSCHEMCHEM',
-::
-#==============================================================================
   RadioNuclide.template:       '%y4%m2%d2_%h2%n2z.nc4',
   RadioNuclide.format:         'CFIO',
   RadioNuclide.timestampStart: .true.
@@ -1890,6 +1874,22 @@ PC360x181-DC.LM: 72
                             'Met_V              ', 'GEOSCHEMCHEM',
                             'Met_V10M           ', 'GEOSCHEMCHEM',
                             'Met_Z0             ', 'GEOSCHEMCHEM',
+::
+#==============================================================================
+  StateMetLevEdge.template:       '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.format:         'CFIO',
+  StateMetLevEdge.timestampStart: .true.
+  StateMetLevEdge.monthly:        1
+  StateMetLevEdge.frequency:      010000
+  StateMetLevEdge.duration:       010000
+  StateMetLevEdge.mode:           'time-averaged'
+  StateMetLevEdge.fields:    'Met_CMFMC          ', 'GEOSCHEMCHEM',
+                             'Met_PEDGE          ', 'GEOSCHEMCHEM',
+                             'Met_PEDGEDRY       ', 'GEOSCHEMCHEM',
+                             'Met_PFICU          ', 'GEOSCHEMCHEM',
+                             'Met_PFILSAN        ', 'GEOSCHEMCHEM',
+                             'Met_PFLCU          ', 'GEOSCHEMCHEM',
+                             'Met_PFLLSAN        ', 'GEOSCHEMCHEM',
 ::
 #==============================================================================
   WetLossConv.template:       '%y4%m2%d2_%h2%n2z.nc4',

--- a/run/WRF/co2/HISTORY.rc
+++ b/run/WRF/co2/HISTORY.rc
@@ -31,8 +31,8 @@ COLLECTIONS: 'CO2',
              'SpeciesConc',
              #'Budget',
              #'CloudConvFlux',
-             #'LevelEdgeDiags',      
              #'StateMet',
+             #'StateMetLevEdge',
              #'BoundaryConditions',
 ::
 ###############################################################################
@@ -117,21 +117,21 @@ COLLECTIONS: 'CO2',
   CloudConvFlux.fields:       'CloudConvFlux_?ADV?           ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
 #
 # Diagnostics that are defined on grid box level edges
 #
 # Available for all simulations
 #==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   00000000 010000,
-  LevelEdgeDiags.duration:    00000000 120000,
-  LevelEdgeDiags.mode:        'time-averaged'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   00000000 010000,
+  StateMetLevEdge.duration:    00000000 120000,
+  StateMetLevEdge.mode:        'time-averaged'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::

--- a/run/WRF/fullchem/HISTORY.rc
+++ b/run/WRF/fullchem/HISTORY.rc
@@ -37,10 +37,10 @@ COLLECTIONS: 'SpeciesConc',
              #'DryDep',
              #'JValues',
              'KppDiags',
-             #'LevelEdgeDiags',      
              #'ProdLoss',
              #'StateChm',     
-             #'StateMet',      
+             #'StateMet',
+             #'StateMetLevEdge',
              #'WetLossConv',
              #'WetLossLS',
 ::
@@ -298,25 +298,6 @@ COLLECTIONS: 'SpeciesConc',
   KppDiags.fields:        'KppError                  ',
 ::
 #==============================================================================
-# %%%%% THE LevelEdgeDiags COLLECTION %%%%%
-#
-# Diagnostics that are defined on grid box level edges
-#
-# Available for all simulations
-#==============================================================================
-  LevelEdgeDiags.template:    '%y4%m2%d2_%h2%n2z.nc4',
-  LevelEdgeDiags.frequency:   00000000 010000,
-  LevelEdgeDiags.duration:    00000000 120000,
-  LevelEdgeDiags.mode:        'instantaneous'
-  LevelEdgeDiags.fields:      'Met_CMFMC                     ',
-                              'Met_PEDGE                     ',
-                              'Met_PEDGEDRY                  ',
-                              'Met_PFICU                     ',
-                              'Met_PFILSAN                   ',
-                              'Met_PFLCU                     ',
-                              'Met_PFLLSAN                   ',
-::
-#==============================================================================
 # %%%%% THE ProdLoss COLLECTION %%%%%
 #
 # Chemical production and loss rates
@@ -378,7 +359,7 @@ COLLECTIONS: 'SpeciesConc',
 #==============================================================================
 # %%%%% The StateMet COLLECTION %%%%%
 #
-# Fields of the State_Met object (also see the LevelEdgeDiags collection)
+# Fields of the State_Met object (also see the StateMetLevEdge collection)
 #
 # Available for all simulations
 #==============================================================================
@@ -387,6 +368,25 @@ COLLECTIONS: 'SpeciesConc',
   StateMet.duration:          00000000 120000,
   StateMet.mode:              'instantaneous'
   StateMet.fields:            'Met_AD                        ',
+::
+#==============================================================================
+# %%%%% THE StateMetLevEdge COLLECTION %%%%%
+#
+# Diagnostics that are defined on grid box level edges
+#
+# Available for all simulations
+#==============================================================================
+  StateMetLevEdge.template:    '%y4%m2%d2_%h2%n2z.nc4',
+  StateMetLevEdge.frequency:   00000000 010000,
+  StateMetLevEdge.duration:    00000000 120000,
+  StateMetLevEdge.mode:        'instantaneous'
+  StateMetLevEdge.fields:      'Met_CMFMC                     ',
+                               'Met_PEDGE                     ',
+                               'Met_PEDGEDRY                  ',
+                               'Met_PFICU                     ',
+                               'Met_PFILSAN                   ',
+                               'Met_PFLCU                     ',
+                               'Met_PFLLSAN                   ',
 ::
 #==============================================================================
 # %%%%% THE WetLossConv COLLECTION %%%%%

--- a/test/integration/GCHP/integrationTestExecute.sh
+++ b/test/integration/GCHP/integrationTestExecute.sh
@@ -248,10 +248,13 @@ for runDir in *; do
 		mpirun -n 24 ./${exeFile} >> "${log}" 2>&1
             fi
 
-            # Update pass/failed counts and write to results.log
-            if [[ $? -eq 0 ]]; then
+	    # Determine if pass or fail based on if timer info printed to allPEs.log
+            timerReport=$(grep "MAPL.profiler.*All" allPEs.log || echo "missing")
 
-		# The run passed ...
+            # Update pass/failed counts and write to results.log
+            if [[ "${timerReport}" != "missing" ]]; then
+
+		# TimerReport is not missing. Test passed.
                 let passed++
                 print_to_log "${passMsg}" "${results}"
 
@@ -262,7 +265,7 @@ for runDir in *; do
 		   Restarts/GEOSChem.Restart.${new_start_str:0:13}z.c${N}.nc4
             else
 
-		# The run failed
+		# TimerReport is missing. Test failed.
                 let failed++
                 print_to_log "${failMsg}" "${results}"
 


### PR DESCRIPTION
This update requires corresponding updates in GCHP and FV3 repositories to define REAL4 exports. 

### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

**IMPORTANT NOTE:** The minimum ESMF version that works with MAPL 2.59 is ESMF 8.6.1. 

This PR contains assorted changes related to updating GCHP from MAPL 2.26 to MAPL 2.59 Changes are as follows:

1. Timer info for GCHP is now printed to `allPEs.log` rather than the main GCHP log. This is because time info print is now handled by package `PFLogger` in the newer version of MAPL.
2. This PR changes the names of the `GCHPctmEnv` and `DYNAMICS` diagnostic names in `HISTORY.rc`. It is necessary to bypass a MAPL 2.59 bug in which automatic R8->R4 conversion in MAPL History is broken. Additional PRs in `GCHP` and `FVdycoreCubed_GridComp` repos add REAL4 exports with the new name. The update is temporary until a fix is added to MAPL in the future such that we can simply use the names of the existing REAL8 exports again as we did using MAPL 2.26.
3. This PR also renames the `LevelEdgeDiags` diagnostic collection to be more descriptive. The new name is `StateMetLevEdge`. This reflects that the only diagnostics included are meteorology. It impacts both GCHP and GC-Classic run directories.
4. All GCHP run script examples are changed to remove the default printing of run commands to the job's log file. The setting (`set -x`) is kept commented out for debugging.
5. All GCHP run script examples are changed to unset exit upon command failure (`unset -e`) just before running the `gchp` executable. MAPL 2.59 fails on some systems during MPI finalize which triggers the run script to stop executing if exit upon command is enabled. This failure is benign but early exit of the run script is a problem. The run script must go to completion in order to properly rename the restart files at the end of the run. Unsetting exit upon command failure fixes the problem. It remains set earlier in the run script to stop the run if there is a problem setting the restart file link or calling `setCommonRunSettings.sh`.
6. The GCHP integration test execute script is changed to determine if a run passed or failed based on if timer info is printed to log. Previously the criteria was based on run exit code. This is no longer possible because MAPL fails during MPI finalize, a benign bug in the new version of MAPL that is not yet fixed.

### Expected changes

The names of some of the `GCHPctmEnv` and `DYNAMICS` (FV3) advection diagnostics will be different in the output files. It will not impact benchmarking.

For GCHP stretched grid runs the stretch parameters in the output global attributes will be different than before. Instead of `stretch_factor`, `target_longitude`, and `target_latitude`, they will be `STRETCH_FACTOR`, `TARGET_LON`, and `TARGET_LAT`, matching what is in the restart file. 

### Reference(s)

None

### Related Github Issue

MAPL issue: https://github.com/GEOS-ESM/MAPL/issues/3747

**Concurrent PRs required:**
See PRs listed at https://github.com/geoschem/GCHP/pull/496
