### PR TITLE
Update termite CH4 emissions to CAMS-GLOB-TERM_v1.1 product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product
+
+### Removed
+- Retired Fung termite and soil absorption emission options from carbon simulation
+
 ## [14.7.0] - 2026-02-05
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -76,8 +76,7 @@ Mask fractions:              false
     --> SEEPS                  :       true     # 2012
     --> LAKES                  :       false    # 2009-2015
     --> RESERVOIRS             :       true     # 2022
-    --> FUNG_TERMITES          :       true     # 1985
-    --> FUNG_SOIL_ABSORPTION   :       false    # 2009-2015
+    --> CAMS_TERMITES          :       true     # 2000
     --> MeMo_SOIL_ABSORPTION   :       true     # 1990-2009 or clim.
     --> CMIP6_SFC_LAND_ANTHRO  :       false    # 1850-2100
     --> CMIP6_SHIP             :       false    # 1850-2100
@@ -539,19 +538,11 @@ Mask fractions:              false
 )))RESERVOIRS
 
 #==============================================================================
-# --- CH4: Soil absorption & termites from Fung et al, 1991 ---
-#
-# NOTES:
-# - Multiply soil absorption by -1 to get a "negative" flux.
-#   (Only apply the scaling factor when adding to the total CH4 simulation)
-# - Use updated soil absorption emissions with seasonality applied
+# --- CH4: Termites from CAMS-GLOB-TERM.v1.1 ---
 #==============================================================================
-(((FUNG_TERMITES
-0 CH4_TERMITES     $ROOT/CH4/v2022-11/4x5/termites.geos.4x5.nc CH4 1985/1/1/0 C xy kg/m2/s CH4 - 13 1
-)))FUNG_TERMITES
-(((FUNG_SOIL_ABSORPTION
-0 CH4_SOILABSORB   $ROOT/CH4/v2019-10/Fung_SoilAbs/Soil_Absorption_4x5_$YYYY.nc CH4 2009-2015/1-12/1/0 C xy molec/cm2/s CH4 1 14 1
-)))FUNG_SOIL_ABSORPTION
+(((CAMS_TERMITES
+0 CH4_TERMITES $ROOT/HEMCO/CH4/v2026-02/CAMS_Termites/CAMS-GLOB-TERM_v1.1_methane_2000.nc CH4_termites 2000/1-12/1/0 C xy kg/m2/s CH4 - 13 1
+)))CAMS_TERMITES
 
 #==============================================================================
 # --- CH4: Soil absorption from MeMo model (Murguia-Flores et al. 2018, GMD) ---
@@ -1337,8 +1328,7 @@ ${RUNDIR_CO2_COPROD}
 #------------------------------------------------------------------------------
 # --- Perturbation factors ---
 #
-# Add factors to perturb OH, emissions, and other fields here for
-# analytical inversions.
+# Default scaling factor of 1.0 for OH field, which will be changed for Jacobian and posterior OptimizeOH run
 #------------------------------------------------------------------------------
 2 OH_pert_factor  1.0 - - - xy 1 1
 

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -258,8 +258,8 @@ CH4_SEEPS kg/m2/s N Y - none none  emi_ch4  ./HcoDir/CH4/v2020-04/Seeps/Etiope_C
 CH4_RES_DAM kg/m2/s N Y - none none CH4emis  ./HcoDir/CH4/v2024-01/ResME/ResME_Dam_Emissions.0.1x0.1.nc
 CH4_RES_SFC kg/m2/s N Y - none none CH4emis  ./HcoDir/CH4/v2024-01/ResME/ResME_Surface_Emissions.0.1x0.1.nc
 
-# --- Emissions from termites (Fung et al 1991) ---
-CH4_TERMITES    kg/m2/s N Y - none none  CH4  ./HcoDir/CH4/v2022-11/4x5/termites.geos.4x5.nc
+# --- Emissions from termites (CAMS-GLOB-TERM.v1.1) ---
+CH4_TERMITES kg/m2/s Y Y F2000-%m2-01T00:00:00 none none  CH4  ./HcoDir/CH4/2026-02/CAMS_Termites/CAMS-GLOB-TERM_v1.1_methane_2000.nc
 
 # --- Soil absorption fro MeMo model (Murguia-Flores et al. 2018, GMD) ---
 #

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -76,8 +76,7 @@ Mask fractions:              false
     --> SEEPS                  :       true     # 2012
     --> LAKES                  :       false    # 2009-2015
     --> RESERVOIRS             :       true     # 2022
-    --> FUNG_TERMITES          :       true     # 1985
-    --> FUNG_SOIL_ABSORPTION   :       false    # 2009-2015
+    --> CAMS_TERMITES          :       true     # 2000
     --> MeMo_SOIL_ABSORPTION   :       true     # 1990-2009 or clim.
     --> CMIP6_SFC_LAND_ANTHRO  :       false    # 1850-2100
     --> CMIP6_SHIP             :       false    # 1850-2100
@@ -539,19 +538,11 @@ Mask fractions:              false
 )))RESERVOIRS
 
 #==============================================================================
-# --- CH4: Soil absorption & termites from Fung et al, 1991 ---
-#
-# NOTES:
-# - Multiply soil absorption by -1 to get a "negative" flux.
-#   (Only apply the scaling factor when adding to the total CH4 simulation)
-# - Use updated soil absorption emissions with seasonality applied
+# --- CH4: Termites from CAMS-GLOB-TERM.v1.1 ---
 #==============================================================================
-(((FUNG_TERMITES
-0 CH4_TERMITES     $ROOT/CH4/v2022-11/4x5/termites.geos.4x5.nc CH4 1985/1/1/0 C xy kg/m2/s CH4 - 13 1
-)))FUNG_TERMITES
-(((FUNG_SOIL_ABSORPTION
-0 CH4_SOILABSORB   $ROOT/CH4/v2019-10/Fung_SoilAbs/Soil_Absorption_4x5_$YYYY.nc CH4 2009-2015/1-12/1/0 C xy molec/cm2/s CH4 1 14 1
-)))FUNG_SOIL_ABSORPTION
+(((CAMS_TERMITES
+0 CH4_TERMITES $ROOT/HEMCO/CH4/v2026-02/CAMS_Termites/CAMS-GLOB-TERM_v1.1_methane_2000.nc CH4_termites 2000/1-12/1/0 C xy kg/m2/s CH4 - 13 1
+)))CAMS_TERMITES
 
 #==============================================================================
 # --- CH4: Soil absorption from MeMo model (Murguia-Flores et al. 2018, GMD) ---
@@ -1240,6 +1231,7 @@ Mask fractions:              false
 * XLAI72 $ROOT/Yuan_XLAI/v2021-06/Yuan_proc_MODIS_XLAI.025x025.$YYYY.nc XLAI72 2000-2020/1-12/1-31/0 I xy cm2/cm2 * - 1 1
 )))YUAN_MODIS_LAI
 
+#==============================================================================
 # --- Chemistry inputs ---
 #==============================================================================
 (((CHEMISTRY_INPUT
@@ -1333,7 +1325,7 @@ ${RUNDIR_CO2_COPROD}
 #------------------------------------------------------------------------------
 1 NEGATIVE -1.0 - - - xy 1 1
 
-#==============================================================================
+#------------------------------------------------------------------------------
 # --- Perturbation factors ---
 #
 # Default scaling factor of 1.0 for OH field, which will be changed for Jacobian and posterior OptimizeOH run
@@ -1346,7 +1338,7 @@ ${RUNDIR_CO2_COPROD}
 # Entries below are provided for examples only. Add your own here!
 #==============================================================================
 (((Emis_PosteriorSF
-3 EMIS_SF    gridded_posterior.nc            ScaleFactor 2000/1/1/0 C xy 1 1
+3 EMIS_SF    gridded_posterior.nc  ScaleFactor 2000/1/1/0         C xy 1 1
 )))Emis_PosteriorSF
 
 #==============================================================================


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The Fung (1992) termite emissions of CH4 were dated and at a coarse resolution (4x5). We now update to the more recent CAMS-GLOB-TERM_v1.1 termite emissions available on the 0.5x0.5 degree grid and at monthly resolution (averaged over 2000-2017). 

In this update, we also retire both Fung termite emissions and Fung soil absorption as options in the carbon simulation.

### Expected changes

This PR does not change the full-chemistry benchmark simulation.

With this update, annual termite emission totals for CH4 are expected to increase from 12 Tg/year (Fung 1992) to 20 Tg/year (CAMS).

Comparison of Fung 1992 and CAMS termite emissions for January:
<img width="743" height="655" alt="Screenshot 2026-02-05 at 2 27 16 PM" src="https://github.com/user-attachments/assets/1d1998ef-e91f-4981-a662-8784c0746832" />


Comparison of Fung 1992 and CAMS termite emissions for July:
<img width="753" height="645" alt="Screenshot 2026-02-05 at 2 27 54 PM" src="https://github.com/user-attachments/assets/d217a8b7-d3d9-485d-9f47-f6d6973fc86d" />

### Reference(s)

- Doubalova, J. and K. Sinderlarova, CAMS_81 – Global and Regional emissions: D81.3.4.1 Gridded CH4 emissions from termites, 2018. [PDF](https://atmosphere.copernicus.eu/sites/default/files/2019-11/26_CAMS81_2017SC1_D81.3.4.1-201808_v1_APPROVED_Ver1.pdf)
