### PR TITLE
Do not reference OHdiurnalFac in carbon_gases_mod.F90 for carbon simulations where OH is not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change precision of area import from GCHP advection from `REAL*4` to native `REAL*8`
 - Fixed time-range and units for CH4 emission inventories to be consistent with the corresponding netCDF files in ExtData directory for `HEMCO_Config.rc` and `ExtData.rc`
 - Updated scaling factor ID at 3000 to avoid conflicts with CEDS_01x01 scaling factor enabled in carbon simulation for IMI analytical inversion
-- Fixed typos in ind_ variable names in `KPP/carbon/carbon_Funcs.F90`
+- Fixed typos in `ind_` variable names in `KPP/carbon/carbon_Funcs.F90`
 - Fixed typo in GCHP operational run script for Harvard Cannon to properly retrieve the run duration string
-- Fixed bug in ObsPack to include instantaneously-sampled data whose  timestamps are within 1/2 of a model timestep of the end of the day 
+- Fixed bug in ObsPack to include instantaneously-sampled data whose
+  timestamps are within 1/2 of a model timestep of the end of the day
+- Fixed out-of-bounds error in `carbon_gases_mod.F90` that is caused by refernencing `OHdiurnalFac` array when it is not defined
 
 ### Removed
 - Removed entries for FINN v1.5 biomass burning emissions from template HEMCO configuration files

--- a/GeosCore/carbon_gases_mod.F90
+++ b/GeosCore/carbon_gases_mod.F90
@@ -414,34 +414,33 @@ CONTAINS
             State_Grid   = State_Grid,                                       &
             State_Met    = State_Met,                                        &
             OHdiurnalFac = OHdiurnalFac                                     )
-    ENDIF
 
-    !========================================================================
-    ! HISTORY: Diagnostic archival of OH [molec/cm3]
-    !========================================================================
-    IF ( State_Diag%Archive_OHconcAfterChem ) THEN
+       !========================================================================
+       ! HISTORY: Diagnostic archival of OH [molec/cm3]
+       !========================================================================
+       IF ( State_Diag%Archive_OHconcAfterChem ) THEN
 
-       !$OMP PARALLEL DO                                                     &
-       !$OMP DEFAULT( SHARED                                                )&
-       !$OMP PRIVATE( I, J, L                                               )&
-       !$OMP COLLAPSE( 3                                                    )
-       DO L = 1, State_Grid%NZ
-       DO J = 1, State_Grid%NY
-       DO I = 1, State_Grid%NX
+          !$OMP PARALLEL DO                                                  &
+          !$OMP DEFAULT( SHARED                                             )&
+          !$OMP PRIVATE( I, J, L                                            )&
+          !$OMP COLLAPSE( 3                                                 )
+          DO L = 1, State_Grid%NZ
+          DO J = 1, State_Grid%NY
+          DO I = 1, State_Grid%NX
 
-          ! Archive OH if we are in the chemistry grid [molec/cm3]
-          IF ( State_Met%InChemGrid(I,J,L) ) THEN
-             IF ( State_Diag%Archive_OHconcAfterChem ) THEN
-                State_Diag%OHconcAfterChem(I,J,L) = Global_OH(I,J,L)         &
-                                                  * OHdiurnalFac(I,J)
+             ! Archive OH if we are in the chemistry grid [molec/cm3]
+             IF ( State_Met%InChemGrid(I,J,L) ) THEN
+                IF ( State_Diag%Archive_OHconcAfterChem ) THEN
+                   State_Diag%OHconcAfterChem(I,J,L) = Global_OH(I,J,L)         &
+                                                     * OHdiurnalFac(I,J)
+                ENDIF
              ENDIF
-          ENDIF
 
-       ENDDO
-       ENDDO
-       ENDDO
-       !$OMP END PARALLEL DO
-
+          ENDDO
+          ENDDO
+          ENDDO
+          !$OMP END PARALLEL DO
+       ENDIF
     ENDIF
 
     ! Do not call KPP if neither CH4 or CO are advected species


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR fixes an out-of-bounds error that can occur in the CO2-only and OCS-only carbon simulations when the State_Diag%OHconcAfterChem diagnostic is selected to be archived, but when the OHdiurnalFac array is not allocated.  To fix the error we enclose the IF block where the diagnostic is updated with in the `IF ( id_CH4_adv > 0 .or. id_CO_adv > 0 )` block.

### Expected changes
This fix will allow the CO2-only and OCS-only carbon simulations to proceed to completion.

### Related Github Issue

- See #3074 