### PR TITLE
Updates for GCHP conservation of restart file species mass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added operational run scripts for WashU Compute2
 - Added the option for LPJ_MERRA2 wetland CH4 emissions in CH4 and carbon simulations
 - Added GC-Classic config file option to read restart file as `REAL*8` via GEOS-Chem rather than HEMCO
+- Added new GCHP run-time option in GCHP.rc to print species mass proxy (Species 1 only) to log file from FV3
+- Added GEOS-Chem export in GCHP to send restart file (internal state) delta pressures to FV3 for mixing ratio scaling upon start-up
 
 ### Changed
 - Replaced comments in template HEMCO configuration files directing users to obsolete wiki documentation with comments directing users to `hemco.readthedocs.io`
@@ -47,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 - Removed entries for FINN v1.5 biomass burning emissions from template HEMCO configuration files
 - Removed `Is_Advected` tags from `run/shared/species_database*.yml` template files
+- Removed GCHP initialization of State_Met fields TropLev, BxHeight, and DELP_DRY from restart file values since over-written with values of current meteorology
 
 ## [14.6.3] - 2025-07-28
 ### Added

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -481,6 +481,22 @@ CONTAINS
 #endif
 
 !
+! !EXPORT STATE:
+!
+    ! Export delta pressure from internal state for first timestep
+    ! pressure scaling before advection, to conserve mass in
+    ! restart file. Use name DELPDRY to not conflict with name
+    ! DELP_DRY used in restart file and internal state.
+    call MAPL_AddExportSpec(GC, &
+       SHORT_NAME         = 'DELPDRY',                       &
+       LONG_NAME          = 'Delta dry pressure across box', &
+       UNITS              = 'hPa',                &
+       PRECISION          = ESMF_KIND_R8,         &
+       DIMS               = MAPL_DimsHorzVert,    &
+       VLOCATION          = MAPL_VLocationCenter, &
+       RC=STATUS  )
+    _VERIFY(STATUS)
+!
 ! !INTERNAL STATE:
 !
 #if defined( MODEL_GEOS )

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -1237,6 +1237,8 @@ CONTAINS
     INTEGER                      :: N, trcID
     TYPE(MAPL_MetaComp), POINTER :: STATE => NULL()
     REAL(ESMF_KIND_R8), POINTER  :: Ptr3D(:,:,:) => NULL()
+    REAL(ESMF_KIND_R8), POINTER  :: Ptr3D_int(:,:,:) => NULL()
+    REAL(ESMF_KIND_R8), POINTER  :: Ptr3D_exp(:,:,:) => NULL()
 #endif
 
     ! Internal run alarms
@@ -1690,6 +1692,18 @@ CONTAINS
 
        ENDDO
     ENDIF
+#endif
+
+#ifdef MODEL_GCHPCTM
+    ! Set delta pressure export to interal state variable DELP_DRY.
+    ! This is used in the first timestep in FV3, before advection, to
+    ! adjust species v/v for conservation of restart file mass, if
+    ! delta pressure present in the restart file.
+    call MAPL_GetPointer ( Export, Ptr3d_exp, 'DELPDRY', ALLOC=.TRUE., __RC__ )
+    CALL ESMF_StateGet( INTSTATE, 'DELP_DRY', GcFld, RC=STATUS )
+    CALL ESMF_FieldGet( GcFld, 0, Ptr3D, __RC__ )
+       Ptr3d_exp = Ptr3d * 100.d0
+       Ptr3d => NULL()
 #endif
 
     !=======================================================================

--- a/run/GCHP/GCHP.rc.template
+++ b/run/GCHP/GCHP.rc.template
@@ -41,6 +41,10 @@ USE_TOTAL_AIR_PRESSURE_IN_ADVECTION: ${RUNDIR_USE_TOTAL_AIR_PRESSURE_IN_ADVECTIO
 #-----------------------------------------------------------------------
 CORRECT_MASS_FLUX_FOR_HUMIDITY: 1
 
+# Print mass time series in advection (0=false, 1=true)
+#-----------------------------------------------------------------------
+PRINT_MASS_IN_ADVECTION: 0
+
 # Use when running a perturbation
 # scenario with RRTMG's FDH or SEFDH
 # options. Set to 0 to CALCULATE dynamical


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR adds a new export to the `GCHPchem` gridded component of GCHP. The new export `DELPDRY` is set equal to the internal state value of `DELP_DRY` during initialize, for use in restart species mass conservation in dynamics prior to running offline advection in the first timestep. In addition, an existing print option in advection, to print proxy mass for air and species, is now a run-time option in config file `GCHP.rc`.

**There are two companion PRs required with this update:**
https://github.com/geoschem/FVdycoreCubed_GridComp/pull/11
https://github.com/geoschem/GCHP/pull/515

### Expected changes

This update results in small differences in all species in all GCHP simulations. GEOS-Chem Classic is not affected.

### Reference(s)

None

### Related Github Issue

Closes https://github.com/geoschem/geos-chem/issues/2536
