### PR TITLE
Fix bugs in HEMCO_Diagn.rc template files for DustL23M

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Fixed incorrect dust species names in `run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem.onlineE` 
+- Fixed incorrect extension number for `InvDustL23M` entries in `run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem`
+
 ## [14.7.0] - 2026-02-05
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files

--- a/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem.onlineE
+++ b/run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem.onlineE
@@ -181,12 +181,24 @@ EmisDMS_Ocean      DMS    101    -1  -1   2   kg/m2/s  DMS_emission_flux_from_oc
 ###############################################################################
 #####  Dust emissions                                                     #####
 ###############################################################################
-EmisDST1_Total     DST1   -1     -1  -1   2   kg/m2/s  DST1_emission_flux_from_all_sectors
-EmisDST1_Anthro    DST1   0      1   -1   2   kg/m2/s  DST1_emission_flux_from_anthropogenic
-EmisDST1_Natural   DST1   105    -1  -1   2   kg/m2/s  DST1_emission_flux_from_natural_sources
-EmisDST2_Natural   DST2   105    -1  -1   2   kg/m2/s  DST2_emission_flux_from_natural_sources
-EmisDST3_Natural   DST3   105    -1  -1   2   kg/m2/s  DST3_emission_flux_from_natural_sources
-EmisDST4_Natural   DST4   105    -1  -1   2   kg/m2/s  DST4_emission_flux_from_natural_sources
+# NOTE: Uncomment EmisDST_Total if you wish to obtain total
+# dust emissions from HEMCO standalone simulations
+#EmisDST_Total         TDST      -1     -1  -1   2   kg/m2/s  Total_dust_emission_flux_from_natural_sources
+EmisDSTbin1_Total     DSTbin1   -1     -1  -1   2   kg/m2/s  DSTbin1_emission_flux_from_all_sectors
+EmisDSTbin1_Anthro    DSTbin1   0      1   -1   2   kg/m2/s  DSTbin1_emission_flux_from_anthropogenic
+EmisDSTbin1_Natural   DSTbin1   0      3   -1   2   kg/m2/s  DSTbin1_emission_flux_from_natural_sources
+EmisDSTbin2_Total     DSTbin2   -1     -1  -1   2   kg/m2/s  DSTbin2_emission_flux_from_all_sectors
+EmisDSTbin2_Anthro    DSTbin2   0      1   -1   2   kg/m2/s  DSTbin2_emission_flux_from_anthropogenic
+EmisDSTbin2_Natural   DSTbin2   0      3   -1   2   kg/m2/s  DSTbin2_emission_flux_from_natural_sources
+EmisDSTbin3_Total     DSTbin3   -1     -1  -1   2   kg/m2/s  DSTbin3_emission_flux_from_all_sectors
+EmisDSTbin3_Anthro    DSTbin3   0      1   -1   2   kg/m2/s  DSTbin3_emission_flux_from_anthropogenic
+EmisDSTbin3_Natural   DSTbin3   0      3   -1   2   kg/m2/s  DSTbin3_emission_flux_from_natural_sources
+EmisDSTbin4_Total     DSTbin4   -1     -1  -1   2   kg/m2/s  DSTbin4_emission_flux_from_all_sectors
+EmisDSTbin4_Anthro    DSTbin4   0      1   -1   2   kg/m2/s  DSTbin4_emission_flux_from_anthropogenic
+EmisDSTbin4_Natural   DSTbin4   0      3   -1   2   kg/m2/s  DSTbin4_emission_flux_from_natural_sources
+EmisDSTbin5_Natural   DSTbin5   0      3   -1   2   kg/m2/s  DSTbin5_emission_flux_from_natural_sources
+EmisDSTbin6_Natural   DSTbin6   0      3   -1   2   kg/m2/s  DSTbin6_emission_flux_from_natural_sources
+EmisDSTbin7_Natural   DSTbin7   0      3   -1   2   kg/m2/s  DSTbin7_emission_flux_from_natural_sources
 
 ###############################################################################
 #####  EOH emissions                                                      #####

--- a/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
+++ b/run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem
@@ -716,14 +716,14 @@ HcoConvectiveCloudTopHeight     -1 103 -1 -1 2 level           Convective_cloud_
 #=============================
 # NOTE: Uncomment InvDustL23M_TDST if you wish to obtain total
 # dust emissions from HEMCO standalone simulations
-##InvDustL23M_TDST            TDST      105  -1  -1  2   kg/m2/s  Total_dust_emission_flux_from_DustL23M_extension
-#InvDustL23M_DSTbin1         DSTbin1   105  -1  -1  2   kg/m2/s  DSTbin1_emission_flux_from_DustL23M_extension
-#InvDustL23M_DSTbin2         DSTbin2   105  -1  -1  2   kg/m2/s  DSTbin2_emission_flux_from_DustL23M_extension
-#InvDustL23M_DSTbin3         DSTbin3   105  -1  -1  2   kg/m2/s  DSTbin3_emission_flux_from_DustL23M_extension
-#InvDustL23M_DSTbin4         DSTbin4   105  -1  -1  2   kg/m2/s  DSTbin4_emission_flux_from_DustL23M_extension
-#InvDustL23M_DSTbin5         DSTbin5   105  -1  -1  2   kg/m2/s  DSTbin5_emission_flux_from_DustL23M_extension
-#InvDustL23M_DSTbin6         DSTbin6   105  -1  -1  2   kg/m2/s  DSTbin6_emission_flux_from_DustL23M_extension
-#InvDustL23M_DSTbin7         DSTbin7   105  -1  -1  2   kg/m2/s  DSTbin7_emission_flux_from_DustL23M_extension
+##InvDustL23M_TDST            TDST      125  -1  -1  2   kg/m2/s  Total_dust_emission_flux_from_DustL23M_extension
+#InvDustL23M_DSTbin1         DSTbin1   125  -1  -1  2   kg/m2/s  DSTbin1_emission_flux_from_DustL23M_extension
+#InvDustL23M_DSTbin2         DSTbin2   125  -1  -1  2   kg/m2/s  DSTbin2_emission_flux_from_DustL23M_extension
+#InvDustL23M_DSTbin3         DSTbin3   125  -1  -1  2   kg/m2/s  DSTbin3_emission_flux_from_DustL23M_extension
+#InvDustL23M_DSTbin4         DSTbin4   125  -1  -1  2   kg/m2/s  DSTbin4_emission_flux_from_DustL23M_extension
+#InvDustL23M_DSTbin5         DSTbin5   125  -1  -1  2   kg/m2/s  DSTbin5_emission_flux_from_DustL23M_extension
+#InvDustL23M_DSTbin6         DSTbin6   125  -1  -1  2   kg/m2/s  DSTbin6_emission_flux_from_DustL23M_extension
+#InvDustL23M_DSTbin7         DSTbin7   125  -1  -1  2   kg/m2/s  DSTbin7_emission_flux_from_DustL23M_extension
 
 #===================================
 # DEAD (dust) Extension, for TOMAS


### PR DESCRIPTION

### Name and Institution (Required)

Name:
Institution:

### Describe the update
This is the companion PR to #3162.  We have made the following fixes:

1. In `run/GCClassic/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem.onlineE`, we have added diagnostic emission entries for DSTbin1..DSTbin7, following what we did for the GEOS-Chem Classic HEMCO_Diagn.rc template. The inventory number/category will be changed if using online dust at rundir creation.

2. In `run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.fullchem`, we have fixed the incorrect extension number for the `InvDustL23M` diagnostics.  The extension number was 105 but should be 125.

### Expected changes
This is a no-diff-to-benchmark update.  The InvDustL23M diagnostic entries will now be correct in the benchmark table, but the results of the benchmark output will not change otherwise.

NOTE: After merging this PR, we can remove the shunt for InvDustL23M in GCPy.

### Related Github Issue

- Closes #3162 
