### PR TITLE
Remove hardwired MaxChemLev; now compute this as the 1 hPa level and store in State_Met

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added error trap to routine `Get_GC_Restart` to halt simulations that use `read_restart_as_real8: true` with a reduced vertical grid
 - Added `State_Met%MaxChemLev` and `State_Met%MaxStratLev` integer fields
 - Added `Init_MaxChemLev` routine in `GeosUtil/pressure_mod.F90`, called from routine `Init_Pressure`
-- Added `State_Met` argument to routines `Init_CloudJ`, `Init_Photolysis`, `Set_Clim_Profiles`, `GC_Init_Extra`, `Init_Pressure`, `Init_Mercury`, `Init_Sulfate`
+- Added `State_Met` argument to routines `Init_Photolysis`, `Set_Clim_Profiles`, `GC_Init_Extra`, `Init_Pressure`, `Init_Mercury`, `Init_Sulfate`
 
 ### Changed
 - Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added ExtData2G yaml configuration file for GCHP transport tracer simulation
 - Added `${RUNDIR_READ_RESTART_AS_REAL8}` to GEOS-Chem Classic  `geoschem_config.yml` template files
 - Added error trap to routine `Get_GC_Restart` to halt simulations that use `read_restart_as_real8: true` with a reduced vertical grid
+- Added `State_Met%MaxChemLev` and `State_Met%MaxStratLev` integer fields
+- Added `Init_MaxChemLev` routine in `GeosUtil/pressure_mod.F90`, called from routine `Init_Pressure`
+- Added `State_Met` argument to routines `Init_CloudJ`, `Init_Photolysis`, `Set_Clim_Profiles`, `GC_Init_Extra`, `Init_Pressure`, `Init_Mercury`, `Init_Sulfate`
 
 ### Changed
 - Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product
@@ -35,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Renamed `Carbon` collection to `ProdLoss` collection in GCClassic and GCHP `HISTORY.rc.carbon` templates
 - Updated GitHub Action `stale@v5` to `stale@v10` in order to avoid deprecation warnings
 - Moved logic to determine whether we read the restart file as `REAL*8` from `run/shared/setupConfigFiles.sh` to `run/GCClassic/createRunDir.sh`
+- Simplified the logic where `isGMAO` and `State_Grid%NativeNZ` are computed in `GeosUtil/gc_grid_mod.F90`
+- Changed definition of `State_Grid%MaxChemLev` and `State_Grid%MaxStratLev` to be the 1 hPa level
 
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`
@@ -48,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Retired Fung termite and soil absorption emission options from carbon simulation
 - Removed `GeosUtil/grid_registry_mod.F90`.
 - Removed `OHconcAfterChem` from GCClassic and GCHP `HISTORY.rc.carbon` templates, as OH is fixed during the simulation
+- Removed `State_Grid%MaxChemLev`, `State_Grid%MaxStratLev`, and `State_Grid%MaxTropLev` fields
 
 ## [14.7.0] - 2026-02-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `State_Met%MaxChemLev` and `State_Met%MaxStratLev` integer fields
 - Added `Init_MaxChemLev` routine in `GeosUtil/pressure_mod.F90`, called from routine `Init_Pressure`
 - Added `State_Met` argument to routines `Init_CloudJ`, `Init_Photolysis`, `Set_Clim_Profiles`, `GC_Init_Extra`, `Init_Pressure`, `Init_Mercury`, `Init_Sulfate`
-- Added `State_Met%MaxChemLev` and `State_Met%MaxStratLev` integer fields
-- Added `Init_MaxChemLev` routine in `GeosUtil/pressure_mod.F90`, called from routine `Init_Pressure`
-- Added `State_Met` argument to routines `Init_CloudJ`, `Init_Photolysis`, `Set_Clim_Profiles`, `GC_Init_Extra`, `Init_Pressure`, `Init_Mercury`, `Init_Sulfate`, and `Set_Prof_FJX`
 
 ### Changed
 - Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product
@@ -43,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Moved logic to determine whether we read the restart file as `REAL*8` from `run/shared/setupConfigFiles.sh` to `run/GCClassic/createRunDir.sh`
 - Simplified the logic where `isGMAO` and `State_Grid%NativeNZ` are computed in `GeosUtil/gc_grid_mod.F90`
 - Changed definition of `State_Grid%MaxChemLev` and `State_Grid%MaxStratLev` to be the 1 hPa level
+- Moved `MaxChemLev` and `MaxStratLev` fields from `State_Grid` to `State_Met`
+- Removed `State_Grid%MaxTropLev` field
 
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`
@@ -56,8 +55,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Retired Fung termite and soil absorption emission options from carbon simulation
 - Removed `GeosUtil/grid_registry_mod.F90`.
 - Removed `OHconcAfterChem` from GCClassic and GCHP `HISTORY.rc.carbon` templates, as OH is fixed during the simulation
-- Removed `State_Grid%MaxChemLev`, `State_Grid%MaxStratLev`, and `State_Grid%MaxTropLev` fields
-- Removed `State_Grid%MaxChemLev`, `State_Grid%MaxStratLev`, and `State_Grid%MaxTropLev` fields
 - Removed `State_Grid` argument from `Set_Prof_FJX` routine
 
 ## [14.7.0] - 2026-02-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `State_Met%MaxChemLev` and `State_Met%MaxStratLev` integer fields
 - Added `Init_MaxChemLev` routine in `GeosUtil/pressure_mod.F90`, called from routine `Init_Pressure`
 - Added `State_Met` argument to routines `Init_CloudJ`, `Init_Photolysis`, `Set_Clim_Profiles`, `GC_Init_Extra`, `Init_Pressure`, `Init_Mercury`, `Init_Sulfate`
+- Added `State_Met%MaxChemLev` and `State_Met%MaxStratLev` integer fields
+- Added `Init_MaxChemLev` routine in `GeosUtil/pressure_mod.F90`, called from routine `Init_Pressure`
+- Added `State_Met` argument to routines `Init_CloudJ`, `Init_Photolysis`, `Set_Clim_Profiles`, `GC_Init_Extra`, `Init_Pressure`, `Init_Mercury`, `Init_Sulfate`, and `Set_Prof_FJX`
 
 ### Changed
 - Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product
@@ -54,6 +57,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed `GeosUtil/grid_registry_mod.F90`.
 - Removed `OHconcAfterChem` from GCClassic and GCHP `HISTORY.rc.carbon` templates, as OH is fixed during the simulation
 - Removed `State_Grid%MaxChemLev`, `State_Grid%MaxStratLev`, and `State_Grid%MaxTropLev` fields
+- Removed `State_Grid%MaxChemLev`, `State_Grid%MaxStratLev`, and `State_Grid%MaxTropLev` fields
+- Removed `State_Grid` argument from `Set_Prof_FJX` routine
 
 ## [14.7.0] - 2026-02-05
 ### Added

--- a/GeosCore/aero_drydep.F90
+++ b/GeosCore/aero_drydep.F90
@@ -305,11 +305,11 @@
              ENDDO
 
              ! We know the boundary condition at the model top
-             L     = State_Grid%MaxChemLev
+             L     = State_Met%MaxChemLev
              DELZ  = BXHEIGHT(I,J,L)           ![=] meter
              TC(L) = TC(L) / ( 1.d0 + DTCHEM * VTS(L) / DELZ )
 
-             DO L = State_Grid%MaxChemLev-1, 1, -1
+             DO L = State_Met%MaxChemLev-1, 1, -1
                 DELZ  = BXHEIGHT(I,J,L)
                 DELZ1 = BXHEIGHT(I,J,L+1)
                 TC(L) = 1.d0 / &
@@ -364,7 +364,7 @@
     !$OMP SCHEDULE( DYNAMIC )
     DO I = 1, State_Grid%NX
     DO J = 1, State_Grid%NY
-    DO L = 1, State_Grid%MaxChemLev
+    DO L = 1, State_Met%MaxChemLev
 
        ! Initialize for safety's sake
        AREA_CM2 = 0d0

--- a/GeosCore/aerosol_mod.F90
+++ b/GeosCore/aerosol_mod.F90
@@ -1894,7 +1894,7 @@ CONTAINS
                 !  Hygroscopic growth of Sea Salt (accum)   [unitless]
                 !  Hygroscopic growth of Sea Salt (coarse)  [unitless]
                 IF ( State_Diag%Archive_AerHygGrowth .AND. &
-                     L <= State_Grid%MaxChemLev      .AND. &
+                     L <= State_Met%MaxChemLev       .AND. &
                      ODSWITCH.EQ.1 ) THEN
                    S = State_Diag%Map_AerHygGrowth%id2slot(NA)
                    IF ( S > 0 ) THEN

--- a/GeosCore/calc_met_mod.F90
+++ b/GeosCore/calc_met_mod.F90
@@ -579,10 +579,10 @@ CONTAINS
 
        ! Is this grid box within the stratosphere (but not mesosphere)?
        State_Met%InStratosphere(I,J,L) = &
-            ( L <= State_Grid%MaxStratLev .and. State_Met%InStratMeso(I,J,L) )
+            ( L <= State_Met%MaxStratLev .and. State_Met%InStratMeso(I,J,L) )
 
        ! Is grid box (I,J,L) within the chemistry grid?
-       State_Met%InChemGrid(I,J,L) = ( L <= State_Grid%MaxChemLev )
+       State_Met%InChemGrid(I,J,L) = ( L <= State_Met%MaxChemLev )
 
     ENDDO
     ENDDO

--- a/GeosCore/carbon_mod.F90
+++ b/GeosCore/carbon_mod.F90
@@ -1819,7 +1819,7 @@ CONTAINS
    !$OMP PRIVATE( VALUE,    UPPER,     LOWER,  MNEW,  TOL                   )&
    !$OMP PRIVATE( ORG_AER,  ORG_GAS,   KOM,    MPOC                         )&
    !$OMP PRIVATE( KRO2NO,   KRO2HO2,   JSV                                  )
-   DO L = 1, State_Grid%MaxChemLev
+   DO L = 1, State_Met%MaxChemLev
    DO J = 1, State_Grid%NY
    DO I = 1, State_Grid%NX
 
@@ -2303,8 +2303,8 @@ CONTAINS
                               GLOB_AM0_POA(IIDEBUG,JJDEBUG,2,1,2,2), &
                               GLOB_AM0_POA(IIDEBUG,JJDEBUG,10,1,2,2)
 
-         print*, 'POA to trop', SUM(Spc(id_POA1)%Conc(:,:,1:State_Grid%MaxChemLev))+ &
-                                SUM(Spc(id_POA2)%Conc(:,:,1:State_Grid%MaxChemLev))
+         print*, 'POA to trop', SUM(Spc(id_POA1)%Conc(:,:,1:State_Met%MaxChemLev))+ &
+                                SUM(Spc(id_POA2)%Conc(:,:,1:State_Met%MaxChemLev))
       ENDIF ! OPOA (hotp 8/24/09)
 
    ENDIF
@@ -5846,7 +5846,7 @@ CONTAINS
 
       ! Get O3 [v/v] for this gridbox & month
       ! O3 is defined only in the chemistry grid
-      IF ( L <= State_Grid%MaxChemLev ) THEN
+      IF ( L <= State_Met%MaxChemLev ) THEN
 
          ! O3 from HEMCO is in mol/mol, convert to molec/cm3
          O3_MOLEC_CM3 = OFFLINE_O3(I,J,L) * State_Met%AIRNUMDEN(I,J,L)
@@ -6589,7 +6589,7 @@ CONTAINS
    !$OMP PARALLEL DO       &
    !$OMP DEFAULT( SHARED ) &
    !$OMP PRIVATE( NOX, JHC, JSV, I, J, L )
-   DO L = 1, State_Grid%MaxChemLev
+   DO L = 1, State_Met%MaxChemLev
    DO J = 1, State_Grid%NY
    DO I = 1, State_Grid%NX
 
@@ -6731,7 +6731,7 @@ CONTAINS
    !$OMP PRIVATE( NOX,         JHC,        JSV,    IPR ) &
    !$OMP PRIVATE( TEMPDELTA,   TEMPSOAG,   MBDIFF      ) &
    !$OMP PRIVATE( I, J, L                              )
-   DO L = 1, State_Grid%MaxChemLev
+   DO L = 1, State_Met%MaxChemLev
    DO J = 1, State_Grid%NY
    DO I = 1, State_Grid%NX
 

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -69,7 +69,6 @@ CONTAINS
     USE State_Chm_Mod,  ONLY : ChmState
     USE State_Grid_Mod, ONLY : GrdState
     USE State_Diag_Mod, ONLY : DgnState
-    USE State_Met_Mod,  ONLY : MetState
 !
 ! !INPUT PARAMETERS:
 !

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -55,7 +55,7 @@ CONTAINS
 ! !INTERFACE:
 !
   SUBROUTINE INIT_CLOUDJ( Input_Opt, State_Grid, State_Diag,                 &
-                          State_Chm, State_Met,  RC                         )
+                          State_Chm, RC                                     )
 !
 ! !USES:
 !
@@ -76,7 +76,6 @@ CONTAINS
     TYPE(OptInput), INTENT(IN)     :: Input_Opt   ! Input Options object
     TYPE(GrdState), INTENT(IN)     :: State_Grid  ! Grid State object
     TYPE(DgnState), INTENT(IN)     :: State_Diag  ! Diagnostics State object
-    TYPE(MetState), INTENT(IN)     :: State_Met   ! Meteorology State object
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -54,7 +54,8 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE INIT_CLOUDJ( Input_Opt, State_Grid, State_Diag, State_Chm, RC )
+  SUBROUTINE INIT_CLOUDJ( Input_Opt, State_Grid, State_Diag,                 &
+                          State_Chm, State_Met,  RC                         )
 !
 ! !USES:
 !
@@ -68,13 +69,14 @@ CONTAINS
     USE State_Chm_Mod,  ONLY : ChmState
     USE State_Grid_Mod, ONLY : GrdState
     USE State_Diag_Mod, ONLY : DgnState
-
+    USE State_Met_Mod,  ONLY : MetState
 !
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput), INTENT(IN)     :: Input_Opt   ! Input Options object
     TYPE(GrdState), INTENT(IN)     :: State_Grid  ! Grid State object
     TYPE(DgnState), INTENT(IN)     :: State_Diag  ! Diagnostics State object
+    TYPE(MetState), INTENT(IN)     :: State_Met   ! Meteorology State object
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -171,8 +173,8 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Run_CloudJ( Input_Opt, State_Chm, State_Diag, &
-                         State_Grid, State_Met, RC )
+  SUBROUTINE Run_CloudJ( Input_Opt,  State_Chm, State_Diag,                  &
+                         State_Grid, State_Met, RC                          )
 !
 ! !USES:
 !
@@ -494,10 +496,11 @@ CONTAINS
        O3_CTM(1:MaxLev) = State_Chm%Species(id_O3)%Conc(I,J,1:MaxLev)
 
        ! Compute climatology. This subroutine is analogous to Cloud-J ACLIM_FJX.
-       CALL Set_Clim_Profiles (I,          J,        MONTH,    DAY,      &
-                               T_CTM,      P_CTM,    O3_CTM,             &
-                               T_CLIM,     O3_CLIM,  Z_CLIM,   AIR_CLIM, &
-                               Input_Opt,  State_Grid, State_Chm )
+       CALL Set_Clim_Profiles( I,          J,         MONTH,                 &
+                               DAY,        T_CTM,     P_CTM,                 &
+                               O3_CTM,     T_CLIM,    O3_CLIM,               &
+                               Z_CLIM,     AIR_CLIM,  Input_Opt,             &
+                               State_Grid, State_Chm, State_Met             )
 
        !-----------------------------------------------------------------
        ! Clouds and humidity
@@ -956,7 +959,7 @@ CONTAINS
        !-----------------------------------------------------------------
        ! Fill GEOS-Chem array ZPJ with J-values
        !-----------------------------------------------------------------
-       DO L=1,State_Grid%MaxChemLev
+       DO L=1,State_Met%MaxChemLev
           DO K=1,State_Chm%Phot%nPhotRxns
              IF (JIND(K).gt.0) THEN
                 State_Chm%Phot%ZPJ(L,K,I,J) = VALJXX(L,JIND(K))*JFACTA(K)
@@ -967,8 +970,8 @@ CONTAINS
        ENDDO
 
        ! Set J-rates outside the chemgrid to zero
-       IF (State_Grid%MaxChemLev.lt.L_) THEN
-          DO L=State_Grid%MaxChemLev+1,L_
+       IF (State_Met%MaxChemLev.lt.L_) THEN
+          DO L=State_Met%MaxChemLev+1,L_
              DO K=1,State_Chm%Phot%nPhotRxns
                 State_Chm%Phot%ZPJ(L,K,I,J) = 0.e+0_fp
              ENDDO
@@ -1072,10 +1075,11 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Set_Clim_Profiles( ILON,       ILAT,       MONTH,   DAY,       &
-                                T_CTM,      P_CTM,      O3_CTM,             &
-                                T_CLIM,     O3_CLIM,    Z_CLIM,  AIR_CLIM,  &
-                                Input_Opt,  State_Grid, State_Chm )
+  SUBROUTINE Set_Clim_Profiles( ILON,       ILAT,       MONTH,               &
+                                DAY,        T_CTM,      P_CTM,               &
+                                O3_CTM,     T_CLIM,     O3_CLIM,             &
+                                Z_CLIM,     AIR_CLIM,   Input_Opt,           &
+                                State_Grid, State_Chm,  State_Met           )
 !
 ! !USES:
 !
@@ -1084,26 +1088,28 @@ CONTAINS
     USE PhysConstants,   ONLY : AIRMW, AVO, g0, BOLTZ
     USE State_Grid_Mod,  ONLY : GrdState
     USE State_Chm_Mod,   ONLY : ChmState
+    USE State_Met_Mod,   ONLY : MetState
 !
 ! !INPUT PARAMETERS:
 !
-    INTEGER,        INTENT(IN) :: ILON              ! Longitude index
-    INTEGER,        INTENT(IN) :: ILAT              ! Latitude index
-    INTEGER,        INTENT(IN) :: MONTH             ! Month
-    INTEGER,        INTENT(IN) :: DAY               ! Day *of month*
-    REAL(fp),       INTENT(IN) :: T_CTM(L1_)        ! CTM temperatures (K)
-    REAL(fp),       INTENT(IN) :: P_CTM(L1_+1)      ! CTM edge pressures (hPa)
-    REAL(fp),       INTENT(IN) :: O3_CTM(L1_)       ! CTM ozone (molec/cm3)
-    TYPE(OptInput), INTENT(IN) :: Input_Opt         ! Input Options object
-    TYPE(GrdState), INTENT(IN) :: State_Grid        ! Grid State object
-    TYPE(ChmState), INTENT(IN) :: State_Chm         ! Chemistry State object
+    INTEGER,        INTENT(IN) :: ILON            ! Longitude index
+    INTEGER,        INTENT(IN) :: ILAT            ! Latitude index
+    INTEGER,        INTENT(IN) :: MONTH           ! Month
+    INTEGER,        INTENT(IN) :: DAY             ! Day *of month*
+    REAL(fp),       INTENT(IN) :: T_CTM(L1_)      ! CTM temperatures (K)
+    REAL(fp),       INTENT(IN) :: P_CTM(L1_+1)    ! CTM edge pressures (hPa)
+    REAL(fp),       INTENT(IN) :: O3_CTM(L1_)     ! CTM ozone (molec/cm3)
+    TYPE(OptInput), INTENT(IN) :: Input_Opt       ! Input Options object
+    TYPE(GrdState), INTENT(IN) :: State_Grid      ! Grid State object
+    TYPE(ChmState), INTENT(IN) :: State_Chm       ! Chemistry State object
+    TYPE(MetState), INTENT(IN) :: State_Met       ! Meteorology State object
 !
 ! !OUTPUT VARIABLES:
 !
-    REAL(fp), INTENT(OUT)      :: T_CLIM(L1_)       ! Clim. temperatures (K)
-    REAL(fp), INTENT(OUT)      :: Z_CLIM(L1_+1)     ! Edge altitudes (cm)
-    REAL(fp), INTENT(OUT)      :: O3_CLIM(L1_)      ! O3 column depth (#/cm2)
-    REAL(fp), INTENT(OUT)      :: AIR_CLIM(L1_)     ! O3 column depth (#/cm2)
+    REAL(fp), INTENT(OUT)      :: T_CLIM(L1_)     ! Clim. temperatures (K)
+    REAL(fp), INTENT(OUT)      :: Z_CLIM(L1_+1)   ! Edge altitudes (cm)
+    REAL(fp), INTENT(OUT)      :: O3_CLIM(L1_)    ! O3 column depth (#/cm2)
+    REAL(fp), INTENT(OUT)      :: AIR_CLIM(L1_)   ! O3 column depth (#/cm2)
 !
 ! !REMARKS:
 !
@@ -1211,7 +1217,7 @@ CONTAINS
        ! Use online O3 values in the chemistry grid if selected; otherwise use
        ! O3 values from the met fields or TOMS/SBUV
        IF ( ( Input_opt%Use_Online_O3 )             &
-            .AND. ( L <= State_Grid%MaxChemLev )    &
+            .AND. ( L <= State_Met%MaxChemLev )    &
             .AND. ( O3_CTM(L) > 0e+0_fp ) ) THEN
 
           ! Convert from molec/cm3 to molec/cm2

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -1452,9 +1452,9 @@ CONTAINS
        ! SatDiagnOH: OH concentration [molec/cm3]:
        !---------------------------------------------------------------------
        IF ( State_Diag%Archive_SatDiagnOH ) THEN
-          State_Diag%SatDiagnOH(I,:,1:State_Grid%MaxChemLev) =               &
-               ( Spc(id_OH)%Conc(I,:,1:State_Grid%MaxChemLev) * good  *      &
-               State_Met%AIRDEN(I,:,1:State_Grid%MaxChemLev)  * AVO ) /      &
+          State_Diag%SatDiagnOH(I,:,1:State_Met%MaxChemLev) =               &
+               ( Spc(id_OH)%Conc(I,:,1:State_Met%MaxChemLev) * good  *      &
+               State_Met%AIRDEN(I,:,1:State_Met%MaxChemLev)  * AVO ) /      &
                ( State_Chm%SpcData(id_OH)%Info%MW_g ) / 1.0e+3_fp
        ENDIF
 

--- a/GeosCore/dust_mod.F90
+++ b/GeosCore/dust_mod.F90
@@ -827,12 +827,12 @@ CONTAINS
           ENDDO
 
           ! We know the boundary condition at the model top
-          L           = State_Grid%MaxChemLev
+          L           = State_Met%MaxChemLev
           DELZ        = State_Met%BXHEIGHT(I,J,L)
           Spc(NA)%Conc(I,J,L) =Spc(NA)%Conc(I,J,L) / &
                          ( 1.e+0_fp + DT_SETTL * VTS(L) / DELZ )
 
-          DO L = State_Grid%MaxChemLev-1, 1, -1
+          DO L = State_Met%MaxChemLev-1, 1, -1
              DELZ         = State_Met%BXHEIGHT(I,J,L)
              DELZ1        = State_Met%BXHEIGHT(I,J,L+1)
              Spc(NA)%Conc(I,J,L) = 1.e+0_fp / &
@@ -1450,7 +1450,7 @@ CONTAINS
        !$OMP PRIVATE( I, J, L, N, W, NOUT, LINTERP, S )
        DO W = 1, Input_Opt%NWVSELECT
        DO N = 1, NDUST
-       DO L = 1, State_Grid%MaxChemLev
+       DO L = 1, State_Met%MaxChemLev
        DO J = 1, State_Grid%NY
        DO I = 1, State_Grid%NX
 
@@ -1511,7 +1511,7 @@ CONTAINS
           !$OMP PARALLEL DO       &
           !$OMP DEFAULT( SHARED ) &
           !$OMP PRIVATE( I, J, L )
-          DO L = 1, State_Grid%MaxChemLev
+          DO L = 1, State_Met%MaxChemLev
           DO J = 1, State_Grid%NY
           DO I = 1, State_Grid%NX
              State_Diag%AODDust(I,J,L) = SUM( tempOD(I,J,L,:,:) )
@@ -1528,7 +1528,7 @@ CONTAINS
        !$OMP PARALLEL DO       &
        !$OMP DEFAULT( SHARED ) &
        !$OMP PRIVATE( I, J, L )
-       DO L = 1, State_Grid%MaxChemLev
+       DO L = 1, State_Met%MaxChemLev
        DO J = 1, State_Grid%NY
        DO I = 1, State_Grid%NX
           State_Diag%AerSurfAreaDust(I,J,L) = SUM( TAREA(I,J,L,1:NDUST) )

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -395,8 +395,8 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE GC_Init_Extra( Diag_List,  Input_Opt,  State_Chm, &
-                            State_Diag, State_Grid, RC )
+  SUBROUTINE GC_Init_Extra( Diag_List,  Input_Opt,  State_Chm,               &
+                            State_Diag, State_Grid, State_Met, RC           )
 !
 ! !USES:
 !
@@ -422,6 +422,7 @@ CONTAINS
     USE State_Chm_Mod,      ONLY : ChmState
     USE State_Diag_Mod,     ONLY : DgnState
     USE State_Grid_Mod,     ONLY : GrdState
+    USE State_Met_Mod,      ONLY : MetState
     USE Sulfate_Mod,        ONLY : Init_Sulfate
     USE Tagged_O3_Mod,      ONLY : Init_Tagged_O3
     USE Vdiff_Mod,          ONLY : Init_Vdiff
@@ -437,6 +438,7 @@ CONTAINS
     TYPE(OptInput), INTENT(INOUT) :: Input_Opt   ! Input Options object
     TYPE(ChmState), INTENT(INOUT) :: State_Chm   ! Chemistry state object
     TYPE(DgnState), INTENT(INOUT) :: State_Diag  ! Diagnostics State object
+    TYPE(MetState), INTENT(INOUT) :: State_Met   ! Meteorology State object
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -489,7 +491,7 @@ CONTAINS
     !=======================================================================
     ! Initialize the hybrid pressure module.  Define Ap and Bp.
     !=======================================================================
-    CALL Init_Pressure( Input_Opt, State_Grid, RC )
+    CALL Init_Pressure( Input_Opt, State_Grid, State_Met, RC )
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "Init_Pressure"!'
        CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -616,7 +618,8 @@ CONTAINS
     ! Initialize "sulfate_mod.F90"
     !-----------------------------------------------------------------
     IF ( Input_Opt%LSULF ) THEN
-       CALL Init_Sulfate( Input_Opt, State_Chm, State_Diag, State_Grid, RC )
+       CALL Init_Sulfate( Input_Opt,  State_Chm, State_Diag,                 &
+                          State_Grid, State_Met, RC                         )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_Sulfate"!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -645,8 +648,8 @@ CONTAINS
     ! Carbon gases via KPP
     !-----------------------------------------------------------------
     IF ( Input_Opt%ITS_A_CARBON_SIM ) THEN
-       CALL Init_Carbon_Gases( Input_Opt,  State_Chm, State_Diag,             &
-                               State_Grid, RC                                )
+       CALL Init_Carbon_Gases( Input_Opt,  State_Chm, State_Diag,            &
+                               State_Grid, RC                               )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_Carbon_Gases"!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -660,7 +663,8 @@ CONTAINS
     IF ( Input_Opt%ITS_A_MERCURY_SIM ) THEN
 
        ! Main mercury module
-       CALL Init_Mercury( Input_Opt, State_Grid, State_Chm, State_Diag, RC )
+       CALL Init_Mercury( Input_Opt,  State_Grid, State_Chm,                 &
+                          State_Diag, State_Met,  RC                        )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_Mercury"!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/global_br_mod.F90
+++ b/GeosCore/global_br_mod.F90
@@ -259,8 +259,8 @@ CONTAINS
     ENDIF
 
     ! Only set values up to max chemistry level
-    IF ( State_Grid%MaxChemLev < State_Grid%NZ ) THEN
-       J_BrO(:,:,State_Grid%MaxChemLev+1:State_Grid%NZ) = 0e+0_fp 
+    IF ( State_Met%MaxChemLev < State_Grid%NZ ) THEN
+       J_BrO(:,:,State_Met%MaxChemLev+1:State_Grid%NZ) = 0e+0_fp
     ENDIF
 
   END SUBROUTINE GET_GLOBAL_Br

--- a/GeosCore/hco_utilities_gc_mod.F90
+++ b/GeosCore/hco_utilities_gc_mod.F90
@@ -1999,7 +1999,7 @@ CONTAINS
 
             ! For non-advected species at levels above chemistry grid,
             ! use a small number for background
-            IF ( L > State_Grid%MaxChemLev .and. &
+            IF ( L > State_Met%MaxChemLev .and. &
                      .NOT. SpcInfo%Is_Advected ) THEN
 
                Spc(N)%Conc(I,J,L) = SMALL_NUM

--- a/GeosCore/mercury_mod.F90
+++ b/GeosCore/mercury_mod.F90
@@ -2814,7 +2814,7 @@ CONTAINS
        !======================================================================
        ! Proceed only if gridbox is below the stratopause
        !======================================================================
-       IF ( L > State_Grid%MaxStratLev ) CYCLE
+       IF ( L > State_Met%MaxStratLev ) CYCLE
 
        !----------------------------------------------------------------------
        ! Copy values into THREADPRIVATE variables in gckpp_Global.F90
@@ -3499,7 +3499,8 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE Init_Mercury( Input_Opt, State_Grid, State_Chm, State_Diag, RC )
+  SUBROUTINE Init_Mercury( Input_Opt,  State_Grid, State_Chm,                &
+                           State_Diag, State_Met,  RC                       )
 !
 ! !USES:
 !
@@ -3514,11 +3515,13 @@ CONTAINS
     USE State_Chm_Mod,      ONLY : ChmState
     USE State_Diag_Mod,     ONLY : DgnState
     USE State_Grid_Mod,     ONLY : GrdState
+    USE State_Met_Mod,      ONLY : MetState
 !
 ! !INPUT PARAMETERS:
 !
     TYPE(OptInput), INTENT(IN)    :: Input_Opt     ! Input Options object
     TYPE(GrdState), INTENT(IN)    :: State_Grid    ! Grid State object
+    TYPE(MetState), INTENT(IN)    :: State_Met     ! Meteorology State object
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -3900,7 +3903,8 @@ CONTAINS
     !========================================================================
     ! Initialize photolysis
     !========================================================================
-    CALL Init_Photolysis( Input_Opt, State_Grid, State_Chm, State_Diag, RC )
+    CALL Init_Photolysis( Input_Opt,  State_Grid, State_Chm,                 &
+                          State_Diag, State_Met,  RC                        )
     IF ( RC /= GC_SUCCESS ) THEN
        errMsg = 'Error encountered in "Init_Photolysis"!'
        CALL GC_Error( errMsg, RC, thisLoc )

--- a/GeosCore/ocean_mercury_mod.F90
+++ b/GeosCore/ocean_mercury_mod.F90
@@ -378,7 +378,7 @@ CONTAINS
     ENDIF
 
     ! convert REAL*4 to REAL(fpp)
-    SO4_GC(:,:,1:State_Grid%MaxChemLev) = ARRAYso4(:,:,1:State_Grid%MaxChemLev)
+    SO4_GC(:,:,1:State_Met%MaxChemLev) = ARRAYso4(:,:,1:State_Met%MaxChemLev)
 
     !---------------------------
     ! Read NH4 from HEMCO
@@ -389,7 +389,7 @@ CONTAINS
     ENDIF
 
     ! convert REAL*4 to REAL(fpp)
-    NH4_CONC(:,:,1:State_Grid%MaxChemLev) = ARRAYnh4(:,:,1:State_Grid%MaxChemLev)
+    NH4_CONC(:,:,1:State_Met%MaxChemLev) = ARRAYnh4(:,:,1:State_Met%MaxChemLev)
 
     !---------------------------
     ! Read NIT from HEMCO
@@ -400,7 +400,7 @@ CONTAINS
     ENDIF
 
     ! convert REAL*4 to REAL(fpp)
-    NIT_CONC(:,:,1:State_Grid%MaxChemLev) = ARRAYnit(:,:,1:State_Grid%MaxChemLev)
+    NIT_CONC(:,:,1:State_Met%MaxChemLev) = ARRAYnit(:,:,1:State_Met%MaxChemLev)
 
     !---------------------------
     ! Read BCPI+BCPO from HEMCO
@@ -425,7 +425,7 @@ CONTAINS
     ! convert REAL*4 to REAL(fpp)
     ARRAYtemp           = 0.e0_f4
     ARRAYtemp(:,:,1:LL) = ARRAYbcpi + ARRAYbcpo
-    BC_CONC(:,:,1:State_Grid%MaxChemLev) = ARRAYtemp(:,:,1:State_Grid%MaxChemLev)
+    BC_CONC(:,:,1:State_Met%MaxChemLev) = ARRAYtemp(:,:,1:State_Met%MaxChemLev)
 
     !---------------------------
     ! Read OCPI+OCPO from HEMCO
@@ -450,7 +450,7 @@ CONTAINS
     ! convert REAL*4 to REAL(fpp)
     ARRAYtemp           = 0.e0_f4
     ARRAYtemp(:,:,1:LL) = ARRAYocpi + ARRAYocpo
-    OC_CONC(:,:,1:State_Grid%MaxChemLev) = ARRAYtemp(:,:,1:State_Grid%MaxChemLev)
+    OC_CONC(:,:,1:State_Met%MaxChemLev) = ARRAYtemp(:,:,1:State_Met%MaxChemLev)
 
     !---------------------------
     ! Read DST1 from HEMCO
@@ -461,7 +461,7 @@ CONTAINS
     ENDIF
 
     ! convert REAL*4 to REAL(fpp)
-    DST_CONC(:,:,1:State_Grid%MaxChemLev) = ARRAYdst1(:,:,1:State_Grid%MaxChemLev)
+    DST_CONC(:,:,1:State_Met%MaxChemLev) = ARRAYdst1(:,:,1:State_Met%MaxChemLev)
 
     !$OMP PARALLEL DO                                                        &
     !$OMP DEFAULT( SHARED                                                   )&

--- a/GeosCore/photolysis_mod.F90
+++ b/GeosCore/photolysis_mod.F90
@@ -55,7 +55,8 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE INIT_PHOTOLYSIS( Input_Opt, State_Grid, State_Chm, State_Diag, RC )
+  SUBROUTINE INIT_PHOTOLYSIS( Input_Opt,  State_Grid, State_Chm,             &
+                              State_Diag, State_Met,  RC                    )
 !
 ! !USES:
 !
@@ -71,6 +72,7 @@ CONTAINS
     USE State_Chm_Mod,  ONLY : ChmState, Ind_
     USE State_Diag_Mod, ONLY : DgnState
     USE State_Grid_Mod, ONLY : GrdState
+    USE State_Met_Mod,  ONLY : MetState
 #ifdef FASTJX
     USE Fjx_Interface_Mod,  ONLY : Init_FastJX
 #else
@@ -82,6 +84,7 @@ CONTAINS
     TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
     TYPE(GrdState), INTENT(IN)    :: State_Grid  ! Grid State object
     TYPE(DgnState), INTENT(IN)    :: State_Diag  ! Diagnostics State object
+    TYPE(MetState), INTENT(IN)    :: State_Met   ! Meteorology State object
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -152,7 +155,8 @@ CONTAINS
           CALL GC_Error( ErrMsg, RC, ThisLoc )
           RETURN
        ENDIF
-       CALL Init_CloudJ( Input_Opt, State_Grid, State_Diag, State_Chm, RC )
+       CALL Init_CloudJ( Input_Opt, State_Grid, State_Diag,                  &
+                         State_Chm, State_Met,  RC                          )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_CloudJ"!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/photolysis_mod.F90
+++ b/GeosCore/photolysis_mod.F90
@@ -156,7 +156,7 @@ CONTAINS
           RETURN
        ENDIF
        CALL Init_CloudJ( Input_Opt, State_Grid, State_Diag,                  &
-                         State_Chm, State_Met,  RC                          )
+                         State_Chm, RC                                      )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Init_CloudJ"!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/seasalt_mod.F90
+++ b/GeosCore/seasalt_mod.F90
@@ -774,11 +774,11 @@ CONTAINS
        TC0  = TC(I,J,:)
 
        ! We know the boundary condition at the model top
-       L         = State_Grid%MaxChemLev
+       L         = State_Met%MaxChemLev
        DELZ      = State_Met%BXHEIGHT(I,J,L)
        TC(I,J,L) = TC(I,J,L) / ( 1.e+0_fp + DTCHEM * VTS(L) / DELZ )
 
-       DO L = State_Grid%MaxChemLev-1, 1, -1
+       DO L = State_Met%MaxChemLev-1, 1, -1
           DELZ      = State_Met%BXHEIGHT(I,J,L)
           DELZ1     = State_Met%BXHEIGHT(I,J,L+1)
           TC(I,J,L) = 1.0_fp / ( 1.0_fp + DTCHEM * VTS(L) / DELZ  )          &

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -1843,12 +1843,12 @@ CONTAINS
        ENDDO
 
        ! We know the boundary condition at the model top
-       L    = State_Grid%MaxChemLev
+       L    = State_Met%MaxChemLev
        DELZ = State_Met%BXHEIGHT(I,J,L)
 
        TC(I,J,L) = TC(I,J,L) / ( 1.e+0_fp + DTCHEM * VTS(L) / DELZ )
 
-       DO L = State_Grid%MaxChemLev-1, 1, -1
+       DO L = State_Met%MaxChemLev-1, 1, -1
           DELZ  = State_Met%BXHEIGHT(I,J,L)
           DELZ1 = State_Met%BXHEIGHT(I,J,L+1)
           TC(I,J,L) = 1.e+0_fp / ( 1.e+0_fp + DTCHEM * VTS(L) / DELZ ) &
@@ -2774,7 +2774,7 @@ CONTAINS
        ELSE IF ( Input_Opt%ITS_AN_AEROSOL_SIM ) THEN
           ! Get offline mean O3 [v/v] for this gridbox and month
           O3 = 0.0_fp
-          IF ( L <= State_Grid%MaxChemLev ) THEN
+          IF ( L <= State_Met%MaxChemLev ) THEN
              O3 = O3m(I,J,L)
           ENDIF
        ENDIF
@@ -8377,7 +8377,7 @@ CONTAINS
       !$OMP DEFAULT( SHARED )    &
       !$OMP PRIVATE( I, J, L)    &
       !$OMP SCHEDULE( DYNAMIC, 1 )
-      DO L = 1, State_Grid%MaxChemLev
+      DO L = 1, State_Met%MaxChemLev
       DO J = 1, State_Grid%NY
       DO I = 1, State_Grid%NX
 
@@ -8969,7 +8969,8 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE INIT_SULFATE( Input_Opt, State_Chm, State_Diag, State_Grid, RC )
+  SUBROUTINE INIT_SULFATE( Input_Opt,  State_Chm, State_Diag,                &
+                           State_Grid, State_Met, RC                        )
 !
 ! !USES:
 !
@@ -8980,6 +8981,7 @@ CONTAINS
     USE State_Chm_Mod,  ONLY : Ind_
     USE State_Diag_Mod, ONLY : DgnState
     USE State_Grid_Mod, ONLY : GrdState
+    USE State_Met_Mod,  ONLY : MetState
 !
 ! !INPUT PARAMETERS:
 !
@@ -8987,6 +8989,7 @@ CONTAINS
     TYPE(ChmState), INTENT(IN)  :: State_Chm   ! Chemistry State object
     TYPE(DgnState), INTENT(IN)  :: State_Diag  ! Diagnostics State object
     TYPE(GrdState), INTENT(IN)  :: State_Grid  ! Grid State object
+    TYPE(MetState), INTENT(IN)  :: State_Met   ! Grid State object
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -9042,78 +9045,78 @@ CONTAINS
     IF ( RC /= GC_SUCCESS ) RETURN
     DMSo = 0e+0_fp
 
-    ALLOCATE( PMSA_DMS( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), &
+    ALLOCATE( PMSA_DMS( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), &
               STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PMSA_DMS', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PMSA_DMS = 0e+0_fp
 
-    ALLOCATE( PSO2_DMS( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), &
+    ALLOCATE( PSO2_DMS( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), &
               STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PSO2_DMS', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PSO2_DMS = 0e+0_fp
 
-    ALLOCATE( PSO4_SO2( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), &
+    ALLOCATE( PSO4_SO2( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), &
               STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PSO4_SO2', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PSO4_SO2 = 0e+0_fp
 
-    ALLOCATE( PHMS_SO2( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), &
+    ALLOCATE( PHMS_SO2( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), &
               STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PHMS_SO2', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PHMS_SO2 = 0e+0_fp
 
-    ALLOCATE( PSO2_HMS( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), &
+    ALLOCATE( PSO2_HMS( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), &
               STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PSO2_HMS', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PSO2_HMS = 0e+0_fp
 
-    ALLOCATE( PSO4_HMS( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), &
+    ALLOCATE( PSO4_HMS( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), &
               STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PSO4_HMS', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PSO4_HMS = 0e+0_fp
 
-    ALLOCATE( PSO4_ss( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), &
+    ALLOCATE( PSO4_ss( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), &
               STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PSO4_ss', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PSO4_ss = 0e+0_fp
 
-    ALLOCATE( PNITs( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), &
+    ALLOCATE( PNITs( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), &
               STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PNITs', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PNITs = 0e+0_fp
     !xnw
-    ALLOCATE( PNIT( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev), STAT=RC )
+    ALLOCATE( PNIT( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev), STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F:PNIT', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PNIT = 0e+0_fp
     !xnw
-    ALLOCATE( PACL( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), STAT=RC )
+    ALLOCATE( PACL( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F:PACL', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PACL = 0e+0_fp
     !xnw
-    ALLOCATE( PCCL( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev ), STAT=RC )
+    ALLOCATE( PCCL( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev ), STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F:PCCL', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PCCL = 0e+0_fp
 
     !tdf
-    ALLOCATE( PSO4_dust( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev, &
+    ALLOCATE( PSO4_dust( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev, &
                          NDSTBIN ), STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PSO4_dust', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
     PSO4_dust = 0e+0_fp
 
     !tdf
-    ALLOCATE( PNIT_dust( State_Grid%NX, State_Grid%NY, State_Grid%MaxChemLev, &
+    ALLOCATE( PNIT_dust( State_Grid%NX, State_Grid%NY, State_Met%MaxChemLev, &
                          NDSTBIN ), STAT=RC )
     CALL GC_CheckVar( 'sulfate_mod.F90:PNIT_dust', 0, RC )
     IF ( RC /= GC_SUCCESS ) RETURN

--- a/GeosUtil/gc_grid_mod.F90
+++ b/GeosUtil/gc_grid_mod.F90
@@ -116,46 +116,26 @@ CONTAINS
     ! Vertical Grid
     !======================================================================
 
-    ! Both GEOS-FP and MERRA-2 have native vertical resolution of 72 levels
-    State_Grid%NativeNZ = 72
-
-    ! Hardcode maximum number of levels below tropopause and stratopause
-    IF ( State_Grid%NZ == 47 ) THEN
-       State_Grid%MaxTropLev  = 38
-       State_Grid%MaxStratLev = 44
-    ELSE IF ( State_Grid%NZ == 72 ) THEN
-       State_Grid%MaxTropLev  = 40
-       State_Grid%MaxStratLev = 59
-    ELSE IF ( State_Grid%NZ == 40 ) THEN
-       State_Grid%NativeNZ = 40
-       State_Grid%MaxTropLev  = 28
-       State_Grid%MaxStratLev = 40
-    ELSE IF ( State_Grid%NZ == 74 ) THEN
-       State_Grid%NativeNZ = 102
-       State_Grid%MaxTropLev  = 60
-       State_Grid%MaxStratLev = 72
-    ELSE IF ( State_Grid%NZ == 102 ) THEN
-       State_Grid%NativeNZ = 102
-       State_Grid%MaxTropLev  = 60
-       State_Grid%MaxStratLev = 91
-    ELSE
-       ErrMsg = 'State_Grid%GridRes = ' // Trim( State_Grid%GridRes)// &
-                ' does not have MaxTropLev and MaxStratLev defined.'// &
-                ' Please add these definitions in gc_grid_mod.F90.'
-       CALL GC_Error( ErrMsg, RC, ThisLoc )
-       RETURN
-    ENDIF
-
-    ! Set maximum number of levels in the chemistry grid
-    State_Grid%MaxChemLev  = State_Grid%MaxStratLev
-
     ! Set a flag to denote if this is a GMAO met field
-    ! (which has half-sized polar grid boxes)
+    ! and also determine the native vertical resolution
     SELECT CASE( TRIM( Input_Opt%MetField ) )
-       CASE( 'MERRA2', 'GEOSFP' )
-          is_GMAO = .TRUE.
+
+       ! GMAO met fields
+       CASE( 'GEOSFP', 'GEOSIT', 'MERRA2' )
+          is_GMAO             = .TRUE.
+          State_Grid%NativeNZ = 72
+
+       CASE( 'ModelE2.1' )
+          is_GMAO             = .FALSE.
+          State_Grid%NativeNZ = 102
+
        CASE DEFAULT
-          is_GMAO = .FALSE.
+          ErrMsg = 'Met field ' // TRIM( Input_Opt%MetField ) // ' does ' // &
+                   'not have State_Grid%NativeNZ defined.  Please add '   // &
+                   'this definition in GeosUtil/gc_grid_mod.F90.'
+          CALL GC_Error( ErrMsg, RC, ThisLoc )
+          RETURN
+
     END SELECT
 
     !======================================================================

--- a/GeosUtil/gc_grid_mod.F90
+++ b/GeosUtil/gc_grid_mod.F90
@@ -125,7 +125,7 @@ CONTAINS
           is_GMAO             = .TRUE.
           State_Grid%NativeNZ = 72
 
-       CASE( 'ModelE2.1' )
+       CASE( 'MODELE2.1' )
           is_GMAO             = .FALSE.
           State_Grid%NativeNZ = 102
 

--- a/GeosUtil/pressure_mod.F90
+++ b/GeosUtil/pressure_mod.F90
@@ -1332,18 +1332,68 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
 !
+    ! Scalars
     INTEGER :: L
 
-    ! State_Met%MaxStratLev is the 1 hPa level
-    ! State_Met%MaxChemLev is set to State_Chm%MaxStratLev by default
-    ! (but this could be defined differently if desired)
-    DO L = State_Grid%NZ+1, 1, -1
-       IF ( Get_Ap(L) > 1.0 ) THEN
-          State_Met%MaxStratLev = L
-          State_Met%MaxChemLev  = L
-          EXIT
-       ENDIF
-    ENDDO
+    ! Strings
+    CHARACTER(LEN=255) :: thisLoc
+    CHARACTER(LEN=512) :: errMsg
+
+    !========================================================================
+    ! Init_MaxChemLev begins here!
+    !========================================================================
+
+    ! Initialize
+    RC      = GC_SUCCESS
+    errMsg  = ''
+    thisLoc = ' -> at Init_MaxChemLev (in GeosUtil/pressure_mod.F90)'
+
+    SELECT CASE( State_Grid%NZ )
+
+       !---------------------------------------------------------------------
+       ! GMAO met fields
+       !
+       ! State_Met%MaxStratLev is the 1 hPa level
+       ! State_Met%MaxChemLev is set to State_Chm%MaxStratLev by default
+       ! (but this could be defined differently if desired)
+       !---------------------------------------------------------------------
+       CASE( 72, 47 )
+          DO L = State_Grid%NZ+1, 1, -1
+             IF ( Get_Ap(L) > 1.0 ) THEN
+                State_Met%MaxChemLev  = L
+                State_Met%MaxStratLev = L
+                EXIT
+             ENDIF
+          ENDDO
+
+       !---------------------------------------------------------------------
+       ! GCAP / ModelE 2.1
+       !
+       ! For now, use the previous definitions to ensure
+       ! zero-diff results w/r/t older GEOS-Chem versions.
+       !---------------------------------------------------------------------
+       CASE( 102 )
+          State_Met%MaxChemLev  = 91
+          State_Met%MaxStratLev = 91
+       CASE( 74 )
+          State_Met%MaxChemLev  = 72
+          State_Met%MaxStratLev = 72
+       CASE( 40 )
+          State_Met%MaxChemLev  = 40
+          State_Met%MaxStratLev = 40
+
+       !---------------------------------------------------------------------
+       ! Otherwise stop with error
+       !---------------------------------------------------------------------
+       CASE DEFAULT
+          ErrMsg =                                                           &
+             'State_Grid%GridRes = ' // Trim( State_Grid%GridRes )        // &
+             ' does not have MaxTropLev and MaxStratLev defined.  Please' // &
+             ' add these definitions to the CASE statement in routine'    // &
+             ' "Init_MaxChemLev" (located in GeosUtil/pressure_mod.F90).' 
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    END SELECT
 
   END SUBROUTINE Init_MaxChemLev
 !EOC

--- a/GeosUtil/pressure_mod.F90
+++ b/GeosUtil/pressure_mod.F90
@@ -476,7 +476,7 @@ CONTAINS
 !\\
 ! !INTERFACE:
 !
-  SUBROUTINE INIT_PRESSURE( Input_Opt, State_Grid, RC )
+  SUBROUTINE INIT_PRESSURE( Input_Opt, State_Grid, State_Met, RC )
 !
 ! !USES:
 !
@@ -484,15 +484,20 @@ CONTAINS
     USE ERROR_MOD,      ONLY : ALLOC_ERR
     USE Input_Opt_Mod,  ONLY : OptInput
     USE State_Grid_Mod, ONLY : GrdState
+    USE State_Met_Mod,  ONLY : MetState
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(OptInput), INTENT(IN)  :: Input_Opt   ! Input Options object
-    TYPE(GrdState), INTENT(IN)  :: State_Grid  ! Grid State object
+    TYPE(OptInput), INTENT(IN)    :: Input_Opt   ! Input Options object
+    TYPE(GrdState), INTENT(IN)    :: State_Grid  ! Grid State object
+!
+! INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(MetState), INTENT(INOUT) :: State_Met   ! Meteorology State object
 !
 ! !OUTPUT PARAMETERS:
 !
-    INTEGER,        INTENT(OUT) :: RC          ! Success or failure
+    INTEGER,        INTENT(OUT)   :: RC          ! Success or failure
 !
 ! !REVISION HISTORY:
 !  27 Aug 2002 - D. Abbot, S. Wu, & R. Yantosca - Initial version
@@ -1100,6 +1105,17 @@ CONTAINS
 
     ENDIF
 
+    !=======================================================================
+    ! Compute the maximum vertical level in the chemistry grid.
+    ! This corresponds to the 1 hPa level
+    !=======================================================================
+    CALL Init_MaxChemLev( State_Grid, State_Met, RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       ErrMsg = 'Error encountered in "Init_MaxChemLev"!'
+       CALL GC_Error( ErrMsg, RC, ThisLoc )
+       RETURN
+    ENDIF
+
 #if ( !defined( ESMF_ ) && !defined( MODEL_ ) ) || defined( MODEL_GEOS )
     ! Echo info to std output (skip if interfacing with external models)
     IF ( Input_Opt%amIRoot .and. ( .not. Input_Opt%DryRun ) ) THEN
@@ -1272,6 +1288,63 @@ CONTAINS
     RC             = GC_SUCCESS
 
   END SUBROUTINE Accept_External_ApBp
-!EOC
 #endif
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Init_MaxChemLev
+!
+! !DESCRIPTION: Computes the maximum level at which chemsitry will be
+!  performed. This corresponds to the 1 hPa level.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE Init_MaxChemLev( State_Grid, State_Met, RC )
+!
+! !USES:
+!
+    USE ErrCode_Mod
+    USE State_Grid_Mod, ONLY : GrdState
+    USE State_Met_Mod,  ONLY : MetState
+!
+! !INPUT PARAMETERS:
+!
+    TYPE(GrdState), INTENT(IN)    :: State_Grid  ! Grid State object
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(MetState), INTENT(INOUT) :: State_Met   ! Meteorology State object
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,        INTENT(OUT)   :: RC          ! Success/failure
+!
+! !REVISION HISTORY:
+!  07 Sep 2017 - E. Lundgren - Initial version
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    INTEGER :: L
+
+    ! State_Met%MaxStratLev is the 1 hPa level
+    ! State_Met%MaxChemLev is set to State_Chm%MaxStratLev by default
+    ! (but this could be defined differently if desired)
+    DO L = State_Grid%NZ+1, 1, -1
+       IF ( Get_Ap(L) > 1.0 ) THEN
+          State_Met%MaxStratLev = L
+          State_Met%MaxChemLev  = L
+          EXIT
+       ENDIF
+    ENDDO
+
+  END SUBROUTINE Init_MaxChemLev
+!EOC
 END MODULE PRESSURE_MOD

--- a/Headers/state_grid_mod.F90
+++ b/Headers/state_grid_mod.F90
@@ -101,6 +101,17 @@ MODULE State_Grid_Mod
      REAL(f8)           :: P0               ! Reference pressure (hPa)
      REAL(f8), POINTER  :: Time       (:  ) ! Time
 
+     !----------------------------------------
+     ! Grid fields computed in gc_grid_mod.F90
+     !----------------------------------------
+     INTEGER            :: GlobalNX    ! NX on the global grid
+     INTEGER            :: GlobalNY    ! NY on the global grid
+     INTEGER            :: NativeNZ    ! NZ on the native-resolution grid
+     INTEGER            :: XMinOffset  ! X offset from global grid
+     INTEGER            :: XMaxOffset  ! X offset from global grid
+     INTEGER            :: YMinOffset  ! Y offset from global grid
+     INTEGER            :: YMaxOffset  ! Y offset from global grid
+
 #ifdef LUO_WETDEP
      !----------------------------------------------------------------------
      ! Fields needed for the Luo et al wet deposition scheme
@@ -249,6 +260,56 @@ CONTAINS
     State_Grid%CPU_Subdomain_ID      =  -1
     State_Grid%CPU_Subdomain_FirstID =  -1
 #endif
+    State_Grid%GridRes               = ''
+    State_Grid%DX                    = 0e+0_fp
+    State_Grid%DY                    = 0e+0_fp
+    State_Grid%XMin                  = 0e+0_fp
+    State_Grid%XMax                  = 0e+0_fp
+    State_Grid%YMin                  = 0e+0_fp
+    State_Grid%YMax                  = 0e+0_fp
+    State_Grid%NX                    = 0
+    State_Grid%NY                    = 0
+    State_Grid%NZ                    = 0
+    State_Grid%HalfPolar             = .FALSE.
+    State_Grid%Center180             = .FALSE.
+    State_Grid%NestedGrid            = .FALSE.
+    State_Grid%NorthBuffer           = 0
+    State_Grid%SouthBuffer           = 0
+    State_Grid%EastBuffer            = 0
+    State_Grid%WestBuffer            = 0
+
+    !----------------------------------------
+    ! Grid fields computed in gc_grid_mod.F90
+    !----------------------------------------
+    State_Grid%GlobalNX     = 0
+    State_Grid%GlobalNY     = 0
+    State_Grid%NativeNZ     = 0
+    State_Grid%XMinOffset   = 0
+    State_Grid%XMaxOffset   = 0
+    State_Grid%YMinOffset   = 0
+    State_Grid%YMaxOffset   = 0
+
+    !---------------------------------------------------------------
+    ! Nullify all fields for safety's sake before allocating them
+    !---------------------------------------------------------------
+    State_Grid%GlobalXMid   => NULL()
+    State_Grid%GlobalYMid   => NULL()
+    State_Grid%GlobalXEdge  => NULL()
+    State_Grid%GlobalYEdge  => NULL()
+    State_Grid%XMid         => NULL()
+    State_Grid%XEdge        => NULL()
+    State_Grid%YMid         => NULL()
+    State_Grid%YEdge        => NULL()
+    State_Grid%YMid_R       => NULL()
+    State_Grid%YEdge_R      => NULL()
+    State_Grid%YSIN         => NULL()
+    State_Grid%Area_M2      => NULL()
+#ifdef LUO_WETDEP
+    State_Grid%DXSN_M         => NULL()
+    State_Grid%DYWE_M         => NULL()
+#endif
+
+>>>>>>> f9c99497c (Now compute MaxChemLev and MaxStratLev as the 1 hPa level)
 #if defined( MODEL_GEOS )
     State_Grid%PredictorIsActive     =  .FALSE.
 #endif

--- a/Headers/state_grid_mod.F90
+++ b/Headers/state_grid_mod.F90
@@ -62,9 +62,6 @@ MODULE State_Grid_Mod
      INTEGER            :: GlobalNX         ! NX on the global grid
      INTEGER            :: GlobalNY         ! NY on the global grid
      INTEGER            :: NativeNZ         ! NZ on the native-resolution grid
-     INTEGER            :: MaxChemLev       ! Max # levels in chemistry grid
-     INTEGER            :: MaxStratLev      ! Max # levels below strat
-     INTEGER            :: MaxTropLev       ! Max # levels below trop
      INTEGER            :: XMinOffset       ! Min X offset from global grid
      INTEGER            :: XMaxOffset       ! Max X offset from global grid
      INTEGER            :: YMinOffset       ! Min Y offset from global grid
@@ -237,9 +234,6 @@ CONTAINS
     State_Grid%GlobalNX              =  0
     State_Grid%GlobalNY              =  0
     State_Grid%NativeNZ              =  0
-    State_Grid%MaxChemLev            =  0
-    State_Grid%MaxStratLev           =  0
-    State_Grid%MaxTropLev            =  0
     State_Grid%XMinOffset            =  0
     State_Grid%XMaxOffset            =  0
     State_Grid%YMinOffset            =  0

--- a/Headers/state_grid_mod.F90
+++ b/Headers/state_grid_mod.F90
@@ -101,17 +101,6 @@ MODULE State_Grid_Mod
      REAL(f8)           :: P0               ! Reference pressure (hPa)
      REAL(f8), POINTER  :: Time       (:  ) ! Time
 
-     !----------------------------------------
-     ! Grid fields computed in gc_grid_mod.F90
-     !----------------------------------------
-     INTEGER            :: GlobalNX    ! NX on the global grid
-     INTEGER            :: GlobalNY    ! NY on the global grid
-     INTEGER            :: NativeNZ    ! NZ on the native-resolution grid
-     INTEGER            :: XMinOffset  ! X offset from global grid
-     INTEGER            :: XMaxOffset  ! X offset from global grid
-     INTEGER            :: YMinOffset  ! Y offset from global grid
-     INTEGER            :: YMaxOffset  ! Y offset from global grid
-
 #ifdef LUO_WETDEP
      !----------------------------------------------------------------------
      ! Fields needed for the Luo et al wet deposition scheme
@@ -309,7 +298,6 @@ CONTAINS
     State_Grid%DYWE_M         => NULL()
 #endif
 
->>>>>>> f9c99497c (Now compute MaxChemLev and MaxStratLev as the 1 hPa level)
 #if defined( MODEL_GEOS )
     State_Grid%PredictorIsActive     =  .FALSE.
 #endif

--- a/Headers/state_met_mod.F90
+++ b/Headers/state_met_mod.F90
@@ -278,6 +278,9 @@ MODULE State_Met_Mod
      REAL(fp), POINTER :: LocalSolarTime(:,:  ) ! Local solar time
      LOGICAL,  POINTER :: IsLocalNoon   (:,:  ) ! Is it local noon (between 11
                                                 !  and 13 local solar time?
+     INTEGER           :: MaxStratLev           ! Maximum extent of the strat
+     INTEGER           :: MaxChemLev            ! Level at the top of the
+                                                !  chemistry grid (1 hPa)
 
      !----------------------------------------------------------------------
      ! Fields for wet scavenging module
@@ -529,6 +532,8 @@ CONTAINS
     State_Met%ICESF          => NULL()
     State_Met%RADCD          => NULL()
 #endif
+    State_Met%MaxChemLev     = 0
+    State_Met%MaxStratLev    = 0
 
   END SUBROUTINE Zero_State_Met
 !EOC

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -508,8 +508,8 @@ PROGRAM GEOS_Chem
   ! This removes the init calls from the run-stage, which cannot
   ! happen when connecting GEOS-Chem to external ESMs.
   !--------------------------------------------------------------------------
-  CALL GC_Init_Extra( Diag_List,  Input_Opt,  State_Chm, &
-                      State_Diag, State_Grid, RC )
+  CALL GC_Init_Extra( Diag_List,  Input_Opt,  State_Chm,                     &
+                      State_Diag, State_Grid, State_Met, RC )
   IF ( RC /= GC_SUCCESS ) THEN
      ErrMsg = 'Error encountered in "GC_Init_Extra"!'
      CALL Error_Stop( ErrMsg, ThisLoc )
@@ -707,7 +707,8 @@ PROGRAM GEOS_Chem
   IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or. &
        Input_Opt%ITS_AN_AEROSOL_SIM .or. &
        Input_Opt%ITS_A_MERCURY_SIM  ) THEN
-     CALL Init_Photolysis( Input_Opt, State_Grid, State_Chm, State_Diag, RC )
+     CALL Init_Photolysis( Input_Opt,  State_Grid, State_Chm,                &
+                           State_Diag, State_Met,  RC                       )
      IF ( RC /= GC_SUCCESS ) THEN
         ErrMsg = 'Error encountered in "Init_Photolysis"!'
         CALL Error_Stop( ErrMsg, ThisLoc )

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -2724,7 +2724,7 @@ CONTAINS
                 DO L = 1, State_Grid%NZ
                 DO J = 1, State_Grid%NY
                 DO I = 1, State_Grid%NX
-                   IF ( L > State_Grid%MaxChemLev .AND. &
+                   IF ( L > State_Met%MaxChemLev .AND. &
                             ( .NOT. ThisSpc%Is_Advected ) ) THEN
                       ! For non-advected spc at L > MaxChemLev, use small number
                       State_Chm%Species(IND)%Conc(I,J,L) = 1.0E-30_FP
@@ -2794,8 +2794,8 @@ CONTAINS
 
           CALL MAPL_GetPointer( INTSTATE, Ptr3d_R8, 'KPPHvalue', notFoundOK=.TRUE., __RC__ )
           IF ( ASSOCIATED(Ptr3d_R8) .AND. ASSOCIATED(State_Chm%KPPHvalue) ) THEN
-             State_Chm%KPPHvalue(:,:,1:State_Grid%MaxChemLev) =       &
-            Ptr3d_R8(:,:,State_Grid%NZ:State_Grid%NZ-State_Grid%MaxChemLev+1:-1)
+             State_Chm%KPPHvalue(:,:,1:State_Met%MaxChemLev) =       &
+            Ptr3d_R8(:,:,State_Grid%NZ:State_Grid%NZ-State_Met%MaxChemLev+1:-1)
           ENDIF
           Ptr3d_R8 => NULL()
 
@@ -3186,9 +3186,9 @@ CONTAINS
        CALL MAPL_GetPointer( INTSTATE, Ptr3d_R8, 'KPPHvalue', &
                              notFoundOK=.TRUE., __RC__ )
        IF (ASSOCIATED(Ptr3d_R8) .AND. ASSOCIATED(State_Chm%KPPHvalue)) THEN
-          Ptr3d_R8(:,:,1:State_Grid%NZ-State_Grid%MaxChemLev) = 0.0
-          Ptr3d_R8(:,:,State_Grid%NZ:State_Grid%NZ-State_Grid%MaxChemLev+1:-1)=&
-             State_Chm%KPPHvalue(:,:,1:State_Grid%MaxChemLev)
+          Ptr3d_R8(:,:,1:State_Grid%NZ-State_Met%MaxChemLev) = 0.0
+          Ptr3d_R8(:,:,State_Grid%NZ:State_Grid%NZ-State_Met%MaxChemLev+1:-1)=&
+             State_Chm%KPPHvalue(:,:,1:State_Met%MaxChemLev)
        ENDIF
        Ptr3d_R8 => NULL()
 

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -1525,12 +1525,6 @@ CONTAINS
     State_Grid%XMaxOffset  = State_Grid%NX ! X offset from global grid
     State_Grid%YMinOffset  = 1             ! Y offset from global grid
     State_Grid%YMaxOffset  = State_Grid%NY ! Y offset from global grid
-    State_Grid%MaxTropLev  = 40            ! # trop. levels
-#if defined( MODEL_GEOS )
-    State_Grid%MaxStratLev = value_LLSTRAT ! # strat. levels
-#else
-    State_Grid%MaxStratLev = 59            ! # strat. levels
-#endif
 
     ! Call the GCHP initialize routine
     CALL GCHP_Chunk_Init( nymdB     = nymdB,      & ! YYYYMMDD @ start of run

--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -502,8 +502,8 @@ CONTAINS
 #endif
 
     ! Initialize other GEOS-Chem modules
-    CALL GC_Init_Extra( HistoryConfig%DiagList, Input_Opt,    &
-                        State_Chm, State_Diag, State_Grid, RC )
+    CALL GC_Init_Extra( HistoryConfig%DiagList, Input_Opt,  State_Chm,       &
+                        State_Diag,             State_Grid, State_Met, RC   )
     _ASSERT(RC==GC_SUCCESS, 'Error calling GC_Init_Extra')
 
 
@@ -523,7 +523,8 @@ CONTAINS
     IF ( Input_Opt%ITS_A_FULLCHEM_SIM .or. &
          Input_Opt%ITS_AN_AEROSOL_SIM .or. &
          Input_Opt%ITS_A_MERCURY_SIM  ) THEN
-       CALL Init_Photolysis ( Input_Opt, State_Grid, State_Chm, State_Diag, RC )
+       CALL Init_Photolysis( Input_Opt,  State_Grid, State_Chm,              &
+                             State_Diag, State_Met,  RC                     )
        _ASSERT(RC==GC_SUCCESS, 'Error calling Init_Photolysis')
     ENDIF
 

--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -214,9 +214,6 @@ CONTAINS
     CALL GC_Init_Grid( Input_Opt, State_Grid, RC )
     _ASSERT(RC==GC_SUCCESS, 'Error calling GC_Init_Grid')
 
-    ! Set maximum number of levels in the chemistry grid
-    State_Grid%MaxChemLev  = State_Grid%MaxStratLev
-
     ! In the ESMF/MPI environment, we can get the total overhead ozone
     ! either from the met fields (GCHPsa) or from the Import State (GEOS-5)
     Input_Opt%USE_O3_FROM_MET = .TRUE.


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #284, in which we do the following:

1. Remove `State_Grid%MaxTropLev`, `State_Grid%MaxStratLev`, and `State_Grid%MaxChemLev` fields.

2. Add `State_Met%MaxChemLev` and `State_Met%MaxStratLev` fields

3. Compute `State_Met%MaxStratLev` as the 1 hPa level instead of hardwiring it (for GMAO fields only.  GCAP/ModelE2.1 fields still set these to hardwired values in order to ensure backwards compatibility with previous model versions).

4. Set `State_Met%MaxChemLev` equal to `State_Met%MaxStratLev`, so that chemistry will be done to the top of the stratosphere.  This can be changed in the future to push chemistry higher up in the atmosphere.

5. Reference `State_Met%MaxChemLev` and `State_Met%MaxStratLev` in various routines.  In some cases this has involved adding `State_Met` as an argument to routines.

6. Simplify the logic in `gc_grid_mod.F90` where `isGMAO` and `State_Grid%NativeNZ` are computed.

### Expected changes
This is a no-diff-to-benchmark update.

### Related Github Issue
- Closes #284