### PR TITLE
Update sample restart file for the carbon simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Replace hardwired values with constant parameters in routine `Aerosol_Conc` (in `GeosCore/aerosol_mod.F90`
 - Updated species database so that dust species use the anchor `&DSTbin properties` and metals species use `&METALSproperties`
 - Updated call to `ExtData_Set` in `hco_gc_interface_mod.F90` to accept `ExtState%SNOMAS`
+- Upated sample carbon simulation restart file to output generated from 10-year simulation
 
 ### Fixed
 - Restored entries for TMB emissions in `HEMCO_Config.rc.fullchem` template files for GCClassic and GCHP

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -702,7 +702,7 @@ elif [[ "x${sim_name}" == "xTransportTracers" ]]; then
     restart_name="${sim_name}"
 elif [[ ${sim_name} = "carbon" ]]; then
     start_date='20190101'
-    restart_dir='v2025-07'
+    restart_dir='GC_14.7.0'
     restart_name="${sim_name}"
 fi
 for N in 24 30 48 90 180

--- a/run/shared/download_data.yml
+++ b/run/shared/download_data.yml
@@ -58,7 +58,7 @@ restarts:
     remote: GC_14.7.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4
     local:  GEOSChem.Restart.20190701_0000z.nc4
   carbon:
-    remote: v2025-07/GEOSChem.Restart.carbon.20190101_0000z.nc4
+    remote: GC_14.7.0/GEOSChem.Restart.carbon.20190101_0000z.nc4
     local:  GEOSChem.Restart.20190101_0000z.nc4
   fullchem:
     remote: GC_14.7.0/GEOSChem.Restart.fullchem.20190701_0000z.nc4


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

A new sample restart file for the carbon simulation can be found in GEOSChem_Restarts/GC_14.7.0/. This file was taken from the end of a 10-year (2009-2018) GEOS-Chem Classic simulation using MERRA-2 4x5 meteorology. The file was regridded for GCHP cube-sphere resolutions using GCPy routines.

### Expected changes

This is a zero difference change with respect to the full-chemistry benchmark simulation.

### Related Github Issue

- Closes https://github.com/geoschem/geos-chem/issues/2963
