### PR TITLE
Pass in second when calling Accept_External_Date_Time

### DIFF
--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -918,6 +918,7 @@ CONTAINS
                                     value_DAYOFYR  = dayOfYr,    &
                                     value_HOUR     = hour,       &
                                     value_MINUTE   = minute,     &
+                                    value_SECOND   = second,     &
                                     value_HELAPSED = hElapsed,   &
                                     value_UTC      = utc,        &
                                     RC             = RC         )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Haipeng Lin
Institution: UCAR/Harvard - this is a PR on personal time

### Describe the update

This is a fix to the GEOS-Chem/GCHP chunk interface to pass in the "second" information to Accept_External_Date_Time from GCHP_Chunk_Run.

The omission of this argument caused a bug within WRF-GC, which uses a fork of this interface, to have the incorrect time stamp when calling HEMCO after updating the GEOS-Chem clock on fractional minutes (i.e., when `second /= 0`). This would cause the HEMCO clock to "rewind" itself from the correct time to hh:mm:00 and lose the "first timestep" flag (because it is lost whenever time is updated to be different from the previous one), necessary for loading information on MEGAN biogenic emissions and possibly other initialization subroutines in HEMCO.

This update should not impact other models using GEOS-Chem (maybe GCHP if running on timesteps that are not whole minutes), but is being contributed here in order to keep the interface robust (and minimize divergence of the WRF-GC code to the underlying GCHP implementation)

See detailed writeup below.

### Expected changes

bit for bit unchanged when timestep is >= 60 seconds

Potentially hidden bugs in GCHP when timestep is < 60 seconds are resolved by this PR.

### Reference(s)

N/A

### Related Github Issue

https://github.com/WRF-GC/wrf-gc-release/issues/17

The main symptom is missing biogenic emissions and zero isoprene concentrations throughout the simulation domain in WRF-GC, but there could be other hidden effects. Thanks to Xiao Deng (Peking Univ.), Katherine Travis (NASA), and Will Porter (UCR) for assistance for diagnosing the issue. This bug was reported by several WRF-GC users over the past few months, was difficult to reproduce (because sub-minute timesteps are usually at very high resolution), and so I was asked to help out with debugging on a couple of beautiful weekends :-)

#### Detailed analysis

This happens because in `GCHP_Chunk_Run` on a fractional minute
* `Accept_External_Date_Time` updates the GEOS-Chem clock with the missing second information
* `SetHcoTime` is called when `!defined(MODEL_GEOS)` and updates the HEMCO clock **with** the second information -- internally, the HEMCO clock will record this hh:mm:ss (ss /= 0)
```fortran
    ! Pass time values obtained from the ESMF environment to GEOS-Chem
    CALL Accept_External_Date_Time( value_NYMD     = nymd,       &
                                    value_NHMS     = nhms,       &
                                    value_YEAR     = year,       &
                                    value_MONTH    = month,      &
                                    value_DAY      = day,        &
                                    value_DAYOFYR  = dayOfYr,    &
                                    value_HOUR     = hour,       &
                                    value_MINUTE   = minute,     &  ! note missing second
                                    value_HELAPSED = hElapsed,   &
                                    value_UTC      = utc,        &
                                    RC             = RC         )

    ! Pass time values obtained from the ESMF environment to HEMCO
#if !defined( MODEL_GEOS )
    CALL SetHcoTime ( HcoState,   ExtState,   year,    month,   day,   &
                      dayOfYr,    hour,       minute,  second,  DoEmis,  RC )
#endif
```

Then:
* `EMISSIONS_RUN` is called which calls `HCOI_GC_Run` which **calls `SetHcoTime` a second time, now using the GEOS-Chem clock information**
```fortran
    !=======================================================================
    ! Make sure HEMCO time is in sync with simulation time
    ! Now done through a universal function in HCO_Interface_Common
    !=======================================================================
    year      = GET_YEAR()
    month     = GET_MONTH()
    day       = GET_DAY()
    dayOfYr   = GET_DAY_OF_YEAR()
    hour      = GET_HOUR()
    minute    = GET_MINUTE()
    second    = GET_SECOND()   ! !!!! this would be zero !!!!

    CALL SetHcoTime( HcoState, ExtState, year,   month,     day, dayOfYr, &
                     hour,     minute,   second, EmisTime,  HMRC         )
```

* The HEMCO clock determines whether a "new timestep" is set by comparing the information passed to `SetHcoTime` with the information in the module; so when hh:mm:ss is rewind to hh:mm:00 it will cause an increase in the nSteps / nEmisSteps counter:
```fortran
       ! Check if previous emission time step is different
       IF ( ( Clock%ThisEYear   /= Clock%ThisYear   ) .OR. &
            ( Clock%ThisEMonth  /= Clock%ThisMonth  ) .OR. &
            ( Clock%ThisEDay    /= Clock%ThisDay    ) .OR. &
            ( Clock%ThisEHour   /= Clock%ThisHour   ) .OR. &
            ( Clock%ThisEMin    /= Clock%ThisMin    ) .OR. &
            ( Clock%ThisESec    /= Clock%ThisSec    )       ) THEN
...
          ! Increase counter
          Clock%nEmisSteps = Clock%nEmisSteps + 1
```

This would cause `HcoClock_First` which is implemented like this
```fortran
    IF ( EmisTime ) THEN
       !First = ( Clock%nEmisSteps == 1 )
       First = ( Clock%nEmisSteps <= 1 )
    ELSE
       !First = ( Clock%nSteps     == 1 )
       First = ( Clock%nSteps     <= 1 )
    ENDIF
```

to then never return true, because all of the above happens in a single `GCHP_Chunk_Run` call; this means that `HcoClock_First` can never be `.true.`

* This would affect extensions like MEGAN which initialize their scale factors based on this flag. Luckily for GCHP, when `#if defined( ESMF_ ) || defined( MODEL_GEOS )` is true in MEGAN, the "FIRST" flag is ignored and data is recomputed every time, this is why the bug only manifested itself in WRF-GC:
```fortran
    ! Time information
    FIRST     = HcoClock_First  ( HcoState%Clock, .TRUE. )

...
#else  ! ... this is when ESMF_ && MODEL_GEOS aren't set
    IF ( FIRST ) THEN

       ! Generate annual emission factors for MEGAN inventory
       CALL CALC_AEF( HcoState, ExtState, Inst, RC )
```

but this merely masks the nature of the bug. I would think GCHP would never have a "first" HEMCO time step either when the timestep is smaller than 60 seconds; it just wouldn't show up as an issue in MEGAN. I think other places might have some kind of similar initialization as well that could be broken.
