### PR TITLE
Disable PARANOx when using C360 or C720 cubed-sphere grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed indexing error in routine `Grav_Settling` (in module `GeosCore/sulfate_mod.F90`), which caused incorrect dry deposition diagnostics for some species
 - Fixed incorrect met vertical flipping in GCHP for cases where advection and non-advection met are from different sources, e.g. raw versus processed
 - Fixed several inconsistencies in `species_database.yml`
+- Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`
 
 ### Removed
 - Removed entries for FINN v1.5 biomass burning emissions from template HEMCO configuration files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product
+
+### Removed
+- Retired Fung termite and soil absorption emission options from carbon simulation
+
 ## [14.7.0] - 2026-02-05
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Added
+- Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP
+
+### Removed
+- Removed `ARCTAS_SHIP`, `CORBETT_SHIP`, `ICOADS_SHIP` from `HEMCO_Config.rc` template files
+
 ## [14.7.0] - 2026-02-05
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files

--- a/GeosCore/planeflight_mod.F90
+++ b/GeosCore/planeflight_mod.F90
@@ -1518,7 +1518,7 @@ CONTAINS
     USE ErrCode_Mod
     USE Input_Opt_Mod,      ONLY : OptInput
     USE Ncdf_Mod,           ONLY : GET_TAU0
-    USE OCEAN_MERCURY_MOD,  ONLY : Fg !eds 10/27/11
+    USE OCEAN_MERCURY_MOD,  ONLY : Fg
     USE OCEAN_MERCURY_MOD,  ONLY : OMMFp => Fp
     USE PhysConstants,      ONLY : AIRMW, AVO, CONSVAP
     USE Species_Mod,        ONLY : SpcConc
@@ -1527,7 +1527,6 @@ CONTAINS
     USE State_Grid_Mod,     ONLY : GrdState
     USE State_Met_Mod,      ONLY : MetState
     USE TIME_MOD
-    USE UnitConv_Mod,       ONLY : Convert_Spc_Units
 !
 ! !INPUT PARAMETERS:
 !
@@ -1736,17 +1735,20 @@ CONTAINS
              SELECT CASE ( PVAR(V) )
 
              !---------------------------------------------------------------
-             ! GEOS-Chem Chemical species [molec/cm3]
+             ! GEOS-Chem Chemical species [mol/mol dry] or [molec/cm3]
              !---------------------------------------------------------------
-             CASE ( 1:996)
+             CASE ( 1:996 )
 
                 ! Only archive where chemistry is done
                 IF ( State_Met%InChemGrid(I,J,L) ) THEN
 
                    ! Species concentration [v/v dry] -> [molec/cm3]
                    N       = PVAR(V)
-                   VARI(V) = Spc(N)%Conc(I,J,L) / AIRMW * State_Met%AIRDEN(I,J,L) &
-                             * AVO * 1.0e-9_fp
+                   VARI(V) = Spc(N)%Conc(I,J,L)                              &
+                           / AIRMW                                           &
+                           * State_Met%AIRDEN(I,J,L)                         &
+                           * AVO                                             &
+                           * 1.0e-3_fp
                 ENDIF
 
              !---------------------------------------------------------------

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.aerosol
@@ -100,9 +100,6 @@ VerboseOnCores:              root       # Accepted values: root all
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       ${RUNDIR_USE_CEDS}    # 1980-2019
     --> HTAPv3_SHIP            :       false    # 2000-2018
-    --> ICOADS_SHIP            :       false    # 2002
-    --> ARCTAS_SHIP            :       false    # 2008
-    --> CORBETT_SHIP           :       false    # 1985
 # ----- RCP FUTURE EMISSIONS --------------------------------------------------
     --> RCP_3PD                :       false    # 2005-2100
     --> RCP_45                 :       false    # 2005-2100
@@ -1462,19 +1459,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #     CORBETT, and HTAP for SO2 and ICOADS should be used for CO and NO.
 #==============================================================================
 (((SHIP
-
-(((ARCTAS_SHIP
-0  ARCTAS_SHIP_SO2     $ROOT/ARCTAS_SHIP/v2014-07/ARCTAS_ship.generic.1x1.nc           SO2             2008/1/1/0             C xy kg/m2/s  SO2  11/19       10 1
-)))ARCTAS_SHIP
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_SO2      $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                SO2             2002/1-12/1/0          C xy kg/m2/s  SO2  11/15/60    10 2
-0 ICOADS_SHIP_SOAP     $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                CO              2002/1-12/1/0          C xy kg/m2/s  SOAP 6/10/280    10 2
-)))ICOADS_SHIP
-
-(((CORBETT_SHIP
-0 CORBETT_SHIP_SO2     $ROOT/CORBETT_SHIP/v2014-07/CORBETT_ship.geos.1x1.nc            SO2_SHIP        1985/1-12/1/0          C xy kg/m2/s  SO2  -           10 3
-)))CORBETT_SHIP
 
 (((HTAPv3_SHIP
 0 HTAPv3_SOAP_SHP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_CO_0.1x0.1_$YYYY.nc  CO_SHP  2000-2018/1-12/1/0 C xy kg/m2/s SOAP  26/280 10 4

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -76,8 +76,7 @@ Mask fractions:              false
     --> SEEPS                  :       true     # 2012
     --> LAKES                  :       false    # 2009-2015
     --> RESERVOIRS             :       true     # 2022
-    --> FUNG_TERMITES          :       true     # 1985
-    --> FUNG_SOIL_ABSORPTION   :       false    # 2009-2015
+    --> CAMS_TERMITES          :       true     # 2000
     --> MeMo_SOIL_ABSORPTION   :       true     # 1990-2009 or clim.
     --> CMIP6_SFC_LAND_ANTHRO  :       false    # 1850-2100
     --> CMIP6_SHIP             :       false    # 1850-2100
@@ -539,19 +538,11 @@ Mask fractions:              false
 )))RESERVOIRS
 
 #==============================================================================
-# --- CH4: Soil absorption & termites from Fung et al, 1991 ---
-#
-# NOTES:
-# - Multiply soil absorption by -1 to get a "negative" flux.
-#   (Only apply the scaling factor when adding to the total CH4 simulation)
-# - Use updated soil absorption emissions with seasonality applied
+# --- CH4: Termites from CAMS-GLOB-TERM.v1.1 ---
 #==============================================================================
-(((FUNG_TERMITES
-0 CH4_TERMITES     $ROOT/CH4/v2022-11/4x5/termites.geos.4x5.nc CH4 1985/1/1/0 C xy kg/m2/s CH4 - 13 1
-)))FUNG_TERMITES
-(((FUNG_SOIL_ABSORPTION
-0 CH4_SOILABSORB   $ROOT/CH4/v2019-10/Fung_SoilAbs/Soil_Absorption_4x5_$YYYY.nc CH4 2009-2015/1-12/1/0 C xy molec/cm2/s CH4 1 14 1
-)))FUNG_SOIL_ABSORPTION
+(((CAMS_TERMITES
+0 CH4_TERMITES $ROOT/HEMCO/CH4/v2026-02/CAMS_Termites/CAMS-GLOB-TERM_v1.1_methane_2000.nc CH4_termites 2000/1-12/1/0 C xy kg/m2/s CH4 - 13 1
+)))CAMS_TERMITES
 
 #==============================================================================
 # --- CH4: Soil absorption from MeMo model (Murguia-Flores et al. 2018, GMD) ---
@@ -1337,8 +1328,7 @@ ${RUNDIR_CO2_COPROD}
 #------------------------------------------------------------------------------
 # --- Perturbation factors ---
 #
-# Add factors to perturb OH, emissions, and other fields here for
-# analytical inversions.
+# Default scaling factor of 1.0 for OH field, which will be changed for Jacobian and posterior OptimizeOH run
 #------------------------------------------------------------------------------
 2 OH_pert_factor  1.0 - - - xy 1 1
 

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -115,7 +115,7 @@ Mask fractions:              false
 # ..... Ship emissions ...............
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       true     # 1980-2019
-    --> ICOADS_SHIP            :       false    # 2004
+    --> HTAP_SHIP              :       false    # 2000-2018
 #------ OCS FLUX DATA ---------------------------------------------------------
     --> OCS_ANTHRO_FLUX        :       true     # 2012-2016
     --> OCS_BIOMASS_FLUX       :       true     # 2012-2016
@@ -758,9 +758,6 @@ Mask fractions:              false
 #     zero.
 #==============================================================================
 (((SHIP
-(((ICOADS_SHIP
-0  ICOADS_SHIP_CO  $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc CO 2002/1-12/1/0 C xy kg/m2/s  CO 6/10 10 2
-)))ICOADS_SHIP
 
 (((HTAP_SHIP
 0 HTAP_SHIP_CO  $ROOT/HTAP/v2015-03/EDGAR_HTAP_CO_SHIPS.generic.01x01.nc CO 2008-2010/1/1/0 C xy kg/m2/s CO 506/528 10 4

--- a/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCClassic/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -110,9 +110,6 @@ VerboseOnCores:              root       # Accepted values: root all
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       ${RUNDIR_USE_CEDS}    # 1980-2019
     --> HTAPv3_SHIP            :       false    # 2000-2018
-    --> ICOADS_SHIP            :       false    # 2002
-    --> ARCTAS_SHIP            :       false    # 2008
-    --> CORBETT_SHIP           :       false    # 1985
 # ----- RCP FUTURE EMISSIONS --------------------------------------------------
     --> RCP_3PD                :       false    # 2005-2100
     --> RCP_45                 :       false    # 2005-2100
@@ -2580,20 +2577,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 (((SHIP
 
-(((ARCTAS_SHIP
-0  ARCTAS_SHIP_SO2     $ROOT/ARCTAS_SHIP/v2014-07/ARCTAS_ship.generic.1x1.nc           SO2             2008/1/1/0             C xy kg/m2/s  SO2  11/19        10 1
-)))ARCTAS_SHIP
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_SO2      $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                SO2             2002/1-12/1/0          C xy kg/m2/s  SO2  11/15/60     10 2
-0 ICOADS_SHIP_CO       $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                CO              2002/1-12/1/0          C xy kg/m2/s  CO   6/10         10 2
-0 ICOADS_SHIP_SOAP     -                                                               -               -                      - -  -        SOAP 6/10/280     10 2
-)))ICOADS_SHIP
-
-(((CORBETT_SHIP
-0 CORBETT_SHIP_SO2     $ROOT/CORBETT_SHIP/v2014-07/CORBETT_ship.geos.1x1.nc            SO2_SHIP        1985/1-12/1/0          C xy kg/m2/s  SO2  -            10 3
-)))CORBETT_SHIP
-
 (((HTAPv3_SHIP
 0 HTAPv3_CO_SHP   $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_CO_0.1x0.1_$YYYY.nc  CO_SHP  2000-2018/1-12/1/0 C xy kg/m2/s CO    26     10 4
 0 HTAPv3_SOAP_SHP -                                                       -       -                  - -  -       SOAP  26/280 10 4
@@ -2717,10 +2700,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #------------------------------------------------------------------------------
 (((ParaNOx
 
-(((ICOADS_SHIP
-102  ICOADS_SHIP_NO $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc NO 2002/1-12/1/0 C xy kg/m2/s NO 1/5 10 1
-)))ICOADS_SHIP
-
 (((HTAPv3_SHIP
 102 HTAPv3_NO_SHP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_NO_0.1x0.1_$YYYY.nc NO_SHP 2000-2018/1-12/1/0 C xy kg/m2/s NO 25 10 4
 )))HTAPv3_SHIP
@@ -2738,10 +2717,6 @@ VerboseOnCores:              root       # Accepted values: root all
 # into the base emissions rather than sending them through PARANOX.
 #------------------------------------------------------------------------------
 (((.not.ParaNOx
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_NO $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc             NO     2002/1-12/1/0      C xy kg/m2/s NO 1/5  10 1
-)))ICOADS_SHIP
 
 (((HTAPv3_SHIP
 0 HTAPv3_NO_SHIP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_NO_0.1x0.1_$YYYY.nc NO_SHP 2000-2018/1-12/1/0 C xy kg/m2/s NO 25 10 4

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.carbon
@@ -258,8 +258,8 @@ CH4_SEEPS kg/m2/s N Y - none none  emi_ch4  ./HcoDir/CH4/v2020-04/Seeps/Etiope_C
 CH4_RES_DAM kg/m2/s N Y - none none CH4emis  ./HcoDir/CH4/v2024-01/ResME/ResME_Dam_Emissions.0.1x0.1.nc
 CH4_RES_SFC kg/m2/s N Y - none none CH4emis  ./HcoDir/CH4/v2024-01/ResME/ResME_Surface_Emissions.0.1x0.1.nc
 
-# --- Emissions from termites (Fung et al 1991) ---
-CH4_TERMITES    kg/m2/s N Y - none none  CH4  ./HcoDir/CH4/v2022-11/4x5/termites.geos.4x5.nc
+# --- Emissions from termites (CAMS-GLOB-TERM.v1.1) ---
+CH4_TERMITES kg/m2/s Y Y F2000-%m2-01T00:00:00 none none  CH4  ./HcoDir/CH4/2026-02/CAMS_Termites/CAMS-GLOB-TERM_v1.1_methane_2000.nc
 
 # --- Soil absorption fro MeMo model (Murguia-Flores et al. 2018, GMD) ---
 #

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -76,8 +76,7 @@ Mask fractions:              false
     --> SEEPS                  :       true     # 2012
     --> LAKES                  :       false    # 2009-2015
     --> RESERVOIRS             :       true     # 2022
-    --> FUNG_TERMITES          :       true     # 1985
-    --> FUNG_SOIL_ABSORPTION   :       false    # 2009-2015
+    --> CAMS_TERMITES          :       true     # 2000
     --> MeMo_SOIL_ABSORPTION   :       true     # 1990-2009 or clim.
     --> CMIP6_SFC_LAND_ANTHRO  :       false    # 1850-2100
     --> CMIP6_SHIP             :       false    # 1850-2100
@@ -539,19 +538,11 @@ Mask fractions:              false
 )))RESERVOIRS
 
 #==============================================================================
-# --- CH4: Soil absorption & termites from Fung et al, 1991 ---
-#
-# NOTES:
-# - Multiply soil absorption by -1 to get a "negative" flux.
-#   (Only apply the scaling factor when adding to the total CH4 simulation)
-# - Use updated soil absorption emissions with seasonality applied
+# --- CH4: Termites from CAMS-GLOB-TERM.v1.1 ---
 #==============================================================================
-(((FUNG_TERMITES
-0 CH4_TERMITES     $ROOT/CH4/v2022-11/4x5/termites.geos.4x5.nc CH4 1985/1/1/0 C xy kg/m2/s CH4 - 13 1
-)))FUNG_TERMITES
-(((FUNG_SOIL_ABSORPTION
-0 CH4_SOILABSORB   $ROOT/CH4/v2019-10/Fung_SoilAbs/Soil_Absorption_4x5_$YYYY.nc CH4 2009-2015/1-12/1/0 C xy molec/cm2/s CH4 1 14 1
-)))FUNG_SOIL_ABSORPTION
+(((CAMS_TERMITES
+0 CH4_TERMITES $ROOT/HEMCO/CH4/v2026-02/CAMS_Termites/CAMS-GLOB-TERM_v1.1_methane_2000.nc CH4_termites 2000/1-12/1/0 C xy kg/m2/s CH4 - 13 1
+)))CAMS_TERMITES
 
 #==============================================================================
 # --- CH4: Soil absorption from MeMo model (Murguia-Flores et al. 2018, GMD) ---
@@ -1240,6 +1231,7 @@ Mask fractions:              false
 * XLAI72 $ROOT/Yuan_XLAI/v2021-06/Yuan_proc_MODIS_XLAI.025x025.$YYYY.nc XLAI72 2000-2020/1-12/1-31/0 I xy cm2/cm2 * - 1 1
 )))YUAN_MODIS_LAI
 
+#==============================================================================
 # --- Chemistry inputs ---
 #==============================================================================
 (((CHEMISTRY_INPUT
@@ -1333,7 +1325,7 @@ ${RUNDIR_CO2_COPROD}
 #------------------------------------------------------------------------------
 1 NEGATIVE -1.0 - - - xy 1 1
 
-#==============================================================================
+#------------------------------------------------------------------------------
 # --- Perturbation factors ---
 #
 # Default scaling factor of 1.0 for OH field, which will be changed for Jacobian and posterior OptimizeOH run
@@ -1346,7 +1338,7 @@ ${RUNDIR_CO2_COPROD}
 # Entries below are provided for examples only. Add your own here!
 #==============================================================================
 (((Emis_PosteriorSF
-3 EMIS_SF    gridded_posterior.nc            ScaleFactor 2000/1/1/0 C xy 1 1
+3 EMIS_SF    gridded_posterior.nc  ScaleFactor 2000/1/1/0         C xy 1 1
 )))Emis_PosteriorSF
 
 #==============================================================================

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.carbon
@@ -115,7 +115,7 @@ Mask fractions:              false
 # ..... Ship emissions ...............
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       true     # 1980-2019
-    --> ICOADS_SHIP            :       false    # 2004
+    --> HTAP_SHIP              :       false    # 2000-2018
 #------ OCS FLUX DATA ---------------------------------------------------------
     --> OCS_ANTHRO_FLUX        :       true     # 2012-2016
     --> OCS_BIOMASS_FLUX       :       true     # 2012-2016
@@ -758,9 +758,6 @@ Mask fractions:              false
 #     zero.
 #==============================================================================
 (((SHIP
-(((ICOADS_SHIP
-0  ICOADS_SHIP_CO  $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc CO 2002/1-12/1/0 C xy kg/m2/s  CO 6/10 10 2
-)))ICOADS_SHIP
 
 (((HTAP_SHIP
 0 HTAP_SHIP_CO  $ROOT/HTAP/v2015-03/EDGAR_HTAP_CO_SHIPS.generic.01x01.nc CO 2008-2010/1/1/0 C xy kg/m2/s CO 506/528 10 4

--- a/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
+++ b/run/GCHP/HEMCO_Config.rc.templates/HEMCO_Config.rc.fullchem
@@ -109,9 +109,6 @@ VerboseOnCores:              root       # Accepted values: root all
     --> SHIP                   :       true
     --> CEDS_01x01_SHIP        :       ${RUNDIR_USE_CEDS}    # 1980-2019
     --> HTAPv3_SHIP            :       false    # 2000-2018
-    --> ICOADS_SHIP            :       false    # 2002
-    --> ARCTAS_SHIP            :       false    # 2008
-    --> CORBETT_SHIP           :       false    # 1985
 # ----- RCP FUTURE EMISSIONS --------------------------------------------------
     --> RCP_3PD                :       false    # 2005-2100
     --> RCP_45                 :       false    # 2005-2100
@@ -2579,20 +2576,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #==============================================================================
 (((SHIP
 
-(((ARCTAS_SHIP
-0  ARCTAS_SHIP_SO2     $ROOT/ARCTAS_SHIP/v2014-07/ARCTAS_ship.generic.1x1.nc           SO2             2008/1/1/0             C xy kg/m2/s  SO2  11/19        10 1
-)))ARCTAS_SHIP
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_SO2      $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                SO2             2002/1-12/1/0          C xy kg/m2/s  SO2  11/15/60     10 2
-0 ICOADS_SHIP_CO       $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                CO              2002/1-12/1/0          C xy kg/m2/s  CO   6/10         10 2
-0 ICOADS_SHIP_SOAP     -                                                               -               -                      - -  -        SOAP 6/10/280     10 2
-)))ICOADS_SHIP
-
-(((CORBETT_SHIP
-0 CORBETT_SHIP_SO2     $ROOT/CORBETT_SHIP/v2014-07/CORBETT_ship.geos.1x1.nc            SO2_SHIP        1985/1-12/1/0          C xy kg/m2/s  SO2  -            10 3
-)))CORBETT_SHIP
-
 (((HTAPv3_SHIP
 0 HTAPv3_CO_SHP   $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_CO_0.1x0.1_$YYYY.nc  CO_SHP  2000-2018/1-12/1/0 C xy kg/m2/s CO    26     10 4
 0 HTAPv3_SOAP_SHP -                                                       -       -                  - -  -       SOAP  26/280 10 4
@@ -2716,10 +2699,6 @@ VerboseOnCores:              root       # Accepted values: root all
 #------------------------------------------------------------------------------
 (((ParaNOx
 
-(((ICOADS_SHIP
-102  ICOADS_SHIP_NO $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc NO 2002/1-12/1/0 C xy kg/m2/s NO 1/5 10 1
-)))ICOADS_SHIP
-
 (((HTAPv3_SHIP
 102 HTAPv3_NO_SHP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_NO_0.1x0.1_$YYYY.nc NO_SHP 2000-2018/1-12/1/0 C xy kg/m2/s NO 25 10 4
 )))HTAPv3_SHIP
@@ -2737,10 +2716,6 @@ VerboseOnCores:              root       # Accepted values: root all
 # into the base emissions rather than sending them through PARANOX.
 #------------------------------------------------------------------------------
 (((.not.ParaNOx
-
-(((ICOADS_SHIP
-0 ICOADS_SHIP_NO $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc             NO     2002/1-12/1/0      C xy kg/m2/s NO 1/5  10 1
-)))ICOADS_SHIP
 
 (((HTAPv3_SHIP
 0 HTAPv3_NO_SHIP $ROOT/HTAPv3/v2022-12/$YYYY/HTAPv3_NO_0.1x0.1_$YYYY.nc NO_SHP 2000-2018/1-12/1/0 C xy kg/m2/s NO 25 10 4


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca (Harvard) on behalf of Eloise Marais (UCL)

### Describe the update
@eamarais wrote:

> PARANOX at the finer resolutions leads to very high surface O3 concentrations, especially in busy shipping lanes. We noticed this issue when we compared GEOS-Chem at 0.25 deg to a regional UK CTM run at a similar resolution.

In PR #3011, we disabled PARANOx in GEOS-Chem Classic simulations for 0.25 x 0.3125 degree resolution or finer.  However, we did not make the corresponding update in GCHP.  

In this PR, we have modified the  `run/GCHP/setCommonRunSettings.sh.template` file to turn off the PARANOx extension in `HEMCO_Config.rc` for simulations using C360 or C720 cubed-sphere resolution.  PARANOx will be toggled back on when switching from C360/C720  to any other cubed-sphere grid.

### Expected changes
This will be a no-diff-to-benchmark update, as the GCHP benchmarks run at C24 resolution.  It will only affect GCHP simulations at greater than C360 resolution.

### Related Github Issue

- See PR #3011
