### PR TITLE
Turn off PARANOx when using C360 or C720 grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Moved coordinate variables for GC-Classic History netCDF files from `GeosUtil/grid_registry_mod.F90` to the `State_Grid` object
 - Changed several `State_Grid` fields from `fp` to `f8` precision. (In practice both are `REAL*8` but this makes it more explicit.)
 - Moved the population of coordinate variables for History netCDF  output from `grid_registry_mod.F90` to `history_mod.F90` (in routine `History_InitCoordVars`)
+- Updated `run/GCHP/setCommonRunSettings.template` to disable the HEMCO PARANOx extension for C360 or C720 grids
 
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -967,6 +967,17 @@ if [[ ${soilExt} != "missing" ]]; then
     fi
 fi
 
+# Deactivate PARANOx in HEMCO_Config.rc for C360 or C720 grids
+# but activate it for all other cubed-sphere resolutions
+paranoxExt=$(grep "102.*ParaNOx"  HEMCO_Config.rc || echo "missing")
+if [[ "x${paranoxExt}" != "xmissing" ]]; then
+    if [[ "x${CS_RES}" == "x360" || "x${CS_RES}" == "x720" ]]; then
+        sed -i -E '/ParaNOx/s/: (on |off)/: off/' HEMCO_Config.rc
+    else
+        sed -i -E '/ParaNOx/s/: (on |off)/: on /' HEMCO_Config.rc
+    fi
+fi
+
 #### Done
 print_msg " "
 print_msg "setCommonRunSettings.sh done"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca (Harvard) on behalf of Eloise Marais (UCL)

### Describe the update
@eamarais wrote:

> PARANOX at the finer resolutions leads to very high surface O3 concentrations, especially in busy shipping lanes. We noticed this issue when we compared GEOS-Chem at 0.25 deg to a regional UK CTM run at a similar resolution.

In PR #3011, we disabled PARANOx in GEOS-Chem Classic simulations for 0.25 x 0.3125 degree resolution or finer.  However, we did not make the corresponding update in GCHP.  

In this PR, we have modified the  `run/GCHP/setCommonRunSettings.sh.template` file to turn off the PARANOx extension in `HEMCO_Config.rc` for simulations using C360 or C720 cubed-sphere resolution.  PARANOx will be toggled back on when switching from C360/C720  to any other cubed-sphere grid.

### Expected changes
This will be a no-diff-to-benchmark update, as the GCHP benchmarks run at C24 resolution.  It will only affect GCHP simulations at greater than C360 resolution.

### Related Github Issue

- See PR #3011