### PR TITLE
Fix for GEOS-Chem Classic compilation issue with GNU 14 compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Added missing 3rd element in assigment of `Item%NcChunkSizes` in `History/histitem_mod.F90`
+
 ## [14.6.2] - 2025-06-11
 ### Added
 - Added MCHgMAP geogenic emissions (2010-2020) from Dastoor et al. (2025)

--- a/History/histitem_mod.F90
+++ b/History/histitem_mod.F90
@@ -697,7 +697,7 @@ CONTAINS
                 CASE( 'xy' )
                    Item%NcChunkSizes = (/ Dims(1), Dims(2), 1 /)   ! xy
                 CASE( 'bx', 'by' )
-                   Item%NcChunkSizes = (/ Dims(1), 1          /)   ! bx, by
+                   Item%NcChunkSizes = (/ Dims(1), 1,       1 /)   ! bx, by
                 CASE DEFAULT
                    Item%NcChunkSizes = (/ Dims(1), 1,       1 /)   ! xz or yz
              END SELECT


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This update fixes a bug in `History/histitem_mod.F90` that prevents GEOS-Chem Classic from being compiled with the GNU 14 (and probably also GNU 13) compiler.  

In `History/histitem_mod.F90`, we have changed:
```F90
Item%NcChunkSizes = (/ Dims(1), 1 /)
```
to
```F90
Item%NcChunkSizes = (/ Dims(1), 1, 1 /)
```
in a location where `Item%NcChunkSizes` has allocated 3 elements.  This was raising a compilation error with GNU 14 but not with GNU 10, 11, or 12.

### Expected changes
The GEOS-Chem Classic executable will be able to be built with GNU 14 (and probably also GNU 13) compilers.  Otherwise, this is a "no-diff-to-benchmark" update.