### PR TITLE
Changed DMS entry in species_database.yml to use "Is_Gas: true" instead of "Is_Aerosol: true"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed `OHconcAfterChem` from GCClassic and GCHP `HISTORY.rc.carbon` templates, as OH is fixed during the simulation
 - Removed `State_Grid` argument from `Set_Prof_FJX` routine
 
+### Fixed
+- Fixed the species database entry of `DMS` to use `Is_Gas: true`, as DMS is a gas-phase species and not an aerosol
+
 ## [14.7.0] - 2026-02-05
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -1274,7 +1274,7 @@ DMS:
   FullName: Dimethyl sulfide
   Henry_CR: 3100.0
   Henry_K0: 0.48
-  Is_Aerosol: true
+  Is_Gas: true
   MW_g: 62.13
 DSTbin_PROP: &DSTbinproperties
   DD_DustDryDep: true


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #3127 by @gordonnova.  We have fixed an issue in the `run/shared/species_database.yml` file where DMS was wrongly listed as an aerosol instead of a gas-phase species.

### Expected changes
This is a no-diff-to-benchmark update.

### Related Github Issue
- Closes #3127