### PR TITLE
Update GFEIv3 files to correct for issue found during peer review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Updated operational run script sample for WashU Compute1
 - Update GCHP AWS EFA operational run script examples to avoid crashes over large core counts
+- Updated GFEIv3 files to correct issue in original version
 
 ### Fixed
 - Fixed Hg directional ocean flux diagnostics in the Hg simulation so that they equal net flux

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
@@ -363,9 +363,9 @@ VerboseOnCores:              root       # Accepted values: root all
 # This inventory will replace EDGAR (oil, gas, & coal)
 #==============================================================================
 (((GFEIv3
-0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  Oil_All 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
-0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  Gas_All 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
-0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     Coal    2020/1/1/0 C xy kg/m2/s CH4 -  3 5
+0 GFEI_CH4_OIL  $ROOT/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  Oil_All 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
+0 GFEI_CH4_GAS  $ROOT/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  Gas_All 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
+0 GFEI_CH4_COAL $ROOT/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     Coal    2020/1/1/0 C xy kg/m2/s CH4 -  3 5
 )))GFEIv3
 
 #==============================================================================

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -401,9 +401,9 @@ Mask fractions:              false
 # This inventory will replace EDGAR (oil, gas, & coal)
 #==============================================================================
 (((GFEIv3
-0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  Oil_All 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
-0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  Gas_All 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
-0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     Coal    2020/1/1/0 C xy kg/m2/s CH4 -  3 5
+0 GFEI_CH4_OIL  $ROOT/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  Oil_All 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
+0 GFEI_CH4_GAS  $ROOT/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  Gas_All 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
+0 GFEI_CH4_COAL $ROOT/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     Coal    2020/1/1/0 C xy kg/m2/s CH4 -  3 5
 )))GFEIv3
 
 #==============================================================================

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -190,9 +190,9 @@ CAN_WASTEWATER          kg/m2/s N Y - none none  wastewater_total           ./Hc
 CAN_OTHER               kg/m2/s N Y - none none  other_minor_sources_total  ./HcoDir/CH4/v2022-01/Scarpelli_Canada/can_emis_other_minor_sources_2018.nc
 
 # --- GFEI ---
-GFEI_CH4_OIL  kg/m2/s N Y - none none Oil_All  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc
-GFEI_CH4_GAS  kg/m2/s N Y - none none Gas_All  ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc
-GFEI_CH4_COAL kg/m2/s N Y - none none Coal     ./HcoDir/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc
+GFEI_CH4_OIL  kg/m2/s N Y - none none Oil_All  ./HcoDir/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc
+GFEI_CH4_GAS  kg/m2/s N Y - none none Gas_All  ./HcoDir/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc
+GFEI_CH4_COAL kg/m2/s N Y - none none Coal     ./HcoDir/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc
 
 # --- GRPI ---
 GRPI_CH4_RICE kg/m2/s N Y F2022-%m2-01T00:00:00  none none emi_ch4 ./HcoDir/CH4/v2025-01/GRPI/GRPI_01x01.nc

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -401,9 +401,9 @@ Mask fractions:              false
 # This inventory will replace EDGAR (oil, gas, & coal)
 #==============================================================================
 (((GFEIv3
-0 GFEI_CH4_OIL  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  Oil_All 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
-0 GFEI_CH4_GAS  $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  Gas_All 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
-0 GFEI_CH4_COAL $ROOT/CH4/v2025-04/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     Coal    2020/1/1/0 C xy kg/m2/s CH4 -  3 5
+0 GFEI_CH4_OIL  $ROOT/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Oil_All.nc  Oil_All 2020/1/1/0 C xy kg/m2/s CH4 -  1 5
+0 GFEI_CH4_GAS  $ROOT/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Gas_All.nc  Gas_All 2020/1/1/0 C xy kg/m2/s CH4 -  2 5
+0 GFEI_CH4_COAL $ROOT/CH4/v2025-08/GFEIv3/Global_Fuel_Exploitation_Inventory_v3_2020_Coal.nc     Coal    2020/1/1/0 C xy kg/m2/s CH4 -  3 5
 )))GFEIv3
 
 #==============================================================================


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

There was an issue in the original GFEIv3 files available at https://doi.org/10.7910/DVN/HH4EUM. The files were corrected in July 2025 and redownloaded and processed for use in GEOS-Chem. The corrected files can now be found in `ExtData/HEMCO/CH4/v2025-08/GFEIv3/`,

### Expected changes

This is a zero difference fix for the benchmark simulation, but it will impact carbon and CH4 simulation emissions.

### Reference(s)

- Scarpelli, T. R., Roy, E., Jacob, D. J., Sulprizio, M. P., Tate, R. D., and Cusworth, D. H., Using new geospatial data and 2020 fossil fuel methane emissions for the Global Fuel Exploitation Inventory (GFEI) v3, Earth Syst. Sci. Data Discuss. [preprint], https://doi.org/10.5194/essd-2024-552, in review, 2025.

### Related Github Issue

- https://github.com/geoschem/geos-chem/pull/2801
