### PR TITLE
Fixed parallelization error in PR #3014

### DIFF
--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -1927,9 +1927,9 @@ CONTAINS
             ! Also print mass based on restart file mixing ratio and meteorology
             SpcMass = 0.d0
             SpcMassPtr => SpcMass
-            !$OMP PARALLEL DO        &
-            !$OMP DEFAULT( SHARED  ) &
-            !$OMP PRIVATE( I, J, L ) &
+            !$OMP PARALLEL DO                 &
+            !$OMP DEFAULT( SHARED           ) &
+            !$OMP PRIVATE( I, J, L, AirMass ) &
             !$OMP COLLAPSE( 3 )
             DO L = 1, State_Grid%NZ
             DO J = 1, State_Grid%NY
@@ -1941,6 +1941,7 @@ CONTAINS
             ENDDO
             ENDDO
             ENDDO
+            !$OMP END PARALLEL DO
             WRITE(6,550) SUM( SpcMassPtr )
             SpcMassPtr => NULL()
 
@@ -1960,6 +1961,7 @@ CONTAINS
                ENDDO
                ENDDO
                ENDDO
+               !$OMP END PARALLEL DO
             ENDIF
 
          ENDIF


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR fixes a parallelization issue from PR #3014.  The `AirMass` variable is now declared `!$OMP PRIVATE` in the parallel loop at line 1930 in `hco_utilities_gc_mod.F90`.  This was causing numerical noise differences in the initial restart file mass.

### Expected changes
This PR eliminates the numerical noise differences.

### Related Github Issue

- See PR #3014 