### PR TITLE
Do not divide PH2O2m by TS_EMIS in routine CHEM_H2O2 (aerosol-only bugfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed `Is_Advected` tags from `run/shared/species_database*.yml` template files
 - Removed GCHP initialization of `State_Met` fields `TropLev`, `BxHeight`, and `DELP_DRY` from restart file values since over-written with values of current meteorology
 - Removed `OH_PosteriorSF` entry in carbon and CH4 HEMCO_Config.rc since never used
+- Removed extraneous division by `TS_EMIS` in routine `Chem_H2O2` (located in `GeosCore/sulfate_mod.F90`)
 
 ## [14.6.3] - 2025-07-28
 ### Added

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -2315,7 +2315,7 @@ CONTAINS
        ALPHA = 1.0_fp + ( KOH + PHOTJ + FREQ ) * DT
 
        ! Delta H2O2 [v/v]
-       DH2O2 = ( PH2O2m(I,J,L) / TS_EMIS ) * DT / ( ALPHA * M )
+       DH2O2 = ( PH2O2m(I,J,L) * DT ) / ( ALPHA * M )
 
        ! Final H2O2 [v/v]
        H2O2  = ( H2O20 / ALPHA + DH2O2 )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #3100, which was reported by @CraigYEUNG.   We now change this computation in routine `CHEM_H2O2` (in `GeosCore/sulfate_mod.F90`) from:
```F90
        DH2O2 = ( PH2O2m(I,J,L) )  /TS_EMIS* DT / ( ALPHA * M )
```
to
```F90
        DH2O2 = ( PH2O2m(I,J,L) * DT ) / ( ALPHA * M )
```
as the PH2O2m array is already in molec/cm3/s and does not need to be divided by seconds.

### Expected changes
This is a no-diff-to-benchmark update.  It only affects aerosol-only simulations that have H2O2 as a transported species.

### Related Github Issue

- Closes #3100 