### PR TITLE
Update ESMF to 8.6.1 in the sample GCHP environment file for Harvard Cannon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Added
+- Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files
+- Added comments to `HEMCO_Diagn.rc` template files instructing users on which ExtNr/Cat/Hier to use for online vs. offline biomass burning emissions
+
+### Changed
+- Replaced comments in template HEMCO configuration files directing users to obsolete wiki documentation with comments directing users to `hemco.readthedocs.io`
+- Updated `EmisOCS_Bioburn` to `EmisOCS_BiomassBurn` in both GCHP `HEMCO_Diagn.rc.carbon` and `HISTORY.rc.carbon` template files
+
+### Fixed
+- Restored entries for TMB emissions in `HEMCO_Config.rc.fullchem` template files for GCClassic and GCHP
+- Moved `EmisOCS_Total` to the head of the `EmisOCS` diagnostic entries in the GCHP `HISTORY.rc.carbon` template file
+
+### Removed
+- Removed entries for FINN v1.5 biomass burning emissions from template HEMCO configuration files
+
 ## [14.6.2] - 2025-06-11
 ### Added
 - Added MCHgMAP geogenic emissions (2010-2020) from Dastoor et al. (2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Replaced comments in template HEMCO configuration files directing users to obsolete wiki documentation with comments directing users to `hemco.readthedocs.io`
 - Updated `EmisOCS_Bioburn` to `EmisOCS_BiomassBurn` in both GCHP `HEMCO_Diagn.rc.carbon` and `HISTORY.rc.carbon` template files
+- Updated the ESMF version from 8.4.2 to 8.6.1 in sample environment file `gchp.gcc12_openmpi4_cannon_rocky.env`
 
 ### Fixed
 - Restored entries for TMB emissions in `HEMCO_Config.rc.fullchem` template files for GCClassic and GCHP

--- a/GeosCore/convection_mod.F90
+++ b/GeosCore/convection_mod.F90
@@ -501,6 +501,7 @@ CONTAINS
     REAL(fp), PARAMETER    :: TINYNUM = 1e-14_fp
 #ifdef LUO_WETDEP
     REAL(fp), PARAMETER    :: pHRain = 5.6_fp
+    REAL(fp)               :: F_RAIN
 #endif
 !
 ! !LOCAL VARIABLES:
@@ -1120,6 +1121,21 @@ CONTAINS
              ENDIF
           ENDDO     ! End of loop over levels above cloud base
 
+#ifdef LUO_WETDEP
+          F_WASHOUT = 0e+0_fp
+          DO K = KTOP, CLDBASE, -1
+            IF(PDOWN(K)>1.D-20)THEN
+              IF(DQRCU(K)>1.D-20)THEN
+                K_RAIN = 1.5e-3_fp
+                F_RAIN = CONV_F_PRIME( DQRCU(K), K_RAIN, 1.08e4_fp )
+                F_WASHOUT = MAX(F_WASHOUT, F_RAIN*SDT/1.08e4_fp)
+              ENDIF
+            ELSE
+              F_WASHOUT = 0e+0_fp
+            ENDIF
+          ENDDO
+#endif
+
           !==================================================================
           ! (4)  B e l o w   C l o u d   B a s e
           !==================================================================
@@ -1127,7 +1143,9 @@ CONTAINS
 
              ! Initialize
              QDOWN       = 0e+0_fp
+#ifndef LUO_WETDEP	     
              F_WASHOUT   = 0e+0_fp
+#endif
              WASHFRAC    = 0e+0_fp
              ALPHA       = 0e+0_fp
              ALPHA2      = 0e+0_fp
@@ -1141,7 +1159,11 @@ CONTAINS
              ! Check if...
              ! (1) there is precip coming into box (I,J,K) from (I,J,K+1)
              ! (2) there is species to re-evaporate
+#ifdef LUO_WETDEP
+             IF ( PDOWN(K+1)  > 0 .and. F_WASHOUT> 0 .and. &
+#else
              IF ( PDOWN(K+1)  > 0 .and. &
+#endif	     
                   T0_SUM      > 0        ) THEN
 
                 ! Compute F_WASHOUT, the fraction of grid box (I,J,L)
@@ -1149,15 +1171,15 @@ CONTAINS
                 ! the downward flux of precip leaving grid box (K+1)
                 ! from [cm3 H20/cm2 area/s] to [cm3 H20/cm3 air/s]
                 ! by dividing by box height in cm
+#ifdef LUO_WETDEP
+                QDOWN = PDOWN(K+1)
+#else
                 QDOWN = PDOWN(K+1) / ( BXHEIGHT(K+1) * 100e+0_fp  )
+#endif
 
                 ! Compute K_RAIN and F_WASHOUT based on the flux of precip 
                 ! leaving grid box (K+1).
-#ifdef LUO_WETDEP
-                ! Luo et al scheme: Use COND_WATER_CONTENT = 2e-6 [cm3/cm3]
-                K_RAIN   = LS_K_RAIN( QDOWN, 2.0e-6_fp )
-                F_WASHOUT= CONV_F_PRIME( QDOWN, K_RAIN, SDT )
-#else
+#ifndef LUO_WETDEP
                 ! Default scheme: Use COND_WATER_CONTENT = 1e-6 [cm3/cm3]
                 ! (which was recommended by Qiaoqiao Wang et al [2014])
                 K_RAIN   = LS_K_RAIN(  QDOWN,         1.0e-6_fp )

--- a/GeosCore/vdiff_mod.F90
+++ b/GeosCore/vdiff_mod.F90
@@ -1725,6 +1725,12 @@ CONTAINS
     ! Scalars
     INTEGER             :: I, J, L, N, NA, nAdvect, EC
     REAL(fp)            :: dtime
+#ifdef LUO_WETDEP
+    REAL(fp)            :: F_CLD
+    REAL(fp)            :: YCLDICE, FICE, YB, volx34pi_cd, rrate, SQM, STK
+    REAL(fp)            :: log2R, DFKG, uptkrate
+    REAL(fp), PARAMETER :: ROOT_TWO_THIRDS = SQRT(2.D0/3.D0)
+#endif
 
     ! Arrays
     REAL(fp), TARGET    :: tpert (State_Grid%NX,State_Grid%NY)
@@ -1897,6 +1903,106 @@ CONTAINS
 
     ! Convert kg/kg -> g/kg
     p_shp    = p_shp * 1.0e+3_fp
+
+#ifdef LUO_WETDEP
+!$OMP PARALLEL DO DEFAULT( SHARED )      &
+!$OMP PRIVATE( I, J, L, F_CLD ) &
+!$OMP PRIVATE( YCLDICE, FICE, YB, volx34pi_cd, rrate, SQM, STK ) &
+!$OMP PRIVATE( log2R, DFKG, uptkrate )
+    DO L = 1, State_Grid%NZ
+    DO J = 1, State_Grid%NY
+    DO I = 1, State_Grid%NX
+
+      IF(L>State_Met%PBL_TOP_L(I,J))THEN
+      State_Met%WUP(I,J,L)=(0.5D0*(kvh(I,J,L)+kvh(I,J,L+1))/30.D0/&
+                            0.516D0)*ROOT_TWO_THIRDS
+      ELSE
+      State_Met%WUP(I,J,L)=(0.5D0*(kvh(I,J,L)+kvh(I,J,L+1))/&
+           MAX(30.D0,(1.D0/(1.D0/(0.4D0*SUM(State_Met%BXHEIGHT(I,J,1:L)))+&
+                            1.D0/300.D0)))/&
+                            0.516D0)*ROOT_TWO_THIRDS
+      ENDIF
+      State_Met%WUP(I,J,L)=MIN(20.D0,MAX(0.2D0,State_Met%WUP(I,J,L)))
+
+      F_CLD = State_Met%CLDF(I,J,L)
+
+      IF(F_CLD>1.D-4)THEN
+        State_Met%KINC(I,J,L) = State_Met%WUP(I,J,L)*&
+                 (SQRT(F_CLD)*State_Met%BXHEIGHT(I,J,L)*&
+                 (State_Grid%DYWE_M(I,J)+State_Grid%DXSN_M(I,J))+&
+                  F_CLD*State_Grid%Area_M2(I,J))/&
+                 (1.D-30+F_CLD*State_Grid%Area_M2(I,J)*&
+                               State_Met%BXHEIGHT(I,J,L))
+      ELSE
+        State_Met%KINC(I,J,L) = 1.D-30
+        F_CLD = 1.D-4
+      ENDIF
+                
+      State_Met%KINC(I,J,L) = MAX(1.D-30,State_Met%KINC(I,J,L))
+
+      State_Met%NUMCD(I,J,L) = 1.D-30
+      State_Met%ICESF(I,J,L) = 1.D-30
+      State_Met%RADCD(I,J,L) = 20.D-4
+      State_Met%TKICE(I,J,L) = 0.D0
+
+      IF(State_Met%T(I,J,L)<237.D0 .AND. State_Met%CLDF(I,J,L)>1.D-6)THEN
+
+      YCLDICE = State_Met%QI(I,J,L)*State_Met%AIRDEN(I,J,L)*1.0D3
+      IF(YCLDICE>1.D-20)THEN
+
+        FICE=State_Met%CLDF(I,J,L)*YCLDICE/&
+        (YCLDICE+State_Met%QL(I,J,L)*State_Met%AIRDEN(I,J,L)*1.0D3)
+
+        IF(FICE>1.D-6)THEN
+          YCLDICE=YCLDICE/FICE
+          State_Met%RADCD(I,J,L) = 0.5d0*53.005d0*(YCLDICE**0.006d0)*&
+                                   exp(0.013d0*(State_Met%T(I,J,L)-273.d0))
+
+          State_Met%RADCD(I,J,L) = max(5.D0,MIN(1000.D0,State_Met%RADCD(I,J,L)))
+          State_Met%RADCD(I,J,L) = State_Met%RADCD(I,J,L)*1.D-4
+          log2R = log(State_Met%RADCD(I,J,L)*2.d0)
+
+          IF(State_Met%T(I,J,L)<218.15D0)THEN
+            volx34pi_cd = exp(-9.24318d0+0.57189d0*log2R-&
+                          0.17865d0*(log2R*log2R))
+            State_Met%ICESF(I,J,L) = exp(-2.43451d0+1.60639d0*log2R-&
+                    0.01164d0*(log2R*log2R))
+          ELSE IF(State_Met%T(I,J,L)<233.15D0)THEN
+            volx34pi_cd = exp(-6.44787d0+1.64429d0*log2R-&
+                          0.07788d0*(log2R*log2R))
+            State_Met%ICESF(I,J,L) = exp(-2.38913d0+1.40166d0*log2R-&
+                    0.05219d0*(log2R*log2R))
+          ELSE
+            volx34pi_cd = exp(-6.67252d0+1.36857d0*log2R-&
+                          0.12293d0*(log2R*log2R))
+            State_Met%ICESF(I,J,L) = exp(-2.40314d0+1.29749d0*log2R-&
+                    0.07233d0*(log2R*log2R))
+          ENDIF
+          State_Met%NUMCD(I,J,L) = YCLDICE/volx34pi_cd*1.D-6
+
+          rrate = 7.0D-3 - 4.D-3*MAX(0.D0,MIN(1.D0,(State_Met%T(I,J,L)-209.5D0)/&
+                 (220.D0-209.5D0)))
+
+          SQM = sqrt(63.D0)
+          STK = sqrt(State_Met%T(I,J,L))
+          DFKG = 9.45e+17_f8/State_Met%AIRNUMDEN(I,J,L) * STK * &
+                 SQRT(3.472e-2_f8 + 1.e+0_f8/(SQM*SQM))
+
+          uptkrate = State_Met%NUMCD(I,J,L)*State_Met%ICESF(I,J,L)/&
+                    (State_Met%RADCD(I,J,L)/DFKG+2.749064D-4*SQM/(rrate*STK))
+
+          State_Met%TKICE(I,J,L) = uptkrate*(State_Met%KINC(I,J,L)/&
+                   (State_Met%KINC(I,J,L)+(1.D0-State_Met%CLDF(I,J,L))*uptkrate))
+
+        ENDIF
+      ENDIF
+      ENDIF
+
+    ENDDO
+    ENDDO
+    ENDDO
+!$OMP END PARALLEL DO
+#endif
 
     ! Nullify pointers
     p_sflx   => NULL()

--- a/GeosCore/wetscav_mod.F90
+++ b/GeosCore/wetscav_mod.F90
@@ -1253,6 +1253,7 @@ CONTAINS
     REAL(fp)               :: Ki, SO2LOSS
 #ifdef LUO_WETDEP
     REAL(fp)               :: LIQCLD, ICECLD
+    REAL(fp)               :: YCLDICE, FICE, FC, RAINRATE
 #endif
 
     ! Pointers
@@ -1370,6 +1371,34 @@ CONTAINS
 
     ENDIF
     
+#ifdef LUO_WETDEP
+    IF(p_T<237.D0 .AND. State_Met%CLDF(I,J,L)>1.D-6)THEN
+
+      YCLDICE = State_Met%QI(I,J,L)*State_Met%AIRDEN(I,J,L)*1.0D3
+      IF(YCLDICE>1.D-20)THEN
+
+        FICE=State_Met%CLDF(I,J,L)*YCLDICE/&
+        (YCLDICE+State_Met%QL(I,J,L)*State_Met%AIRDEN(I,J,L)*1.0D3)
+
+        IF(FICE>1.D-6)THEN
+
+          IF(SpcInfo%WD_RainoutEff(3)>0.6D0)THEN
+            RAINFRAC = RAINFRAC*(1.D0-EXP(-MIN(100.D0,DT*State_Met%TKICE(I,J,L))))
+          ENDIF
+        ENDIF
+      ENDIF
+    ENDIF
+
+    FC=MAX(1.D-4,State_Met%CLDF(I,J,L))
+    IF(RAINFRAC>0.D0)THEN
+      RAINRATE = RAINFRAC/DT/FC
+
+      RAINFRAC = RAINFRAC*(State_Met%KINC(I,J,L)/ &
+                (State_Met%KINC(I,J,L)+ &
+                (1.D0-FC)*RAINRATE))
+    ENDIF
+#endif
+
     ! Free pointer
     p_pHCloud => NULL()
 #else
@@ -1679,6 +1708,7 @@ CONTAINS
 #endif
 #ifdef LUO_WETDEP
     REAL(f8)               :: Hplus, HCSO2, HCNH3, Ks1, Ks2, T_Term
+    REAL(fp)               :: WASHRATE
 #endif
 
     ! Strings
@@ -1933,12 +1963,17 @@ CONTAINS
 
        ! Compute washout fraction
 #ifdef LUO_WETDEP
+       IF(TK>258.D0)THEN
        ! Luo et al scheme: Compute washout fraction.  If the efficiency
        ! for T > 258 K is less than .999, treat it as hydrophobic aerosol
        IF ( SpcInfo%WD_RainoutEff(3) < 0.999_fp ) THEN
           WASHFRAC = WASHFRAC_FINE_AEROSOLLUOPO( DT, F, PP, TK )
        ELSE
           WASHFRAC = WASHFRAC_FINE_AEROSOLLUOPI( DT, F, PP, TK )
+       ENDIF
+
+       ELSE
+          WASHFRAC = WASHFRAC_FINE_AEROSOLLUOPO( DT, F, PP, TK )
        ENDIF
 #else
        ! Default scheme: Compute washout fraction, but always
@@ -1955,6 +1990,22 @@ CONTAINS
     IF(.not.KIN)THEN
       KIN      = .TRUE.
       WASHFRAC = F*WASHFRAC
+    ENDIF
+    ENDIF
+
+    IF(WASHFRAC>0.D0)THEN
+      IF(KIN)THEN
+        WASHRATE = WASHFRAC/DT/F
+
+        WASHFRAC = WASHFRAC*(State_Met%KINC(I,J,L)/ &
+                  (State_Met%KINC(I,J,L)+ &
+                  (1.D0-F)*WASHRATE))
+      ELSE
+        WASHRATE = WASHFRAC/DT
+
+        WASHFRAC = WASHFRAC*(State_Met%KINC(I,J,L)/ &
+                  (State_Met%KINC(I,J,L)+ &
+                  (1.D0-F)*WASHRATE))
     ENDIF
     ENDIF
 #endif
@@ -4544,8 +4595,13 @@ CONTAINS
 
           ! Define ALPHA, the fraction of the raindrops that
           ! re-evaporate when falling from (I,J,L+1) to (I,J,L)
+#ifdef LUO_WETDEP
+          ALPHA = ( ABS( Q ) * State_Met%BXHEIGHT(I,J,L) * 100e+0_fp )       &
+                  / MAX( 1.D-30, PDOWN(L+1,I,J) )
+#else
           ALPHA = ( ABS( Q ) * State_Met%BXHEIGHT(I,J,L) * 100e+0_fp )       &
                   / ( PDOWN(L+1,I,J) )
+#endif
 
           ! Restrict ALPHA to be less than 1 (>1 is unphysical)
           ! (hma, 24-Dec-2010)

--- a/GeosUtil/gc_grid_mod.F90
+++ b/GeosUtil/gc_grid_mod.F90
@@ -449,6 +449,24 @@ CONTAINS
        State_Grid%Area_M2(I,J) = ( State_Grid%DX * PI_180 ) * &
                                    ( Re**2 ) * SIN_DIFF
 
+#ifdef LUO_WETDEP
+       State_Grid%DXSN_M(I,J) = Re *                                         &
+             ACOS( SIN( State_Grid%YMid(I,J)    * PI_180 ) *                 &
+                   SIN( State_Grid%YMid(I,J)    * PI_180 ) +                 &
+                   COS( State_Grid%YMid(I,J)    * PI_180 ) *                 &
+                   COS( State_Grid%YMid(I,J)    * PI_180 ) *                 &
+                   COS( State_Grid%XEdge(I+1,J) * PI_180   -                 &
+                        State_Grid%XEdge(I,J)   * PI_180) )
+
+       State_Grid%DYWE_M(I,J) = Re *                                         &
+             ACOS( SIN( State_Grid%YEdge_R(I,J  ) ) *                        &
+                   SIN( State_Grid%YEdge_R(I,J+1) ) +                        &
+                   COS( State_Grid%YEdge_R(I,J  ) ) *                        &
+                   COS( State_Grid%YEdge_R(I,J+1) ) *                        &
+                   COS( State_Grid%XMid(I,J)        * PI_180 -               &
+                        State_Grid%XMid(I,J)        * PI_180 ) )
+#endif
+
     ENDDO
     ENDDO
 

--- a/Headers/state_grid_mod.F90
+++ b/Headers/state_grid_mod.F90
@@ -88,6 +88,10 @@ MODULE State_Grid_Mod
      REAL(fp),  POINTER :: YEdge_R    (:,:) ! Lat edges   [radians]
      REAL(fp),  POINTER :: YSIN       (:,:) ! SIN( lat edges )
      REAL(fp),  POINTER :: Area_M2    (:,:) ! Grid box area [m2]
+#ifdef LUO_WETDEP
+     REAL(fp),  POINTER :: DXSN_M       (:,:) ! Averange grid box width at the southern and northern edges [m]
+     REAL(fp),  POINTER :: DYWE_M       (:,:) ! Averange grid box width at the western and eastern edges [m]
+#endif
 
 #if defined( MODEL_GEOS )
      ! Are we in the predictor step?
@@ -204,6 +208,10 @@ CONTAINS
     State_Grid%YEdge_R      => NULL()
     State_Grid%YSIN         => NULL()
     State_Grid%Area_M2      => NULL()
+#ifdef LUO_WETDEP
+    State_Grid%DXSN_M         => NULL()
+    State_Grid%DYWE_M         => NULL()
+#endif
 
 #if defined( MODEL_GEOS )
     State_Grid%PredictorIsActive = .FALSE.
@@ -306,6 +314,16 @@ CONTAINS
     CALL GC_CheckVar( 'State_Grid%Area_M2', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     State_Grid%Area_M2 = 0e+0_fp
+#ifdef LUO_WETDEP
+    ALLOCATE( State_Grid%DXSN_M( State_Grid%NX, State_Grid%NY ), STAT=RC )
+    CALL GC_CheckVar( 'State_Grid%DXSN_M', 0, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+    State_Grid%DXSN_M = 0e+0_fp
+    ALLOCATE( State_Grid%DYWE_M( State_Grid%NX, State_Grid%NY ), STAT=RC )
+    CALL GC_CheckVar( 'State_Grid%DYWE_M', 0, RC )
+    IF ( RC /= GC_SUCCESS ) RETURN
+    State_Grid%DYWE_M = 0e+0_fp
+#endif
 
   END SUBROUTINE Allocate_State_Grid
 !EOC
@@ -428,6 +446,21 @@ CONTAINS
        IF ( RC /= GC_SUCCESS ) RETURN
        State_Grid%Area_M2 => NULL()
     ENDIF
+
+#ifdef LUO_WETDEP
+    IF ( ASSOCIATED( State_Grid%DXSN_M ) ) THEN
+       DEALLOCATE( State_Grid%DXSN_M, STAT=RC )
+       CALL GC_CheckVar( 'State_Grid%DXSN_M', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Grid%DXSN_M => NULL()
+    ENDIF
+    IF ( ASSOCIATED( State_Grid%DYWE_M ) ) THEN
+       DEALLOCATE( State_Grid%DYWE_M, STAT=RC )
+       CALL GC_CheckVar( 'State_Grid%DYWE_M', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Grid%DYWE_M => NULL()
+    ENDIF
+#endif
 
   END SUBROUTINE Cleanup_State_Grid
 !EOC

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -156,6 +156,14 @@ MODULE State_Met_Mod
      !----------------------------------------------------------------------
      ! 3-D Fields
      !----------------------------------------------------------------------
+#ifdef LUO_WETDEP
+     REAL(fp), POINTER :: KINC          (:,:,:) ! Air refreshing rate [s-1]
+     REAL(fp), POINTER :: WUP           (:,:,:) ! TKE wind speed [m/s]
+     REAL(fp), POINTER :: TKICE         (:,:,:) ! Ice uptake rate [s-1]
+     REAL(fp), POINTER :: NUMCD         (:,:,:) ! Cloud Ice Number [cm-3]
+     REAL(fp), POINTER :: ICESF         (:,:,:) ! Cloud Ice Surface Area [cm2]
+     REAL(fp), POINTER :: RADCD         (:,:,:) ! Cloud Ice Radius [cm]
+#endif
      REAL(fp), POINTER :: CLDF          (:,:,:) ! 3-D cloud fraction [1]
      REAL(fp), POINTER :: CMFMC         (:,:,:) ! Cloud mass flux [kg/m2/s]
      REAL(fp), POINTER :: DQRCU         (:,:,:) ! Conv precip production rate
@@ -513,6 +521,14 @@ CONTAINS
     State_Met%REEVAP         => NULL()
     State_Met%REEVAP         => NULL()
     State_Met%PBL_MAX_L      = 0
+#ifdef LUO_WETDEP
+    State_Met%KINC           => NULL()
+    State_Met%WUP            => NULL()
+    State_Met%TKICE          => NULL()
+    State_Met%NUMCD          => NULL()
+    State_Met%ICESF          => NULL()
+    State_Met%RADCD          => NULL()
+#endif
 
   END SUBROUTINE Zero_State_Met
 !EOC
@@ -2059,6 +2075,74 @@ CONTAINS
        RETURN
     ENDIF
 
+#ifdef LUO_WETDEP
+    !------------------------------------------------------------------------
+    ! KINC [s-1]: Air refreshing rate
+    !------------------------------------------------------------------------
+    metId = 'KINC'
+    CALL Init_and_Register(                                                  &
+         Input_Opt  = Input_Opt,                                             &
+         State_Met  = State_Met,                                             &
+         State_Grid = State_Grid,                                            &
+         metId      = metId,                                                 &
+         Ptr2Data   = State_Met%KINC,                                        &
+         RC         = RC                                                    )
+    !------------------------------------------------------------------------
+    ! WUP [m/s]: TKE wind speed
+    !------------------------------------------------------------------------
+    metId = 'WUP'
+    CALL Init_and_Register(                                                  &
+         Input_Opt  = Input_Opt,                                             &
+         State_Met  = State_Met,                                             &
+         State_Grid = State_Grid,                                            &
+         metId      = metId,                                                 &
+         Ptr2Data   = State_Met%WUP,                                         &
+         RC         = RC                                                    )
+    !------------------------------------------------------------------------
+    ! TKICE [s]: Ice uptake rate
+    !------------------------------------------------------------------------
+    metId = 'TKICE'
+    CALL Init_and_Register(                                                  &
+         Input_Opt  = Input_Opt,                                             &
+         State_Met  = State_Met,                                             &
+         State_Grid = State_Grid,                                            &
+         metId      = metId,                                                 &
+         Ptr2Data   = State_Met%TKICE,                                       &
+         RC         = RC                                                    )
+    !------------------------------------------------------------------------
+    ! NUMCD [cm-3]: Cloud Ice Number
+    !------------------------------------------------------------------------
+    metId = 'NUMCD'
+    CALL Init_and_Register(                                                  &
+         Input_Opt  = Input_Opt,                                             &
+         State_Met  = State_Met,                                             &
+         State_Grid = State_Grid,                                            &
+         metId      = metId,                                                 &
+         Ptr2Data   = State_Met%NUMCD,                                        &
+         RC         = RC                                                    )
+    !------------------------------------------------------------------------
+    ! ICESF [cm2]: Cloud Ice Surface Area
+    !------------------------------------------------------------------------
+    metId = 'ICESF'
+    CALL Init_and_Register(                                                  &
+         Input_Opt  = Input_Opt,                                             &
+         State_Met  = State_Met,                                             &
+         State_Grid = State_Grid,                                            &
+         metId      = metId,                                                 &
+         Ptr2Data   = State_Met%ICESF,                                        &
+         RC         = RC                                                    )
+    !------------------------------------------------------------------------
+    ! RADCD [cm]: Cloud Ice Radius
+    !------------------------------------------------------------------------
+    metId = 'RADCD'
+    CALL Init_and_Register(                                                  &
+         Input_Opt  = Input_Opt,                                             &
+         State_Met  = State_Met,                                             &
+         State_Grid = State_Grid,                                            &
+         metId      = metId,                                                 &
+         Ptr2Data   = State_Met%RADCD,                                        &
+         RC         = RC                                                    )
+#endif
     !------------------------------------------------------------------------
     ! CLDF [1]
     !------------------------------------------------------------------------
@@ -3895,6 +3979,68 @@ CONTAINS
 #endif
     ENDIF
 
+#ifdef LUO_WETDEP
+    IF ( ASSOCIATED( State_Met%KINC ) ) THEN
+#if defined( ESMF_ ) || defined( MODEL_WRF )
+       State_Met%KINC => NULL()
+#else
+       DEALLOCATE( State_Met%KINC, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%KINC', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%KINC => NULL()
+#endif
+    ENDIF
+    IF ( ASSOCIATED( State_Met%WUP ) ) THEN
+#if defined( ESMF_ ) || defined( MODEL_WRF )
+       State_Met%WUP => NULL()
+#else
+       DEALLOCATE( State_Met%WUP, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%WUP', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%WUP => NULL()
+#endif
+    ENDIF
+    IF ( ASSOCIATED( State_Met%TKICE ) ) THEN
+#if defined( ESMF_ ) || defined( MODEL_WRF )
+       State_Met%TKICE => NULL()
+#else
+       DEALLOCATE( State_Met%TKICE, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%TKICE', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%TKICE => NULL()
+#endif
+    ENDIF
+    IF ( ASSOCIATED( State_Met%NUMCD ) ) THEN
+#if defined( ESMF_ ) || defined( MODEL_WRF )
+       State_Met%NUMCD => NULL()
+#else
+       DEALLOCATE( State_Met%NUMCD, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%NUMCD', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%NUMCD => NULL()
+#endif
+    ENDIF
+    IF ( ASSOCIATED( State_Met%ICESF ) ) THEN
+#if defined( ESMF_ ) || defined( MODEL_WRF )
+       State_Met%ICESF => NULL()
+#else
+       DEALLOCATE( State_Met%ICESF, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%ICESF', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%ICESF => NULL()
+#endif
+    ENDIF
+    IF ( ASSOCIATED( State_Met%RADCD ) ) THEN
+#if defined( ESMF_ ) || defined( MODEL_WRF )
+       State_Met%RADCD => NULL()
+#else
+       DEALLOCATE( State_Met%RADCD, STAT=RC  )
+       CALL GC_CheckVar( 'State_Met%RADCD', 2, RC )
+       IF ( RC /= GC_SUCCESS ) RETURN
+       State_Met%RADCD => NULL()
+#endif
+    ENDIF
+#endif
     IF ( ASSOCIATED( State_Met%CLDF ) ) THEN
 #if defined( ESMF_ ) || defined( MODEL_WRF )
        State_Met%CLDF => NULL()
@@ -4950,6 +5096,39 @@ CONTAINS
           IF ( isUnits ) Units = 'm'
           IF ( isRank  ) Rank  = 3
           IF ( isVLoc  ) VLoc  = VLocationCenter
+
+#ifdef LUO_WETDEP
+       CASE ( 'KINC' )
+          IF ( isDesc  ) Desc  = 'air refreshing rate'
+          IF ( isUnits ) Units = 's-1'
+          IF ( isRank  ) Rank  = 3
+          IF ( isVLoc  ) VLoc  = VLocationCenter
+       CASE ( 'WUP' )
+          IF ( isDesc  ) Desc  = 'TKE wind speed'
+          IF ( isUnits ) Units = 'm s-1'
+          IF ( isRank  ) Rank  = 3
+          IF ( isVLoc  ) VLoc  = VLocationCenter
+       CASE ( 'TKICE' )
+          IF ( isDesc  ) Desc  = 'ice uptake rate'
+          IF ( isUnits ) Units = 's-1'
+          IF ( isRank  ) Rank  = 3
+          IF ( isVLoc  ) VLoc  = VLocationCenter
+       CASE ( 'NUMCD' )
+          IF ( isDesc  ) Desc  = 'cloud ice number'
+          IF ( isUnits ) Units = 'cm-3'
+          IF ( isRank  ) Rank  = 3
+          IF ( isVLoc  ) VLoc  = VLocationCenter
+       CASE ( 'ICESF' )
+          IF ( isDesc  ) Desc  = 'cloud ice surface area'
+          IF ( isUnits ) Units = 'cm2'
+          IF ( isRank  ) Rank  = 3
+          IF ( isVLoc  ) VLoc  = VLocationCenter
+       CASE ( 'RADCD' )
+          IF ( isDesc  ) Desc  = 'cloud ice radius'
+          IF ( isUnits ) Units = 'cm'
+          IF ( isRank  ) Rank  = 3
+          IF ( isVLoc  ) VLoc  = VLocationCenter
+#endif
 
        CASE ( 'CLDF' )
           IF ( isDesc  ) Desc  = '3-D cloud fraction'

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.Hg
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.Hg
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the Hg simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.POPs
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.POPs
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the POPs simulation for ${RUNDIR_POP_SPC}.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.TransportTracers
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.TransportTracers
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the Transport Tracers simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the offline aerosol simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+# See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history
@@ -121,6 +119,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> GFAS                   :       false    # 2003-2021
     --> BB4MIPS                :       ${RUNDIR_CMIP6_FIELDS}    # 1850-2100
     --> GFED4_CLIMATOLOGY      :       false    # If true, turn off GFED ext below
+    --> FINNv25                :       false    # 2012-2023
 # ----- OFFLINE EMISSIONS -----------------------------------------------------
 # To use online emissions instead set the offline emissions to 'false' and the
 # corresponding HEMCO extension to 'on':
@@ -189,13 +188,6 @@ VerboseOnCores:              root       # Accepted values: root all
     --> CO to SOAP             :       0.013
     --> GFED_subgrid_coag      :       false
 #see the note near scale factor 281 for the source of this emis factor
-114     FINN                   : off   NO/CO/ALK4/ACET/MEK/ALD2/PRPE/C2H2/C2H4/C3H8/CH2O/C2H6/SO2/NH3/BCPI/BCPO/OCPI/OCPO/GLYC/HAC/SOAP
-    --> FINN_daily             :       false
-    --> Scaling_CO             :       1.0
-    --> Scaling_SOAP           :       0.013
-    --> hydrophilic BC         :       0.2
-    --> hydrophilic OC         :       0.5
-    --> FINN_subgrid_coag      :       false
 115     DustAlk                : ${RUNDIR_DUSTALK_EXT}   DSTAL1/DSTAL2/DSTAL3/DSTAL4
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
@@ -1650,6 +1642,52 @@ VerboseOnCores:              root       # Accepted values: root all
 0 GFAS_DMS   $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc c2h6sfire     2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s DMS  75     5 3
 )))GFAS
 
+(((EMISSIONS
+
+#==============================================================================
+# --- FINNv2.5 biomass burning ---
+# Uses dataset derived with combined fire detection from MODIS and VIIRS.
+# Data downloaded from: https://rda.ucar.edu/datasets/d312009/dataaccess/
+# Uses FINN emissions processed for MOZART for multiple species not processed
+#       for general use (not specific to any model) or for GEOS-Chem.
+#       Naming convention of inventory developers preserved for traceability.
+# Description of development of data available here:
+#       https://gmd.copernicus.org/articles/16/3873/2023/
+#==============================================================================
+(((FINNv25
+0 FINNv25_SOAP  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_CO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_CO              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s SOAP   75/281 5 3
+0 FINNv25_BCPI  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_BC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_BC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s BCPI   75/70  5 3
+0 FINNv25_BCPO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_BC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_BC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s BCPO   75/71  5 3
+0 FINNv25_OCPI  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_OC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_OC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s OCPI   75/72  5 3
+0 FINNv25_OCPO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_OC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_OC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s OCPO   75/73  5 3
+0 FINNv25_SO2   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_SO2_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc             fire_modisviirs_SO2             2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s SO2    75     5 3
+0 FINNv25_NH3   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-NH3_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc      fire_modisviirs_MOZART-NH3      2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s NH3    75     5 3
+0 FINNv25_ACET  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-ACET_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-ACET   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ACET   75     5 3
+0 FINNv25_ALK4  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-ALK4_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-ALK4   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ALK4   75     5 3
+0 FINNv25_PRPE  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-PRPE_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-PRPE   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s PRPE   75     5 3
+0 FINNv25_C2H2  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C2H2_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C2H2   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C2H2   75     5 3
+0 FINNv25_C2H4  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C2H4_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C2H4   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C2H4   75     5 3
+0 FINNv25_C2H6  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C2H6_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C2H6   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C2H6   75     5 3
+0 FINNv25_C3H8  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C3H8_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C3H8   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C3H8   75     5 3
+0 FINNv25_CH2O  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-CH2O_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-CH2O   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s CH2O   75     5 3
+0 FINNv25_ISOP  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-ISOP_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc     fire_modisviirs_MOZART-ISOP     2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ISOP   75     5 3
+0 FINNv25_BENZ  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-BENZ_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-BENZ   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s BENZ   75     5 3
+0 FINNv25_TOLU  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-TOLU_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-TOLU   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s TOLU   75     5 3
+0 FINNv25_XYLE  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-XYLE_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-XYLE   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s XYLE   75     5 3
+0 FINNv25_GLYC  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-GLYC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-GLYC   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s GLYC   75     5 3
+0 FINNv25_MGLY  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-MGLY_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-MGLY   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MGLY   75     5 3
+0 FINNv25_HAC   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-HAC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_GEOSCHEM-HAC    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s HAC    75     5 3
+0 FINNv25_MEK   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-MEK_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_GEOSCHEM-MEK    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MEK    75     5 3
+0 FINNv25_HCOOH $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-HCOOH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_MOZART-HCOOH    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s HCOOH  75     5 3
+0 FINNv25_HONO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-HONO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc     fire_modisviirs_MOZART-HONO     2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s HNO2   75     5 3
+0 FINNv25_ALD2  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-CH3CHO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_MOZART-CH3CHO   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ALD2   75     5 3
+0 FINNv25_EOH   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-C2H5OH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_MOZART-C2H5OH   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s EOH    75     5 3
+0 FINNv25_MOH   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-CH3OH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_MOZART-CH3OH    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MOH    75     5 3
+0 FINNv25_ACTA  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-CH3COOH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc  fire_modisviirs_MOZART-CH3COOH  2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ACTA   75     5 3
+0 FINNv25_MVK   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-MVK_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc      fire_modisviirs_MOZART-MVK      2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MVK    75     5 3
+0 FINNv25_MACR  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-MACR_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc     fire_modisviirs_MOZART-MACR     2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MACR   75     5 3
+)))FINNv25
+
 #==============================================================================
 # --- BB4MIPs biomass burning ---
 #==============================================================================
@@ -1876,32 +1914,6 @@ VerboseOnCores:              root       # Accepted values: root all
 111 GFED_FRAC_3HOUR $ROOT/GFED4/v2023-03/$YYYY/GFED4_3hrfrac_gen.025x025.$YYYY$MM.nc   GFED_FRAC3HR 2010-2023/1-12/1/0-23  RF xy 1 * - 1 1
 )))GFED_3hourly
 )))GFED4
-
-#==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114)
-#==============================================================================
-(((.not.FINN_daily
-114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP2       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype2 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP3       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype3 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP4       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype4 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP5       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype5 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP9       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype9 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-))).not.FINN_daily
-
-(((FINN_daily
-114 FINN_DAILY_VEGTYP1 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP2 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype2 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP3 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype3 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP4 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype4 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP5 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype5 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP9 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype9 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-
-(((FINN_subgrid_coag
-114 FINN_DAILY_NUMBER  $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25_with_num.nc     number        2002-2016/1-12/1/0 RF xy unitless * - 1 1
-)))FINN_subgrid_coag
-
-)))FINN_daily
 
 )))EMISSIONS
 

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the carbon simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history
@@ -101,6 +99,7 @@ Mask fractions:              false
     --> BBIO_SIB3              :       true     # 2006-2010
     --> NET_TERR_EXCH          :       true     # 2000
     --> CO2CORR                :       true     # 2000-2018
+    --> FINNv25                :       false    # 2012-2023  
 # ..... Regional inventories .........
     --> APEI                   :       false    # 1989-2014
     --> NEI2016_MONMEAN        :       false    # 2002-2020
@@ -821,6 +820,11 @@ Mask fractions:              false
 (((GFAS
 0 GFAS_CO $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO 75 5 3
 )))GFAS
+
+# --- FINNv2.5 biomass burning ---
+(((FINNv25
+0 FINNv25_CO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_CO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc  fire_modisviirs_CO  2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s CO 75 5 3
+)))FINNv25
 
 # --- BB4MIPs ---
 (((BB4MIPS

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -13,8 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history
@@ -130,6 +129,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> GFAS                   :       false    # 2003-2021
     --> BB4MIPS                :       ${RUNDIR_CMIP6_FIELDS}    # 1850-2100
     --> GFED4_CLIMATOLOGY      :       false    # If true, turn off GFED ext below
+    --> FINNv25                :       false    # 2012-2023
 # ----- OFFLINE EMISSIONS -----------------------------------------------------
 # To use online emissions instead set the offline emissions to 'false' and the
 # corresponding HEMCO extension to 'on':
@@ -213,13 +213,6 @@ VerboseOnCores:              root       # Accepted values: root all
     --> CO to SOAP             :       0.013
     --> GFED_subgrid_coag      :       false
 #see the note near scale factor 281 for the source of this emis factor
-114     FINN                   : off   NO/CO/ALK4/ACET/MEK/ALD2/PRPE/C2H2/C2H4/C3H8/CH2O/C2H6/SO2/NH3/BCPI/BCPO/OCPI/OCPO/GLYC/HAC/SOAP/STYR/EBZ/TMB/ROH/RCOOH/RCHO/ACTA/EOH/HCOOH/ISOP/MACR/MVK/MOH/R4N2/FURA
-    --> FINN_daily             :       false
-    --> Scaling_CO             :       1.0
-    --> Scaling_SOAP           :       0.013
-    --> hydrophilic BC         :       0.2
-    --> hydrophilic OC         :       0.5
-    --> FINN_subgrid_coag      :       false
 115     DustAlk                : ${RUNDIR_DUSTALK_EXT}   DSTAL1/DSTAL2/DSTAL3/DSTAL4
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
@@ -3039,6 +3032,54 @@ VerboseOnCores:              root       # Accepted values: root all
 )))GFAS
 
 #==============================================================================
+# --- FINNv2.5 biomass burning ---
+# Uses dataset derived with combined fire detection from MODIS and VIIRS.
+# Data downloaded from: https://rda.ucar.edu/datasets/d312009/dataaccess/
+# Uses FINN emissions processed for MOZART for multiple species not processed
+#       for general use (not specific to any model) or for GEOS-Chem.
+#       Naming convention of inventory developers preserved for traceability.
+# Description of development of data available here:
+#       https://gmd.copernicus.org/articles/16/3873/2023/
+#==============================================================================
+(((FINNv25
+0 FINNv25_CO    $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_CO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_CO              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s CO     75     5 3
+0 FINNv25_SOAP  -                                                                                                                     -                               -                     -  -  -                SOAP   75/281 5 3
+0 FINNv25_NO    $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_NO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_NO              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s NO     75     5 3
+0 FINNv25_NO2   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_NO2_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc             fire_modisviirs_NO2             2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s NO2    75     5 3
+0 FINNv25_BCPI  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_BC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_BC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s BCPI   75/70  5 3
+0 FINNv25_BCPO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_BC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_BC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s BCPO   75/71  5 3
+0 FINNv25_OCPI  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_OC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_OC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s OCPI   75/72  5 3
+0 FINNv25_OCPO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_OC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_OC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s OCPO   75/73  5 3
+0 FINNv25_SO2   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_SO2_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc             fire_modisviirs_SO2             2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s SO2    75     5 3
+0 FINNv25_pFe   -                                                                                                                     -                               -                     -  -  -                pFe    75/66  5 3
+0 FINNv25_NH3   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-NH3_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc      fire_modisviirs_MOZART-NH3      2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s NH3    75     5 3
+0 FINNv25_ACET  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-ACET_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-ACET   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ACET   75     5 3
+0 FINNv25_ALK4  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-ALK4_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-ALK4   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ALK4   75     5 3
+0 FINNv25_PRPE  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-PRPE_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-PRPE   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s PRPE   75     5 3
+0 FINNv25_C2H2  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C2H2_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C2H2   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C2H2   75     5 3
+0 FINNv25_C2H4  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C2H4_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C2H4   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C2H4   75     5 3
+0 FINNv25_C2H6  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C2H6_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C2H6   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C2H6   75     5 3
+0 FINNv25_C3H8  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C3H8_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C3H8   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C3H8   75     5 3
+0 FINNv25_CH2O  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-CH2O_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-CH2O   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s CH2O   75     5 3
+0 FINNv25_ISOP  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-ISOP_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc     fire_modisviirs_MOZART-ISOP     2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ISOP   75     5 3
+0 FINNv25_BENZ  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-BENZ_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-BENZ   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s BENZ   75     5 3
+0 FINNv25_TOLU  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-TOLU_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-TOLU   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s TOLU   75     5 3
+0 FINNv25_XYLE  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-XYLE_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-XYLE   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s XYLE   75     5 3
+0 FINNv25_GLYC  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-GLYC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-GLYC   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s GLYC   75     5 3
+0 FINNv25_MGLY  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-MGLY_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-MGLY   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MGLY   75     5 3
+0 FINNv25_HAC   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-HAC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_GEOSCHEM-HAC    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s HAC    75     5 3
+0 FINNv25_MEK   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-MEK_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_GEOSCHEM-MEK    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MEK    75     5 3
+0 FINNv25_HCOOH $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-HCOOH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_MOZART-HCOOH    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s HCOOH  75     5 3
+0 FINNv25_HONO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-HONO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc     fire_modisviirs_MOZART-HONO     2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s HNO2   75     5 3
+0 FINNv25_ALD2  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-CH3CHO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_MOZART-CH3CHO   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ALD2   75     5 3
+0 FINNv25_EOH   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-C2H5OH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_MOZART-C2H5OH   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s EOH    75     5 3
+0 FINNv25_MOH   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-CH3OH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_MOZART-CH3OH    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MOH    75     5 3
+0 FINNv25_ACTA  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-CH3COOH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc  fire_modisviirs_MOZART-CH3COOH  2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ACTA   75     5 3
+0 FINNv25_MVK   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-MVK_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc      fire_modisviirs_MOZART-MVK      2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MVK    75     5 3
+0 FINNv25_MACR  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-MACR_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc     fire_modisviirs_MOZART-MACR     2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MACR   75     5 3
+)))FINNv25
+
+#==============================================================================
 # --- BB4MIPs biomass burning ---
 #==============================================================================
 (((BB4MIPS
@@ -3397,32 +3438,6 @@ VerboseOnCores:              root       # Accepted values: root all
 111 GFED_FRAC_3HOUR $ROOT/GFED4/v2023-03/$YYYY/GFED4_3hrfrac_gen.025x025.$YYYY$MM.nc   GFED_FRAC3HR 2010-2023/1-12/1/0-23  RF xy 1 * - 1 1
 )))GFED_3hourly
 )))GFED4
-
-#==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114)
-#==============================================================================
-(((.not.FINN_daily
-114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP2       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype2 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP3       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype3 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP4       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype4 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP5       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype5 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP9       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype9 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-))).not.FINN_daily
-
-(((FINN_daily
-114 FINN_DAILY_VEGTYP1 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP2 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype2 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP3 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype3 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP4 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype4 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP5 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype5 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP9 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype9 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-
-(((FINN_subgrid_coag
-114 FINN_DAILY_NUMBER  $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25_with_num.nc     number        2002-2016/1-12/1/0 RF xy unitless * - 1 1
-)))FINN_subgrid_coag
-
-)))FINN_daily
 
 )))EMISSIONS
 

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.gcap2_metfields
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.gcap2_metfields
@@ -10,8 +10,7 @@
 #\\
 #\\
 # !REMARKS:
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.gmao_metfields
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.gmao_metfields
@@ -10,8 +10,7 @@
 #\\
 #\\
 # !REMARKS:
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.gmao_metfields_0125
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.gmao_metfields_0125
@@ -10,8 +10,7 @@
 #\\
 #\\
 # !REMARKS:
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.metals
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.metals
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the trace metals simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagO3
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagO3
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the tagO3 simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.Hg
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.Hg
@@ -5,11 +5,12 @@
 #
 # !MODULE: HEMCO_Diagn.rc 
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for the Hg simulation).
 #\\
 #\\
 # !REMARKS:
-#  Customized for the Hg simulation.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
 # !REVISION HISTORY:
 #  Use the gitk browser to view the Git history

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.POPs
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.POPs
@@ -5,11 +5,12 @@
 #
 # !MODULE: HEMCO_Diagn.rc 
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for POPs simulations).
 #\\
 #\\
 # !REMARKS:
-#  Customized for the POPs simulation.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
 # !REVISION HISTORY:
 #  13 Mar 2019 - M. Sulprizio- Initial version

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.TransportTracers
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.TransportTracers
@@ -5,11 +5,12 @@
 #
 # !MODULE: HEMCO_Diagn.rc 
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for TransportTracers simulations).
 #\\
 #\\
 # !REMARKS:
-#  Customized for the Transport Tracers simulation.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
 # !REVISION HISTORY:
 #  13 Feb 2018 - E. Lundgren - Initial version

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.aerosol
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.aerosol
@@ -5,20 +5,16 @@
 #
 # !MODULE: HEMCO_Diagn.rc 
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for aerosol-only simulation).
 #\\
 #\\
 # !REMARKS:
-#  For more information about scheduling HEMCO diagnostics, see:
-#  http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide#Diagnostics
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
-#  For a list of species by inventory, please see:
-#  http://wiki.geos-chem.org/HEMCO_data_directories#Default_GEOS-Chem_emissions_configurations
-#
-#  All diagnostics will now be saved out in units of kg/m2/s.  If necessary, 
-#  you can convert hydrocarbon species to e.g. kg C/m2/s in post-processing.
-#
-#  This file has been customized for the aerosol-only simulation.
+#  NOTES FOR BIOMASS BURNING:
+#  1. For GFED extension,    set ExtNr = 111, Cat = -1, Hier = -1.
+#  2. For offline emissions, set ExtNr = 0,   Cat =  5, Hier = -1
 #
 # !REVISION HISTORY:
 #  13 Feb 2018 - E. Lundgren - Initial version

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.aerosol.onlineE
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.aerosol.onlineE
@@ -6,19 +6,15 @@
 # !MODULE: HEMCO_Diagn.rc 
 #
 # !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+#  (for aerosol-only simulations with ModelE meteorology).
 #\\
 #\\
 # !REMARKS:
-#  For more information about scheduling HEMCO diagnostics, see:
-#  http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide#Diagnostics
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
-#  For a list of species by inventory, please see:
-#  http://wiki.geos-chem.org/HEMCO_data_directories#Default_GEOS-Chem_emissions_configurations
-#
-#  All diagnostics will now be saved out in units of kg/m2/s.  If necessary, 
-#  you can convert hydrocarbon species to e.g. kg C/m2/s in post-processing.
-#
-#  This file has been customized for the aerosol-only simulation.
+#  NOTES FOR BIOMASS BURNING:
+#  1. For GFED extension,    set ExtNr = 111, Cat = -1, Hier = -1.
+#  2. For offline emissions, set ExtNr = 0,   Cat =  5, Hier = -1
 #
 # !REVISION HISTORY:
 #  13 Feb 2018 - E. Lundgren - Initial version

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.carbon
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.carbon
@@ -5,11 +5,16 @@
 #
 # !MODULE: HEMCO_Diagn.rc
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for carbon gases simulations).
 #\\
 #\\
 # !REMARKS:
-#  Customized for the carbon simulation.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
+#
+#  NOTES FOR BIOMASS BURNING:
+#  1. For GFED extension,    set ExtNr = 111, Cat = -1, Hier = -1.
+#  2. For offline emissions, set ExtNr = 0,   Cat =  5, Hier = -1
 #EOP
 #------------------------------------------------------------------------------
 #BOC

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
@@ -5,21 +5,19 @@
 #
 # !MODULE: HEMCO_Diagn.rc
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for fullchem simulations).
 #\\
 #\\
 # !REMARKS:
-#  For more information about scheduling HEMCO diagnostics, see:
-#  http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide#Diagnostics
-#
-#  For a list of species by inventory, please see:
-#  http://wiki.geos-chem.org/HEMCO_data_directories#Default_GEOS-Chem_emissions_configurations
-#
-#  All diagnostics will now be saved out in units of kg/m2/s.  If necessary,
-#  you can convert hydrocarbon species to e.g. kg C/m2/s in post-processing.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
 #  The INVENTORY DIAGNOSTICS (starting with "Inv")  are only needed for
 #  benchmark simulations, and can be left commented out for production runs.
+#
+#  NOTES FOR BIOMASS BURNING:
+#  1. For GFED extension,    set ExtNr = 111, Cat = -1, Hier = -1.
+#  2. For offline emissions, set ExtNr = 0,   Cat =  5, Hier = -1
 #
 # !REVISION HISTORY:
 #  13 Feb 2018 - E. Lundgren - Initial version
@@ -494,6 +492,13 @@ EmisSOAS_Biogenic  SOAS   0      4   -1   2   kg/m2/s  SOAS_emission_flux_from_b
 ###############################################################################
 EmisSTYR_Total     STYR   -1     -1  -1   3   kg/m2/s  STYR_emission_flux_from_all_sectors
 EmisSTYR_BioBurn   STYR   111    -1  -1   2   kg/m2/s  STYR_emission_flux_from_biomass_burning
+
+###############################################################################
+#####  TMB emissions                                                      #####
+###############################################################################
+EmisTMB_Total      TMB    -1     -1  -1   3   kg/m2/s  TMB_emission_flux_from_all_sectors
+EmisTMB_Anthro     TMB    0      1   -1   3   kg/m2/s  TMB_emission_flux_from_anthropogenic
+EmisTMB_Ship       TMB    0      10  -1   2   kg/m2/s  TMB_emission_flux_from_ships
 
 ###############################################################################
 #####  TOLU emissions                                                     #####

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem.onlineE
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem.onlineE
@@ -5,18 +5,16 @@
 #
 # !MODULE: HEMCO_Diagn.rc
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for fullchem simulations with ModelE metoerology).
 #\\
 #\\
 # !REMARKS:
-#  For more information about scheduling HEMCO diagnostics, see:
-#  http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide#Diagnostics
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
-#  For a list of species by inventory, please see:
-#  http://wiki.geos-chem.org/HEMCO_data_directories#Default_GEOS-Chem_emissions_configurations
-#
-#  All diagnostics will now be saved out in units of kg/m2/s.  If necessary,
-#  you can convert hydrocarbon species to e.g. kg C/m2/s in post-processing.
+#  NOTES FOR BIOMASS BURNING:
+#  1. For GFED extension,    set ExtNr = 111, Cat = -1, Hier = -1.
+#  2. For offline emissions, set ExtNr = 0,   Cat =  5, Hier = -1
 #
 # !REVISION HISTORY:
 #  13 Feb 2018 - E. Lundgren - Initial version

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.metals
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.metals
@@ -5,11 +5,12 @@
 #
 # !MODULE: HEMCO_Diagn.rc 
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for trace metals simulations).
 #\\
 #\\
 # !REMARKS:
-#  Customized for the trace metals simulation.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
 # !REVISION HISTORY:
 #  13 Feb 2018 - E. Lundgren - Initial version

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.tagO3
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.tagO3
@@ -5,11 +5,12 @@
 #
 # !MODULE: HEMCO_Diagn.rc 
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for tagO3 simulations).
 #\\
 #\\
 # !REMARKS:
-#  Customized for the tagCO simulation.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
 # !REVISION HISTORY:
 #  13 Mar 2019 - M. Sulprizio- Initial version

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -1815,7 +1815,7 @@ GFED_FRAC_DAY 1 N Y %y4-%m2-%d2T00:00:00 none none GFED_FRACDAY ./HcoDir/GFED4/v
 GFED_FRAC_3HOUR 1 N Y %y4-%m2-01T%h2:00:00 none none GFED_FRAC3HR ./HcoDir/GFED4/v2023-03/%y4/GFED4_3hrfrac_gen.025x025.%y4%m2.nc
 #
 #==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114)
+# --- FINN v2.5 biomass burning emissions (Extension 114)
 # FINN is off by default in HEMCO_Config.rc; fill in this section if turning on
 #==============================================================================
 #

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.CO2
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.CO2
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the CO2 simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.TransportTracers
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.TransportTracers
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the Transport Tracers simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the carbon simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history
@@ -101,6 +99,7 @@ Mask fractions:              false
     --> BBIO_SIB3              :       true     # 2006-2010
     --> NET_TERR_EXCH          :       true     # 2000
     --> CO2CORR                :       true     # 2000-2018
+    --> FINNv25                :       false    # 2012-2023  
 # ..... Regional inventories .........
     --> APEI                   :       false    # 1989-2014
     --> NEI2016_MONMEAN        :       false    # 2002-2020
@@ -821,6 +820,11 @@ Mask fractions:              false
 (((GFAS
 0 GFAS_CO $ROOT/GFAS/v2018-09/$YYYY/GFAS_$YYYY$MM.nc cofire 2003-2021/1-12/1-31/0 C xyL=1:scal300 kg/m2/s CO 75 5 3
 )))GFAS
+
+# --- FINNv2.5 biomass burning ---
+(((FINNv25
+0 FINNv25_CO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_CO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc  fire_modisviirs_CO  2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s CO 75 5 3
+)))FINNv25
 
 # --- BB4MIPs ---
 (((BB4MIPS

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -13,8 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history
@@ -129,6 +128,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> GFAS                   :       false    # 2003-2021
     --> BB4MIPS                :       ${RUNDIR_CMIP6_FIELDS}    # 1850-2100
     --> GFED4_CLIMATOLOGY      :       false    # If true, turn off GFED ext below
+    --> FINNv25                :       false    # 2012-2023
 # ----- OFFLINE EMISSIONS -----------------------------------------------------
 # To use online emissions instead set the offline emissions to 'false' and the
 # corresponding HEMCO extension to 'on':
@@ -212,13 +212,6 @@ VerboseOnCores:              root       # Accepted values: root all
     --> CO to SOAP             :       0.013
     --> GFED_subgrid_coag      :       false
 #see the note near scale factor 281 for the source of this emis factor
-114     FINN                   : off   NO/CO/ALK4/ACET/MEK/ALD2/PRPE/C2H2/C2H4/C3H8/CH2O/C2H6/SO2/NH3/BCPI/BCPO/OCPI/OCPO/GLYC/HAC/SOAP/STYR/EBZ/TMB/ROH/RCOOH/RCHO/ACTA/EOH/HCOOH/ISOP/MACR/MVK/MOH/R4N2/FURA
-    --> FINN_daily             :       false
-    --> Scaling_CO             :       1.0
-    --> Scaling_SOAP           :       0.013
-    --> hydrophilic BC         :       0.2
-    --> hydrophilic OC         :       0.5
-    --> FINN_subgrid_coag      :       false
 115     DustAlk                : ${RUNDIR_DUSTALK_EXT}   DSTAL1/DSTAL2/DSTAL3/DSTAL4
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
@@ -3038,6 +3031,54 @@ VerboseOnCores:              root       # Accepted values: root all
 )))GFAS
 
 #==============================================================================
+# --- FINNv2.5 biomass burning ---
+# Uses dataset derived with combined fire detection from MODIS and VIIRS.
+# Data downloaded from: https://rda.ucar.edu/datasets/d312009/dataaccess/
+# Uses FINN emissions processed for MOZART for multiple species not processed
+#       for general use (not specific to any model) or for GEOS-Chem.
+#       Naming convention of inventory developers preserved for traceability.
+# Description of development of data available here:
+#       https://gmd.copernicus.org/articles/16/3873/2023/
+#==============================================================================
+(((FINNv25
+0 FINNv25_CO    $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_CO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_CO              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s CO     75     5 3
+0 FINNv25_SOAP  -                                                                                                                     -                               -                     -  -  -                SOAP   75/281 5 3
+0 FINNv25_NO    $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_NO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_NO              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s NO     75     5 3
+0 FINNv25_NO2   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_NO2_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc             fire_modisviirs_NO2             2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s NO2    75     5 3
+0 FINNv25_BCPI  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_BC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_BC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s BCPI   75/70  5 3
+0 FINNv25_BCPO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_BC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_BC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s BCPO   75/71  5 3
+0 FINNv25_OCPI  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_OC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_OC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s OCPI   75/72  5 3
+0 FINNv25_OCPO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_OC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc              fire_modisviirs_OC              2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s OCPO   75/73  5 3
+0 FINNv25_SO2   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_SO2_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc             fire_modisviirs_SO2             2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s SO2    75     5 3
+0 FINNv25_pFe   -                                                                                                                     -                               -                     -  -  -                pFe    75/66  5 3
+0 FINNv25_NH3   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-NH3_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc      fire_modisviirs_MOZART-NH3      2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s NH3    75     5 3
+0 FINNv25_ACET  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-ACET_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-ACET   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ACET   75     5 3
+0 FINNv25_ALK4  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-ALK4_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-ALK4   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ALK4   75     5 3
+0 FINNv25_PRPE  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-PRPE_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-PRPE   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s PRPE   75     5 3
+0 FINNv25_C2H2  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C2H2_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C2H2   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C2H2   75     5 3
+0 FINNv25_C2H4  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C2H4_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C2H4   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C2H4   75     5 3
+0 FINNv25_C2H6  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C2H6_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C2H6   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C2H6   75     5 3
+0 FINNv25_C3H8  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-C3H8_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-C3H8   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s C3H8   75     5 3
+0 FINNv25_CH2O  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-CH2O_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-CH2O   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s CH2O   75     5 3
+0 FINNv25_ISOP  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-ISOP_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc     fire_modisviirs_MOZART-ISOP     2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ISOP   75     5 3
+0 FINNv25_BENZ  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-BENZ_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-BENZ   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s BENZ   75     5 3
+0 FINNv25_TOLU  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-TOLU_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-TOLU   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s TOLU   75     5 3
+0 FINNv25_XYLE  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-XYLE_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-XYLE   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s XYLE   75     5 3
+0 FINNv25_GLYC  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-GLYC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-GLYC   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s GLYC   75     5 3
+0 FINNv25_MGLY  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-MGLY_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_GEOSCHEM-MGLY   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MGLY   75     5 3
+0 FINNv25_HAC   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-HAC_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_GEOSCHEM-HAC    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s HAC    75     5 3
+0 FINNv25_MEK   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_GEOSCHEM-MEK_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_GEOSCHEM-MEK    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MEK    75     5 3
+0 FINNv25_HCOOH $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-HCOOH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_MOZART-HCOOH    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s HCOOH  75     5 3
+0 FINNv25_HONO  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-HONO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc     fire_modisviirs_MOZART-HONO     2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s HNO2   75     5 3
+0 FINNv25_ALD2  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-CH3CHO_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_MOZART-CH3CHO   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ALD2   75     5 3
+0 FINNv25_EOH   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-C2H5OH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc   fire_modisviirs_MOZART-C2H5OH   2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s EOH    75     5 3
+0 FINNv25_MOH   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-CH3OH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc    fire_modisviirs_MOZART-CH3OH    2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MOH    75     5 3
+0 FINNv25_ACTA  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-CH3COOH_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc  fire_modisviirs_MOZART-CH3COOH  2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s ACTA   75     5 3
+0 FINNv25_MVK   $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-MVK_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc      fire_modisviirs_MOZART-MVK      2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MVK    75     5 3
+0 FINNv25_MACR  $ROOT/FINNv25/v2025-06/$YYYY/emissions-finnv2.5modvrs_MOZART-MACR_bb_surface_daily_$YYYY0101-$YYYY1231_0.1x0.1.nc     fire_modisviirs_MOZART-MACR     2012-2023/1-12/1-31/0 EF xy molecules/cm^2/s MACR   75     5 3
+)))FINNv25
+
+#==============================================================================
 # --- BB4MIPs biomass burning ---
 #==============================================================================
 (((BB4MIPS
@@ -3396,32 +3437,6 @@ VerboseOnCores:              root       # Accepted values: root all
 111 GFED_FRAC_3HOUR $ROOT/GFED4/v2023-03/$YYYY/GFED4_3hrfrac_gen.025x025.$YYYY$MM.nc   GFED_FRAC3HR 2010-2023/1-12/1/0-23  RF xy 1 * - 1 1
 )))GFED_3hourly
 )))GFED4
-
-#==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114)
-#==============================================================================
-(((.not.FINN_daily
-114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP2       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype2 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP3       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype3 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP4       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype4 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP5       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype5 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_VEGTYP9       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype9 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-))).not.FINN_daily
-
-(((FINN_daily
-114 FINN_DAILY_VEGTYP1 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP2 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype2 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP3 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype3 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP4 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype4 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP5 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype5 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-114 FINN_DAILY_VEGTYP9 $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25.compressed.nc   fire_vegtype9 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
-
-(((FINN_subgrid_coag
-114 FINN_DAILY_NUMBER  $ROOT/FINN/v2015-02/FINN_daily_$YYYY_0.25x0.25_with_num.nc     number        2002-2016/1-12/1/0 RF xy unitless * - 1 1
-)))FINN_subgrid_coag
-
-)))FINN_daily
 
 )))EMISSIONS
 

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagO3
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.tagO3
@@ -13,9 +13,7 @@
 #\\
 #\\
 # !REMARKS:
-#  This file has been customized for the tagO3 simulation.
-#  See The HEMCO User's Guide for file details:
-#    http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide
+#  See hemco.readthedocs.io for more information.
 #
 # !REVISION HISTORY:
 #  See https://github.com/geoschem/geos-chem for complete history

--- a/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.TransportTracers
+++ b/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.TransportTracers
@@ -5,11 +5,12 @@
 #
 # !MODULE: HEMCO_Diagn.rc 
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for TransportTracers simulations).
 #\\
 #\\
 # !REMARKS:
-#  Customized for the Transport Tracers simulation.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
 # !REVISION HISTORY:
 #  13 Feb 2018 - E. Lundgren - Initial version

--- a/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.carbon
+++ b/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.carbon
@@ -5,11 +5,16 @@
 #
 # !MODULE: HEMCO_Diagn.rc
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for carbon gases simulations).
 #\\
 #\\
 # !REMARKS:
-#  Customized for the carbon simulation.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
+#
+#  NOTES FOR BIOMASS BURNING:
+#  1. For GFED extension,    set ExtNr = 111, Cat = -1, Hier = -1.
+#  2. For offline emissions, set ExtNr = 0,   Cat =  5, Hier = -1
 #EOP
 #------------------------------------------------------------------------------
 #BOC
@@ -62,7 +67,6 @@ EmisCO2_BiomassBurn   CO2    111   -1   -1   2  kg/m2/s  CO2_biomass_burning_emi
 ###############################################################################
 EmisOCS_Total         OCS      0   -1   -1   2  kg/m2/s  OCS_emission_flux_from_all_sectors
 EmisOCS_Anthro        OCS      0    1   -1   2  kg/m2/s  OCS_emission_flux_from_anthropogenic
-EmisOCS_Bioburn       OCS      0    2   -1   2  kg/m2/s  OCS_emission_flux_from_biomass_burning
+EmisOCS_BiomassBurn   OCS      0    2   -1   2  kg/m2/s  OCS_emission_flux_from_biomass_burning
 EmisOCS_MissingOcean  OCS      0    3   -1   2  kg/m2/s  OCS_emission_flux_from_missing_ocean
 EmisOCS_Ocean         OCS      0    4   -1   2  kg/m2/s  OCS_emission_flux_from_ocean
-

--- a/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
+++ b/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
@@ -5,21 +5,19 @@
 #
 # !MODULE: HEMCO_Diagn.rc
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for fullchem simulations).
 #\\
 #\\
 # !REMARKS:
-#  For more information about scheduling HEMCO diagnostics, see:
-#  http://wiki.geos-chem.org/The_HEMCO_User%27s_Guide#Diagnostics
-#
-#  For a list of species by inventory, please see:
-#  http://wiki.geos-chem.org/HEMCO_data_directories#Default_GEOS-Chem_emissions_configurations
-#
-#  All diagnostics will now be saved out in units of kg/m2/s.  If necessary,
-#  you can convert hydrocarbon species to e.g. kg C/m2/s in post-processing.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
 #  The INVENTORY DIAGNOSTICS (starting with "Inv")  are only needed for
 #  benchmark simulations, and can be left commented out for production runs.
+#
+#  NOTES FOR BIOMASS BURNING:
+#  1. For GFED extension,    set ExtNr = 111, Cat = -1, Hier = -1.
+#  2. For offline emissions, set ExtNr = 0,   Cat =  5, Hier = -1
 #
 # !REVISION HISTORY:
 #  13 Feb 2018 - E. Lundgren - Initial version

--- a/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.tagO3
+++ b/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.tagO3
@@ -5,11 +5,12 @@
 #
 # !MODULE: HEMCO_Diagn.rc 
 #
-# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
+# !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO
+#  (for tagO3 simulations).
 #\\
 #\\
 # !REMARKS:
-#  Customized for the tagCO simulation.
+#  For more information about HEMCO diagnostics, see hemco.readthedocs.io.
 #
 # !REVISION HISTORY:
 #  13 Mar 2019 - M. Sulprizio- Initial version

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -147,11 +147,11 @@ COLLECTIONS: 'Emissions',
                               'EmisCO2_Aviation     ', 'GCHPchem',
                               'EmisCO2_CO2SurfCorr  ', 'GCHPchem',
                               'EmisCO2_BiomassBurn  ', 'GCHPchem',
+                              'EmisOCS_Total        ', 'GCHPchem',
                               'EmisOCS_Anthro       ', 'GCHPchem',
-                              'EmisOCS_Bioburn      ', 'GCHPchem',
+                              'EmisOCS_BiomassBurn  ', 'GCHPchem',
                               'EmisOCS_MissingOcean ', 'GCHPchem',
                               'EmisOCS_Ocean        ', 'GCHPchem',
-                              'EmisOCS_Total        ', 'GCHPchem',
 ::
 #==============================================================================
   Metrics.template:           '%y4%m2%d2_%h2%n2z.nc4',

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.gcc12_openmpi4_cannon_rocky.env
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.gcc12_openmpi4_cannon_rocky.env
@@ -71,7 +71,7 @@ export NETCDF_FORTRAN_ROOT="${NETCDF_FORTRAN_HOME}"
 # ESMF
 export ESMF_COMPILER="gfortran"
 export ESMF_COMM="openmpi"
-export ESMF_DIR="/n/jacob_lab/Lab/RockyLinux/ESMF/ESMF_8_4_2"
+export ESMF_DIR="/n/jacob_lab/Lab/RockyLinux/ESMF/ESMF_8_6_1"
 export ESMF_INSTALL_PREFIX="${ESMF_DIR}/INSTALL_gnu12_openmpi4"
 export ESMF_ROOT="${ESMF_INSTALL_PREFIX}"
 #----------------------------------------------------------------------------
@@ -87,7 +87,6 @@ export KPP_FLEX_LIB_DIR="${FLEX_HOME}/lib64"
 # Set limits
 #==============================================================================
 
-ulimit -c unlimited   # coredumpsize
 ulimit -u 50000       # maxproc
 ulimit -v unlimited   # vmemoryuse
 ulimit -s unlimited   # stacksize


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR updates the ESMF version from 8.4.2 to 8.6.1  in the sample GCHP environment file `gchp.gcc12_openmpi4_cannon_rocky.env` , which is used on the Harvard Cannon cluster.

### Expected changes
This will be a no-diff-to-benchmark update for GEOS-Chem Classic, and for GCHP runs done on clusters other than Cannon.

GCHP runs on Harvard Cannon using ESMF 8.6.1 will show small differences w/r/t runs using ESMF 8.4.2, as verified by @lizziel.  These differences are attributed to "under-the-hood" changes in ESMF 8.6.1.

### Related Github Issue

- See #2885 