### PR TITLE
Turn on offline bulk seasalt and offline dust emissions in TOMAS simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed several `State_Grid` fields from `fp` to `f8` precision. (In practice both are `REAL*8` but this makes it more explicit.)
 - Moved the population of coordinate variables for History netCDF  output from `grid_registry_mod.F90` to `history_mod.F90` (in routine `History_InitCoordVars`)
 - Updated `run/GCHP/setCommonRunSettings.template` to disable the HEMCO PARANOx extension for C360 or C720 grids
+- Updated `createRunDir.sh` scripts for GC-Classic and GCHP to turn on offline bulk seasalt emissions and bulk dust emissions in TOMAS simulations
 
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`
+- Fixed typo in the call to `Finalize` for the
+  `State_Diag%ProdOCPIfromOCPO` diagnostic array
 
 ### Removed
 - Removed `ARCTAS_SHIP`, `CORBETT_SHIP`, `ICOADS_SHIP` from `HEMCO_Config.rc` template files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`
-- Fixed typo in the call to `Finalize` for the
-  `State_Diag%ProdOCPIfromOCPO` diagnostic array
+- Fixed typo in the call to `Finalize` for the `State_Diag%ProdOCPIfromOCPO` diagnostic array
 
 ### Removed
 - Removed `ARCTAS_SHIP`, `CORBETT_SHIP`, `ICOADS_SHIP` from `HEMCO_Config.rc` template files

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -13256,7 +13256,7 @@ CONTAINS
     IF ( RC /= GC_SUCCESS ) RETURN
 
     CALL Finalize( diagId   = 'ProdOCPIfromOCPO',                            &
-                   Ptr2Data = State_Diag%ProdBCPIfromBCPO,                   &
+                   Ptr2Data = State_Diag%ProdOCPIfromOCPO,                   &
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -1158,20 +1158,17 @@ else
 	    RUNDIR_VARS+="RUNDIR_TOMAS_SEASALT='off'\n"
 	else
 	    RUNDIR_VARS+="RUNDIR_SEASALT_EXT='off'\n"
+	    RUNDIR_VARS+="RUNDIR_OFFLINE_SEASALT='true '\n"
 	    if [[ ${sim_extra_option} =~ "TOMAS" ]]; then
 		RUNDIR_VARS+="RUNDIR_TOMAS_SEASALT='on '\n"
-		RUNDIR_VARS+="RUNDIR_OFFLINE_SEASALT='false'\n"
 	    else
 		RUNDIR_VARS+="RUNDIR_TOMAS_SEASALT='off'\n"
-		RUNDIR_VARS+="RUNDIR_OFFLINE_SEASALT='true '\n"
 	    fi
 	fi
 	if [[ ${sim_extra_option} =~ "TOMAS" ]]; then
 	    RUNDIR_VARS+="RUNDIR_TOMAS_DUSTDEAD='on '\n"
-	    RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='false'\n"
 	else
 	    RUNDIR_VARS+="RUNDIR_TOMAS_DUSTDEAD='off'\n"
-	    RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='true '\n"
 	fi
 	RUNDIR_VARS+="RUNDIR_DUSTDEAD_EXT='off'\n"
 	RUNDIR_VARS+="RUNDIR_DUSTL23M_EXT='off'\n"
@@ -1179,6 +1176,7 @@ else
 	RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='off'\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_BIOVOC='true '\n"
 	RUNDIR_VARS+="RUNDIR_OFFLINE_SOILNOX='true '\n"
+	RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='true '\n"
     fi
     RUNDIR_VARS+="$(cat ${gcdir}/run/shared/settings/gmao_hemco.txt)\n"
 fi

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -774,26 +774,23 @@ else
 	RUNDIR_VARS+="RUNDIR_TOMAS_SEASALT='off'\n"
     else
 	RUNDIR_VARS+="RUNDIR_SEASALT_EXT='off'\n"
+	RUNDIR_VARS+="RUNDIR_OFFLINE_SEASALT='true '\n"
 	if [[ ${sim_extra_option} =~ "TOMAS" ]]; then
 	    RUNDIR_VARS+="RUNDIR_TOMAS_SEASALT='on '\n"
-	    RUNDIR_VARS+="RUNDIR_OFFLINE_SEASALT='false'\n"
 	else
 	    RUNDIR_VARS+="RUNDIR_TOMAS_SEASALT='off'\n"
-	    RUNDIR_VARS+="RUNDIR_OFFLINE_SEASALT='true '\n"
 	fi
     fi
     if [[ ${sim_extra_option} =~ "TOMAS" ]]; then
-        RUNDIR_VARS+="RUNDIR_DUSTL23M_EXT='off'\n"
         RUNDIR_VARS+="RUNDIR_TOMAS_DUSTDEAD='on '\n"
-        RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='false'\n"
     else
-        RUNDIR_VARS+="RUNDIR_DUSTL23M_EXT='off'\n"
         RUNDIR_VARS+="RUNDIR_TOMAS_DUSTDEAD='off'\n"
-        RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='true '\n"
     fi
     RUNDIR_VARS+="RUNDIR_MEGAN_EXT='off'\n"
     RUNDIR_VARS+="RUNDIR_SOILNOX_EXT='off'\n"
+    RUNDIR_VARS+="RUNDIR_DUSTL23M_EXT='off'\n"
     RUNDIR_VARS+="RUNDIR_OFFLINE_BIOVOC='true '\n"
+    RUNDIR_VARS+="RUNDIR_OFFLINE_DUST='true '\n"
     RUNDIR_VARS+="RUNDIR_OFFLINE_SOILNOX='true '\n"
 fi
 RUNDIR_VARS+="$(cat ${metSettingsDir}/gmao_hemco.txt)\n"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #3179, in which @BettyCroft pointed out that the bulk seasalt emissions are disabled by default in TOMAS simulations. 

In this PR we have edited the `run/GCClassic/createRunDir.sh` and `run/GCHP/createRunDir.sh` files so that
```bash
RUNDIR_VARS+="RUNDIR_OFFLINE_SEASALT='true '\n"
```
is applied for all fullchem simulations except benchmark and marinePOA.

We have also fixed a typo in the deallocation statement for the `State_Diag%ProdOCPIfromOCPO` diagnostic array.

### Expected changes
This will change
```console
    --> OFFLINE_SEASALT        :       false    # 1980-2019
```
to
```console
    --> OFFLINE_SEASALT        :       true     # 1980-2019
```
in the `HEMCO_Config.rc` file that ships with TOMAS run directories.

### Related Github Issue

- Closes #3179 
