### PR TITLE
Fix erroneous unit conversion from mol/mol dry to molec/cm3 in planeflight_mod.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed indexing error in routine `Grav_Settling` (in module `GeosCore/sulfate_mod.F90`), which caused incorrect dry deposition diagnostics for some species
 - Fixed incorrect met vertical flipping in GCHP for cases where advection and non-advection met are from different sources, e.g. raw versus processed
 - Fixed several inconsistencies in `species_database.yml`
+- Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`
 
 ### Removed
 - Removed entries for FINN v1.5 biomass burning emissions from template HEMCO configuration files

--- a/GeosCore/planeflight_mod.F90
+++ b/GeosCore/planeflight_mod.F90
@@ -1518,7 +1518,7 @@ CONTAINS
     USE ErrCode_Mod
     USE Input_Opt_Mod,      ONLY : OptInput
     USE Ncdf_Mod,           ONLY : GET_TAU0
-    USE OCEAN_MERCURY_MOD,  ONLY : Fg !eds 10/27/11
+    USE OCEAN_MERCURY_MOD,  ONLY : Fg
     USE OCEAN_MERCURY_MOD,  ONLY : OMMFp => Fp
     USE PhysConstants,      ONLY : AIRMW, AVO, CONSVAP
     USE Species_Mod,        ONLY : SpcConc
@@ -1527,7 +1527,6 @@ CONTAINS
     USE State_Grid_Mod,     ONLY : GrdState
     USE State_Met_Mod,      ONLY : MetState
     USE TIME_MOD
-    USE UnitConv_Mod,       ONLY : Convert_Spc_Units
 !
 ! !INPUT PARAMETERS:
 !
@@ -1736,17 +1735,20 @@ CONTAINS
              SELECT CASE ( PVAR(V) )
 
              !---------------------------------------------------------------
-             ! GEOS-Chem Chemical species [molec/cm3]
+             ! GEOS-Chem Chemical species [mol/mol dry] or [molec/cm3]
              !---------------------------------------------------------------
-             CASE ( 1:996)
+             CASE ( 1:996 )
 
                 ! Only archive where chemistry is done
                 IF ( State_Met%InChemGrid(I,J,L) ) THEN
 
                    ! Species concentration [v/v dry] -> [molec/cm3]
                    N       = PVAR(V)
-                   VARI(V) = Spc(N)%Conc(I,J,L) / AIRMW * State_Met%AIRDEN(I,J,L) &
-                             * AVO * 1.0e-9_fp
+                   VARI(V) = Spc(N)%Conc(I,J,L)                              &
+                           / AIRMW                                           &
+                           * State_Met%AIRDEN(I,J,L)                         &
+                           * AVO                                             &
+                           * 1.0e-3_fp
                 ENDIF
 
              !---------------------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #3180, in which @rnassau discovered an error in the unit conversion from mol/mol dry air to molec/cm3.  The erroneous unit conversion used a scale factor of 1.0e-9, but the proper unit conversion should use a scale factor of 1.0e-3, as per this dimensional analysis:

```console
mol spc     | mol dry air     | 1e3 g dry air | AIRDEN kg dry air | 1 m^3    | AVO molec spc      AIRDEN * AVO molec
------------+-----------------+---------------+-------------------+----------+--------------- = -----------------------
mol dry air | AIRMW g dry air | kg dry air    | m^3 dry air       | 1e6 cm^3 |    mol spc          AIRMW * 1e3 cm^3
```

### Related Github Issue
- Closes #3180