### PR TITLE
Fix several additional issues in the ObsPack diagnostic 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Assigned ObsPack averaging interval end times (instead of start times) to the `aveEnd` variable in routine `ObsPack_Write_Output`
+- Fixed logic in `Obspack_Sample` to include observations whose averaging windows span a UTC date boundary
 
 ## [14.6.1] - 2025-05-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Added
+- Added error check to exclude sampling ObsPack observations located outside of a nested-grid domain
+
+### Changed
+- Updated logic to include ObsPack observations that span UTC date boundaries
+- Assigned ObsPack averaging interval end times (instead of start times) to the `aveEnd` variable in routine `ObsPack_Write_Output`
+
 ## [14.6.2] - 2025-06-11
 ### Added
 - Added MCHgMAP geogenic emissions (2010-2020) from Dastoor et al. (2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Restored unit convertion for boundary conditions from mol/mol to kg/kg dry air
 
+### Fixed
+- Assigned ObsPack averaging interval end times (instead of start times) to the `aveEnd` variable in routine `ObsPack_Write_Output`
+
 ## [14.6.1] - 2025-05-27
 ### Added
 - Added `#InvCEDSshipALK6`, `#InvCEDS_TMB`, and `#InvCEDSship_TMB` (commented out by default) to `HEMCO_Diagn*` and GCHP `HISTORY.rc.fullchem` files

--- a/ObsPack/obspack_mod.F90
+++ b/ObsPack/obspack_mod.F90
@@ -527,7 +527,7 @@ CONTAINS
        !-----------------------
        ! Test for valid data
        !-----------------------
-       IF ( State_Diag%ObsPack_Longitude(N) <   - 180.0_f4 .or.              &
+       IF ( State_Diag%ObsPack_Longitude(N) <    -180.0_f4 .or.              &
             State_Diag%ObsPack_Longitude(N) >     180.0_f4 .or.              &
             State_Diag%ObsPack_Latitude(N)  <     -90.0_f4 .or.              &
             State_Diag%ObsPack_Latitude(N)  >      90.0_f4 .or.              &
@@ -605,7 +605,6 @@ CONTAINS
 
              State_Diag%ObsPack_Ival_End(N) =                                &
                   State_Diag%ObsPack_Ival_center(N)    + 1800.0_f8
-
 
           !------------------
           ! 90-minute window
@@ -948,7 +947,7 @@ CONTAINS
     ALLOCATE( aveEnd( nObs ), STAT=RC )
     CALL GC_CheckVar( 'obspack_mod.F90:aveEnd', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
-    aveEnd = State_Diag%ObsPack_Ival_Start
+    aveEnd = State_Diag%ObsPack_Ival_End
 
     ! Compute averaging interval
     ALLOCATE( aveTime( nObs ), STAT=RC )
@@ -1298,7 +1297,7 @@ CONTAINS
     USE State_Grid_Mod, ONLY : GrdState
     USE State_Met_Mod,  ONLY : MetState
     USE Time_Mod,       ONLY : Ymd_Extract
-    USE Timers_Mod,     ONLY : Timer_End, Timer_Start
+    USE Timers_Mod,     ONLY : Timer_End,   Timer_Start
     USE UnitConv_Mod,   ONLY : Check_Units, MOLES_SPECIES_PER_MOLES_DRY_AIR
 !
 ! !INPUT PARAMETERS:
@@ -1378,7 +1377,7 @@ CONTAINS
     ENDIF
 
     !=======================================================================
-    ! Sample the GEOS-CHem data corresponding to this location & time
+    ! Sample the GEOS-Chem data corresponding to this location & time
     !=======================================================================
 
     ! Extract date and time into components


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR adds the following fixes for the GEOS-Chem ObsPack diagnostic

1. In routine `ObsPack_Write_Output`, we now assign averaging interval end times to variable `aveEnd` (instead of the averaging interval start times, which was a bug).

2. In routine `ObsPack_Sample`, we have adjusted the logic to include observations whose averaging windows span UTC date boundaries.  We also set the end of the averaging interval for these observations to the Unix time (seconds since 1970) at the end of the current date.
   - NOTE: This only accounts for the fraction of the averaging window that lies within the current UTC date.  We as yet have not figured out a way to apply the fraction of the averaging window lying in the next UTC date to the next UTC date's ObsPack diagnostic output.  This is an edge case that would involve more complex coding and as such we are deferring this to a later time.

3. In routine `ObsPack_Get_Indices`, we now test if the longitude and/or latitude of Obspack observations lie within a nested-grid domain before including them in the sampling.

4. In routine `ObsPack_Sample`, we no longer print verbose output for observations lying outside of a nested-grid domain, as these have been excluded from the sampling.

### Expected changes
This is a no-diff-to-benchmark update that only applies to ObsPack diagnostic output.  Specific changes are:
1. The correct averaging interval end times will be written to the ObsPack netCDF files.
2. Observations near the end of a UTC date should now be accounted for in the ObsPack diagnostic output for that date.
3. Out-of-bounds errors should be avoided when using ObsPack in nested-grid simulations.
4. ditto
 
### Related Github Issue
- Closes #2897
- Closes #2881 

Tagging @aschuh @laestrada @eastjames @jhaskinsPhD 