### PR TITLE
Unhide feature to bypass HEMCO to read GC-Classic restart file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files
 - Added comments to `HEMCO_Diagn.rc` template files instructing users on which ExtNr/Cat/Hier to use for online vs. offline biomass burning emissions
+- Added GC-Classic config file option to read restart file as REAL8 via GEOS-Chem rather than HEMCO
 
 ### Changed
 - Replaced comments in template HEMCO configuration files directing users to obsolete wiki documentation with comments directing users to `hemco.readthedocs.io`

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.Hg
@@ -20,6 +20,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
+  read_restart_as_real8: false
 
 #============================================================================
 # Grid settings

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.POPs
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.POPs
@@ -20,6 +20,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
+  read_restart_as_real8: false
 
 #============================================================================
 # Grid settings

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
@@ -20,6 +20,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
+  read_restart_as_real8: false
 
 #============================================================================
 # Grid settings

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.aerosol
@@ -20,6 +20,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
+  read_restart_as_real8: false
 
 #============================================================================
 # Grid settings

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.carbon
@@ -17,6 +17,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
+  read_restart_as_real8: false
 
 #============================================================================
 # Grid settings

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -20,6 +20,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
+  read_restart_as_real8: false
 
 #============================================================================
 # Grid settings

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.metals
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.metals
@@ -20,6 +20,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
+  read_restart_as_real8: false
 
 #============================================================================
 # Grid settings

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCO
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagCO
@@ -20,6 +20,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
+  read_restart_as_real8: false
 
 #============================================================================
 # Grid settings

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagO3
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.tagO3
@@ -20,6 +20,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
+  read_restart_as_real8: false
 
 #============================================================================
 # Grid settings


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update adds the option to use GEOS-Chem to read the GC-Classic restart file and therefore preserve native precision stored in the file. This option has been present since 14.6.3 but it was not visible in the `geoschem_config.yml` files as an option. The default is currently false.

Accompanying ReadTheDocs updates are pushed to the docs/dev branch.

### Expected changes

None

### Reference(s)

None

### Related Github Issue

https://github.com/geoschem/geos-chem/pull/2967
