### PR TITLE
unit fix for 0th hour boundary conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Added missing 3rd element in assigment of `Item%NcChunkSizes` in `History/histitem_mod.F90`
+- Removed extra unit conversion to mol/mol on 0th hour boundary conditions in `History/history_mod.F90`
 
 ### Removed
 - Removed `#ifndef TOMAS` block at the start of the parallel loop in `DO_CONVECTION`

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -2988,8 +2988,7 @@ CONTAINS
           !$OMP PRIVATE( N, S   )
           DO S = 1, mapData%nSlots
              N = mapData%slot2id(S)
-             State_Diag%SpeciesBC(:,:,:,S) = State_Chm%Species(N)%Conc(:,:,:) &
-                                 * ( AIRMW / State_Chm%SpcData(N)%Info%MW_g )
+             State_Diag%SpeciesBC(:,:,:,S) = State_Chm%Species(N)%Conc(:,:,:)
           ENDDO
           !$OMP END PARALLEL DO
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Nick Balasus
Institution: Harvard University

### Describe the update

Removed extra unit conversion to mol/mol on 0th hour boundary conditions in `History/history_mod.F90`.

### Expected changes

Just to the 0th hour of the first BoundaryCondition file that is archived by a simulation.

### Reference(s)

n/a

### Related Github Issue

#2922 
