### PR TITLE
Add GC-Classic integration test straddling the 00 UTC date boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added new GCHP run-time option in GCHP.rc to print species mass proxy (Species 1 only) to log file from FV3
 - Added GEOS-Chem export in GCHP to send restart file (internal state) delta pressures to FV3 for mixing ratio scaling upon start-up
 - Added chemistry budget diagnostics to GCHP carbon HISTORY.rc
+- Added `gc_4x5_merra2_carbon_ch4_straddle_00utc` integraton test which runs across a UTC date boundary
 
 ### Changed
 - Replaced comments in template HEMCO configuration files directing users to obsolete wiki documentation with comments directing users to `hemco.readthedocs.io`

--- a/test/integration/GCClassic/integrationTestCreate.sh
+++ b/test/integration/GCClassic/integrationTestCreate.sh
@@ -281,7 +281,7 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
 
     #=========================================================================
     # Simulation with all diagnostics on
-    #==========================================================================
+    #=========================================================================
 
     # Configuration files
     allDiagsDir="gc_4x5_merra2_fullchem_alldiags"
@@ -314,8 +314,27 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
     cp -r "${obsPk}" .
     toggle_geoschem_config_option "geoschem_config.yml" "obspack"     "true "
 
-    # Switch back to the present directory
-    cd "${thisDir}"
+    # Switch back to the rundirs folder
+    cd "${rundirsDir}"
+
+    #=========================================================================
+    # Simulation running across the 00 UTC boundary
+    #==================q======================================================
+    
+    # Create a run directory for this test by copying the carbon_CH4 rundir
+    straddleDir="gc_4x5_merra2_carbon_CH4_straddle_00z"
+    echo "... ${itRoot}/rundirs/${straddleDir}"
+    cp -r "gc_4x5_merra2_carbon_CH4" "${straddleDir}"
+    cd "${straddleDir}"
+
+    # Update config files (start at 18 UTC, end at 01 UTC next day)
+    sed_ie "s|20190101\, 000000|20190101\, 180000|" "geoschem_config.yml"
+    sed_ie "s|20190101\, 010000|20190102\, 010000|" "geoschem_config.yml"
+    sed_ie "s|00000000 010000|00000000 070000|"     "HISTORY.rc"
+    sed_ie "s|EFYO|EY|"                             "HEMCO_Config.rc"
+
+    # Switch back to the rundirs folder
+    cd "${rundirsDir}"
 
     #=========================================================================
     # Create rundirs for dry-run tests
@@ -326,18 +345,14 @@ if [[ "X${testsToRun}" == "XALL" ]]; then
            "gc_4x5_merra2_carbon"               \
 	   "gc_4x5_merra2_fullchem"             \
            "gc_4x5_merra2_fullchem_APM"         \
-           "gc_4x5_merra2_47L_fullchem_TOMAS15" \
            "gc_4x5_merra2_fullchem_benchmark"   \
            "gc_4x5_merra2_fullchem_RRTMG"       \
            "gc_4x5_merra2_Hg"                   \
            "gc_4x5_merra2_metals"               \
-           "gc_4x5_merra2_tagCO"                \
            "gc_4x5_merra2_tagO3"                \
-           "gc_4x5_merra2_TransportTracers"       )
+           "gc_4x5_merra2_TransportTracers"     \
+           "gc_4x5_47L_merra2_fullchem_TOMAS15" )
 
-    # Navigate to the rundirs folder
-    cd "${rundirsDir}"
-    
     # Create dryrun directories by direct copy
     for dir in ${dirs[@]}; do
 	echo "... ${itRoot}/rundirs/${dir}_dryrun"
@@ -370,6 +385,7 @@ unset rundirsDir
 unset superProjectDir
 unset scriptsDir
 unset sharedDir
+unset straddleDir
 unset thisDir
 unset utilsDir
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR introduces a new GEOS-Chem Classic integration test (based on gc_4x5_merra2_carbon_CH4) that straddles a UTC date boundary.  The test starts at `20190101T18:00:00 UTC` and ends on `20190102T01:00:00 UTC`.

This is one of the "wish list" integration tests described in #714.

### Expected changes
This is a no-diff-to-benchmark update.

### Related Github Issue

- See #714
