### PR TITLE
Dynamically scale GCHP mass flux and courant number based on timestep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## TBD
+## Fixed
+- Fixed wrong timestep scaling for GCHP mass flux runs and added dynamically scaling mass flux and courant number based on timestep
+
 ## [14.6.2] - 2025-06-11
 ### Added
 - Added MCHgMAP geogenic emissions (2010-2020) from Dastoor et al. (2025)

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -389,12 +389,15 @@ MassFlux_Entry=$(grep "MFXC" ExtData.rc || echo "missing")
 if [[ ${MassFlux_Entry} != "missing" ]]; then
 
     #### Get met grid res (assume GEOS-IT and GEOS-FP are the only options)
-    C180_Entry=$(grep "MFXC.*C180x180x6" ExtData.rc || echo "missing")
+    C180_Entry=$(grep "MFXC.*C180" ExtData.rc || echo "missing")
     if [[ ${C180_Entry} != "missing" ]]; then
 	input_res=180
     else
 	input_res=720
     fi
+    trans_timestep_scale=$(printf "%.7f" $(echo "${TransConv_Timestep_sec} / 450" | bc -l) | awk '{if ($0 ~ /^\./) print "0" $0; else print $0}')
+    sed -i -e "0,/MFXC/ s/\(none\)[[:space:]].*\(MFXC\)/\1 ${trans_timestep_scale} \2/" ExtData.rc
+    sed -i -e "0,/CX/ s/\(none\)[[:space:]].*\(CX\)/\1 ${trans_timestep_scale} \2/" ExtData.rc
     if (( ${CS_RES} < ${input_res} )); then
 	lowest_res=${CS_RES}
 	highest_res=${input_res}

--- a/run/shared/settings/geosfp/advection_met/geosfp.raw_1hr_c720_mass_flux_PS_SPHU_C.txt
+++ b/run/shared/settings/geosfp/advection_met/geosfp.raw_1hr_c720_mass_flux_PS_SPHU_C.txt
@@ -3,7 +3,7 @@ RUNDIR_USE_TOTAL_AIR_PRESSURE_IN_ADVECTION=0
 
 RUNDIR_MET_EXTDATA_PRIMARY_EXPORTS_FOR_ADVECTION="""
 # --- Mass fluxes and Courant numbers, 1-hr time-averaged ---
-MFXC;MFYC Pa_m+2_s-1    N H F0;003000 none  0.6666666 MFXC;MFYC  ./MetDir/../../GEOS_C720/GEOS_FP_Raw/Y%y4/M%m2/D%d2/GEOS.fp.asm.tavg_1hr_ctm_c0720_v72.%y4%m2%d2_%h2%n2.V01.nc4 2021-03-11T00:30:00P01:00
+MFXC;MFYC Pa_m+2_s-1    N H F0;003000 none  none MFXC;MFYC  ./MetDir/../../GEOS_C720/GEOS_FP_Raw/Y%y4/M%m2/D%d2/GEOS.fp.asm.tavg_1hr_ctm_c0720_v72.%y4%m2%d2_%h2%n2.V01.nc4 2021-03-11T00:30:00P01:00
 CXC;CYC   1             N H F0;003000 none  none CX;CY           ./MetDir/../../GEOS_C720/GEOS_FP_Raw/Y%y4/M%m2/D%d2/GEOS.fp.asm.tavg_1hr_ctm_c0720_v72.%y4%m2%d2_%h2%n2.V01.nc4 2021-03-11T00:30:00P01:00
 
 # --- Surface pressure and specific humidity, 1-hr instantaneous ---

--- a/run/shared/settings/geosit/advection_met/geosit.preprocessed_1hr_c180_mass_flux.txt
+++ b/run/shared/settings/geosit/advection_met/geosit.preprocessed_1hr_c180_mass_flux.txt
@@ -8,7 +8,7 @@ RUNDIR_MET_EXTDATA_PRIMARY_EXPORTS_FOR_ADVECTION="""
 
 # Cubed-sphere 1-hourly mass fluxes
 UA;VA     m_s-1      N Y F0;013000 none  none      U;V       ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A3dyn.C180.nc
-MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  0.6666666 MFXC;MFYC ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_A1.C180.nc
+MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  none.     MFXC;MFYC ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_A1.C180.nc
 CXC;CYC   1          N H F0;003000 none  none      CX;CY     ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_A1.C180.nc
 PS1       hPa        N Y  0        none  none      PS        ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_I1.C180.nc
 PS2       hPa        N Y  0;001000 none  none      PS        ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_I1.C180.nc

--- a/run/shared/settings/geosit/advection_met/geosit.preprocessed_1hr_c180_mass_flux.txt
+++ b/run/shared/settings/geosit/advection_met/geosit.preprocessed_1hr_c180_mass_flux.txt
@@ -8,7 +8,7 @@ RUNDIR_MET_EXTDATA_PRIMARY_EXPORTS_FOR_ADVECTION="""
 
 # Cubed-sphere 1-hourly mass fluxes
 UA;VA     m_s-1      N Y F0;013000 none  none      U;V       ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.A3dyn.C180.nc
-MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  none.     MFXC;MFYC ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_A1.C180.nc
+MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  none      MFXC;MFYC ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_A1.C180.nc
 CXC;CYC   1          N H F0;003000 none  none      CX;CY     ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_A1.C180.nc
 PS1       hPa        N Y  0        none  none      PS        ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_I1.C180.nc
 PS2       hPa        N Y  0;001000 none  none      PS        ./MetDir/%y4/%m2/GEOSIT.%y4%m2%d2.CTM_I1.C180.nc

--- a/run/shared/settings/geosit/advection_met/geosit.raw_1hr_c180_mass_flux.txt
+++ b/run/shared/settings/geosit/advection_met/geosit.raw_1hr_c180_mass_flux.txt
@@ -8,7 +8,7 @@ RUNDIR_MET_EXTDATA_PRIMARY_EXPORTS_FOR_ADVECTION="""
 
 # Cubed-sphere 1-hourly mass fluxes
 UA;VA     m_s-1      N Y F0;013000 none  none      U;V       ./MetDir/%y4/%m2/%d2/GEOS.it.asm.asm_tavg_3hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T01:30:00P03:00
-MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  0.6666666 MFXC;MFYC ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_tavg_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:30:00P01:00
+MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  none.     MFXC;MFYC ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_tavg_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:30:00P01:00
 CXC;CYC   1          N H F0;003000 none  none      CX;CY     ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_tavg_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:30:00P01:00
 PS1       Pa         N Y  0        none  0.01      PS        ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_inst_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:00:00P01:00
 PS2       Pa         N Y  0;001000 none  0.01      PS        ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_inst_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:00:00P01:00

--- a/run/shared/settings/geosit/advection_met/geosit.raw_1hr_c180_mass_flux.txt
+++ b/run/shared/settings/geosit/advection_met/geosit.raw_1hr_c180_mass_flux.txt
@@ -8,7 +8,7 @@ RUNDIR_MET_EXTDATA_PRIMARY_EXPORTS_FOR_ADVECTION="""
 
 # Cubed-sphere 1-hourly mass fluxes
 UA;VA     m_s-1      N Y F0;013000 none  none      U;V       ./MetDir/%y4/%m2/%d2/GEOS.it.asm.asm_tavg_3hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T01:30:00P03:00
-MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  none.     MFXC;MFYC ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_tavg_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:30:00P01:00
+MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  none      MFXC;MFYC ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_tavg_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:30:00P01:00
 CXC;CYC   1          N H F0;003000 none  none      CX;CY     ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_tavg_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:30:00P01:00
 PS1       Pa         N Y  0        none  0.01      PS        ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_inst_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:00:00P01:00
 PS2       Pa         N Y  0;001000 none  0.01      PS        ./MetDir/%y4/%m2/%d2/GEOS.it.asm.ctm_inst_1hr_glo_C180x180x6_v72.GEOS5294.%y4-%m2-%d2T%h2%n2.V01.nc4 2015-01-01T00:00:00P01:00

--- a/run/shared/settings/geosit/discover/geosit.raw_1hr_c180_mass_flux.txt
+++ b/run/shared/settings/geosit/discover/geosit.raw_1hr_c180_mass_flux.txt
@@ -9,7 +9,7 @@ RUNDIR_MET_EXTDATA_PRIMARY_EXPORTS_FOR_ADVECTION="""
 
 # Raw cubed-sphere 1-hourly mass fluxes
 UA;VA     m_s-1      N Y F0;013000 none  none      U;V       ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.asm_tavg_3hr_glo_L576x361_v72.%y4-%m2-%d2T%h2%n2Z.nc4   2015-01-01T01:30:00P03:00
-MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  none.     MFXC;MFYC ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_tavg_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:30:00P01:00
+MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  none      MFXC;MFYC ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_tavg_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:30:00P01:00
 CXC;CYC   1          N H F0;003000 none  none      CX;CY     ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_tavg_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:30:00P01:00
 PS1       Pa         N Y  0        none  0.01      PS        ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_inst_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:00:00P01:00
 PS2       Pa         N Y  0;001000 none  0.01      PS        ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_inst_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:00:00P01:00

--- a/run/shared/settings/geosit/discover/geosit.raw_1hr_c180_mass_flux.txt
+++ b/run/shared/settings/geosit/discover/geosit.raw_1hr_c180_mass_flux.txt
@@ -9,7 +9,7 @@ RUNDIR_MET_EXTDATA_PRIMARY_EXPORTS_FOR_ADVECTION="""
 
 # Raw cubed-sphere 1-hourly mass fluxes
 UA;VA     m_s-1      N Y F0;013000 none  none      U;V       ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.asm_tavg_3hr_glo_L576x361_v72.%y4-%m2-%d2T%h2%n2Z.nc4   2015-01-01T01:30:00P03:00
-MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  0.6666666 MFXC;MFYC ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_tavg_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:30:00P01:00
+MFXC;MFYC Pa_m+2_s-1 N H F0;003000 none  none.     MFXC;MFYC ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_tavg_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:30:00P01:00
 CXC;CYC   1          N H F0;003000 none  none      CX;CY     ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_tavg_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:30:00P01:00
 PS1       Pa         N Y  0        none  0.01      PS        ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_inst_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:00:00P01:00
 PS2       Pa         N Y  0;001000 none  0.01      PS        ./MetDir/Y%y4/M%m2/d5294_geosit_jan18.ctm_inst_1hr_glo_C180x180x6_v72.%y4-%m2-%d2T%h2%n2Z.nc4 2015-01-01T00:00:00P01:00


### PR DESCRIPTION
Diagnosed mass flux and courant number are already time-integrated. So we need to adapt it to the current model timestep by applying a scale of t_run / t_diag.

### Name and Institution (Required)

Name: Yuanjian Zhang
Institution: WashU

### Describe the update

Dynamically scale GCHP mass flux and courant number based on timestep.

Diagnosed mass flux and courant number are already time-integrated. So
we need to adapt it to the current model timestep by applying a scale of
t_run / t_diag (450s).

### Expected changes

This update can help correct mass flux for GCHP.

### Related Github Issue

https://github.com/geoschem/GCHP/issues/503 https://github.com/GEOS-ESM/MAPL/issues/3093
