### PR TITLE
Fix GCHP restart for Jacobian tracers

### DIFF
--- a/Headers/species_database_mod.F90
+++ b/Headers/species_database_mod.F90
@@ -157,7 +157,7 @@ CONTAINS
     REAL(f4)                    :: wd_rainouteff_luo(3)
 
     ! String arrays
-    CHARACTER(LEN=17)           :: tags(66)
+    CHARACTER(LEN=17)           :: tags(67) ! For Is_JacobianTracer (D. Zhang, Aug 6, 2025)
     CHARACTER(LEN=QFYAML_StrLen):: a_str(2)
 
     ! Objects
@@ -213,6 +213,7 @@ CONTAINS
              "Henry_K0         ",  &
              "Henry_K0_Luo     ",  &
              "Henry_pKa        ",  &
+             "Is_JacobianTracer",  &
              "Is_Aerosol       ",  &
              "Is_DryAlt        ",  &
              "Is_DryDep        ",  &
@@ -602,6 +603,13 @@ CONTAINS
                 SpcCount%nTracer       = SpcCount%nTracer + 1
                 ThisSpc%TracerId       = SpcCount%nTracer
                 ThisSpc%Is_Tracer      = v_bool
+             ENDIF
+         
+         ELSE IF ( INDEX( key, "%Is_JacobianTracer" ) > 0 ) THEN
+             CALL QFYAML_Add_Get( yml, key, v_bool, "", RC )
+             IF ( RC /= GC_SUCCESS ) GOTO 999
+             IF ( v_bool ) THEN
+                ThisSpc%Is_JacobianTracer = v_bool
              ENDIF
 
           ELSE IF ( INDEX( key, "%Is_WetDep" ) > 0 ) THEN

--- a/Headers/species_mod.F90
+++ b/Headers/species_mod.F90
@@ -118,6 +118,7 @@ MODULE Species_Mod
      LOGICAL            :: Is_Photolysis    ! Is it an photolysis species?
      LOGICAL            :: Is_RadioNuclide  ! Is it a radionuclide species?
      LOGICAL            :: Is_Tracer        ! Is it a transport tracer?
+     LOGICAL            :: Is_JacobianTracer  ! Is it a Jacobian tracer?
      LOGICAL            :: Is_WetDep        ! Is it wet-deposited?
      LOGICAL            :: Is_InRestart     ! Is it in the restart file?
 
@@ -402,6 +403,7 @@ CONTAINS
     Spc%Is_Photolysis   = MISSING_BOOL
     Spc%Is_RadioNuclide = MISSING_BOOL
     Spc%Is_Tracer       = MISSING_BOOL
+    Spc%Is_JacobianTracer = MISSING_BOOL
     Spc%Is_WetDep       = MISSING_BOOL
     Spc%Src_Add         = MISSING_BOOL
     Spc%MP_SizeResAer   = MISSING_BOOL
@@ -731,7 +733,14 @@ CONTAINS
           WRITE( 6, 110 )    "Snk_Vert       ",  TRIM(ThisSpc%Snk_Vert)
 
        ENDIF
-
+       
+       !--------------------------------------------------------------------
+       ! Is the species a Jacobian Tracer (for IMI)?
+       !--------------------------------------------------------------------
+       IF ( ThisSpc%Is_JacobianTracer ) THEN
+          WRITE( 6, 130 )    "Is_JacobianTracer ",  ThisSpc%Is_JacobianTracer
+       ENDIF
+       
        !--------------------------------------------------------------------
        ! Is the species a mercury species?
        !--------------------------------------------------------------------

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -2645,8 +2645,8 @@ CONTAINS
                   VALUE=RST, RC=STATUS )
 
              ! Set spc conc to background value if rst skipped or var not there
-             IF ( RC /= ESMF_SUCCESS .OR. RST == MAPL_RestartBootstrap .OR.   &
-                      RST == MAPL_RestartSkipInitial ) THEN
+             IF ( (RC /= ESMF_SUCCESS .OR. RST == MAPL_RestartBootstrap .OR.   &
+                  RST == MAPL_RestartSkipInitial) .AND. (.not. ThisSpc%Is_JacobianTracer) ) THEN
                 DO L = 1, State_Grid%NZ
                 DO J = 1, State_Grid%NY
                 DO I = 1, State_Grid%NX
@@ -2667,6 +2667,17 @@ CONTAINS
                         //' for species '//trim(ThisSpc%Name) 
                 ENDIF
              ENDIF
+
+             ! Do special handling if this is a Jacobian tracer             
+             IF ( ThisSpc%Is_JacobianTracer ) THEN
+                State_Chm%Species(IND)%Conc = State_Chm%Species(IND_('CH4'))%Conc
+                IF ( MAPL_am_I_Root()) THEN
+                   WRITE(*,*)  &
+                        '   INFO: using the initial concentrations of CH4'&
+                        //' for the Jacobian tracer '//trim(ThisSpc%Name) 
+                ENDIF
+             ENDIF
+
              ThisSpc => NULL()
           ENDDO
        ENDIF


### PR DESCRIPTION
### Name and Institution (Required)

Name: Dandan Zhang
Institution: Harvard University

### Describe the update

All changes are based on `geos-chem` version 14.6.2
Currently GCHP simulations cannot use the restart concentrations for one species to other species like GCC, which is needed or more efficient for methane perturbation runs. To allow GCHP perturbation runs to use the initial concentrations of `CH4` for Jacobian tracers of `CH4_000N`, I add a logical flag of `Is_JacobianTracer` in `species_database.yml`. Thanks to @lizziel for the idea of implementing this into `<geos-chem>/Interfaces/GCHP/Chem_GridCompMod.F90`.

### Expected changes

It will only affect GCHP perturbation runs with the flag of `Is_JacobianTracer` in `species_database.yml`, without interference with the standard geos-chem.
