### PR TITLE
Restore missing HEMCO manual diagnostics needed for APM simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Optimized parallel loops in `AIRQNT` routine in `GeosCore/calc_met_mod.F90`
 - Optimized parallel loops in `VDIFF` routine in `GeosCore/vdiff_mod.F90`
 - Placed error checks for infinity or NaN in `DO_CONVECTION` in `#ifdef DEBUG` preprocessor blocks
+- Collapsed several parallel DO loops in `GeosCore/carbon_mod.F90`
 
 ### Fixed
 - Added missing 3rd element in assigment of `Item%NcChunkSizes` in `History/histitem_mod.F90`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added sample environment file for Harvard Cannon with GNU 14.2.0 compilers
 - Converted `F` in `DO_CONVECTION` from a variable to a pointer, for computational speedup
 - Changed OpenMP loop scheduling from `DYNAMIC` to `GUIDED` in routine `DO_CONVECTION`
+- Added `Diagn_APM` routine in `GeosCore/hcoi_gc_diagn_mod.F90` to restore HEMCO manual diagnostics for use w/ APM
 
 ### Changed
 - Updated logic to include ObsPack observations that span UTC date boundaries

--- a/GeosCore/carbon_mod.F90
+++ b/GeosCore/carbon_mod.F90
@@ -581,11 +581,11 @@ CONTAINS
                        AutoFill=1,                             &
                        COL=HcoState%Diagn%HcoDiagnIDManual )
 
-
        IF ( FLAG==GC_SUCCESS ) THEN
-          !$OMP PARALLEL DO       &
-          !$OMP DEFAULT( SHARED ) &
-          !$OMP PRIVATE( J, I )
+          !$OMP PARALLEL DO                                                  &
+          !$OMP DEFAULT( SHARED                                             )&
+          !$OMP PRIVATE( J, I                                               )&
+          !$OMP COLLAPSE( 2                                                 )
           DO J = 1, State_Grid%NY
           DO I = 1, State_Grid%NX
              EMITRATE(I,J) = EMITRATE(I,J) + &
@@ -611,9 +611,10 @@ CONTAINS
        DTSRCE = HcoState%TS_EMIS
 
        IDCARBON   = HCO_GetHcoID( 'BCPO',   HcoState )
-       !$OMP PARALLEL DO       &
-       !$OMP DEFAULT( SHARED ) &
-       !$OMP PRIVATE( L, J, I, A_M2, E_CARBON, N )
+       !$OMP PARALLEL DO                                                     &
+       !$OMP DEFAULT( SHARED                                                )&
+       !$OMP PRIVATE( L, J, I, A_M2, E_CARBON, N                            )&
+       !$OMP COLLAPSE( 3                                                    )
        DO L = 1, State_Grid%NZ
        DO J = 1, State_Grid%NY
        DO I = 1, State_Grid%NX
@@ -624,6 +625,8 @@ CONTAINS
           ! Get emissions [kg/m2/s] and convert to [kg/box]
           E_CARBON = HcoState%Spc(IDCARBON)%Emis%Val(I,J,L) * A_M2 * DTSRCE
 
+          ! Tell OpenMP to vectorize this loop
+          !$ OMP SIMD
           DO N = 1, NBCOC
              Spc(APMIDS%id_BCBIN1+N-1)%Conc(I,J,L) = &
                 Spc(APMIDS%id_BCBIN1+N-1)%Conc(I,J,L)+ &
@@ -637,9 +640,10 @@ CONTAINS
        !$OMP END PARALLEL DO
 
        IDCARBON   = HCO_GetHcoID( 'BCPI',   HcoState )
-       !$OMP PARALLEL DO       &
-       !$OMP DEFAULT( SHARED ) &
-       !$OMP PRIVATE( L, J, I, A_M2, E_CARBON, N )
+       !$OMP PARALLEL DO                                                     &
+       !$OMP DEFAULT( SHARED                                                )&
+       !$OMP PRIVATE( L, J, I, A_M2, E_CARBON, N                            )&
+       !$OMP COLLAPSE( 3                                                    )
        DO L = 1, State_Grid%NZ
        DO J = 1, State_Grid%NY
        DO I = 1, State_Grid%NX
@@ -650,6 +654,8 @@ CONTAINS
           ! Get emissions [kg/m2/s] and convert to [kg/box]
           E_CARBON = HcoState%Spc(IDCARBON)%Emis%Val(I,J,L) * A_M2 * DTSRCE
 
+          ! Tell OpenMP to vectorize this loop
+          !$ OMP SIMD
           DO N = 1, NBCOC
              Spc(APMIDS%id_BCBIN1+N-1)%Conc(I,J,L)= &
                 Spc(APMIDS%id_BCBIN1+N-1)%Conc(I,J,L)+ &
@@ -690,9 +696,10 @@ CONTAINS
 
        ! Add anthropogenic OCPO diagnostic to EMITRATE (if it's found)
        IF(FLAG==GC_SUCCESS)THEN
-          !$OMP PARALLEL DO       &
-          !$OMP DEFAULT( SHARED ) &
-          !$OMP PRIVATE( J, I )
+          !$OMP PARALLEL DO                                                  &
+          !$OMP DEFAULT( SHARED                                             )&
+          !$OMP PRIVATE( J, I                                               )&
+          !$OMP COLLAPSE( 2                                                 )
           DO J = 1, State_Grid%NY
           DO I = 1, State_Grid%NX
              EMITRATE(I,J) = EMITRATE(I,J) + &
@@ -717,9 +724,10 @@ CONTAINS
       DTSRCE = HcoState%TS_EMIS
 
       IDCARBON   = HCO_GetHcoID( 'OCPO',   HcoState )
-      !$OMP PARALLEL DO       &
-      !$OMP DEFAULT( SHARED ) &
-      !$OMP PRIVATE( L, J, I, A_M2, E_CARBON, N )
+      !$OMP PARALLEL DO                                                      &
+      !$OMP DEFAULT( SHARED                                                 )&
+      !$OMP PRIVATE( L, J, I, A_M2, E_CARBON, N                             )&
+      !$OMP COLLAPSE( 3                                                     )
       DO L = 1, State_Grid%NZ
       DO J = 1, State_Grid%NY
       DO I = 1, State_Grid%NX
@@ -730,6 +738,8 @@ CONTAINS
          ! Get emissions [kg/m2/s] and convert to [kg/box]
          E_CARBON = HcoState%Spc(IDCARBON)%Emis%Val(I,J,L) * A_M2 * DTSRCE
 
+         ! Tell OpenMP to vectorize this loop
+         !$OMP SIMD
          DO N=1,NBCOC
             Spc(APMIDS%id_OCBIN1+N-1)%Conc(I,J,L)= &
                Spc(APMIDS%id_OCBIN1+N-1)%Conc(I,J,L)+ &
@@ -743,9 +753,10 @@ CONTAINS
       !$OMP END PARALLEL DO
 
       IDCARBON   = HCO_GetHcoID( 'OCPI',   HcoState )
-      !$OMP PARALLEL DO       &
-      !$OMP DEFAULT( SHARED ) &
-      !$OMP PRIVATE( L, J, I, A_M2, E_CARBON, N )
+      !$OMP PARALLEL DO                                                      &
+      !$OMP DEFAULT( SHARED                                                 )&
+      !$OMP PRIVATE( L, J, I, A_M2, E_CARBON, N                             )&
+      !$OMP COLLAPSE( 3                                                     )
       DO L = 1, State_Grid%NZ
       DO J = 1, State_Grid%NY
       DO I = 1, State_Grid%NX
@@ -756,6 +767,8 @@ CONTAINS
          ! Get emissions [kg/m2/s] and convert to [kg/box]
          E_CARBON = HcoState%Spc(IDCARBON)%Emis%Val(I,J,L) * A_M2 * DTSRCE
 
+         ! Tell OpenMP to vectorize this loop
+         !$OMP SIMD
          DO N=1,NBCOC
             Spc(APMIDS%id_OCBIN1+N-1)%Conc(I,J,L)= &
                Spc(APMIDS%id_OCBIN1+N-1)%Conc(I,J,L)+ &
@@ -776,12 +789,16 @@ CONTAINS
    ! (sum(Spc(id_BCPO)%conc(:,:,1))+sum(Spc(id_BCPI)%Conc(:,:,1))), conc_sum
 
    IF( ( id_POG1 + id_POA1 ) > 2 )THEN
-      !$OMP PARALLEL DO       &
-      !$OMP DEFAULT( SHARED ) &
-      !$OMP PRIVATE( L, J, I )
+      !$OMP PARALLEL DO                                                      &
+      !$OMP DEFAULT( SHARED                                                 )&
+      !$OMP PRIVATE( L, J, I, N                                             )&
+      !$OMP COLLAPSE( 3                                                     )
       DO L = 1, State_Grid%NZ
       DO J = 1, State_Grid%NY
       DO I = 1, State_Grid%NX
+
+         ! Tell OpenMP to vectorize this looop
+         !$OMP SIMD
          DO N=1,NBCOC
             Spc(APMIDS%id_OCBIN1+N-1)%Conc(I,J,L)= &
                Spc(APMIDS%id_OCBIN1+N-1)%Conc(I,J,L)+ &
@@ -819,9 +836,10 @@ CONTAINS
       CALL CHECKMN( 0, 0, 0, Input_Opt, State_Chm, State_Grid, &
                  State_Met, State_Diag,'CHECKMN from chemcarbon', RC)
 
-      !$OMP PARALLEL DO       &
-      !$OMP DEFAULT( SHARED ) &
-      !$OMP PRIVATE( I, J, L, NEWSOA, BOXVOL, TEMPTMS, PRES, BOXMASS )
+      !$OMP PARALLEL DO                                                      &
+      !$OMP DEFAULT( SHARED                                                 )&
+      !$OMP PRIVATE( I, J, L, NEWSOA, BOXVOL, TEMPTMS, PRES, BOXMASS        )&
+      !$OMP COLLAPSE( 3                                                     )
       DO L = 1, State_Grid%NZ
       DO J = 1, State_Grid%NY
       DO I = 1, State_Grid%NX
@@ -842,9 +860,9 @@ CONTAINS
       ENDDO
       !$OMP END PARALLEL DO
 #else
-      !$OMP PARALLEL DO       &
-      !$OMP DEFAULT( SHARED ) &
-      !$OMP PRIVATE( L, NEWSOA )
+      !$OMP PARALLEL DO                                                      &
+      !$OMP DEFAULT( SHARED                                                 )&
+      !$OMP PRIVATE( L, NEWSOA                                              )
       DO L = 1, State_Grid%NZ
          !NEWSOA used in a different context than above.
          !above is absolute mass, here is a relative decay factor
@@ -989,10 +1007,10 @@ CONTAINS
    ! Hydrophobic(2) --> Hydrophilic(1) ,  k  = 1.0e-5
    ! Both aerosols are dry-deposited,     kd = Dvel/DELZ (sec-1)
    !=================================================================
-   !$OMP PARALLEL DO       &
-   !$OMP DEFAULT( SHARED ) &
-   !$OMP PRIVATE( I, J, L, TC0, FREQ, RKT, CNEW ) &
-   !$OMP SCHEDULE( DYNAMIC )
+   !$OMP PARALLEL DO                                                         &
+   !$OMP DEFAULT( SHARED                                                    )&
+   !$OMP PRIVATE( I, J, L, TC0, FREQ, RKT, CNEW                             )&
+   !$OMP COLLAPSE( 3                                                        )
    DO L = 1, State_Grid%NZ
    DO J = 1, State_Grid%NY
    DO I = 1, State_Grid%NX
@@ -1107,10 +1125,10 @@ CONTAINS
    RC =  GC_SUCCESS
    TC => State_Chm%Species(spcId)%Conc
 
-   !$OMP PARALLEL DO       &
-   !$OMP DEFAULT( SHARED ) &
-   !$OMP PRIVATE( I, J, L, TC0, CCV, CNEW ) &
-   !$OMP SCHEDULE( DYNAMIC )
+   !$OMP PARALLEL DO                                                         &
+   !$OMP DEFAULT( SHARED                                                    )&
+   !$OMP PRIVATE( I, J, L, TC0, CCV, CNEW                                   )&
+   !$OMP COLLAPSE( 3                                                        ) 
    DO L = 1, State_Grid%NZ
    DO J = 1, State_Grid%NY
    DO I = 1, State_Grid%NX
@@ -1229,10 +1247,10 @@ CONTAINS
    !    Hydrophobic --> Hydrophilic,  k  = 1.0e-5
    !    Aerosols are dry-deposited,   kd = dry dep freq (sec-1)
    !=================================================================
-   !$OMP PARALLEL DO       &
-   !$OMP DEFAULT( SHARED ) &
-   !$OMP PRIVATE( I, J, L, TC0, FREQ, RKT, CNEW ) &
-   !$OMP SCHEDULE( DYNAMIC )
+   !$OMP PARALLEL DO                                                         &
+   !$OMP DEFAULT( SHARED                                                    )&
+   !$OMP PRIVATE( I, J, L, TC0, FREQ, RKT, CNEW                             )&
+   !$OMP COLLAPSE( 3                                                        )
    DO L = 1, State_Grid%NZ
    DO J = 1, State_Grid%NY
    DO I = 1, State_Grid%NX
@@ -1344,10 +1362,10 @@ CONTAINS
    RC =  GC_SUCCESS
    TC => State_Chm%Species(spcId)%Conc
 
-   !$OMP PARALLEL DO       &
-   !$OMP DEFAULT( SHARED ) &
-   !$OMP PRIVATE( I, J, L, TC0, CCV, CNEW ) &
-   !$OMP SCHEDULE( DYNAMIC )
+   !$OMP PARALLEL DO                                                         &
+   !$OMP DEFAULT( SHARED                                                    )&
+   !$OMP PRIVATE( I, J, L, TC0, CCV, CNEW                                   )&
+   !$OMP COLLAPSE( 3                                                        )
    DO L = 1, State_Grid%NZ
    DO J = 1, State_Grid%NY
    DO I = 1, State_Grid%NX

--- a/GeosCore/hcoi_gc_diagn_mod.F90
+++ b/GeosCore/hcoi_gc_diagn_mod.F90
@@ -628,7 +628,7 @@ CONTAINS
                        Cat       =  CATEGORY_BIOMASS,                        &
                        Hier      = -1,                                       &
                        HcoID     =  id_BCPO,                                 &
-                       SpaceDim  =  3,                                       &
+                       SpaceDim  =  2,                                       &
                        LevIDx    = -1,                                       &
                        OutUnit   = 'kg/m2/s',                                &
                        COL       =  HcoState%Diagn%HcoDiagnIDManual,         &
@@ -652,7 +652,7 @@ CONTAINS
                        Cat       =  CATEGORY_BIOMASS,                        &
                        Hier      = -1,                                       &
                        HcoID     =  id_OCPO,                                 &
-                       SpaceDim  =  3,                                       &
+                       SpaceDim  =  2,                                       &
                        LevIDx    = -1,                                       &
                        OutUnit   = 'kg/m2/s',                                &
                        COL       =  HcoState%Diagn%HcoDiagnIDManual,         &

--- a/GeosCore/hcoi_gc_diagn_mod.F90
+++ b/GeosCore/hcoi_gc_diagn_mod.F90
@@ -135,6 +135,11 @@ CONTAINS
     IF ( RC /= HCO_SUCCESS ) RETURN
 #endif
 
+#ifdef APM
+    CALL Diagn_APM( Input_Opt, HcoState, ExtState, RC )
+    IF ( RC /= HCO_SUCCESS ) RETURN
+#endif
+
     ! Return
     RC = HCO_SUCCESS
 
@@ -420,7 +425,7 @@ CONTAINS
     ENDIF
 
     !-----------------------------------------------------------------
-    ! %%%%% SO4 from ANTRHO (Category ? or species SO4_ANTH)  %%%%%
+    ! %%%%% SO4 from ANTHRO (Category ? or species SO4_ANTH)  %%%%%
     !-----------------------------------------------------------------
     ExtNr     = 0
     Cat       = CATEGORY_ANTHRO
@@ -446,7 +451,7 @@ CONTAINS
     ENDIF
 
     !-----------------------------------------------------------------
-    ! %%%%% CO from ANTRHO (Category ? or species CO_ANTH)  %%%%%
+    ! %%%%% CO from ANTHRO (Category ? or species CO_ANTH)  %%%%%
     !-----------------------------------------------------------------
     ExtNr     = 0
     Cat       = CATEGORY_ANTHRO
@@ -510,6 +515,159 @@ CONTAINS
 
   END SUBROUTINE Diagn_TOMAS
 !EOC
+#endif
+#ifdef APM
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Diagn_APM
+!
+! !DESCRIPTION: This creates manual diagnostics that will be used for APM.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE Diagn_APM( Input_Opt, HcoState, ExtState, RC )
+!
+! !USES:
+!
+    USE ErrCode_Mod
+    USE HCO_ExtList_Mod, ONLY : GetExtNr
+    USE HCO_State_Mod,   ONLY : HCO_State
+    USE HCO_State_Mod,   ONLY : HCO_GetHcoID
+    USE HCOX_State_Mod,  ONLY : Ext_State
+    USE Input_Opt_Mod,   ONLY : OptInput
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(OptInput),   INTENT(INOUT)  :: Input_Opt  ! Input opts
+    TYPE(HCO_State),  POINTER        :: HcoState   ! HEMCO state object
+    TYPE(EXT_State),  POINTER        :: ExtState   ! Extensions state object
+    INTEGER,          INTENT(INOUT)  :: RC         ! Failure or success
+!
+! !REVISION HISTORY:
+!  23 Sep 2014 - J. Kodros - Initial version
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! Scalars
+    INTEGER            :: HcoId, id_BCPO, id_OCPO
+
+    ! Strings
+    CHARACTER(LEN=255) :: MSG
+    CHARACTER(LEN=255) :: LOC = 'DIAGN_APM (hcoi_gc_diagn_mod.F90)'
+
+    !========================================================================
+    ! Diagn_APM begins here!
+    !========================================================================
+
+    ! Initialize
+    RC      = GC_SUCCESS
+    id_BCPO = HCO_GetHcoID( 'BCPO', HcoState )
+    id_OCPO = HCO_GetHcoID( 'OCPO', HcoState )
+
+    !------------------------------------------------------------------------
+    ! Hydrophobic black carbon from ANTHRO EMISSIONS                  
+    !------------------------------------------------------------------------
+    CALL Diagn_Create( HcoState  =  HcoState,                                &
+                       cName     = 'ANTHROPOGENIC_BCPO',                     &
+                       ExtNr     =  0,                                       &
+                       Cat       =  CATEGORY_ANTHRO,                         &
+                       Hier      = -1,                                       &
+                       HcoID     =  id_BCPO,                                 & 
+                       SpaceDim  =  3,                                       &
+                       LevIDx    = -1,                                       &
+                       OutUnit   = 'kg/m2/s',                                &
+                       COL       =  HcoState%Diagn%HcoDiagnIDManual,         &
+                       AutoFill  =  1,                                       &
+                       RC        =  RC                                      )
+
+    ! Trap potential errors
+    IF ( RC /= HCO_SUCCESS ) THEN
+       Msg = 'Error encountered when defining ANTHROPOGENIC_BCPO" diagnostic!'
+       CALL GC_Error( Msg, RC, Loc )
+       RETURN
+    ENDIF     
+
+
+    !------------------------------------------------------------------------
+    ! Hydrophobic organic carbon from ANTHRO EMISSIONS         
+    !------------------------------------------------------------------------
+    CALL Diagn_Create( HcoState  =  HcoState,                                &
+                       cName     = 'ANTHROPOGENIC_OCPO',                     &
+                       ExtNr     =  0,                                       &
+                       Cat       =  CATEGORY_ANTHRO,                         &
+                       Hier      = -1,                                       &
+                       HcoID     =  id_OCPO,                                 &
+                       SpaceDim  =  3,                                       &
+                       LevIDx    = -1,                                       &
+                       OutUnit   = 'kg/m2/s',                                &
+                       COL       =  HcoState%Diagn%HcoDiagnIDManual,         &
+                       AutoFill  =  1,                                       &
+                       RC        =  RC                                       )
+
+    ! Trap potential errors
+    IF ( RC /= HCO_SUCCESS ) THEN
+       Msg = 'Error encountered when defining "ANTHROPOGENIC_OCPO" diagnostic!'
+       CALL GC_Error( Msg, RC, Loc )
+       RETURN
+    ENDIF 
+
+    !------------------------------------------------------------------------
+    ! Hydrophobic black carbon from BIOMASS EMISSIONS
+    !------------------------------------------------------------------------
+    CALL Diagn_Create( HcoState  =  HcoState,                                &
+                       cName     = 'BIOMASS_BCPO',                           &
+                       ExtNr     =  0,                                       &
+                       Cat       =  CATEGORY_BIOMASS,                        &
+                       Hier      = -1,                                       &
+                       HcoID     =  id_BCPO,                                 &
+                       SpaceDim  =  3,                                       &
+                       LevIDx    = -1,                                       &
+                       OutUnit   = 'kg/m2/s',                                &
+                       COL       =  HcoState%Diagn%HcoDiagnIDManual,         &
+                       AutoFill  =  1,                                       &
+                       RC        =  RC                                      )
+
+
+    ! Trap potential errors
+    IF ( RC /= HCO_SUCCESS ) THEN
+       Msg = 'Error encountered when defining "BIOMASS_BCPO" diagnostic!'
+       CALL GC_Error( Msg, RC, Loc )
+       RETURN
+    ENDIF 
+
+    !------------------------------------------------------------------------
+    ! Hydrophobic organic carbon from BIOMASS EMISSIONS
+    !------------------------------------------------------------------------
+    CALL Diagn_Create( HcoState  =  HcoState,                                &
+                       cName     = 'BIOMASS_OCPO',                           &
+                       ExtNr     =  0,                                       &
+                       Cat       =  CATEGORY_BIOMASS,                        &
+                       Hier      = -1,                                       &
+                       HcoID     =  id_OCPO,                                 &
+                       SpaceDim  =  3,                                       &
+                       LevIDx    = -1,                                       &
+                       OutUnit   = 'kg/m2/s',                                &
+                       COL       =  HcoState%Diagn%HcoDiagnIDManual,         &
+                       AutoFill  =  1,                                       &
+                       RC        =  RC                                      )
+
+
+    ! Trap potential errors
+    IF ( RC /= HCO_SUCCESS ) THEN
+       Msg = 'Error encountered when defining "BIOMASS_OCPO" diagnostic!'
+       CALL GC_Error( Msg, RC, Loc )
+       RETURN
+    ENDIF 
+
+  END SUBROUTINE Diagn_APM
 #endif
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
We have restored the following manual HEMCO diagnostics for APM simulations in `GeosCore/hcoi_gc_diagn_mod.F90`.  These were removed in GEOS-Chem 12.9.3 when the binary punch (BPCH) diagnostics were taken out of GEOS-Chem.
- ANTHROPOGENIC_BCPO
- ANTHROPOGENIC_OCPO
- BIOMASS_BCPO
- BIOMASS_OCPO

Also, the `!$OMP COLLAPSE` clause was added to several OpenMP loops in `GeosCore/carbon_mod.F90`, especially in the APM-only section there.  That should increase the efficiency of the parallelization.

### Expected changes
This will avoid problems such as reported in #2926:

![Image](https://github.com/user-attachments/assets/ae3c4fce-972c-4754-89a8-8768740cdf43)

### Related Github Issue
- Closes #2926
- Closes #2934

