### PR TITLE
Bugfix/update gchp mass flux cn scalings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added missing 3rd element in assigment of `Item%NcChunkSizes` in `History/histitem_mod.F90`
 - Removed extra unit conversion to mol/mol on 0th hour boundary conditions in `History/history_mod.F90`
 - Reordered code in `aerosol_mod.F90` and `gc_environment_mod.F90` so that aerosol optics file paths will be printed to the dry-run log file
-- Fixed wrong timestep scaling for GCHP mass flux runs and added dynamically scaling mass flux and courant number based on timestep
+- Fixed wrong mass flux and Courant number import scaling for GCHP runs that read these fields from offline files
 - Corrected GCHP carbon HISTORY.rc entries for KPPdiags, RxnRates, and RxnConst collections
 
 ### Removed

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -395,9 +395,6 @@ if [[ ${MassFlux_Entry} != "missing" ]]; then
     else
 	input_res=720
     fi
-    trans_timestep_scale=$(printf "%.7f" $(echo "${TransConv_Timestep_sec} / 450" | bc -l) | awk '{if ($0 ~ /^\./) print "0" $0; else print $0}')
-    sed -i -e "0,/MFXC/ s/\(none\)[[:space:]].*\(MFXC\)/\1 ${trans_timestep_scale} \2/" ExtData.rc
-    sed -i -e "0,/CX/ s/\(none\)[[:space:]].*\(CX\)/\1 ${trans_timestep_scale} \2/" ExtData.rc
     if (( ${CS_RES} < ${input_res} )); then
 	lowest_res=${CS_RES}
 	highest_res=${input_res}
@@ -633,8 +630,7 @@ else
     exit 1
 fi
 
-#### Time settings. This includes updating ExtData.rc entries for PS2,
-#### SPHU2, and TMPU2 such that read frequency matches dynamic frequency
+#### Time settings
 if [[ ${Model_Phase} == "FORWARD" ]]; then
    Reverse_Time=0
 else
@@ -659,9 +655,32 @@ replace_val RRTMG_DT      ${RRTMG_Timestep_sec}      GCHP.rc
 replace_val DYNAMICS_DT   ${TransConv_Timestep_sec}  GCHP.rc
 replace_val HEARTBEAT_DT  ${TransConv_Timestep_sec}  CAP.rc
 replace_val GCHPchem_REFERENCE_TIME ${TransConv_Timestep_HHMMSS} GCHP.rc
+
+#### Import modifications. This includes updating ExtData.rc entries for PS2,
+#### SPHU2, and TMPU2 such that read frequency matches dynamic frequency.
+#### It also includes updating mass flux and Courant number scaling if reading
+#### them from file.
+print_msg " "
+print_msg "Import settings:"
+print_msg "--------------------------------"
 update_dyn_freq PS2   ExtData.rc
 update_dyn_freq SPHU2 ExtData.rc
 update_dyn_freq TMPU2 ExtData.rc
+if [[ ${MassFlux_Entry} != "missing" ]]; then
+    # Mass flux scaling
+    mf_scaling=$(printf "%.7f" $(echo "${TransConv_Timestep_sec} / 450 * ${input_res} / ${CS_RES}" | bc -l) | awk '{if ($0 ~ /^\./) print "0" $0; else print $0}')
+    sed -i -e "0,/MFXC/ s/\(none\)[[:space:]].*\(MFXC\)/\1 ${mf_scaling} \2/" ExtData.rc
+
+    # Courant number scaling
+    cn_scaling=$(printf "%.7f" $(echo "${TransConv_Timestep_sec} / 450 / ${input_res} * ${CS_RES}" | bc -l) | awk '{if ($0 ~ /^\./) print "0" $0; else print $0}')
+    sed -i -e "0,/CX/ s/\(none\)[[:space:]].*\(CX\)/\1 ${cn_scaling} \2/" ExtData.rc
+
+    # Print if verbose
+    if [[ ${verbose} = "1" ]]; then
+	printf '%-30s : %-20s %-20s\n' "MFXC and MFYX input scaling" "${mf_scaling}" "ExtData.rc"
+	printf '%-30s : %-20s %-20s\n' "CX and CY input scaling" "${cn_scaling}" "ExtData.rc"
+    fi
+fi
 
 ##### Set commonly changed settings in geoschem_config.yml and GCHP.rc
 print_msg " "


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR builds on the mass flux and Courant number dynamic scaling update submitted by Yuanjian Zhang (@yuanjianz) in https://github.com/geoschem/geos-chem/pull/2959. It applies a grid resolution scaling in addition to the timestep scaling previously added. This makes the mass flux and Courant number scalings consistent with the custom version of MAPL currently used in the model, specifically including the horizontal flux regridding fix added in 14.4.2 in https://github.com/geoschem/MAPL/pull/36.

This scaling will change once we update to MAPL 2.55, anticipated for release in GCHP 14.7.0.

### Expected changes

This is a no diff update for GEOS-Chem except for GCHP runs that read offline mass flux and Courant numbers. We do not use that option in the benchmark simulations and it is currently in beta.

### Reference(s)

None

### Related Github Issue

closes https://github.com/geoschem/GCHP/issues/503