### PR TITLE
Remove Is_Advected tags from species database template files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 - Removed entries for FINN v1.5 biomass burning emissions from template HEMCO configuration files
+- Removed `Is_Advected` tags from `run/shared/species_database*.yml` template files
 
 ## [14.6.3] - 2025-07-28
 ### Added

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -13,7 +13,6 @@ ACET:
   FullName: Acetone
   Henry_CR: 5500.0
   Henry_K0: 2.74e+1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -25,7 +24,6 @@ ACR:
   FullName: Acrolein
   Henry_CR: 5100.0
   Henry_K0: 7.3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   MW_g: 56.06
@@ -36,7 +34,6 @@ ACTA:
   FullName: Acetic acid
   Henry_CR: 6200.0
   Henry_K0: 4.05e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -59,7 +56,6 @@ AERI:
   DD_Hstar: 0.0
   Formula: I
   FullName: Iodine on aerosol
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -75,7 +71,6 @@ APAN:
   FullName: Peroxyacryloyl nitrate
   Henry_CR: 5700.0
   Henry_K0: 2.94
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -86,7 +81,6 @@ DST1_PROP: &DST1properties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Density: 2500.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -100,7 +94,6 @@ DST2_PROP: &DST2properties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Density: 2650.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -115,7 +108,6 @@ DST3_PROP: &DST3properties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Density: 2650.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -130,7 +122,6 @@ DST4_PROP: &DST4properties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Density: 2650.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -158,7 +149,6 @@ ALD2:
   FullName: Acetaldehyde
   Henry_CR: 5900.0
   Henry_K0: 1.32e+1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -167,7 +157,6 @@ ALD2:
   WD_RetFactor: 2.0e-2
 ALK4:
   FullName: Lumped C4+C5 Alkanes
-  Is_Advected: true
   Is_Gas: true
   MW_g: 58.12
 ALK4N1:
@@ -182,7 +171,6 @@ ALK4N2:
   FullName: Lumped alkyl nitrate from ALK4
   Henry_CR: 5800.0
   Henry_K0: 1.0
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -200,7 +188,6 @@ ALK4P:
   FullName: Peroxide from ALK4O2
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -208,12 +195,10 @@ ALK4P:
   WD_RetFactor: 2.0e-2
 ALK6:
   FullName: Lumped >= C6 Alkanes
-  Is_Advected: true
   Formula: C7H16
   Is_Gas: true
   MW_g: 100.20
 aoa_PROP: &aoaproperties
-  Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
   MW_g: 1.0   # Use value of 1.0 to get past checks for missing MW_g
@@ -247,7 +232,6 @@ AONITA:
   DD_Hstar: 2.9e+3
   Formula: C6H6O6N
   FullName: Aerosol-phase organonitrates from aromatics
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -265,7 +249,6 @@ APINP:
   FullName: Hydroperoxide from APIN
   Henry_CR: 6039.0
   Henry_K0: 1.0e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -279,7 +262,6 @@ APINN:
   FullName: 1st gen organic nitrate from APIN
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -295,7 +277,6 @@ AROMP4:
   DD_Hstar: 4.1e+5
   Formula: C4H4O2
   FullName: Generic C4 product of aromatics
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -308,7 +289,6 @@ AROMP5:
   DD_Hstar: 2.0e+6
   Formula: C5H6O2
   FullName: C5 unsaturated dicarbonyl
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -331,7 +311,6 @@ AROMCHO:
   DD_Hstar: 2.0e+6
   Formula: C5H6O4
   FullName: ACCOMECHO from MCM
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -351,7 +330,6 @@ AROMPN:
   FullName: Lumped PN from aromatics
   Henry_CR: 5700.0
   Henry_K0: 2.94
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -373,7 +351,6 @@ ASOA_PROP: &ASOAproperties
   DD_F0: 0.0
   DD_Hstar: 0.0
   FullName: Lumped non-volatile aerosol products of light aromatics + IVOCs
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -396,7 +373,6 @@ ASOG_PROP: &ASOGproperties
   FullName: Lumped non-volatile gas products of light aromatics + IVOCs
   Henry_CR: 6039.0
   Henry_K0: 1.0e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -420,7 +396,6 @@ ATOOH:
   FullName: ATO2 peroxide
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -439,7 +414,6 @@ BALD:
   FullName: Benzaldehyde
   Henry_CR: 5500.0
   Henry_K0: 3.8e+1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -453,7 +427,6 @@ BCPI:
   Density: 1800.0
   Formula: C
   FullName: Hydrophilic black carbon aerosol
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -470,7 +443,6 @@ BCPO:
   Density: 1800.0
   Formula: C
   FullName: Hydrophobic black carbon aerosol
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -484,7 +456,6 @@ Be_PROP: &Beproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
   DD_Hstar: 0.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_RadioNuclide: true
@@ -531,7 +502,6 @@ Be7s:
 BENZ:
   Formula: C6H6
   FullName: Benzene
-  Is_Advected: true
   Is_Gas: true
   MW_g: 78.12
 BENZO:
@@ -551,7 +521,6 @@ BENZP:
   FullName: Phenyl hydroperoxide
   Henry_CR: 6800.0
   Henry_K0: 2.9e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -565,7 +534,6 @@ BPINN:
   FullName: Saturated 1st gen BPIN organic nitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -578,7 +546,6 @@ BPINO:
   FullName: Ketone from BPIN
   Henry_CR: 6039.0
   Henry_K0: 1.0e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -601,7 +568,6 @@ BPINON:
   FullName: Saturated 2nd gen BPIN organic nitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -614,7 +580,6 @@ BPINOOH:
   FullName: 2nd-gen peroxide from BPIN
   Henry_CR: 6039.0
   Henry_K0: 1.0e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -628,7 +593,6 @@ BPINP:
   FullName: Peroxide from BPIN
   Henry_CR: 6039.0
   Henry_K0: 1.0e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -638,7 +602,6 @@ BPINP:
 Br:
   Formula: Br
   FullName: Atomic bromine
-  Is_Advected: true
   Is_Gas: true
   MW_g: 79.90
 Br2:
@@ -648,7 +611,6 @@ Br2:
   FullName: Molecular Bromine
   Henry_CR: 3720.0
   Henry_K0: 7.6e-1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -662,7 +624,6 @@ BrCl:
   Henry_K0: 9.7e-1
   Formula: BrCl
   FullName: Bromine chloride
-  Is_Advected: true
   Is_Gas: true
   Is_DryDep: true
   Is_WetDep: true
@@ -672,7 +633,6 @@ BrCl:
 BrNO2:
   Formula: BrNO2
   FullName: Nitryl bromide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 125.91
@@ -681,7 +641,6 @@ BrNO3:
   DD_Hstar: 1.0e+20
   Formula: BrNO3
   FullName: Bromine nitrate
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -689,7 +648,6 @@ BrNO3:
 BrO:
   Formula: BrO
   FullName: Bromine monoxide
-  Is_Advected: true
   Is_Gas: true
   Is_DryAlt: true
   Is_Photolysis: true
@@ -711,7 +669,6 @@ BUTN:
   FullName: C4H6 alkyl nitrate
   Henry_CR: 0.0
   Henry_K0: 1.0e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: false
@@ -723,7 +680,6 @@ SALA_PROP: &SALAproperties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Density: 2200.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -741,7 +697,6 @@ BrSALA:
 BUTDI:
   Formula: C4H4O2
   FullName: Butenedial
-  Is_Advected: true
   Is_Gas: true
   MW_g: 84.07
 BZCO3:
@@ -756,7 +711,6 @@ BZCO3H:
   FullName: Perbenzoic acid
   Henry_CR: 0.0
   Henry_K0: 2.4e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -770,7 +724,6 @@ BZPAN:
   FullName: Peroxybenzoylnitrate
   Henry_CR: 4600.0
   Henry_K0: 7.0e+1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -781,7 +734,6 @@ SALC_PROP: &SALCproperties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Density: 2200.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -804,13 +756,11 @@ C:
 C2H2:
   Formula: C2H2
   FullName: Acetylene (aka Ethyne)
-  Is_Advected: true
   Is_Gas: true
   MW_g: 26.05
 C2H4:
   Formula: C2H4
   FullName: Ethylene
-  Is_Advected: true
   Is_Gas: true
   MW_g: 28.05
 C2H6:
@@ -818,7 +768,6 @@ C2H6:
   FullName: Ethane
   Henry_CR: 2400.0
   Henry_K0: 1.93e-3
-  Is_Advected: true
   Is_Gas: true
   MW_g: 30.08
 C3H8:
@@ -826,7 +775,6 @@ C3H8:
   FullName: Propane
   Henry_CR: 2400.0
   Henry_K0: 1.52e-3
-  Is_Advected: true
   Is_Gas: true
   MW_g: 44.11
 C4H6:
@@ -834,7 +782,6 @@ C4H6:
   FullName: 1,3-butadiene
   Henry_CR: 4500.0
   Henry_K0: 1.40e-2
-  Is_Advected: true
   Is_Gas: true
   MW_g: 54.09
 C4HVP1:
@@ -854,7 +801,6 @@ C96N:
   FullName: Saturated 2nd gen monoterpene organic nitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -872,7 +818,6 @@ C96O2H:
   FullName: Peroxide from APIN 2nd gen
   Henry_CR: 6039.0
   Henry_K0: 3.14e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -903,7 +848,6 @@ CaC4:
 CCl4:
   Formula: CCl4
   FullName: Carbon tetrachloride
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 153.82
@@ -921,35 +865,30 @@ CdF2:
 CFC11:
   Formula: CCl3F
   FullName: CFC-11
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 137.37
 CFC113:
   Formula: C2Cl3F3
   FullName: CFC-113
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 187.38
 CFC114:
   Formula: C2Cl2F4
   FullName: CFC-114
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 170.92
 CFC115:
   Formula: C2ClF5
   FullName: CFC-115
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 154.47
 CFC12:
   Formula: CCl2F2
   FullName: CFC-12
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 120.91
@@ -958,35 +897,30 @@ CH2Br2:
   FullName: Dibromomethane
   Henry_CR: 5000.0
   Henry_K0: 1.22
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 173.83
 CH2Cl2:
   Formula: CH2Cl2
   FullName: Dichloromethane
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 84.93
 CH2I2:
   Formula: CH2I2
   FullName: Diiodomethane
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 267.84
 CH2IBr:
   Formula: CH2IBr
   FullName: Bromoiodomethane
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 220.84
 CH2ICl:
   Formula: CH2ICl
   FullName: Chloroiodomethane
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 176.38
@@ -998,7 +932,6 @@ CH2O:
   FullName: Formaldehyde
   Henry_CR: 6800.0
   Henry_K0: 3.24e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -1015,14 +948,12 @@ CH3Br:
   FullName: Methyl bromide
   Henry_CR: 2800.0
   Henry_K0: 1.32e-1
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 94.94
 CH3CCl3:
   Formula: CH3CCl3
   FullName: Methyl chloroform
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 133.35
@@ -1034,7 +965,6 @@ CH3CHOO:
 CH3Cl:
   Formula: CH3Cl
   FullName: Chloromethane
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 50.45
@@ -1044,7 +974,6 @@ CH3I:
   FullName: Methyl iodide
   Henry_CR: 3.6e+3
   Henry_K0: 0.20265
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_Tracer: true
@@ -1057,7 +986,6 @@ CH3I:
   MW_g: 141.94
 CH4_PROP: &CH4properties
   Formula: CH4
-  Is_Advected: true
   Is_Gas: true
   MW_g: 16.04
 CH4:
@@ -1129,20 +1057,17 @@ CHBr3:
   FullName: Bromoform
   Henry_CR: 5200.0
   Henry_K0: 1.72
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 252.73
 CHCl3:
   Formula: CHCl3
   FullName: Chloroform
-  Is_Advected: true
   Is_Gas: true
   MW_g: 119.35
 Cl:
   Formula: Cl
   FullName: Atomic chlorine
-  Is_Advected: true
   Is_Gas: true
   MW_g: 35.45
 Cl2:
@@ -1150,7 +1075,6 @@ Cl2:
   DD_Hstar: 9.2e-2
   Formula: Cl2
   FullName: Molecular chlorine
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_DryDep: true
@@ -1160,7 +1084,6 @@ Cl2:
 Cl2O2:
   Formula: Cl2O2
   FullName: Dichlorine dioxide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 102.91
@@ -1169,7 +1092,6 @@ ClNO2:
   DD_Hstar: 4.5e-2
   Formula: ClNO2
   FullName: Nitryl chloride
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_DryDep: true
@@ -1179,7 +1101,6 @@ ClNO3:
   DD_Hstar: 1.0e+20
   Formula: ClNO3
   FullName: Chlorine nitrate
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -1192,7 +1113,6 @@ ClO:
   DD_Hstar: 7.0e-1
   Formula: ClO
   FullName: Chlorine monoxide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_DryDep: true
@@ -1202,7 +1122,6 @@ ClOO:
   DD_Hstar: 1.0
   Formula: ClOO
   FullName: Chlorine dioxide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_DryDep: true
@@ -1212,7 +1131,6 @@ ClOO:
 CLOCK:
   Background_VV: 0.0
   FullName: Clock tracer for diagnosing age of air
-  Is_Advected: true
   Is_Gas: true
   MW_g: 1.0   # Use value of 1.0 to get past checks for missing MW_g
 CO2_PROP: &CO2properties
@@ -1265,7 +1183,6 @@ CO2se:
   FullName: Carbon dioxide from ship emissions
 CO_PROP: &COproperties
   Formula: CO
-  Is_Advected: true
   Is_Gas: true
   MW_g: 28.01
 CO:
@@ -1373,7 +1290,6 @@ CSL:
   FullName: Cresols
   Henry_CR: 8500.0
   Henry_K0: 4.2e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -1384,7 +1300,6 @@ DMS:
   FullName: Dimethyl sulfide
   Henry_CR: 3100.0
   Henry_K0: 0.48
-  Is_Advected: true
   Is_Aerosol: true
   MW_g: 62.13
 DST1:
@@ -1433,7 +1348,6 @@ DummyNMVOC:
   FullName: CO produced from NMVOC oxidation (external input for carbon mechanism)
 e90_PROP: &e90properties
   Background_VV: 1.0e-20
-  Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
   MW_g: 1.0   # Use value of 1.0 to get past checks for missing MW_g
@@ -1463,7 +1377,6 @@ e90_s:
 EBZ:
   Formula: C8H10
   FullName: Ethylbenzene
-  Is_Advected: true
   Is_Gas: true
   MW_g: 106.167
 EOH:
@@ -1473,7 +1386,6 @@ EOH:
   FullName: Ethanol
   Henry_CR: 6400.0
   Henry_K0: 1.93e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -1486,7 +1398,6 @@ ETHLN:
   FullName: Ethanol nitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -1496,7 +1407,6 @@ ETHLN:
 ETHN:
   Formula: HOCH2CH2ONO2
   FullName: hydroxy-nitrooxy-ethane
-  Is_Advected: true
   Is_Gas: true
   MW_g: 107.07
   Is_DryDep: true
@@ -1509,7 +1419,6 @@ ETHN:
 ETHP:
   Formula: HOCH2CH2OOH
   FullName: hydroxy-hydroperoxy-ethane
-  Is_Advected: true
   Is_Gas: true
   MW_g: 78.07
   Is_DryDep: true
@@ -1527,7 +1436,6 @@ ETNO3:
   FullName: Ethyl nitrate
   Henry_CR: 5400.0
   Henry_K0: 1.6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -1554,7 +1462,6 @@ ETP:
   FullName: Ethylhydroperoxide
   Henry_CR: 6000.0
   Henry_K0: 3.34e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -1575,7 +1482,6 @@ FeF2:
 FixedCl:
   Formula: Cl
   FullName: Atomic chlorine (external input for carbon mechanism)
-  Is_Advected: true
   Is_Gas: true
   MW_g: 35.45
 FixedOH:
@@ -1591,7 +1497,6 @@ FURA:
   FullName: Furan
   Henry_CR: 6100.0
   Henry_K0: 1.80e-1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: false
@@ -1610,7 +1515,6 @@ GLYC:
   FullName: Glycoaldehyde
   Henry_CR: 4600.0
   Henry_K0: 4.15e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -1624,7 +1528,6 @@ GLYX:
   FullName: Glyoxal
   Henry_CR: 7500.0
   Henry_K0: 4.15e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -1639,14 +1542,12 @@ H:
 H1211:
   Formula: CBrClF2
   FullName: Halon 1211, Freon 12B1
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 165.36
 H1301:
   Formula: CBrF3
   FullName: Halon 1301, Freon 13B1
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 148.91
@@ -1659,7 +1560,6 @@ H2:
 H2402:
   Formula: C2Br2F4
   FullName: Halon 2402
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 259.82
@@ -1667,7 +1567,6 @@ H2O:
   Background_VV: 1.839e-2
   Formula: H2O
   FullName: Water vapor
-  Is_Advected: true
   Is_Gas: true
   MW_g: 18.02
 H2O2:
@@ -1678,7 +1577,6 @@ H2O2:
   FullName: Hydrogen peroxide
   Henry_CR: 7400.0
   Henry_K0: 8.3e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -1694,7 +1592,6 @@ HAC:
   FullName: Hydroxyacetone
   Henry_CR: 0.0
   Henry_K0: 7800.0
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -1708,7 +1605,6 @@ HACTA:
   FullName: Hydroxyacetic/glycolic acid
   Henry_CR: 4000.0
   Henry_K0: 2.83e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -1721,7 +1617,6 @@ HBr:
   FullName: Hypobromic acid
   Henry_CR: 10200.0
   Henry_K0: 7.1e+13
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -1734,7 +1629,6 @@ HC5A:
   FullName: isoprene-4,1-hydroxyaldehyde
   Henry_CR: 0.0
   Henry_K0: 7.8e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -1743,28 +1637,24 @@ HC5A:
 HCFC123:
   Formula: C2HCl2F3
   FullName: HCFC-123, Freon 123
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 152.93
 HCFC141b:
   Formula: C(CH3)Cl2F
   FullName: HCFC-141b, Freon 141b
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 116.94
 HCFC142b:
   Formula: C(CH3)ClF2
   FullName: HCFC-142b, Freon 142b
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 100.50
 HCFC22:
   Formula: CHClF2
   FullName: HCFC-22, Freon 22
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 86.47
@@ -1775,7 +1665,6 @@ HCl:
   FullName: Hydrochloric acid
   Henry_CR: 9000.0
   Henry_K0: 6.3e+10
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -1788,7 +1677,6 @@ HCOOH:
   FullName: Formic acid
   Henry_CR: 6100.0
   Henry_K0: 8.92e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -1798,7 +1686,6 @@ Hg0_PROP: &Hg0properties
   DD_F0: 3.0e-5
   DD_Hstar: 0.11
   Formula: 'Hg'
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Hg0: true
@@ -1896,7 +1783,6 @@ Hg2_PROP: &Hg2properties
   Formula: 'Hg'
   Henry_CR: 8400.0
   Henry_K0: 1.4e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Hg2: true
@@ -1995,7 +1881,6 @@ HgP_PROP: &HgPproperties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Formula: 'Hg'
-  Is_Advected: true
   Is_DryDep: true
   Is_Aerosol: true
   Is_HgP: true
@@ -2095,7 +1980,6 @@ HgP_waf:
 Hg_OTHER_PROP: &HgChemProperties
   Henry_CR: 8.40e+03
   Henry_K0: 1.40e+06
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2104,14 +1988,12 @@ Hg_OTHER_PROP: &HgChemProperties
 HgBr:
   Fullname: HgBr
   Formula: HgBr
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 280.49
 HgBrNO2:
   Fullname: syn-HgBrONO
   Formula: BrHgONO
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2144,7 +2026,6 @@ HgBr2:
 HgCl:
   Fullname: HgCl
   Formula: HgCl
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_WetDep: false
@@ -2183,7 +2064,6 @@ HgClOH:
 HgOH:
   Fullname: HgOH
   Formula: HgOH
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 201.00
@@ -2231,7 +2111,6 @@ Hg2ClP:
 Hg2ORGP:
   Fullname: Hg(II) organic complex in aerosols
   Formula: R-Hg
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_Photolysis: true
@@ -2243,7 +2122,6 @@ Hg2ORGP:
 Hg2STRP:
   Fullname: Hg(II) in stratospheric aerosols
   Formula: Hg2+
-  Is_Advected: true
   Is_Aerosol: true
   MW_g: 201.00
 HI:
@@ -2253,7 +2131,6 @@ HI:
   FullName: Hydrogen iodide
   Henry_CR: 3.1872e+3
   Henry_K0: 7.43e+13
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -2266,7 +2143,6 @@ HMHP:
   FullName: Hydroxymethyl hydroperoxide
   Henry_CR: 5200.0
   Henry_K0: 1.3e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2280,7 +2156,6 @@ HMML:
   FullName: hydroxymethyl-methyl-a-lactone
   Henry_CR: 7200.0
   Henry_K0: 1.2e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -2294,7 +2169,6 @@ HMS:
   DD_Hstar: 0.0
   Formula: HOCH2SO3−
   FullName: Hydroxymethanesulfonate
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -2306,7 +2180,6 @@ HNO2:
   Background_VV: 4.0e-15
   Formula: HNO2
   FullName: Nitrous acid
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 47.01
@@ -2318,7 +2191,6 @@ HNO3:
   FullName: Nitric acid
   Henry_CR: 7400.0
   Henry_K0: 8.3e+4
-  Is_Advected: true
   Is_DryAlt: true
   Is_DryDep: true
   Is_Gas: true
@@ -2335,7 +2207,6 @@ HNO4:
   Background_VV: 4.0e-15
   Formula: HNO4
   FullName: Peroxynitric acid
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 79.01
@@ -2353,7 +2224,6 @@ HOBr:
   FullName: Hypobromous acid
   Henry_CR: 4000.0
   Henry_K0: 1.3e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2367,7 +2237,6 @@ HOCl:
   FullName: Hypochlorous acid
   Henry_CR: 5900.0
   Henry_K0: 6.50e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2381,7 +2250,6 @@ HOI:
   FullName: Hypoiodous acid
   Henry_CR: 8371.0
   Henry_K0: 1.54e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2394,7 +2262,6 @@ HONIT:
   FullName: 2nd gen monoterpene organic nitrate
   Henry_CR: 5487.0
   Henry_K0: 2.69e+13
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2406,7 +2273,6 @@ HPALD1:
   DD_Hstar: 4.0e+4
   Formula: C5H8O3
   FullName: d-4,1-C5-hydroperoxyaldehyde
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2421,7 +2287,6 @@ HPALD2:
   DD_Hstar: 4.0e+4
   Formula: C5H8O3
   FullName: d-1,4-C5-hydroperoxyaldehyde
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2436,7 +2301,6 @@ HPALD3:
   DD_Hstar: 4.0e+4
   Formula: C5H8O3
   FullName: b-2,1-C5-hydroperoxyaldehyde
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2446,7 +2310,6 @@ HPALD4:
   DD_Hstar: 4.0e+4
   Formula: C5H8O3
   FullName: b-3,4-C5-hydroperoxyaldehyde
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2458,7 +2321,6 @@ HPETHNL:
   FullName: Hydroperoxy ethanal
   Henry_CR: 4600.0
   Henry_K0: 4.1e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2473,7 +2335,6 @@ HSO3m:
 I:
   Formula: I
   FullName: Atomic iodine
-  Is_Advected: true
   Is_Gas: true
   MW_g: 126.90
 I2:
@@ -2483,7 +2344,6 @@ I2:
   FullName: Molecular iodine
   Henry_CR: 7.5074e+3
   Henry_K0: 2.7
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2497,7 +2357,6 @@ I2O2:
   FullName: Diiodine dioxide
   Henry_CR: 1.89e+4
   Henry_K0: 1.0e+20
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2511,7 +2370,6 @@ I2O3:
   FullName: Diiodine trioxide
   Henry_CR: 1.34e+4
   Henry_K0: 1.0e+20
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2525,7 +2383,6 @@ I2O4:
   FullName: Diiodine tetraoxide
   Henry_CR: 1.34e+4
   Henry_K0: 1.0e+20
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2539,7 +2396,6 @@ IBr:
   FullName: Iodine monobromide
   Henry_CR: 4.9167e+3
   Henry_K0: 2.4e+1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2553,7 +2409,6 @@ ICHE:
   FullName: Isoprene hydroxy-carbonyl-epoxides
   Henry_CR: 0.0
   Henry_K0: 8.0e+7
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -2571,7 +2426,6 @@ ICl:
   FullName: Iodine monochloride
   Henry_CR: 2.1055e+3
   Henry_K0: 1.11e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2585,7 +2439,6 @@ ICN:
   FullName: Lumped isoprene carbonyl-nitrates
   Henry_CR: 9200.0
   Henry_K0: 1.70e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2604,7 +2457,6 @@ ICPDH:
   FullName: Isoprene dihydroxy hydroperoxycarbonyl
   Henry_CR: 7200.0
   Henry_K0: 1.0e+8
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2616,7 +2468,6 @@ IDC:
   DD_Hstar: 4.0e+4
   Formula: C5H6O2
   FullName: Lumped isoprene dicarbonyls
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   MW_g: 98.11
@@ -2627,7 +2478,6 @@ IDCHP:
   FullName: Isoprene dicarbonyl hydroxy dihydroperoxide
   Henry_CR: 7200.0
   Henry_K0: 1.0e+8
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2641,7 +2491,6 @@ IDHDP:
   FullName: Isoprene dihydroxy dihydroperoxide
   Henry_CR: 7200.0
   Henry_K0: 1.0e+8
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2670,7 +2519,6 @@ IDHPE:
   FullName: Isoprene dihydroxy hydroperoxy epoxide
   Henry_CR: 7200.0
   Henry_K0: 1.0e+8
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2684,7 +2532,6 @@ IDN:
   FullName: Lumped isoprene dinitrates
   Henry_CR: 7200.0
   Henry_K0: 1.0e+8
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2703,7 +2550,6 @@ IEPOXA:
   FullName: trans-Beta isoprene epoxydiol
   Henry_CR: 0.0
   Henry_K0: 8.0e+7
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -2721,7 +2567,6 @@ IEPOXB:
   FullName: cis-Beta isoprene epoxydiol
   Henry_CR: 0.0
   Henry_K0: 8.0e+7
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -2739,7 +2584,6 @@ IEPOXD:
   FullName: Delta isoprene epoxydiol
   Henry_CR: 0.0
   Henry_K0: 8.0e+7
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -2752,7 +2596,6 @@ IHN1:
   FullName: Isoprene-d-4,1-hydroxynitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2766,7 +2609,6 @@ IHN2:
   FullName: Isoprene-b-1,2-hydroxynitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2780,7 +2622,6 @@ IHN3:
   FullName: Isoprene-b-4,3-hydroxynitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2794,7 +2635,6 @@ IHN4:
   FullName: Isoprene-d-4,1-hydroxynitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2846,7 +2686,6 @@ INDIOL:
   DD_F0: 0.0
   DD_Hstar: 0.0
   FullName: Generic aerosol-phase organonitrate hydrolysis product
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -2858,7 +2697,6 @@ INDIOL:
 INO:
   Formula: INO
   FullName: Nitrosyl iodide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 156.91
@@ -2879,7 +2717,6 @@ INPB:
   FullName: Lumped b-hydroperoxy isoprene nitrates
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2893,7 +2730,6 @@ INPD:
   FullName: Lumped d-hydroperoxy isoprene nitrates
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2903,7 +2739,6 @@ INPD:
 IO:
   Formula: IO
   FullName: Iodine monoxide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 142.90
@@ -2912,7 +2747,6 @@ IONITA:
   DD_F0: 0.0
   DD_Hstar: 0.0
   FullName: Aer-phase organic nitrate from isoprene precursors
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -2928,7 +2762,6 @@ IONO:
   FullName: Nitryl iodide
   Henry_CR: 7.2404e+3
   Henry_K0: 3.0e-1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2942,7 +2775,6 @@ IONO2:
   FullName: Iodine nitrate
   Henry_CR: 3.98e+3
   Henry_K0: 1.0e+20
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2956,7 +2788,6 @@ IPRNO3:
   FullName: Isopropyl nitrate
   Henry_CR: 5400.0
   Henry_K0: 0.79
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -2979,7 +2810,6 @@ ISOP:
   FullName: Isoprene
   Henry_CR: 4400.0
   Henry_K0: 3.45e-2
-  Is_Advected: true
   Is_Gas: true
   MW_g: 68.13
 ISOPNOO1:
@@ -2999,7 +2829,6 @@ ITCN:
   FullName: lumped isoprene tetrafunctional carbonylnitrates
   Henry_CR: 7200.0
   Henry_K0: 1.0e+8
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3013,7 +2842,6 @@ ITHN:
   FullName: Lumped isoprene tetrafunctional hydroxynitrates
   Henry_CR: 7200.0
   Henry_K0: 1.0e+8
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3093,7 +2921,6 @@ LIMAL:
   FullName: Aldehyde from limonene
   Henry_CR: 6039.0
   Henry_K0: 1.0e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3107,7 +2934,6 @@ LIMKB:
   FullName: 2nd gen ketone from limonene
   Henry_CR: 6039.0
   Henry_K0: 1.0e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3120,7 +2946,6 @@ LIMKET:
   FullName: Ketone from limonene
   Henry_CR: 6039.0
   Henry_K0: 1.0e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3138,7 +2963,6 @@ LIMN:
   FullName: Saturated 1st gen limonene organic nitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3151,7 +2975,6 @@ LIMNB:
   FullName: Saturated 1st gen LIMO organic nitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3164,7 +2987,6 @@ LIMO:
   FullName: Limonene
   Henry_CR: 0.0
   Henry_K0: 7.0e-2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3182,7 +3004,6 @@ LIMO2H:
   FullName: Acid from LIMO
   Henry_CR: 6039.0
   Henry_K0: 3.14e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3201,7 +3022,6 @@ LIMO3H:
   FullName: Peracid from LIMO
   Henry_CR: 6039.0
   Henry_K0: 1.0e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3215,7 +3035,6 @@ LIMPAN:
   FullName: PAN from LIMO
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3262,7 +3081,6 @@ LVOC:
   FullName: Gas-phase low-volatility non-IEPOX product of RIP ox
   Henry_CR: 7200.0
   Henry_K0: 1.0e+8
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3274,7 +3092,6 @@ LVOCOA:
   DD_Hstar: 0.0
   Formula: C5H14O5
   FullName: Aer-phase low-volatility non-IEPOX product of RIP ox
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -3300,7 +3117,6 @@ MACR:
   FullName: Methacrolein
   Henry_CR: 4300.0
   Henry_K0: 4.86
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3317,7 +3133,6 @@ MACR1OOH:
   FullName: Peracid from MACR
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3336,7 +3151,6 @@ MAP:
   FullName: Peroxyacetic acid
   Henry_CR: 5300.0
   Henry_K0: 8.4e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3355,7 +3169,6 @@ MCRDH:
   FullName: Dihydroxy-methacrolein
   Henry_CR: 7200.0
   Henry_K0: 1.4e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3368,7 +3181,6 @@ MCRENOL:
   FullName: Lumped enols from MVK/MACR
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3382,7 +3194,6 @@ MCRHN:
   FullName: Nitrate from MACR
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3396,7 +3207,6 @@ MCRHNB:
   FullName: Nitrate from MACR
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3410,7 +3220,6 @@ MCRHP:
   FullName: Hydroxy-hydroperoxy-methacrolein
   Henry_CR: 7200.0
   Henry_K0: 1.4e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3429,7 +3238,6 @@ MCT:
   FullName: Catechols and methyl catechols
   Henry_CR: 8500.0
   Henry_K0: 4.2e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3444,7 +3252,6 @@ MEK:
   FullName: Methyl Ethyl Ketone
   Henry_CR: 5700.0
   Henry_K0: 1.82e+1
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_WetDep: true
@@ -3457,7 +3264,6 @@ MEKPN:
   FullName: MEK peroxyacetyl nitrate
   Henry_CR: 5700.0
   Henry_K0: 2.94
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3470,7 +3276,6 @@ MENO3:
   FullName: Methyl nitrate
   Henry_CR: 4700.0
   Henry_K0: 1.1e+1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3503,7 +3308,6 @@ MGLY:
   FullName: Methylglyoxal
   Henry_CR: 6200.0
   Henry_K0: 3.24e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3534,7 +3338,6 @@ MOH:
   FullName: Methanol
   Henry_CR: 5600.0
   Henry_K0: 2.03e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3545,7 +3348,6 @@ MONITA:
   DD_F0: 0.0
   DD_Hstar: 0.0
   FullName: Aer-phase organic nitrate from monoterpene precursors
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -3561,7 +3363,6 @@ MONITS:
   FullName: Saturated 1st gen monoterpene organic nitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3575,7 +3376,6 @@ MONITU:
   FullName: Unsaturated 1st gen monoterpene organic nitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3589,7 +3389,6 @@ MOPI:
   Density: 1300.0
   Formula: C
   FullName: Hydrophilic marine organic carbon aerosol
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -3605,7 +3404,6 @@ MOPO:
   Density: 1300.0
   Formula: C
   FullName: Hydrophobic marine organic carbon aerosol
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -3619,7 +3417,6 @@ MP:
   FullName: Methyl hydro peroxide
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_WetDep: true
@@ -3632,7 +3429,6 @@ MPAN:
   FullName: Peroxymethacroyl nitrate (PMN)
   Henry_CR: 0.0
   Henry_K0: 1.72
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3643,7 +3439,6 @@ MPN:
   FullName: Methyl peroxy nitrate
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_WetDep: true
@@ -3656,7 +3451,6 @@ MSA:
   DD_Hstar: 0.0
   Formula: CH4SO3
   FullName: Methyl sulfonic acid
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -3671,7 +3465,6 @@ MTPA:
   FullName: a-pinene, b-pinene, sabinene, carene
   Henry_CR: 0.0
   Henry_K0: 4.9e-2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3683,7 +3476,6 @@ MTPO:
   FullName: Terpinene, terpinolene, myrcene, ocimene, other monoterpenes
   Henry_CR: 0.0
   Henry_K0: 4.9e-2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3696,7 +3488,6 @@ MVK:
   FullName: Methyl vinyl ketone
   Henry_CR: 4800.0
   Henry_K0: 2.63e+1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3710,7 +3501,6 @@ MVKDH:
   FullName: dihydroxy-MVK
   Henry_CR: 7200.0
   Henry_K0: 1.4e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3723,7 +3513,6 @@ MVKHC:
   FullName: MVK hydroxy-carbonyl
   Henry_CR: 7200.0
   Henry_K0: 1.4e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3737,7 +3526,6 @@ MVKHCB:
   FullName: MVK hydroxy-carbonyl
   Henry_CR: 7200.0
   Henry_K0: 1.4e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3751,7 +3539,6 @@ MVKHP:
   FullName: MVK hydroxy-hydroperoxide
   Henry_CR: 7200.0
   Henry_K0: 1.4e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3765,7 +3552,6 @@ MVKN:
   FullName: Nitrate from MVK
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3784,7 +3570,6 @@ MVKPC:
   FullName: MVK hydroperoxy-carbonyl
   Henry_CR: 7200.0
   Henry_K0: 1.4e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3798,7 +3583,6 @@ MYRCO:
   FullName: Aldehyde or ketone from myrcene
   Henry_CR: 6039.0
   Henry_K0: 1.0e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3820,7 +3604,6 @@ N2O:
   Background_VV: 3.0e-7
   Formula: N2O
   FullName: Nitrous oxide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 44.02
@@ -3830,7 +3613,6 @@ N2O5:
   DD_Hstar: 1.0e+14
   Formula: N2O5
   FullName: Dinitrogen pentoxide
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3838,11 +3620,9 @@ N2O5:
 NAP:
   Formula: C10H8
   FullName: Naphtalene/IVOC surrogate
-  Is_Advected: true
   Is_Gas: true
   MW_g: 128.18
 nh_PROP: &nhproperties
-  Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
   MW_g: 1.0   # Use value of 1.0 to get past checks for missing MW_g
@@ -3876,7 +3656,6 @@ NH3:
   Henry_CR_Luo: 4200.0
   Henry_K0: 3.3e+6
   Henry_K0_Luo: 59.78175
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -3891,7 +3670,6 @@ NH4:
   DD_Hstar: 0.0
   Formula: NH4
   FullName: Ammonium
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -3917,7 +3695,6 @@ NIT:
   DD_F0: 0.0
   DD_Hstar: 0.0
   FullName: Inorganic nitrates
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_Photolysis: true
@@ -3953,7 +3730,6 @@ NITs:
   Background_VV: 4.0e-13
   Formula: 'NO'
   FullName: Nitrogen oxide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 30.01
@@ -3963,7 +3739,6 @@ NO2:
   DD_Hstar: 1.0e-2
   Formula: NO2
   FullName: Nitrogen dioxide
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3972,7 +3747,6 @@ NO3:
   Background_VV: 4.0e-15
   Formula: NO3
   FullName: Nitrate radical
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 62.01
@@ -3983,7 +3757,6 @@ NPHEN:
   FullName: Nitrophenols
   Henry_CR: 0.0
   Henry_K0: 2.3e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -3997,7 +3770,6 @@ NPRNO3:
   FullName: n-propyl nitrate
   Henry_CR: 5500.0
   Henry_K0: 1.1
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4032,7 +3804,6 @@ O3_PROP: &O3properties
   FullName: Ozone
   Henry_CR: 2800.0
   Henry_K0: 0.0101325e0
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4095,7 +3866,6 @@ O3ut:
 OClO:
   Formula: OClO
   FullName: Chlorine dioxide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 67.45
@@ -4105,7 +3875,6 @@ OCPI:
   DD_Hstar: 0.0
   Density: 1300.0
   FullName: Hydrophilic organic carbon aerosol
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -4122,7 +3891,6 @@ OCPO:
   DD_Hstar: 0.0
   Density: 1300.0
   FullName: Hydrophobic organic carbon aerosol
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -4135,7 +3903,6 @@ OCS:
   Background_VV: 9.0e-15
   Formula: COS
   FullName: Carbonyl sulfide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 60.07
@@ -4148,7 +3915,6 @@ OH:
 OIO:
   Formula: OIO
   FullName: Iodine dioxide
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 158.90
@@ -4222,7 +3988,6 @@ PAN:
   FullName: Peroxyacetyl nitrate
   Henry_CR: 5700.0
   Henry_K0: 2.94
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4232,7 +3997,6 @@ PAN:
 PassiveTracer:
   Background_VV: 1.0e-7
   FullName: Passive tracer for mass conservation evaluation
-  Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
   MW_g: 1.0   # Use value of 1.0 to get past checks for missing MW_g
@@ -4243,7 +4007,6 @@ Pb210_PROP: &Pbproperties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Formula: Pb210
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_RadioNuclide: true
@@ -4300,7 +4063,6 @@ pFe:
   DD_Hstar: 0.0
   Formula: Fe
   FullName: Anthropogenic iron
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -4325,7 +4087,6 @@ PHAN:
   FullName: Peroxyhydroxyacetic nitric anhydride
   Henry_CR: 5700.0
   Henry_K0: 2.94
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4338,7 +4099,6 @@ PHEN:
   FullName: Phenol
   Henry_CR: 2700.0
   Henry_K0: 2.8e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4351,7 +4111,6 @@ PIN:
   FullName: Saturated 1st gen monoterpene organic nitrate
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4364,7 +4123,6 @@ PINAL:
   FullName: Pinonaldehyde
   Henry_CR: 6039.0
   Henry_K0: 1.0e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4383,7 +4141,6 @@ PINO3H:
   FullName: Pinonic peracid
   Henry_CR: 6039.0
   Henry_K0: 1.0e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true  
@@ -4397,7 +4154,6 @@ PINONIC:
   FullName: Pinonic acid
   Henry_CR: 6039.0
   Henry_K0: 3.14e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4411,7 +4167,6 @@ PINPAN:
   FullName: PAN from pinonaldehyde
   Henry_CR: 9200.0
   Henry_K0: 1.7e+4
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4428,7 +4183,6 @@ PIO2:
 PIP:
   Formula: C10H18O3
   FullName: Peroxide from MTPA
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 186.28
@@ -4443,7 +4197,6 @@ POA1:
   DD_Hstar: 0.0
   Density: 1300.0
   FullName: Lumped aerosol primary SVOCs
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -4459,7 +4212,6 @@ POA2:
   DD_Hstar: 0.0
   Density: 1300.0
   FullName: Lumped aerosol primary SVOCs
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -4474,7 +4226,6 @@ POG1:
   FullName: Lumped gas primary SVOCs
   Henry_CF: 4700.0
   Henry_K0: 9.5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4486,7 +4237,6 @@ POG2:
   FullName: Lumped gas primary SVOCs
   Henry_CF: 4700.0
   Henry_K0: 9.5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4500,7 +4250,6 @@ POPG_BaP:
   FullName: Benzo(a)pyrene (gas phase)
   Henry_CR: 5168.269231 # 43.0 / 8.32e-3
   Henry_K0: 1318.496208 # 1.0 / 3.10e-5 / 8.21e-2 / 298.0
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4514,7 +4263,6 @@ POPG_PHE:
   FullName: Phenanthrene (gas phase)
   Henry_CR: 5649.038462 # 47.0/ 8.32e-3
   Henry_K0: 23.49044968 # 1.0 / 1.74e-3 / 8.21e-2 / 298.0
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4528,7 +4276,6 @@ POPG_PYR:
   FullName: Pyrene (gas phase)
   Henry_CR: 5168.269231 # 43.0 / 8.32e-3
   Henry_K0: 76.11430621 # 1.0 / 5.37e-4 / 8.21e-2 / 298.0
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4711,7 +4458,6 @@ PP:
   FullName: Peroxide from PO2
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4725,7 +4471,6 @@ PPN:
   FullName: Lumped peroxypropionyl nitrate
   Henry_CR: 0.0
   Henry_K0: 2.94
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4744,7 +4489,6 @@ PROPNN:
   FullName: Propanone nitrate
   Henry_CR: 0.0
   Henry_K0: 1.0e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4756,7 +4500,6 @@ PRPE:
   FullName: Lumped >= C3 alkenes
   Henry_CR: 3400.0
   Henry_K0: 7.4e-3
-  Is_Advected: true
   Is_Gas: true
   Is_WetDep: true
   MW_g: 42.09
@@ -4768,7 +4511,6 @@ PRPN:
   FullName: Peroxide from PRN1
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4791,7 +4533,6 @@ PYAC:
   FullName: Pyruvic acid
   Henry_CR: 5100.0
   Henry_K0: 3.14e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4810,7 +4551,6 @@ RNO3:
   FullName: Lumped alkyl nitrate
   Henry_CR: 5800.0
   Henry_K0: 1.0
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4823,7 +4563,6 @@ R4N2:
   FullName: Lumped alkyl nitrate
   Henry_CR: 5800.0
   Henry_K0: 1.0
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4842,7 +4581,6 @@ R7N2:
   FullName: C7 Lumped alkyl nitrate
   Henry_CR: 6700.0
   Henry_K0: 0.77
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4860,7 +4598,6 @@ R4P:
   FullName: Peroxide from R4O2
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4879,7 +4616,6 @@ R7P:
   FullName: Peroxide from R7O2
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -4892,7 +4628,6 @@ RA3P:
   FullName: Peroxide from A3O2
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4906,7 +4641,6 @@ RB3P:
   FullName: Peroxide from B3O2
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4918,7 +4652,6 @@ RCHO:
   FullName: Lumped aldehyde >= C3
   Henry_CR: 0.0
   Henry_K0: 1.0e+1
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 58.09
@@ -4935,7 +4668,6 @@ RCOOH:
   FullName: '> C2 organic acids'
   Henry_CR: 6800.0
   Henry_K0: 1.52e+3
-  Is_Advected: true
   Is_DryDep: true
   Is_WetDep: true
   Is_Gas: true
@@ -4948,7 +4680,6 @@ RIPA:
   FullName: 1,2-ISOPOOH
   Henry_CR: 0.0
   Henry_K0: 1.7e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4962,7 +4693,6 @@ RIPB:
   FullName: 4,3-ISOPOOH
   Henry_CR: 0.0
   Henry_K0: 1.7e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4976,7 +4706,6 @@ RIPC:
   FullName: d-1,4-ISOPOOH
   Henry_CR: 0.0
   Henry_K0: 1.7e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -4990,7 +4719,6 @@ RIPD:
   FullName: d-4,1-ISOPOOH
   Henry_CR: 0.0
   Henry_K0: 1.7e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -5004,7 +4732,6 @@ RNO3:
   FullName: Lumped aromatic nitrate
   Henry_CR: 5800.0
   Henry_K0: 1.0
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -5013,7 +4740,6 @@ RNO3:
 Rn222:
   Formula: Rn222
   FullName: Radon-222 isotope
-  Is_Advected: true
   Is_Aerosol: true
   Is_RadioNuclide: true
   Is_Tracer: true
@@ -5039,7 +4765,6 @@ RP:
   FullName: Peroxide from RCO3
   Henry_CR: 5200.0
   Henry_K0: 2.94e+2
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Photolysis: true
@@ -5087,7 +4812,6 @@ SF6:
   Background_VV: 1.0e-20
   Formula: SF6
   FullName: Sulfur hexafluoride
-  Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
   MW_g: 146.06
@@ -5113,7 +4837,6 @@ SO2:
   FullName: Sulfur dioxide
   Henry_CR_Luo: 3100.0
   Henry_K0_Luo: 1.22
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -5139,7 +4862,6 @@ SO4:
   Density: 1700.0
   Formula: SO4
   FullName: Sulfate
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -5197,7 +4919,6 @@ SOAGX:
   DD_Hstar: 0.0
   Formula: C2H2O2
   FullName: Aerosol-phase glyoxal
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -5212,7 +4933,6 @@ SOAIE:
   DD_Hstar: 0.0
   Formula: C5H10O3
   FullName: Aerosol-phase IEPOX
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -5223,7 +4943,6 @@ SOAIE:
   WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 SOAP:
   FullName: SOA Precursor - lumped species for simplified SOA parameterization
-  Is_Advected: true
   Is_Gas: true
   MW_g: 150.0
 SOAS:
@@ -5231,7 +4950,6 @@ SOAS:
   DD_F0: 0.0
   DD_Hstar: 0.0
   FullName: SOA Simple - simplified non-volatile SOA parameterization
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -5242,7 +4960,6 @@ SOAS:
   WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
 st80_25:
   FullName: Stratosphere source 25 day tracer
-  Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
   MW_g: 1.0   # Use value of 1.0 to get past checks for missing MW_g
@@ -5259,7 +4976,6 @@ st80_25:
   Src_Vert: pressures
 stOX:
   FullName: Tracer with O3 values in stratosphere and O3 loss applied in troposphere
-  Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
   MW_g: 1.0   # Use value of 1.0 to get past checks for missing MW_g
@@ -5274,7 +4990,6 @@ stOX:
 STYR:
   Formula: C8H8
   FullName: Styrene
-  Is_Advected: true
   Is_Gas: true
   MW_g: 104.1491
 TiF1:
@@ -5297,7 +5012,6 @@ TLFUONE:
   DD_Hstar: 2.0e+6
   Formula: C5H6O2
   FullName: Aromatic furanones
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -5308,13 +5022,11 @@ TLFUONE:
 TMB:
   Formula: C8H10
   FullName: Trimethylbenzenes
-  Is_Advected: true
   Is_Gas: true
   MW_g: 106.167
 TOLU:
   Formula: C7H8
   FullName: Toluene
-  Is_Advected: true
   Is_Gas: true
   MW_g: 92.15
 TRO2:
@@ -5327,7 +5039,6 @@ TSOA_PROP: &TSOAproperties
   DD_F0: 0.0
   DD_Hstar: 0.0
   FullName: Lumped semivolatile aerosol products of monoterpene + sesquiterpene oxidation
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -5350,7 +5061,6 @@ TSOG_PROP: &TSOGproperties
   FullName: Lumped semivolatile gas products of monoterpene + sesquiterpene oxidation
   Henry_CR: 6039.0
   Henry_K0: 1.0e+5
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -5372,6 +5082,5 @@ XRO2:
 XYLE:
   Formula: C8H10
   FullName: Xylene
-  Is_Advected: true
   Is_Gas: true
   MW_g: 106.18

--- a/run/shared/species_database_apm.yml
+++ b/run/shared/species_database_apm.yml
@@ -9,7 +9,6 @@ APMAMINE1:
   FullName: APM amines 1
   Henry_CR: 4100.0
   Henry_K0: 3.3e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -25,7 +24,6 @@ APMAMINE2:
   FullName: APM amines 2
   Henry_CR: 4100.0
   Henry_K0: 3.3e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -41,7 +39,6 @@ APMAMINE3:
   FullName: APM amines 3
   Henry_CR: 4100.0
   Henry_K0: 3.3e+6
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -55,7 +52,6 @@ APMBCBIN01_PROP: &APMBC1properties
   DD_Hstar: 0.0
   Density: 1800.0
   Formula: C
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -84,7 +80,6 @@ APMBCBIN06_PROP: &APMBC6properties
   DD_Hstar: 0.0
   Density: 1800.0
   Formula: C
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -129,7 +124,6 @@ APMCTBC1:
   Density: 1800.0
   Formula: SO4
   FullName: APM CTSO4
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -144,7 +138,6 @@ APMCTBC2:
   Density: 1800.0
   Formula: LVSOA
   FullName: APM CTSLVSOA
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -160,7 +153,6 @@ APMCTDST1:
   Density: 2650.0
   Formula: SO4
   FullName: APM CTSO4
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -178,7 +170,6 @@ APMCTDST2:
   Density: 2650.0
   Formula: LVSOA
   FullName: APM CTLVSOA
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -195,7 +186,6 @@ APMCTOC1:
   Density: 1800.0
   Formula: SO4
   FullName: APM CTSO4
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -210,7 +200,6 @@ APMCTOC2:
   Density: 1800.0
   Formula: LVSOA
   FullName: APM CTSLVSOA
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -226,7 +215,6 @@ APMCTSEA1:
   Density: 2200.0
   Formula: SO4
   FullName: APM CTSO4
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -245,7 +233,6 @@ APMCTSEA2:
   Density: 2200.0
   Formula: LVSOA
   FullName: APM CTLVSOA
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -263,7 +250,6 @@ APMDSTBIN_PROP: &APMDSTproperties
   DD_Hstar: 0.0
   Density: 2650.0
   Formula: Dust
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -327,7 +313,6 @@ APMH2SO4:
   Density: 1800.0
   Formula: H2SO4
   FullName: APM sulfuric acid
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -342,7 +327,6 @@ APMLVSOA:
   Density: 1800.0
   Formula: LVSOA
   FullName: APM LVSOA
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -361,7 +345,6 @@ APMLVSOG:
   Density: 1800.0
   FullName: APM LV secondary organic gas
   Is_Aerosol: true    # APMLVSOG is aerosol in Ref code, ask Gan Luo
-  Is_Advected: true
   Is_DryDep: true
   #Is_Gas: true       # APMLVSOG is aerosol in Ref code, ask Gan Luo
   Is_WetDep: true
@@ -375,7 +358,6 @@ APMOCBIN_PROP: &APMOC1properties
   DD_Hstar: 0.0
   Density: 1300.0
   Formula: C
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -404,7 +386,6 @@ APMOCBIN06_PROP: &APMOC6properties
   DD_Hstar: 0.0
   Density: 1300.0
   Formula: C
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -448,7 +429,6 @@ APMSEABIN_PROP: &APMSEAproperties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Density: 2200.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true
@@ -525,7 +505,6 @@ APMSPBIN_PROP: &APMSPproperties
   DD_F0: 0.0
   DD_Hstar: 0.0
   Density: 1800.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_HygroGrowth: true

--- a/run/shared/species_database_hg.yml
+++ b/run/shared/species_database_hg.yml
@@ -38,7 +38,6 @@ Hg0:
   DD_Hstar: 0.11
   Formula: 'Hg'
   FullName: Elemental mercury
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_Hg0: true
@@ -48,7 +47,6 @@ Hg_CHEM_PROP: &HgChemProperties
   DD_Hstar: 1.0e+14
   Henry_CR: 8.40e+03
   Henry_K0: 1.40e+06
-  Is_Advected: true
   Is_DryDep: true
   Is_Gas: true
   Is_WetDep: true
@@ -58,7 +56,6 @@ Hg_CHEM_PROP: &HgChemProperties
 HgBr:
   Fullname: HgBr
   Formula: HgBr
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 200.59   # Use mol wt of atomic Hg
@@ -101,7 +98,6 @@ HgBr2:
 HgCl:
   Fullname: HgCl
   Formula: HgCl
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   Is_WetDep: false
@@ -145,7 +141,6 @@ HgClOH:
 HgOH:
   Fullname: HgOH
   Formula: HgOH
-  Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
   MW_g: 200.59   # Use mol wt of atomic Hg
@@ -199,7 +194,6 @@ Hg2ClP:
 Hg2ORGP:
   Fullname: Hg(II) organic complex in aerosols
   Formula: R-Hg
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_Photolysis: true
@@ -212,7 +206,6 @@ Hg2ORGP:
 Hg2STRP:
   Fullname: Hg(II) in stratospheric aerosols
   Formula: Hg2+
-  Is_Advected: true
   Is_Aerosol: true
   Is_HgP: true
   MW_g: 200.59   # Use mol wt of atomic Hg

--- a/run/shared/species_database_tomas.yml
+++ b/run/shared/species_database_tomas.yml
@@ -5,7 +5,6 @@ AW_PROP: &AWproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
   DD_Hstar: 0.0
-  Is_Advected: true
   Is_Aerosol: true
   MP_SizeResAer: true
   MW_g: 18.0
@@ -136,7 +135,6 @@ DUST_PROP: &DUSTproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
   DD_Hstar: 0.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_WetDep: true
   MP_SizeResAer: true
@@ -268,7 +266,6 @@ ECIL_PROP: &ECILproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
   DD_Hstar: 0.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_WetDep: true
   MP_SizeResAer: true
@@ -400,7 +397,6 @@ ECOB_PROP: &ECOBproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
   DD_Hstar: 0.0
-  Is_Advected: true
   Is_Aerosol: true
   MP_SizeResAer: true
   MW_g: 12.01
@@ -532,7 +528,6 @@ H2SO4:
   DD_Hstar: 1.0e5
   Formula: H2SO4
   FullName: Sulfuric acid
-  Is_Advected: true
   Is_Gas: true
   Is_DryDep: true
   Is_WetDep: true
@@ -548,7 +543,6 @@ NK_PROP: &NKproperties
   DD_F0: 0.0
   DD_Hstar: 0.0
   FullName: Aerosol number, size bin = 1
-  Is_Advected: true
   Is_Aerosol: true
   Is_DryDep: true
   Is_WetDep: true
@@ -681,7 +675,6 @@ OCIL_PROP: &OCILproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
   DD_Hstar: 0.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_WetDep: true
   MP_SizeResAer: true
@@ -813,7 +806,6 @@ OCOB_PROP: &OCOBproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
   DD_Hstar: 0.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_WetDep: true
   MP_SizeResAer: true
@@ -945,7 +937,6 @@ SF_PROP: &SFproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
   DD_Hstar: 0.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_WetDep: true
   MP_SizeResAer: true
@@ -1077,7 +1068,6 @@ SS_PROP: &SSproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
   DD_Hstar: 0.0
-  Is_Advected: true
   Is_Aerosol: true
   Is_WetDep: true
   MP_SizeResAer: true


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

As described in #3024, the `Is_Advected` species database tag is redundant. This PR removes all `Is_Advected:true` tags from the following template files:

- run/shared/species_database.yml
- run/shared/species_database_apm.yml
- run/shared/species_database_hg.yml
- run/shared/species_database_tomas.yml

### Expected changes
This will be a zero-diff update.

### Related Github Issue

- Closes #3024 
