### PR TITLE
Fix typo in GCHP operational run script for Harvard Cannon to properly retrieve the run duration string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change precision of area import from GCHP advection from `REAL*4` to native `REAL*8`
 - Fixed time-range and units for CH4 emission inventories to be consistent with the corresponding netCDF files in ExtData directory for `HEMCO_Config.rc` and `ExtData.rc`
 - Updated scaling factor ID at 3000 to avoid conflicts with CEDS_01x01 scaling factor enabled in carbon simulation for IMI analytical inversion
+- Fixed typo in GCHP operational run script for Harvard Cannon to properly retrieve the run duration string
 
 ### Removed
 - Removed entries for FINN v1.5 biomass burning emissions from template HEMCO configuration files

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.submit_consecutive_jobs.sh
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.submit_consecutive_jobs.sh
@@ -14,7 +14,7 @@ fi
 
 # Sanity check number of runs, start date, and duration per run
 echo "Submitting ${numRuns} jobs"
-echo "Duration:  $(grep "DURATION=" setCommonRunSettings.sh | cut -c 14- | xargs)"
+echo "Duration:  $(grep "Run_Duration=" setCommonRunSettings.sh | cut -c 14- | xargs)"
 echo "Start:     $(cat cap_restart)"
 
 # Submit first job   


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The Harvard example script `gchp.submit_consecutive_jobs.sh` was grepping `setCommonRunSettings.sh` for the string "DURATION=" to retrieve the run duration. At some point this string should have been changed to "Run_Duration=" to match what is now in `setCommonRunSettings.sh`. This fix will once more print to screen the run duration when executing `gchp.submit_consecutive_jobs.sh` instead of returning a blank string.

### Expected changes

This is a zero-difference update. It will only impact text printed to the screen when executing `gchp.submit_consecutive_jobs.sh` (found in `run/GCHP/runScriptSamples/operational_examples/harvard_cannon/`).
