### PR TITLE
Turn off PARANOx for GEOS-Chem Classic 0.25 x 0.3125 and 0.125 x 0.15625 grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated operational run script sample for WashU Compute1
 - Update GCHP AWS EFA operational run script examples to avoid crashes over large core counts
 - Updated GFEIv3 files to correct issue in original version
+- Disable PARANOX extension when using GEOS-Chem Classic 0.25x0.3125 or 0.125x0.15625 grids
 
 ### Fixed
 - Fixed Hg directional ocean flux diagnostics in the Hg simulation so that they equal net flux

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -163,7 +163,7 @@ VerboseOnCores:              root       # Accepted values: root all
 # -----------------------------------------------------------------------------
 100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2/MENO3/ETNO3/MOH
-102     ParaNOx                : on    NO/NO2/O3/HNO3
+102     ParaNOx                : ${RUNDIR_PARANOX_EXT}   NO/NO2/O3/HNO3
     --> LUT data format        :       nc
     --> LUT source dir         :       $ROOT/PARANOX/v2015-02
 103     LightNOx               : on    NO

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -1037,6 +1037,17 @@ else
     RUNDIR_VARS+="RUNDIR_USE_GCCLASSIC_TIMERS='false'\n"
 fi
 
+# Disable PARANOX for 0.25 x 0.3125 and finer grids
+# See: https://github.com/geoschem/geos-chem/issues/3009
+if [[ "x${sim_name}" == "xfullchem" ]]; then
+    if [[ "x${grid_res}" == "x0125x015625" ]]  ||   \
+       [[ "x${grid_res}" == "x025x03125"   ]]; then
+       RUNDIR_VARS+="RUNDIR_PARANOX_EXT='off'\n"
+    else
+       RUNDIR_VARS+="RUNDIR_PARANOX_EXT='on '\n"
+    fi
+fi
+
 # Assign appropriate file paths and settings in HEMCO_Config.rc
 if [[ ${met} = "ModelE2.1" ]]; then
     RUNDIR_VARS+="RUNDIR_DUSTDEAD_EXT='on '\n"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This is the companion PR to issue #3009 by @eamarais.  We have added logic into the GEOS-Chem run directory creation process to disable PARANOx when the user requests a run directory at either 0.25&deg; x 0.3125&deg; or 0.125&deg; x 0.15625&deg; resolution.

### Expected changes

See discussion at issue #3009

### Related Github Issue

- Closes #3009
