### PR TITLE
Update carbon simulation restart files for 14.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Placed error checks for infinity or NaN in `DO_CONVECTION` in `#ifdef DEBUG` preprocessor blocks
 - Collapsed several parallel DO loops in `GeosCore/carbon_mod.F90`
 - Changed met guidance in run directory creation to remove beta for GEOS-IT, make GCHP mass fluxes beta, and improve GEOS-FP warning
+- Changed path to carbon, CH4, CO2 simulation restart files to `ExtData/GEOSCHEM_RESTARTS/GC_14.6.3` in `download_data.yml` and the GCHP `createRunDir.sh` script
 
 ### Fixed
 - Added missing 3rd element in assigment of `Item%NcChunkSizes` in `History/histitem_mod.F90`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Placed error checks for infinity or NaN in `DO_CONVECTION` in `#ifdef DEBUG` preprocessor blocks
 - Collapsed several parallel DO loops in `GeosCore/carbon_mod.F90`
 - Changed met guidance in run directory creation to remove beta for GEOS-IT, make GCHP mass fluxes beta, and improve GEOS-FP warning
-- Changed path to carbon, CH4, CO2 simulation restart files to `ExtData/GEOSCHEM_RESTARTS/GC_14.6.3` in `download_data.yml` and the GCHP `createRunDir.sh` script
+- Changed path to carbon, CH4, CO2 simulation restart files to `ExtData/GEOSCHEM_RESTARTS/v2025-07` in `download_data.yml` and the GCHP `createRunDir.sh` script
 
 ### Fixed
 - Added missing 3rd element in assigment of `Item%NcChunkSizes` in `History/histitem_mod.F90`

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -705,7 +705,7 @@ elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
     restart_name="${sim_name}"
 elif [[ ${sim_name} = "carbon" ]]; then
     start_date='20190101'
-    restart_dir='v2023-01'
+    restart_dir='GC_14.6.3'
     restart_name="${sim_name}"
 fi
 for N in 24 30 48 90 180

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -705,7 +705,7 @@ elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
     restart_name="${sim_name}"
 elif [[ ${sim_name} = "carbon" ]]; then
     start_date='20190101'
-    restart_dir='GC_14.6.3'
+    restart_dir='v2025-07'
     restart_name="${sim_name}"
 fi
 for N in 24 30 48 90 180

--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -58,13 +58,13 @@ restarts:
     remote: GC_14.5.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   carbon:
-    remote: v2023-01/GEOSChem.Restart.carbon.20190101_0000z.nc4
+    remote: GC_14.6.3/GEOSChem.Restart.carbon.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   ch4:
-    remote: v2023-01/GEOSChem.Restart.carbon.20190101_0000z.nc4
+    remote: GC_14.6.3/GEOSChem.Restart.carbon.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   co2:
-    remote: v2023-01/GEOSChem.Restart.carbon.20190101_0000z.nc4
+    remote: GC_14.6.3/GEOSChem.Restart.carbon.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   fullchem:
     remote: GC_14.5.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4

--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -58,13 +58,13 @@ restarts:
     remote: GC_14.5.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   carbon:
-    remote: GC_14.6.3/GEOSChem.Restart.carbon.20190101_0000z.nc4
+    remote: v2025-07/GEOSChem.Restart.carbon.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   ch4:
-    remote: GC_14.6.3/GEOSChem.Restart.carbon.20190101_0000z.nc4
+    remote: v2025-07/GEOSChem.Restart.carbon.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   co2:
-    remote: GC_14.6.3/GEOSChem.Restart.carbon.20190101_0000z.nc4
+    remote: v2025-07/GEOSChem.Restart.carbon.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   fullchem:
     remote: GC_14.5.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #2963.   While we expect to have new restart files for the carbon simulation from 1-year benchmarks, in the meantime we need to update the restart files for the 14.6.3 release so that users will not have to manually change the restart file time cycle flag setting in HEMCO_Config.rc.

We have prepared a set of updated restart files in `ExtData/GEOSCHEM_RESTARTS/v2025-07`.  We have also updated the  path to the carbon simulation restart files in `run/GCHP/createRunDir.sh` and `run/shared/download_data.yml`.

### Expected changes
This is a no-diff-to-benchmark PR.  Carbon simulations will no longer require changing the time cycle flag for the restart file entry from `EFYO` to `CYS`, because the restart files now contain the updated species names.

### Related Github Issue
- See #2963 
