### PR TITLE
Fix typo in GEOS-FP settings file used in GCClassic run directory creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed indexing error in routine `Grav_Settling` (in module `GeosCore/sulfate_mod.F90`), which caused incorrect dry deposition diagnostics for some species
 - Fixed incorrect met vertical flipping in GCHP for cases where advection and non-advection met are from different sources, e.g. raw versus processed
 - Fixed several inconsistencies in `species_database.yml`
+- Fixed typo in GEOS-FP settings file used in GCClassic run directory creation
 
 ### Removed
 - Removed entries for FINN v1.5 biomass burning emissions from template HEMCO configuration files

--- a/run/GCClassic/createRunDir.sh
+++ b/run/GCClassic/createRunDir.sh
@@ -342,7 +342,7 @@ while [ "${valid_met}" -eq 0 ]; do
 	RUNDIR_VARS+="RUNDIR_MET_FIELD_CONFIG='HEMCO_Config.rc.gmao_metfields'\n"
     elif [[ ${met_num} = "2" ]]; then
 	met="geosfp"
-	shared_met_settings=${gcdir}/run/shared/settings/geosfp/geosfp.preprocessed_ll.txt
+	shared_met_settings=${gcdir}/run/shared/settings/geosfp/geosfp.nonadv_preprocessed_ll.txt
 	RUNDIR_VARS+="RUNDIR_MET_FIELD_CONFIG='HEMCO_Config.rc.gmao_metfields'\n"
 
 	# Print warning about GEOS-FP and require user to acknowledge it.


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

In pull request #3131, the GEOS-FP met settings file geosfp.preprocessed_ll.txt was renamed to geosfp.nonadv_preprocessed_ll.txt. This was not updated in GCClassic/createRunDir.sh so when creating a GEOS-FP run directory for GCClassic the met settings were not properly set. For example, in geoschem_config.rc it still listed `met_field: ${RUNDIR_MET}.` Fixing the filename corrects this issue.

### Expected changes

This is a fix for setting up run directories using GEOS-FP meteorology. It will not impact benchmark simulations which use MERRA-2.