### PR TITLE
Removed ARCTAS, ICOADS, CORBETT ship emission entries from HEMCO_Config.rc templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Added
+- Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP
+
+### Removed
+- Removed `ARCTAS_SHIP`, `CORBETT_SHIP`, `ICOADS_SHIP` from `HEMCO_Config.rc` template files
+
 ## [14.7.0] - 2026-02-05
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -100,9 +100,6 @@ VerboseOnCores:              root       # Accepted values: root all
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       ${RUNDIR_USE_CEDS}    # 1980-2019
     --> HTAPv3_SHIP            :       false    # 2000-2018
-    --> ICOADS_SHIP            :       false    # 2002
-    --> ARCTAS_SHIP            :       false    # 2008
-    --> CORBETT_SHIP           :       false    # 1985
 # ----- RCP FUTURE EMISSIONS --------------------------------------------------
     --> RCP_3PD                :       false    # 2005-2100
     --> RCP_45                 :       false    # 2005-2100
@@ -1462,19 +1459,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #     CORBETT, and HTAP for SO2 and ICOADS should be used for CO and NO.
 #==============================================================================
 (((SHIP
-
-(((ARCTAS_SHIP
-0  ARCTAS_SHIP_SO2     $ROOT/ARCTAS_SHIP/v2014-07/ARCTAS_ship.generic.1x1.nc           SO2             2008/1/1/0             C xy kg/m2/s  SO2  11/19       10 1
-)))ARCTAS_SHIP
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_SO2      $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                SO2             2002/1-12/1/0          C xy kg/m2/s  SO2  11/15/60    10 2
-0 ICOADS_SHIP_SOAP     $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                CO              2002/1-12/1/0          C xy kg/m2/s  SOAP 6/10/280    10 2
-)))ICOADS_SHIP
-
-(((CORBETT_SHIP
-0 CORBETT_SHIP_SO2     $ROOT/CORBETT_SHIP/v2014-07/CORBETT_ship.geos.1x1.nc            SO2_SHIP        1985/1-12/1/0          C xy kg/m2/s  SO2  -           10 3
-)))CORBETT_SHIP
 
 (((HTAPv3_SHIP
 0 HTAPv3_SOAP_SHP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_CO_0.1x0.1_$YYYY.nc  CO_SHP  2000-2018/1-12/1/0 C xy kg/m2/s SOAP  26/280 10 4

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -115,7 +115,7 @@ Mask fractions:              false
 # ..... Ship emissions ...............
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       true     # 1980-2019
-    --> ICOADS_SHIP            :       false    # 2004
+    --> HTAP_SHIP              :       false    # 2000-2018
 #------ OCS FLUX DATA ---------------------------------------------------------
     --> OCS_ANTHRO_FLUX        :       true     # 2012-2016
     --> OCS_BIOMASS_FLUX       :       true     # 2012-2016
@@ -758,9 +758,6 @@ Mask fractions:              false
 #     zero.
 #==============================================================================
 (((SHIP
-(((ICOADS_SHIP
-0  ICOADS_SHIP_CO  $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc CO 2002/1-12/1/0 C xy kg/m2/s  CO 6/10 10 2
-)))ICOADS_SHIP
 
 (((HTAP_SHIP
 0 HTAP_SHIP_CO  $ROOT/HTAP/v2015-03/EDGAR_HTAP_CO_SHIPS.generic.01x01.nc CO 2008-2010/1/1/0 C xy kg/m2/s CO 506/528 10 4

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -110,9 +110,6 @@ VerboseOnCores:              root       # Accepted values: root all
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       ${RUNDIR_USE_CEDS}    # 1980-2019
     --> HTAPv3_SHIP            :       false    # 2000-2018
-    --> ICOADS_SHIP            :       false    # 2002
-    --> ARCTAS_SHIP            :       false    # 2008
-    --> CORBETT_SHIP           :       false    # 1985
 # ----- RCP FUTURE EMISSIONS --------------------------------------------------
     --> RCP_3PD                :       false    # 2005-2100
     --> RCP_45                 :       false    # 2005-2100
@@ -2580,20 +2577,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 (((SHIP
 
-(((ARCTAS_SHIP
-0  ARCTAS_SHIP_SO2     $ROOT/ARCTAS_SHIP/v2014-07/ARCTAS_ship.generic.1x1.nc           SO2             2008/1/1/0             C xy kg/m2/s  SO2  11/19        10 1
-)))ARCTAS_SHIP
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_SO2      $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                SO2             2002/1-12/1/0          C xy kg/m2/s  SO2  11/15/60     10 2
-0 ICOADS_SHIP_CO       $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                CO              2002/1-12/1/0          C xy kg/m2/s  CO   6/10         10 2
-0 ICOADS_SHIP_SOAP     -                                                               -               -                      - -  -        SOAP 6/10/280     10 2
-)))ICOADS_SHIP
-
-(((CORBETT_SHIP
-0 CORBETT_SHIP_SO2     $ROOT/CORBETT_SHIP/v2014-07/CORBETT_ship.geos.1x1.nc            SO2_SHIP        1985/1-12/1/0          C xy kg/m2/s  SO2  -            10 3
-)))CORBETT_SHIP
-
 (((HTAPv3_SHIP
 0 HTAPv3_CO_SHP   $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_CO_0.1x0.1_$YYYY.nc  CO_SHP  2000-2018/1-12/1/0 C xy kg/m2/s CO    26     10 4
 0 HTAPv3_SOAP_SHP -                                                       -       -                  - -  -       SOAP  26/280 10 4
@@ -2717,10 +2700,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #------------------------------------------------------------------------------
 (((ParaNOx
 
-(((ICOADS_SHIP
-102  ICOADS_SHIP_NO $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc NO 2002/1-12/1/0 C xy kg/m2/s NO 1/5 10 1
-)))ICOADS_SHIP
-
 (((HTAPv3_SHIP
 102 HTAPv3_NO_SHP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_NO_0.1x0.1_$YYYY.nc NO_SHP 2000-2018/1-12/1/0 C xy kg/m2/s NO 25 10 4
 )))HTAPv3_SHIP
@@ -2738,10 +2717,6 @@ VerboseOnCores:              root       # Accepted values: root all
 # into the base emissions rather than sending them through PARANOX.
 #------------------------------------------------------------------------------
 (((.not.ParaNOx
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_NO $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc             NO     2002/1-12/1/0      C xy kg/m2/s NO 1/5  10 1
-)))ICOADS_SHIP
 
 (((HTAPv3_SHIP
 0 HTAPv3_NO_SHIP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_NO_0.1x0.1_$YYYY.nc NO_SHP 2000-2018/1-12/1/0 C xy kg/m2/s NO 25 10 4

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -115,7 +115,7 @@ Mask fractions:              false
 # ..... Ship emissions ...............
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       true     # 1980-2019
-    --> ICOADS_SHIP            :       false    # 2004
+    --> HTAP_SHIP              :       false    # 2000-2018
 #------ OCS FLUX DATA ---------------------------------------------------------
     --> OCS_ANTHRO_FLUX        :       true     # 2012-2016
     --> OCS_BIOMASS_FLUX       :       true     # 2012-2016
@@ -758,9 +758,6 @@ Mask fractions:              false
 #     zero.
 #==============================================================================
 (((SHIP
-(((ICOADS_SHIP
-0  ICOADS_SHIP_CO  $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc CO 2002/1-12/1/0 C xy kg/m2/s  CO 6/10 10 2
-)))ICOADS_SHIP
 
 (((HTAP_SHIP
 0 HTAP_SHIP_CO  $ROOT/HTAP/v2015-03/EDGAR_HTAP_CO_SHIPS.generic.01x01.nc CO 2008-2010/1/1/0 C xy kg/m2/s CO 506/528 10 4

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -109,9 +109,6 @@ VerboseOnCores:              root       # Accepted values: root all
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       ${RUNDIR_USE_CEDS}    # 1980-2019
     --> HTAPv3_SHIP            :       false    # 2000-2018
-    --> ICOADS_SHIP            :       false    # 2002
-    --> ARCTAS_SHIP            :       false    # 2008
-    --> CORBETT_SHIP           :       false    # 1985
 # ----- RCP FUTURE EMISSIONS --------------------------------------------------
     --> RCP_3PD                :       false    # 2005-2100
     --> RCP_45                 :       false    # 2005-2100
@@ -2579,20 +2576,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 (((SHIP
 
-(((ARCTAS_SHIP
-0  ARCTAS_SHIP_SO2     $ROOT/ARCTAS_SHIP/v2014-07/ARCTAS_ship.generic.1x1.nc           SO2             2008/1/1/0             C xy kg/m2/s  SO2  11/19        10 1
-)))ARCTAS_SHIP
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_SO2      $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                SO2             2002/1-12/1/0          C xy kg/m2/s  SO2  11/15/60     10 2
-0 ICOADS_SHIP_CO       $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                CO              2002/1-12/1/0          C xy kg/m2/s  CO   6/10         10 2
-0 ICOADS_SHIP_SOAP     -                                                               -               -                      - -  -        SOAP 6/10/280     10 2
-)))ICOADS_SHIP
-
-(((CORBETT_SHIP
-0 CORBETT_SHIP_SO2     $ROOT/CORBETT_SHIP/v2014-07/CORBETT_ship.geos.1x1.nc            SO2_SHIP        1985/1-12/1/0          C xy kg/m2/s  SO2  -            10 3
-)))CORBETT_SHIP
-
 (((HTAPv3_SHIP
 0 HTAPv3_CO_SHP   $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_CO_0.1x0.1_$YYYY.nc  CO_SHP  2000-2018/1-12/1/0 C xy kg/m2/s CO    26     10 4
 0 HTAPv3_SOAP_SHP -                                                       -       -                  - -  -       SOAP  26/280 10 4
@@ -2716,10 +2699,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #------------------------------------------------------------------------------
 (((ParaNOx
 
-(((ICOADS_SHIP
-102  ICOADS_SHIP_NO $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc NO 2002/1-12/1/0 C xy kg/m2/s NO 1/5 10 1
-)))ICOADS_SHIP
-
 (((HTAPv3_SHIP
 102 HTAPv3_NO_SHP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_NO_0.1x0.1_$YYYY.nc NO_SHP 2000-2018/1-12/1/0 C xy kg/m2/s NO 25 10 4
 )))HTAPv3_SHIP
@@ -2737,10 +2716,6 @@ VerboseOnCores:              root       # Accepted values: root all
 # into the base emissions rather than sending them through PARANOX.
 #------------------------------------------------------------------------------
 (((.not.ParaNOx
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_NO $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc             NO     2002/1-12/1/0      C xy kg/m2/s NO 1/5  10 1
-)))ICOADS_SHIP
 
 (((HTAPv3_SHIP
 0 HTAPv3_NO_SHIP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_NO_0.1x0.1_$YYYY.nc NO_SHP 2000-2018/1-12/1/0 C xy kg/m2/s NO 25 10 4


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR does the following:

1. Removes `ARCTAS_SHIP`, `CORBETT_SHIP`, and `ICOADS_SHIP` entries from GC-Classic and GCHP `HEMCO_Config.rc` template files.  These inventories are obsolete and date for these no longer exists.

2. Adds `--> HTAP_SHIP : false` toggles to the `HEMCO_Config.rc.carbon` template files for GC-Classic and GCHP.  There is an entry for `HTAP_SHIP` but no toggle in these files.

### Expected changes
This is a no-diff-to-benchmark update.  The benchmark simulations do not use any of these obsolete ship inventories.

### Related Github Issue
- Closes #2710 