### PR TITLE
Add LPJ_MERRA2 wetland CH4 emissions as an option in CH4 and carbon simulations

### DIFF
--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.CH4
@@ -67,6 +67,7 @@ VerboseOnCores:              root       # Accepted values: root all
     --> EDGARv8                :       true     # 2010-2022
     --> QFED2                  :       false    # 2009-2015
     --> JPL_WETCHARTS          :       true     # 2009-2017
+    --> LPJ_MERRA2             :       false    # 2018-2023
     --> SEEPS                  :       true     # 2012
     --> LAKES                  :       false    # 2009-2015
     --> RESERVOIRS             :       true     # 2022
@@ -459,13 +460,23 @@ VerboseOnCores:              root       # Accepted values: root all
 )))QFED2
 
 #==============================================================================
-# --- CH4: JPL WetCHARTs v1.0 (Bloom et al., https://doi.org/10.3334/ORNLDAAC/1502) ---
+# --- JPL WetCHARTs v1.0 wetland emissions ---
 #
+# Reference: Bloom et al., https://doi.org/10.3334/ORNLDAAC/1502
 # Use updated files (v2024-01); these are COARDS-compliant.
 #==============================================================================
 (((JPL_WETCHARTS
 0 JPLW_CH4  $ROOT/CH4/v2024-01/JPL_WetCharts/HEensemble/JPL_WetCharts_2010-2019.Ensemble_Mean.0.5x0.5.nc emi_ch4 2010-2019/1-12/1/0 C xy molec/cm2/s CH4 - 10 1
 )))JPL_WETCHARTS
+
+#==============================================================================
+# ---  LPJ MERRA-2 wetland emissions ---
+#
+# Reference: East et al., https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2024GL108494
+#==============================================================================
+(((LPJ_MERRA2
+0 LPJ_CH4 $ROOT/CH4/v2025-09/LPJ_MERRA2/LPJ_MERRA2_$YYYY_0.5x0.5.nc emis_ch4 2018-2023/1-12/1/0 C xy kg/m2/s CH4 - 10 2
+)))LPJ_MERRA2
 
 #==============================================================================
 # --- Geological Seeps ---

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -74,6 +74,7 @@ Mask fractions:              false
     --> EDGARv8                :       true     # 2010-2022
     --> QFED2                  :       false    # 2009-2015
     --> JPL_WETCHARTS          :       true     # 2009-2017
+    --> LPJ_MERRA2             :       false    # 2018-2023
     --> SEEPS                  :       true     # 2012
     --> LAKES                  :       false    # 2009-2015
     --> RESERVOIRS             :       true     # 2022
@@ -497,13 +498,23 @@ Mask fractions:              false
 )))QFED2
 
 #==============================================================================
-# --- CH4: JPL WetCHARTs v1.0 (Bloom et al., https://doi.org/10.3334/ORNLDAAC/1502) ---
+# --- JPL WetCHARTs v1.0 wetland emissions ---
 #
+# Reference: Bloom et al., https://doi.org/10.3334/ORNLDAAC/1502
 # Use updated files (v2024-01); these are COARDS-compliant.
 #==============================================================================
 (((JPL_WETCHARTS
 0 JPLW_CH4  $ROOT/CH4/v2024-01/JPL_WetCharts/HEensemble/JPL_WetCharts_2010-2019.Ensemble_Mean.0.5x0.5.nc emi_ch4 2010-2019/1-12/1/0 C xy molec/cm2/s CH4 - 10 1
 )))JPL_WETCHARTS
+
+#==============================================================================
+# ---  LPJ MERRA-2 wetland emissions ---
+#
+# Reference: East et al., https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2024GL108494
+#==============================================================================
+(((LPJ_MERRA2
+0 LPJ_CH4 $ROOT/CH4/v2025-09/LPJ_MERRA2/LPJ_MERRA2_$YYYY_0.5x0.5.nc emis_ch4 2018-2023/1-12/1/0 C xy kg/m2/s CH4 - 10 2
+)))LPJ_MERRA2
 
 #==============================================================================
 # --- CH4: Geological Seeps ---

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -245,6 +245,9 @@ EDGAR8_CH4_SWD_INC             kg/m2/s N Y F%y4-%m2-01T00:00:00  none none emi_c
 # Include scaling to convert molecules/cm2/s to kg/m2/s
 JPLW_CH4  kg/m2/s N Y F%y4-%m2-01T00:00:00 none 2.66350462E-22 emi_ch4  ./HcoDir/CH4/v2024-01/JPL_WetCharts/HEensemble/JPL_WetCharts_2010-2019.Ensemble_Mean.0.5x0.5.nc
 
+# --- LPJ MERRA2 (East et al., https://doi.org/10.1029/2024GL108494) ---
+LPJ_CH4  kg/m2/s N Y F%y4-%m2-01T00:00:00 none none emis_ch4 /n/holylfs06/LABS/jacob_lab2/Lab/dzhang8/LPJ_MERRA2/LPJ_MERRA2_%y4_0.5x0.5.nc
+
 # --- Geological seeps ---
 CH4_SEEPS kg/m2/s N Y - none none  emi_ch4  ./HcoDir/CH4/v2020-04/Seeps/Etiope_CH4GeologicalEmis_ScaledToHmiel.1x1.nc
 

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -74,6 +74,7 @@ Mask fractions:              false
     --> EDGARv8                :       true     # 2010-2022
     --> QFED2                  :       false    # 2009-2015
     --> JPL_WETCHARTS          :       true     # 2009-2017
+    --> LPJ_MERRA2             :       false    # 2018-2023
     --> SEEPS                  :       true     # 2012
     --> LAKES                  :       false    # 2009-2015
     --> RESERVOIRS             :       true     # 2022
@@ -497,13 +498,23 @@ Mask fractions:              false
 )))QFED2
 
 #==============================================================================
-# --- CH4: JPL WetCHARTs v1.0 (Bloom et al., https://doi.org/10.3334/ORNLDAAC/1502) ---
+# --- JPL WetCHARTs v1.0 wetland emissions ---
 #
+# Reference: Bloom et al., https://doi.org/10.3334/ORNLDAAC/1502
 # Use updated files (v2024-01); these are COARDS-compliant.
 #==============================================================================
 (((JPL_WETCHARTS
 0 JPLW_CH4  $ROOT/CH4/v2024-01/JPL_WetCharts/HEensemble/JPL_WetCharts_2010-2019.Ensemble_Mean.0.5x0.5.nc emi_ch4 2010-2019/1-12/1/0 C xy molec/cm2/s CH4 - 10 1
 )))JPL_WETCHARTS
+
+#==============================================================================
+# ---  LPJ MERRA-2 wetland emissions ---
+#
+# Reference: East et al., https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2024GL108494
+#==============================================================================
+(((LPJ_MERRA2
+0 LPJ_CH4 $ROOT/CH4/v2025-09/LPJ_MERRA2/LPJ_MERRA2_$YYYY_0.5x0.5.nc emis_ch4 2018-2023/1-12/1/0 C xy kg/m2/s CH4 - 10 2
+)))LPJ_MERRA2
 
 #==============================================================================
 # --- CH4: Geological Seeps ---


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

Several recent IMI/CH4 studies are using the JPL-MERRA2 wetland emissions dataset instead of the JPL WetCHARTs inventory because they may better captures observed methane seasonality in the Northern Hemisphere (e.g. East et al., GRL, 2024; He et al., submitted to Sci. Adv, 2025). Here, we introduce the LPJ_MERRA2 inventory as an option (off by default) so that other users can more easily utilize the dataset.

### Expected changes

This is a zero-difference update -- it simply adds an emissions option (off by default) to only CH4 and carbon simulations.

### Reference(s)

- East, J.D., D.J. Jacob, N.Balasus, A.A.Bloom, L.Bruhwiler, Z.Chen, J.O. Kaplan, L.J. Mickley, T.A. Mooring, E.Penn, B.Poulter, M.P. Sulprizio, R.M. Yantosca, J.R. Worden, and Z.Zhang, Interpreting the seasonalityof atmospheric methane, Geophys. Res. Lett., https://doi.org/10.1029/2024GL108494, 2024.
- He, M., D. J. Jacob, L. Estrada, D. J. Varon, M. Sulprizio, N. Balasus, J. D. East, E. Penn, D. C. Pendergrass, Z. Chen, T. A. Mooring, J. D. Maasakkers, P. G. Brodrick, C. Frankenberg, K. W. Bowman, L. Bruhwiler: Attributing 2019-2024 methane growth using TROPOMI satellite observations, submitted to Sci. Adv., https://doi.org/10.22541/essoar.174886142.25607118/v1, 2025.