### PR TITLE
 Added a way to set to 0 for Safety in wetscav_mod.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.6.3] - 2026-01-14
+### Added
+- TL Added a way for SAFETY in /GeosCore/wetscav_mod.F90 to set anything that is small or negative to a zero when it finds a case following suggestion by yantosca (https://github.com/geoschem/geos-chem/issues/501#) 
+Added for errors like: https://github.com/geoschem/geos-chem/issues/501#, https://github.com/geoschem/geos-chem/issues/259, https://github.com/geoschem/geos-chem/issues/2991, https://github.com/geoschem/geos-chem/issues/2663, https://github.com/geoschem/geos-chem/issues/259, https://github.com/geoschem/geos-chem/issues/610, https://github.com/geoschem/geos-chem/issues/759, https://github.com/geoschem/geos-chem/issues/2440, and the like 
+
 ## [14.6.3] - 2025-07-28
 ### Added
 - Added error check to exclude sampling ObsPack observations located outside of a nested-grid domain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [14.6.3] - 2026-01-14
 ### Added
+- TL Changed the SAFETY in /GeosCore/wetscav_mod.F90 procedure following comments by yantosca (https://github.com/geoschem/geos-chem/pull/3164/changes)
 - TL Added a way for SAFETY in /GeosCore/wetscav_mod.F90 to set anything that is small or negative to a zero when it finds a case following suggestion by yantosca (https://github.com/geoschem/geos-chem/issues/501#) 
 Added for errors like: https://github.com/geoschem/geos-chem/issues/501#, https://github.com/geoschem/geos-chem/issues/259, https://github.com/geoschem/geos-chem/issues/2991, https://github.com/geoschem/geos-chem/issues/2663, https://github.com/geoschem/geos-chem/issues/259, https://github.com/geoschem/geos-chem/issues/610, https://github.com/geoschem/geos-chem/issues/759, https://github.com/geoschem/geos-chem/issues/2440, and the like 
 

--- a/GeosCore/wetscav_mod.F90
+++ b/GeosCore/wetscav_mod.F90
@@ -5449,10 +5449,31 @@ CONTAINS
 !
     ! Strings
     CHARACTER(LEN=255) :: ErrMsg, ThisLoc
+    REAL(fp)                      :: BAD !TL Added: 9/29/25: WetDep-Safety-Update
 
     !======================================================================
     ! SAFETY begins here!
     !======================================================================
+
+    ! TL Added: 9/29/25: Start WetDep-Safety-Update 
+    ! TL Added: 9/29/25: Following suggestion by yantosca (https://github.com/geoschem/geos-chem/issues/501)
+    ! TL Added: 9/29/25: To see if actually entering Safety
+    PRINT*, '>>> Entering SAFETY for species ', N
+    CALL FLUSH(6)
+
+    BAD = 0.0
+    ! TL Added: 9/29/25: WetDep-Safety-Update
+    IF ( MINVAL(Spc) < 0.0_fp) THEN
+       BAD = 1.0
+       PRINT*, 'Species', N, 'has a negative value',  &
+                  'at ', I, J, L, 'set to zero'
+    ENDIF
+
+    WHERE ( Spc < 0.0_fp )
+       ! Fix The Negative
+       Spc = 0.0_fp
+    ENDWHERE
+    !TL Added: 9/29/25: End WetDep-Safety-Update
 
     ! Initialize
     RC      = GC_SUCCESS

--- a/GeosCore/wetscav_mod.F90
+++ b/GeosCore/wetscav_mod.F90
@@ -5449,24 +5449,23 @@ CONTAINS
 !
     ! Strings
     CHARACTER(LEN=255) :: ErrMsg, ThisLoc
-    REAL(fp)                      :: BAD !TL Added: 9/29/25: WetDep-Safety-Update
-
+   
     !======================================================================
     ! SAFETY begins here!
     !======================================================================
 
     ! TL Added: 9/29/25: Start WetDep-Safety-Update 
     ! TL Added: 9/29/25: Following suggestion by yantosca (https://github.com/geoschem/geos-chem/issues/501)
-    ! TL Added: 9/29/25: To see if actually entering Safety
-    PRINT*, '>>> Entering SAFETY for species ', N
-    CALL FLUSH(6)
-
-    BAD = 0.0
+    ! TL Added: 2/9/26: Removed Print and Flush Statements and BAD following comment by yantosca (https://github.com/geoschem/geos-chem/pull/3164/changes)
+    
+    
     ! TL Added: 9/29/25: WetDep-Safety-Update
-    IF ( MINVAL(Spc) < 0.0_fp) THEN
-       BAD = 1.0
+    IF ( MINVAL(Spc) < 0.0_fp ) THEN
+       !TL Added: 2/9/26: Wrapped Print in OMP CRITICAL following comment by yantosca (https://github.com/geoschem/geos-chem/pull/3164/changes)
+       !$OMP CRITICAL
        PRINT*, 'Species', N, 'has a negative value',  &
                   'at ', I, J, L, 'set to zero'
+       !$OMP END CRITICAL
     ENDIF
 
     WHERE ( Spc < 0.0_fp )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Tabitha Lee 
Institution: NASA Langley Research Center

### Describe the update

Added a way for SAFETY in /GeosCore/wetscav_mod.F90 to set anything that is small or negative to a zero when it finds such a case (*tested update in WRF-GC)

### Expected changes

Spc will be set to 0 in SAFETY and model will continue running 

### Related Github Issue

Changes added following suggestion by yantosca in https://github.com/geoschem/geos-chem/issues/501#
More related issues: https://github.com/geoschem/geos-chem/issues/501#, https://github.com/geoschem/geos-chem/issues/259, https://github.com/geoschem/geos-chem/issues/2991, https://github.com/geoschem/geos-chem/issues/2663, https://github.com/geoschem/geos-chem/issues/259, https://github.com/geoschem/geos-chem/issues/610, https://github.com/geoschem/geos-chem/issues/759, https://github.com/geoschem/geos-chem/issues/2440, + more
