### PR TITLE
Bug fix: Include instantaneous ObsPack data lying within 1/2 model timestep of the end of the model date in the sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Fixed bug in ObsPack to include instantaneously-sampled data whose  timestamps are within 1/2 of a model timestep of the end of the day 
+
 ## [14.6.3] - 2025-07-28
 ### Added
 - Added error check to exclude sampling ObsPack observations located outside of a nested-grid domain


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #3084, which was raised by @mattloman.  

In this PR, we have updated the logic so that ObsPack data points that are instantaneously-sampled (i.e. having `CT_sampling_strategy = 4`) and that lie within 1/2 model timestep of the end of the day will be included in the sampling.  In doing so, we have also streamlined the logic.

### Expected changes
This is a no-diff-to-benchmark update.  See the discussion in #3084 for details.

### Related Github Issue

- Closes #3084

Also tagging our ObsPack power-users: @aschuh @jhaskinsPhD @eastjames @alli-moon