### PR TITLE
Fix LPJ wetland path in GCHP carbon ExtData.rc to use HEMCO directory

### DIFF
--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -249,7 +249,7 @@ EDGAR8_CH4_SWD_INC             kg/m2/s N Y F%y4-%m2-01T00:00:00  none none emi_c
 JPLW_CH4  kg/m2/s Y Y F2010-%m2-01T00:00:00 none 2.66350462E-22 emi_ch4  ./HcoDir/CH4/v2024-01/JPL_WetCharts/HEensemble/JPL_WetCharts_2010-2019.Ensemble_Mean.0.5x0.5.nc
 
 # --- LPJ MERRA2 (East et al., https://doi.org/10.1029/2024GL108494) ---
-LPJ_CH4  kg/m2/s N Y F%y4-%m2-01T00:00:00 none none emis_ch4 /n/holylfs06/LABS/jacob_lab2/Lab/dzhang8/LPJ_MERRA2/LPJ_MERRA2_%y4_0.5x0.5.nc
+LPJ_CH4  kg/m2/s N Y F%y4-%m2-01T00:00:00 none none emis_ch4 ./HcoDir/CH4/v2025-09/LPJ_MERRA2/LPJ_MERRA2_%y4_0.5x0.5.nc
 
 # --- Geological seeps ---
 CH4_SEEPS kg/m2/s N Y - none none  emi_ch4  ./HcoDir/CH4/v2020-04/Seeps/Etiope_CH4GeologicalEmis_ScaledToHmiel.1x1.nc


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update changes the path for LPJ wetlands emissions in the GCHP carbon-simulation ExtData.rc to use the HEMCO data directory. Previously the path was local on the Harvard Cannon compute cluster. The LPJ wetland emissions were not included in any releases prior to 14.7.0 so no update is needed in the changelog.

### Expected changes

None. This is a no-diff update.

### Reference(s)

None

### Related Github Issue

Builds on top of PR https://github.com/geoschem/geos-chem/pull/3010
