### PR TITLE
Fix typo in carbon_mod.F90 for APM simulations

### DIFF
--- a/GeosCore/carbon_mod.F90
+++ b/GeosCore/carbon_mod.F90
@@ -626,7 +626,7 @@ CONTAINS
           E_CARBON = HcoState%Spc(IDCARBON)%Emis%Val(I,J,L) * A_M2 * DTSRCE
 
           ! Tell OpenMP to vectorize this loop
-          !$ OMP SIMD
+          !$OMP SIMD
           DO N = 1, NBCOC
              Spc(APMIDS%id_BCBIN1+N-1)%Conc(I,J,L) = &
                 Spc(APMIDS%id_BCBIN1+N-1)%Conc(I,J,L)+ &
@@ -655,7 +655,7 @@ CONTAINS
           E_CARBON = HcoState%Spc(IDCARBON)%Emis%Val(I,J,L) * A_M2 * DTSRCE
 
           ! Tell OpenMP to vectorize this loop
-          !$ OMP SIMD
+          !$OMP SIMD
           DO N = 1, NBCOC
              Spc(APMIDS%id_BCBIN1+N-1)%Conc(I,J,L)= &
                 Spc(APMIDS%id_BCBIN1+N-1)%Conc(I,J,L)+ &


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
We have fixed a typo that was introduced in PR #2941.  At line 629 of `GeosCore/carbon_mod.F90`, the text `!$ OMP SIMD` should be replaced by `!$OMP SIMD` (no space between the $ and O).

### Expected changes
This will allow APM simualtions to compile.

### Related Github Issue
- See #2941 
