### PR TITLE
Fix ocean flux diagnostics in Hg simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+- In Hg simulation, fix directional ocean flux diagnostics so they equal net flux
+
 ## [14.6.2] - 2025-06-11
 ### Added
 - Added MCHgMAP geogenic emissions (2010-2020) from Dastoor et al. (2025)

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -362,18 +362,6 @@ CONTAINS
           State_Diag%EmisHg2snowToOcean = 0.0_f4
        ENDIF
 
-      IF ( State_Diag%Archive_FluxHg0fromAirToOcean ) THEN
-          State_Diag%FluxHg0fromAirToOcean = 0.0_f4
-       ENDIF
-
-       IF ( State_Diag%Archive_FluxHg0fromOceantoAir ) THEN
-          State_Diag%FluxHg0fromOceanToAir = 0.0_f4
-       ENDIF
-
-       IF ( State_Diag%Archive_FluxHg2HgPfromAirToOcean ) THEN
-          State_Diag%FluxHg2HgPfromAirToOcean = 0.0_f4
-       ENDIF
-
        IF ( State_Diag%Archive_FluxOCtoDeepOcean ) THEN
           State_Diag%FluxOCtoDeepOcean = 0.0_f4
        ENDIF


### PR DESCRIPTION
Zero values of Hg flux diagnostics were being sent to the history module resulting in erroneous values (too small by 1/2) for some diagnostics `FluxHg0fromOceanToAir` `FluxHg0fromAirToOcean` in netCDF output. This change means that the flux components equal the net flux `EmisHg0ocean`.

### Name and Institution (Required)

Name: Alan Griffiths
Institution: ANSTO

### Describe the update

Previously the diagnostics were:
 - zeroed at the start of each (transport?) timestep
 - sent to the history module for averaging at each heartbeat timestep, but
 - not computed until the middle of the transport timestep, along with other surface fluxes
Therefore, zero values were being sent to the history module for half of the time. 

This is a minimal change which stops zeroing the diagnostics at the start of the timestep, so that instead the value is carried over from the previous timestep.

### Expected changes

`FluxHg0fromOceanToAir` minus `FluxHg0fromAirToOcean` will equal the net flux `EmisHg0ocean`.  No change to chemistry as the net flux (which is seen by the model) is unchanged.

### Related Github Issue

(https://github.com/geoschem/geos-chem/issues/2956)
