### PR TITLE
Fix parallel error in convection_mod.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed OM/OC ratio for OCPO in SimpleSOA to be 1.4 instead of 2.1
 - Fixed precipitation formation rate unit in Luo2023 convective washout
 - Fixed bug where species mass in restart file was not conserved in first timestep if run-time meteorology different from restart file meteorology
+- Fixed parallel errors in `convection_mod.F90` by setting `AER = . TRUE.` and `KIN = .TRUE.` before calling `WASHOUT
 
 ### Removed
 - Removed entries for FINN v1.5 biomass burning emissions from template HEMCO configuration files

--- a/GeosCore/convection_mod.F90
+++ b/GeosCore/convection_mod.F90
@@ -1126,6 +1126,7 @@ CONTAINS
                 LOST        = 0e+0_fp
                 MASS_WASH   = 0e+0_fp
                 MASS_NOWASH = 0e+0_fp
+                AER         = .TRUE.
 
                 ! Check if...
                 ! there is precip coming into box (I,J,K) from (I,J,K+1)
@@ -2026,6 +2027,7 @@ CONTAINS
                 GAINED      = 0e+0_fp
                 WETLOSS     = 0e+0_fp
                 MASS_WASH   = 0e+0_fp
+                KIN         = .TRUE.
 
                 ! Precipitation from upper edge is essential for both
                 ! washout and reevaporation


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantsosca
Institution: Harvard + GCST

### Describe the update

This PR fixes the parallel error reported in issue #3023 by setting the `AER` and `KIN` variables to `.TRUE.` before the call to `WASHOUT`.   This was suggested by @viral211: https://github.com/geoschem/geos-chem/issues/3023#issuecomment-3285456537

### Expected changes
This should remove the parallelization error from PR #3001.  We expect small differences.

### Related Github Issue

- Closes #3023 
- See PR #3001
