### PR TITLE
GCHP carbon simulation diagnostic fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed extra unit conversion to mol/mol on 0th hour boundary conditions in `History/history_mod.F90`
 - Reordered code in `aerosol_mod.F90` and `gc_environment_mod.F90` so that aerosol optics file paths will be printed to the dry-run log file
 - Fixed wrong timestep scaling for GCHP mass flux runs and added dynamically scaling mass flux and courant number based on timestep
+- Corrected GCHP carbon HISTORY.rc entries for KPPdiags, RxnRates, and RxnConst collections
 
 ### Removed
 - Removed `#ifndef TOMAS` block at the start of the parallel loop in `DO_CONVECTION`

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -346,15 +346,15 @@ COLLECTIONS: 'Emissions',
   KppDiags.frequency:         010000
   KppDiags.duration:          010000
   KppDiags.mode:              'time-averaged'
-  KppDiags.fields:            'KppIntCounts                  ',
-                              'KppJacCounts                  ',
-                              'KppTotSteps                   ',
-                              'KppAccSteps                   ',
-                              'KppRejSteps                   ',
-                              'KppLuDecomps                  ',
-                              'KppSubsts                     ',
-                              'KppSmDecomps                  ',
-                              'KppTime                       ',
+  KppDiags.fields:            'KppIntCounts ', 'GCHPchem',
+                              'KppJacCounts ', 'GCHPchem',
+                              'KppTotSteps  ', 'GCHPchem',
+                              'KppAccSteps  ', 'GCHPchem',
+                              'KppRejSteps  ', 'GCHPchem',
+                              'KppLuDecomps ', 'GCHPchem',
+                              'KppSubsts    ', 'GCHPchem',
+                              'KppSmDecomps ', 'GCHPchem',
+                              'KppTime      ', 'GCHPchem',
 ::
 #==============================================================================
   RxnRates.template:          '%y4%m2%d2_%h2%n2z.nc4',
@@ -363,8 +363,8 @@ COLLECTIONS: 'Emissions',
   RxnRates.frequency:         010000
   RxnRates.duration:          010000
   RxnRates.mode:              'time-averaged'
-  RxnRates.fields:            'RxnRate_EQ0001                  ',
-                              'RxnRate_EQ0002                  ',
+  RxnRates.fields:            'RxnRate_EQ0001 ', 'GCHPchem',
+                              'RxnRate_EQ0002 ', 'GCHPchem',
 			      # ... add others as needed ...
 ::
 #==============================================================================
@@ -374,8 +374,8 @@ COLLECTIONS: 'Emissions',
   RxnConst.frequency:         010000
   RxnConst.duration:          010000
   RxnConst.mode:              'time-averaged'
-  RxnConst.fields:            'RxnConst_EQ0001                ',
-                              'RxnConst_EQ0002                ',
+  RxnConst.fields:            'RxnConst_EQ0001 ', 'GCHPchem',
+                              'RxnConst_EQ0002 ', 'GCHPchem',
 			      # ... add others as needed ...
 ::
 #==============================================================================


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR adds the previously omitted component name `GCHPchem` next to the diagnostic fields names for the `KPPdiags`, `RxnRates`, and `RxnConst` collections in the GCHP carbon `HISTORY.rc` file.

### Expected changes

The GCHP carbon simulation will no longer crash if the `KPPdiags`, `RxnRates`, and `RxnConst` collections are turned on in `HISTORY.rc`.

### Reference(s)

none

### Related Github Issue

none
