### PR TITLE
Toggle "read_restart_as_real8" from false to true for fullchem benchmark simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated GFEIv3 files to correct issue in original version
 - Updated `download_data.py` for compatibility with 0.125 x 0.15625 grids plus all pre-defined nested-grids
 - Restructured `download_data.py` to avoid several instances of repeated code
+- Changed `read_restart_as_real8` from `false` to `true` in `geoschem_config.yml` for GC-Classic benchmark simulations
 
 ### Fixed
 - Restored entries for TMB emissions in `HEMCO_Config.rc.fullchem` template files for GCClassic and GCHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `download_data.py` for compatibility with 0.125 x 0.15625 grids plus all pre-defined nested-grids
 - Restructured `download_data.py` to avoid several instances of repeated code
 - Changed `read_restart_as_real8` from `false` to `true` in `geoschem_config.yml` for GC-Classic benchmark simulations
+- Changed the default setting of `read_restart_as_real8` from `false` to `true` in template file `geoschem_config.yml.TransportTracers`
 
 ### Fixed
 - Restored entries for TMB emissions in `HEMCO_Config.rc.fullchem` template files for GCClassic and GCHP

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers
@@ -20,7 +20,7 @@ simulation:
     activate: false
     on_cores: root       # Allowed values: root all
   use_gcclassic_timers: ${RUNDIR_USE_GCCLASSIC_TIMERS}
-  read_restart_as_real8: false
+  read_restart_as_real8: true   # Needed for mass conservation
 
 #============================================================================
 # Grid settings

--- a/run/shared/setupConfigFiles.sh
+++ b/run/shared/setupConfigFiles.sh
@@ -136,6 +136,11 @@ function set_common_settings() {
 
 	# Remove the first comment character on diagnostics
         sed_ie "s|#'|'|"                               HISTORY.rc
+
+	# Make sure that benchmark simulations read the restart file via
+	# GEOS-Chem and not HEMCO.  This will ensure mass conservation
+	# when the run is broken up into several stages.
+	replace_colon_sep_val "read_restart_as_real8" "true" geoschem_config.yml
     fi
 
     #------------------------------------------------------------------------

--- a/run/shared/setupConfigFiles.sh
+++ b/run/shared/setupConfigFiles.sh
@@ -120,9 +120,6 @@ function set_common_settings() {
 	    # Change time cycle flag to allow missing species
 	    sed_ie 's|EFYO|CYS|' HEMCO_Config.rc
 
-	    # Remove the first comment character on diagnostics
-            sed_ie "s|#'|'|"     HISTORY.rc
-
 	    # Make sure that GC-Classic benchmark simulations read the
 	    # restart file via GEOS-Chem and not HEMCO.  This will ensure
 	    # mass conservation when the run is broken up into several
@@ -149,7 +146,10 @@ function set_common_settings() {
 	# Turn @ into # characters for the benchmark simulation,
 	# which should cause MAPL to skip reading these lines.
 	# This is a workaround for a "input file to long" MAPL error.
-	sed_ie 's|@|#|'                                HISTORY.rc
+	sed_ie 's|@|#|'                               HISTORY.rc
+
+	# Remove the first comment character on diagnostics
+        sed_ie "s|#'|'|"                              HISTORY.rc
     fi
 
     #------------------------------------------------------------------------

--- a/run/shared/setupConfigFiles.sh
+++ b/run/shared/setupConfigFiles.sh
@@ -112,11 +112,28 @@ function set_common_settings() {
     #------------------------------------------------------------------------
     if [[ "x${sim_extra_option}" == "xbenchmark" ]]; then
 
-	# Change time cycle flag to allow missing species (GCClassic only)
+	#--------------------------------
+	# Updates for GC-Classic only
+	#--------------------------------
 	if [[ "x${model}" == "xGCClassic" ]]; then
+
+	    # Change time cycle flag to allow missing species
 	    sed_ie 's|EFYO|CYS|' HEMCO_Config.rc
+
+	    # Remove the first comment character on diagnostics
+            sed_ie "s|#'|'|"     HISTORY.rc
+
+	    # Make sure that GC-Classic benchmark simulations read the
+	    # restart file via GEOS-Chem and not HEMCO.  This will ensure
+	    # mass conservation when the run is broken up into several
+	    # stages, since restart file data is stored as REAL*8 but HEMCO
+	    # reads file data as REAL*4.
+	    replace_colon_sep_val "read_restart_as_real8" "true" geoschem_config.yml
 	fi
 
+	#---------------------------------
+	# Updates for GCClassic and GCHP
+	#---------------------------------
         sed_ie 's|NO     0      3 |NO     104    -1|' HEMCO_Diagn.rc   # Use online soil NOx (ExtNr=104)
 	sed_ie 's|SALA  0      3 |SALA  107    -1|'   HEMCO_Diagn.rc   # Use online sea salt (ExtNr=107)
 	sed_ie 's|SALC  0      3 |SALC  107    -1|'   HEMCO_Diagn.rc   #   "   "
@@ -133,14 +150,6 @@ function set_common_settings() {
 	# which should cause MAPL to skip reading these lines.
 	# This is a workaround for a "input file to long" MAPL error.
 	sed_ie 's|@|#|'                                HISTORY.rc
-
-	# Remove the first comment character on diagnostics
-        sed_ie "s|#'|'|"                               HISTORY.rc
-
-	# Make sure that benchmark simulations read the restart file via
-	# GEOS-Chem and not HEMCO.  This will ensure mass conservation
-	# when the run is broken up into several stages.
-	replace_colon_sep_val "read_restart_as_real8" "true" geoschem_config.yml
     fi
 
     #------------------------------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR adds a call to bash function `replace_colon_sep_val` in `run/shared/setupConfigFiles.sh` to change:
```yaml
  read_restart_as_real8: false
```
to
```yaml
  read_restart_as_real8: true
```
in `geoschem_config.yml` files for fullchem benchmark simulations. 

Also, we set `read_restart_as_real8: true` by default in the `run/shared/geoschem_config.yml.templates/geoschem_config.yml.TransportTracers` template file, in order to ensure mass conservation in 1-year TransportTracers benchmarks.

### Expected changes
This will cause numerical noise differences in fullchem benchmark simulations that are split up into several run stages, as there will no longer be any `REAL*8` -> `REAL*4` precision truncation.