### PR TITLE
Restore unit conversion for boundary conditions from mol/mol to kg/kg dry air

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Modified `ObsPack/obspack_mod.F90` to use GEOS-Chem surface geopotential height (`PHIS`) for selecting model layer for comparison to obspack.
 
+### Fixed
+- Restored unit convertion for boundary conditions from mol/mol to kg/kg dry air
+
 ## [14.6.1] - 2025-05-27
 ### Added
 - Added `#InvCEDSshipALK6`, `#InvCEDS_TMB`, and `#InvCEDSship_TMB` (commented out by default) to `HEMCO_Diagn*` and GCHP `HISTORY.rc.fullchem` files

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -2446,6 +2446,7 @@ CONTAINS
    CHARACTER(LEN=255)   :: LOC                ! routine location
    CHARACTER(LEN=255)   :: MSG                ! message
    CHARACTER(LEN=255)   :: v_name_in_hemco    ! variable name
+   REAL(fp)             :: MW_g               ! species molecular weight
    CHARACTER(LEN=16)    :: STAMP
 
    ! Temporary arrays and pointers
@@ -2506,6 +2507,7 @@ CONTAINS
 
       ! Get info about this species from the species database
       SpcInfo => State_Chm%SpcData(N)%Info
+      MW_g    =  SpcInfo%MW_g
 
       ! Define variable name
       v_name_in_hemco = 'BC_' // TRIM( SpcInfo%Name )
@@ -2532,8 +2534,9 @@ CONTAINS
             ENDIF
          ENDIF
 
-         ! Copy data from file to State_Chm%BoundaryCond [mol/mol]
-         State_Chm%BoundaryCond(:,:,:,N) = Ptr3D(:,:,:)
+         ! Copy data from file to State_Chm%BoundaryCond
+         ! and convert from [mol/mol] to [kg/kg dry]
+         State_Chm%BoundaryCond(:,:,:,N) = Ptr3D(:,:,:) * MW_g / AIRMW
 
          ! Debug
          ! Print*, 'BCs found for ', TRIM( SpcInfo%Name ), &


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard University

### Describe the update

In PR #2521 the unit conversion of boundary conditions from mol/mol to kg/kg dry air was removed from routine Get_Boundary_Conditions (GeosCore/hco_utilities_gc_mod.F90). However, when applying boundary conditions in GeosCore/set_boundary_conditions_mod.F90, the expected units are kg/kg dry air. The mismatch in units causes much higher than expected values applied along the boundaries of nested-grid simulations.

This bug fix restores the unit conversion so that State_Chm%BoundaryCond is in the correct units (kg/kg dry).

### Expected changes

This is a zero-difference update with respect to the full-chemistry benchmark simulation. It will impact nested-grid simulations by restoring boundary conditions to the proper units before applying to the boundaries of the nested domain.

### Related Github Issue

- https://github.com/geoschem/geos-chem/issues/2890