### PR TITLE
Fix errors in implementation of PR #3138; Also throw error if GC-Classic History collections are updated more frequently than the diagnostic timestep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Updated `Interfaces/GCClassic/main.F90` so that diagnostic archival is done once per diagnostic timestep (i.e. the larger of the chemistry timestep or dynamic timestep)
 - Updated routine `History_Read_Collection_Data` to set the default update frequency of time-averaged collections to the diagnostic timestep instead of the dynamic timestep
+- Updated the logic when computing `HeartBeatHms` and `DiagTimeHms` in `history_mod.F90` to be more robust
+
 
 ## [14.7.0] - 2026-02-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Added
 - Added routine `Its_Time_For_Diag` to `GeosUtil/time_mod.F90`
+- Added error trap to prevent GC-Classic History collections from being updated more frequently than the diagnostic timestep
 
 ### Changed
 - Updated `Interfaces/GCClassic/main.F90` so that diagnostic archival is done once per diagnostic timestep (i.e. the larger of the chemistry timestep or dynamic timestep)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Added
+- Added routine `Its_Time_For_Diag` to `GeosUtil/time_mod.F90`
+
+### Changed
+- Updated `Interfaces/GCClassic/main.F90` so that diagnostic archival is done once per diagnostic timestep (i.e. the larger of the chemistry timestep or dynamic timestep)
+
 ## [14.7.0] - 2026-02-05
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files
@@ -48,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Commented out met-fields `PEDGEDRY`, `PFICU`, `PFILSAN`, `PFLCU`, and `PFLLSAN` by default in GC-Classic and GCHP carbon HISTORY.rc, and GC-Classic CH4 HISTORY.rc
 - Turned on Carbon collection in `HISTORY.rc` for carbon simulations by default
 - Consolidated Hg species metdata from `run/shared/species_database_hg.yml` into `run/shared/species_database.yml`
+<<<<<<< HEAD
 - Updated `run/shared/download_data.yml` so that aerosol and fullchem simulations will get the restart file from `GEOSCHEM_RESTARTS/GC_14.7.0`
 - Updated `DST1/DST1/DST3/DST4` to `TDST/DSTbin1/DSTbin2/.../DSTbin7` in `geoschem_config.yml`, `HEMCO_Config.rc`, and `HEMCO_Diagn.rc` template files for aerosol & fullchem simulations
 - Updated routine `ExtState_SetFields` in `hco_interface_gc_mod.F90` for readability and clarity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Updated `Interfaces/GCClassic/main.F90` so that diagnostic archival is done once per diagnostic timestep (i.e. the larger of the chemistry timestep or dynamic timestep)
+- Updated routine `History_Read_Collection_Data` to set the default update frequency of time-averaged collections to the diagnostic timestep instead of the dynamic timestep
 
 ## [14.7.0] - 2026-02-05
 ### Added

--- a/GeosUtil/time_mod.F90
+++ b/GeosUtil/time_mod.F90
@@ -71,6 +71,7 @@ MODULE TIME_MOD
   PUBLIC  :: GET_FIRST_BC_TIME
   PUBLIC  :: ITS_TIME_FOR_CHEM
   PUBLIC  :: ITS_TIME_FOR_CONV
+  PUBLIC  :: ITS_TIME_FOR_DIAG
   PUBLIC  :: ITS_TIME_FOR_DYN
   PUBLIC  :: ITS_TIME_FOR_EMIS
   PUBLIC  :: ITS_TIME_FOR_EXCH
@@ -2223,6 +2224,36 @@ CONTAINS
     FLAG = ( MOD( ELAPSED_SEC, TS_CONV ) == 0 )
 
   END FUNCTION ITS_TIME_FOR_CONV
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Its_Time_For_Diag
+!
+! !DESCRIPTION: Function ITS\_TIME\_FOR\_DIAG returns TRUE if it is time to
+!  do diagnostic updating.
+!\\
+!\\
+! !INTERFACE:
+!
+  FUNCTION ITS_TIME_FOR_DIAG() RESULT( FLAG )
+!
+! !RETURN VALUE:
+!
+    LOGICAL :: FLAG
+!
+! !REVISION HISTORY:
+!  21 Mar 2003 - R. Yantosca - Initial Version
+! See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+    ! Is it time for dynamics?
+    FLAG = ( MOD( ELAPSED_SEC, TS_DIAG ) == 0 )
+
+  END FUNCTION ITS_TIME_FOR_DIAG
 !EOC
 !------------------------------------------------------------------------------
 !                  GEOS-Chem Global Chemical Transport Model                  !

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -629,17 +629,18 @@ CONTAINS
                                          yyyymmdd_end, hhmmss_end,           &
                                          deltaYMD,     deltaHMS             )
 
-       ! Convert the HeartBeatDtSec into hours:minutes:seconds
-       Min            = HeartBeatDtSec / 60
-       Hrs            = Min / 60
-       Sec            = HeartBeatDtSec - ( Min * 60 ) - ( Hrs * 3600 )
-       HeartBeatHms   = ( Hrs * 10000 ) + ( Min * 100 ) + Sec
+       ! Convert the DiagDtSec into hours:minutes:seconds
+       Hrs          = HeartBeatDtSec / 3600.0_fp
+       Min          = MOD( HeartBeatDtSec / 60.0_fp, 60.0_fp )
+       Sec          = MOD( HeartBeatDtSec,           60.0_fp )
+       HeartBeatHms = ( Hrs * 10000 ) + ( Min * 100 ) + Sec
+
 
        ! Convert the DiagDtSec into hours:minutes:seconds
-       Min            = DiagDtSec / 60
-       Hrs            = Min / 60
-       Sec            = DiagDtSec - ( Min * 60 ) - ( Hrs * 3600 )
-       DiagTimeHms    = ( Hrs * 10000 ) + ( Min * 100 ) + Sec
+       Hrs          = DiagDtSec / 3600
+       Min          = MOD( DiagDtSec / 60.0_fp, 60.0_fp )
+       Sec          = MOD( DiagDtSec,           60.0_fp )
+       DiagTimeHms  = ( Hrs * 10000 ) + ( Min * 100 ) + Sec
 
        ! Initialize objects and pointers
        Container      => NULL()

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -496,18 +496,22 @@ CONTAINS
     USE State_Diag_Mod
     USE State_Grid_Mod,        ONLY : GrdState
     USE State_Met_Mod
+    USE Time_Mod,              ONLY : Get_Ts_Diag
 !
 ! !INPUT PARAMETERS:
 !
-    TYPE(OptInput),   INTENT(IN)  :: Input_Opt    ! Input Options object
-    TYPE(ChmState),   INTENT(IN)  :: State_Chm    ! Chemistry State object
-    TYPE(DgnState),   INTENT(INOUT)  :: State_Diag   ! Diagnostic State object
-    TYPE(GrdState),   INTENT(IN)  :: State_Grid   ! Grid State Object object
-    TYPE(MetState),   INTENT(IN)  :: State_Met    ! Meteorology State object
+    TYPE(OptInput),   INTENT(IN)    :: Input_Opt    ! Input Options object
+    TYPE(ChmState),   INTENT(IN)    :: State_Chm    ! Chemistry State object
+    TYPE(GrdState),   INTENT(IN)    :: State_Grid   ! Grid State Object object
+    TYPE(MetState),   INTENT(IN)    :: State_Met    ! Meteorology State object
+!
+! !INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(DgnState),   INTENT(INOUT) :: State_Diag   ! Diagnostic State object
 !
 ! !OUTPUT PARAMETERS:
 !
-    INTEGER,          INTENT(OUT) :: RC           ! Success or failure?
+    INTEGER,          INTENT(OUT)   :: RC           ! Success or failure?
 !
 ! !REMARKS:
 !  Private routine, called from History_Init.
@@ -541,13 +545,13 @@ CONTAINS
     INTEGER                      :: Ind_Dry,        Ind_Fix,       Ind_Gas
     INTEGER                      :: Ind_Kpp,        Ind_Pho,       Ind_Rst
     INTEGER                      :: Ind_Var,        Ind_Wet,       Ind
-    INTEGER                      :: HbHrs,          HbMin,         HbSec
-    INTEGER                      :: HeartBeatHms,   nTags
+    INTEGER                      :: Hrs,            Min,           Sec
+    INTEGER                      :: HeartBeatHms,   DiagTimeHms,   nTags
     REAL(f8)                     :: UpdateAlarm,    HeartBeatDtSec
     REAL(f8)                     :: FileWriteAlarm, FileCloseAlarm
     REAL(f8)                     :: JulianDate,     JulianDateEnd
     REAL(f8)                     :: UpdateCheck,    FileWriteCheck
-    REAL(f8)                     :: SimLengthSec
+    REAL(f8)                     :: SimLengthSec,   DiagDtSec
 
     ! Strings
     CHARACTER(LEN=6  )           :: TStr
@@ -609,6 +613,7 @@ CONTAINS
        LineNum        =  0
        SpaceDim       =  0
        HeartBeatDtSec =  DBLE( Input_Opt%TS_DYN )
+       DiagDtSec      =  DBLE( Get_Ts_Diag()    )
        yyyymmdd       =  Input_Opt%NymdB
        hhmmss         =  Input_Opt%NhmsB
        yyyymmdd_end   =  Input_Opt%NymdE
@@ -625,11 +630,16 @@ CONTAINS
                                          deltaYMD,     deltaHMS             )
 
        ! Convert the HeartBeatDtSec into hours:minutes:seconds
-       ! for defining the Update interval for time-averaged collections
-       HbMin          = HeartBeatDtSec / 60
-       HbHrs          = HbMin / 60
-       HbSec          = HeartBeatDtSec - ( HbMin * 60 ) - ( HbHrs * 3600 )
-       HeartBeatHms   = ( HbHrs * 10000 ) + ( HbMin * 100 ) + HbSec
+       Min            = HeartBeatDtSec / 60
+       Hrs            = Min / 60
+       Sec            = HeartBeatDtSec - ( Min * 60 ) - ( Hrs * 3600 )
+       HeartBeatHms   = ( Hrs * 10000 ) + ( Min * 100 ) + Sec
+
+       ! Convert the DiagDtSec into hours:minutes:seconds
+       Min            = DiagDtSec / 60
+       Hrs            = Min / 60
+       Sec            = DiagDtSec - ( Min * 60 ) - ( Hrs * 3600 )
+       DiagTimeHms    = ( Hrs * 10000 ) + ( Min * 100 ) + Sec
 
        ! Initialize objects and pointers
        Container      => NULL()
@@ -1401,7 +1411,8 @@ CONTAINS
              ! Define the "Update" interval
              !
              ! Normally, we will set UpdateYmd and UpdateHms directly from
-             ! the "heartbeat" timestep of the simulation in seconds.
+             ! the diagnostic timestep (= the larger of the dynamic and
+             ! chemistry timesteps) in seconds.
              !
              ! If the ".acc_interval" tag is specified in HISTORY.rc,
              ! then we will set UpdateYmd and UpdateHms from
@@ -1417,9 +1428,9 @@ CONTAINS
              !--------------------------------------------------------------
              IF ( TRIM( CollectionAccInterval(C) ) == UNDEFINED_STR ) THEN
 
-                ! Set UpdateYmd and UpdateHms from the HeartBeat timestep
+                ! Set UpdateYmd and UpdateHms from the diagnostic timestep
                 UpdateYmd = 00000000
-                UpdateHms = HeartBeatHms
+                UpdateHms = DiagTimeHms
 
                 ! SPECIAL CASE: If FileWriteYmd is 240000 then set
                 ! and set FileWriteYmd=000001 and FileWriteHms=000000

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -1491,10 +1491,30 @@ CONTAINS
                    'Incompatible Restart collection metadata!           ',   &
                    'Restart.frequency = ',     FileWriteYmd, FileWriteHms,   &
                    'but Restart.duration  = ', FileCloseYmd, FileCloseHms
- 260             FORMAT( a, a, i8.8, 1x, i6.6, 1x, a, i8.8, 1x, i6.6 )
+ 260            FORMAT( a, a, i8.8, 1x, i6.6, 1x, a, i8.8, 1x, i6.6 )
                 CALL GC_Error( ErrMsg, RC, ThisLoc )
                 RETURN
              ENDIF
+          ENDIF
+
+          !=================================================================
+          ! Sanity check: Prevent a collection from being updated
+          ! more frequently than the diagnostic time step.  This will
+          ! prevent errors such as the one described in GitHub issue
+          ! https://github.com/geoschem/geos-chem/issues/3117.
+          !=================================================================
+          IF ( UpdateHms < DiagTimeHms ) THEN
+             WRITE( ErrMsg, 265 ) TRIM( CollectionName(C) ), UpdateHms,      &
+                  DiagTimeHms, TRIM( CollectionName(C) ), DiagTimeHms
+ 265         FORMAT( 'The ', a, '.frequency setting (', i6.6, ') is ',       &
+                     'smaller than the the diagnostic timestep (', i6.6,     &
+                     ')!  This can lead to spurious results in the ',        &
+                     'diagnostic archival such as were described in ',       &
+                     'https://github.com/geoschem/geos-chem/issues/3117. ',  &
+                     'Please set ', a, '.frequency equal to or greater ',    &
+                     'greater than ', i6.6, '.'                             )
+             CALL GC_Error( ErrMsg, RC, ThisLoc )
+             RETURN
           ENDIF
 
           !=================================================================

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -208,9 +208,6 @@ PROGRAM GEOS_Chem
   INTEGER                  :: id_H2O,        id_CH4,      id_CLOCK
   INTEGER                  :: previous_units
 
-  ! Reals
-  REAL(f8)                 :: TAU,           TAUb
-
   ! Strings
   CHARACTER(LEN=255)       :: ThisLoc,       ZTYPE
   CHARACTER(LEN=255)       :: historyConfigFile
@@ -252,8 +249,8 @@ PROGRAM GEOS_Chem
 
 #ifdef RRTMG
   ! For stratospheric adjustment
-  REAL(f8), ALLOCATABLE          :: DT_3D(:,:,:)
-  REAL(f8), ALLOCATABLE          :: HR_3D(:,:,:)
+  REAL(f8), ALLOCATABLE    :: DT_3D(:,:,:)
+  REAL(f8), ALLOCATABLE    :: HR_3D(:,:,:)
 #endif
 
   !==========================================================================
@@ -316,7 +313,7 @@ PROGRAM GEOS_Chem
   ENDIF
 
   !--------------------------------------------------------------------------
-  ! Initialize GEOS-Chem timers
+  ! Initialize GEOS-Chem Classic timers
   !--------------------------------------------------------------------------
   IF ( Input_Opt%useTimers ) THEN
 
@@ -348,13 +345,14 @@ PROGRAM GEOS_Chem
 
   !--------------------------------------------------------------------------
   ! Prepare the GEOS-Chem "dry run" option
-  ! If in a "dry-run" mode, GEOS-Chem will simply check whether files
-  ! are present (and possibly in the correct format) and go through
-  ! time-steps to check met fields and other IO issues.
-  ! No actual "compute" is performed.
+  !
+  ! If in a "dry-run" mode, GEOS-Chem will simply check whether files are
+  ! present (and possibly in the correct format) and go through time-steps
+  ! to check met fields and other IO issues. ! No actual "compute" is
+  ! performed.
   !
   ! The "dry-run" option is initialized using the command line extra
-  ! argument ./gcclassic --dry-run
+  ! argument ./gcclassic --dryrun
   !
   ! A log file can be specified with --log FILENAME.
   ! If no log file is specified, the default logfile will be
@@ -364,7 +362,6 @@ PROGRAM GEOS_Chem
   !
   ! Additionally, this flag must be set after reading input file, or
   ! its value will be overwritten by READ_INPUT_FILE.
-  ! (hplin, 11/1/19)
   !--------------------------------------------------------------------------
   CALL Init_Dry_Run( Input_Opt, RC )
   IF ( RC /= GC_SUCCESS ) THEN
@@ -492,12 +489,11 @@ PROGRAM GEOS_Chem
   ENDIF
 
   !--------------------------------------------------------------------------
-  ! Skip these operations when in dry-run mode
+  ! Copy to State_Met%AREA_M2 to avoid breaking GCHP benchmarks,  which
+  ! require the AREA_M2 field saved out to the StateMet diagnostic
+  ! collection for computing emission totals.  Skip when in dry-run mode.
   !--------------------------------------------------------------------------
   IF ( notDryRun ) THEN
-     ! Copy to State_Met%AREA_M2 to avoid breaking GCHP benchmarks,
-     ! which require the AREA_M2 field saved out to the StateMet
-     ! diagnostic collection for computing emission totals.
      State_Met%Area_M2 = State_Grid%Area_M2
   ENDIF
 
@@ -546,8 +542,6 @@ PROGRAM GEOS_Chem
 
      ! Initialize module variables
      CALL Init_RRTMG_Rad_Transfer( Input_Opt, State_Diag, State_Grid, RC )
-
-     ! Trap potential errors
      IF ( RC /= GC_SUCCESS ) THEN
         ErrMsg = 'Error encountered in "Init_RRTMG_Rad_Transfer"!'
         CALL Error_Stop( ErrMsg, ThisLoc )
@@ -598,8 +592,6 @@ PROGRAM GEOS_Chem
   !--------------------------------------------------------------------------
   IF ( Input_Opt%LLINOZ ) THEN
      CALL Linoz_Read( Input_Opt, RC )
-
-     ! Trap potential errors
      IF ( RC /= GC_SUCCESS ) THEN
         ErrMsg = 'Error encountered in "Linoz_Read"!'
         CALL Error_Stop( ErrMsg, ThisLoc )
@@ -611,8 +603,6 @@ PROGRAM GEOS_Chem
   NHMSb = GET_NHMSb()
   NYMD  = GET_NYMD()
   NYMDb = GET_NYMDb()
-  TAU   = GET_TAU()
-  TAUb  = GET_TAUb()
 
   !--------------------------------------------------------------------------
   !         ***** H I S T O R Y   I N I T I A L I Z A T I O N *****
@@ -628,8 +618,6 @@ PROGRAM GEOS_Chem
   ! (for dry-run, enter routine to print out HISTORY.rc status)
   CALL History_Init( Input_Opt,  State_Met,  State_Chm,                      &
                      State_Diag, State_Grid, RC                             )
-
-  ! Trap error
   IF ( RC /= GC_SUCCESS ) THEN
      ErrMsg = 'Error encountered in "History_Init"!'
      CALL Error_Stop( ErrMsg, ThisLoc )
@@ -655,8 +643,6 @@ PROGRAM GEOS_Chem
   ENDIF
 
   CALL Emissions_Init( Input_Opt, State_Chm, State_Grid, State_Met, RC )
-
-  ! Trap potential errors
   IF ( RC /= GC_SUCCESS ) THEN
      ErrMsg = 'Error encountered in "Emissions_Init"!'
      CALL Error_Stop( ErrMsg, ThisLoc )
@@ -738,8 +724,6 @@ PROGRAM GEOS_Chem
   ! Capture initial state of atmosphere for STE flux calc (ltm, 06/10/12)
   IF ( Input_Opt%LINEAR_CHEM .and. notDryRun ) THEN
      CALL Init_Linear_Chem( Input_Opt,  State_Chm, State_Met, State_Grid, RC )
-
-     ! Trap potential errors
      IF ( RC /= GC_SUCCESS ) THEN
         ErrMsg = 'Error encountered in "Init_Linear_Chem"!'
         CALL Error_Stop( ErrMsg, ThisLoc )
@@ -811,22 +795,18 @@ PROGRAM GEOS_Chem
     N_DYN  = GET_TS_DYN()
 
     !---------------------------------------------------------------------
-    ! %%%%% HISTORY (netCDF diagnostics) %%%%%
+    !               ***** H I S T O R Y   W R I T E *****
     !
-    ! Write HISTORY ITEMS in each diagnostic collection to disk
-    ! Appears at start of run to output instantaneous boundary conditions
-    ! at the start of the simulation with the correct time:
+    ! Ensure that instantaneous collections (e.g. BoundaryConditions)
+    ! are archived to disk at the start of the simulation.
     !---------------------------------------------------------------------
     IF ( notDryRun ) THEN
        IF ( Input_Opt%useTimers ) THEN
           CALL Timer_Start( "Diagnostics", RC )
        ENDIF
 
-       ! Write collections (such as BoundaryConditions) that need
-       ! to be defined at the start of the run
+       ! Write diagnostics to netCDF files
        CALL History_Write( Input_Opt, State_Chm, State_Diag, RC )
-
-       ! Trap potential errors
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered before timestepping in "History_Write"!'
           CALL Error_Stop( ErrMsg, ThisLoc )
@@ -857,7 +837,6 @@ PROGRAM GEOS_Chem
        HOUR          = GET_HOUR()
        MINUTE        = GET_MINUTE()
        SECOND        = GET_SECOND()
-       TAU           = GET_TAU()
        YEAR          = GET_YEAR()
        ELAPSED_TODAY = ( HOUR * 3600 ) + ( MINUTE * 60 ) + SECOND
 
@@ -931,8 +910,6 @@ PROGRAM GEOS_Chem
        ! Run HEMCO Phase 1
        CALL Emissions_Run( Input_Opt, State_Chm,   State_Diag, State_Grid, &
                            State_Met, TimeForEmis, 1,          RC )
-
-       ! Trap potential errors
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Error encountered in "Emissions_Run"!'
           CALL Error_Stop( ErrMsg, ThisLoc )
@@ -957,8 +934,6 @@ PROGRAM GEOS_Chem
           ! Do not do actual output for dry-run
           ! Write HEMCO diagnostics (ckeller, 4/1/15)
           CALL HCOI_GC_WriteDiagn( Input_Opt, .FALSE., RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "HCOI_GC_WriteDiagn" ' // &
                       '(writing HEMCO diagnostics)!'
@@ -982,8 +957,6 @@ PROGRAM GEOS_Chem
 
           ! Initialize Obspack for the new day
           CALL ObsPack_Init( NYMD,  NHMS, Input_Opt, State_Diag, RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "ObsPack_Init"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1006,8 +979,6 @@ PROGRAM GEOS_Chem
 
           ! Initialize the State_Met%XLAI_NATIVE field from HEMCO
           CALL Get_XlaiNative_from_HEMCO( Input_Opt, State_Grid, State_Met, RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Get_XlaiNative_from_HEMCO"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1016,8 +987,6 @@ PROGRAM GEOS_Chem
           ! Compute State_Met%XLAI (for drydep) and State_Met%MODISLAI,
           ! which is the average LAI per grid box (for soil NOx emissions)
           CALL Compute_Xlai( Input_Opt, State_Grid, State_Met, RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Compute_Xlai"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1053,7 +1022,7 @@ PROGRAM GEOS_Chem
              ENDIF
 
              CALL AirQnt( Input_Opt, State_Chm, State_Grid, State_Met, &
-                  RC, Update_Mixing_Ratio=.TRUE. )
+                          RC, Update_Mixing_Ratio=.TRUE. )
           ENDIF
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "AirQnt"!'
@@ -1071,8 +1040,6 @@ PROGRAM GEOS_Chem
              CALL Set_H2O_Trac( Input_Opt%LSETH2O,                           &
                                 Input_Opt, State_Chm, State_Grid,            &
                                 State_Met, RC )
-
-             ! Trap potential errors
              IF ( RC /= GC_SUCCESS ) THEN
                 ErrMsg = 'Error encountered in "Set_H2O_Trac" #1!'
                 CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1086,8 +1053,6 @@ PROGRAM GEOS_Chem
           ! State_Met%SUNCOS     = at the current time
           ! State_Met%SUNCOSmid  = at the midpt of the chem timestep
           CALL Get_Cosine_SZA( Input_Opt, State_Grid, State_Met, RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Get_Cosine_SZA"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1118,8 +1083,6 @@ PROGRAM GEOS_Chem
              ! Copy UV Albedo data (for photolysis) into the
              ! State_Met%UVALBEDO field. (bmy, 3/20/15)
              CALL Get_UvAlbedo( Input_Opt, State_Grid, State_Met, RC )
-
-             ! Trap potential errors
              IF ( RC /= GC_SUCCESS ) THEN
                 ErrMsg = 'Error encountered in "Get_UvAlbedo"!'
                 CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1172,8 +1135,6 @@ PROGRAM GEOS_Chem
           IF ( Input_Opt%LTRAN ) THEN
              CALL Do_Transport( Input_Opt,  State_Chm, State_Diag, &
                                 State_Grid, State_Met, RC )
-
-             ! Trap potential error
              IF ( RC /= GC_SUCCESS ) THEN
                 ErrMsg = 'Error encountered in "Do_Transport"!'
                 CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1190,8 +1151,6 @@ PROGRAM GEOS_Chem
           ! ... TOMAS microphysics: Always call SETUP_WETSCAV ...
           CALL Setup_WetScav( Input_Opt, State_Chm, State_Grid, &
                               State_Met, RC )
-
-          ! Trap potential error
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Setup_WetScav" (TOMAS)!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1204,8 +1163,6 @@ PROGRAM GEOS_Chem
                Input_Opt%LCHEM ) THEN
              CALL Setup_WetScav( Input_Opt, State_Chm, State_Grid, &
                                  State_Met, RC )
-
-             ! Trap potential error
              IF ( RC /= GC_SUCCESS ) THEN
                 ErrMsg = 'Error encountered in "Setup_WetScav"!'
                 CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1247,7 +1204,6 @@ PROGRAM GEOS_Chem
        ! to better reflect the buffer zone's underlying BCs. (hplin, 7/28/23)
        IF ( State_Grid%NestedGrid .and. notDryRun ) THEN
           CALL Set_Boundary_Conditions( Input_Opt, State_Chm, State_Grid, RC )
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in call to "Set_Boundary_Conditions"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1266,8 +1222,6 @@ PROGRAM GEOS_Chem
           ! height is used by drydep and some of the emissions routines.
           ! (ckeller, 3/5/15)
           CALL Compute_PBL_Height( Input_Opt, State_Grid, State_Met, RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Compute_PBL_Height"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1304,8 +1258,6 @@ PROGRAM GEOS_Chem
              ! Compute drydep velocities
              CALL Do_Drydep( Input_Opt,  State_Chm, State_Diag, &
                              State_Grid, State_Met, RC )
-
-             ! Trap potential errors
              IF ( RC /= GC_SUCCESS ) THEN
                 ErrMsg = 'Error encountered in "Do_Drydep!"!'
                 CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1342,8 +1294,6 @@ PROGRAM GEOS_Chem
           ! (ckeller, 4/1/15)
           CALL Emissions_Run( Input_Opt, State_Chm,   State_Diag, State_Grid, &
                               State_Met, TimeForEmis, 2,          RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Emissions_Run"! after drydep!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1369,10 +1319,8 @@ PROGRAM GEOS_Chem
           ENDIF
 
           ! Set CH4 concentrations
-          CALL SET_CH4( Input_Opt, State_Chm, State_Diag, State_Grid, &
-                        State_Met, RC )
-
-          ! Trap potential errors
+          CALL SET_CH4( Input_Opt,  State_Chm, State_Diag,                   &
+                        State_Grid, State_Met, RC                           )
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in call to "SET_CH4"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1423,7 +1371,6 @@ PROGRAM GEOS_Chem
              CALL Set_DryDepVel_Diagnostics( Input_Opt,  State_Chm,       &
                                              State_Diag, State_Grid,      &
                                              State_Met,  RC              )
-
              IF ( RC /= GC_SUCCESS ) THEN
                 ErrMsg = &
                      'Error encountered in "Update_DryDepVel_for_Turbday"!'
@@ -1447,8 +1394,6 @@ PROGRAM GEOS_Chem
           ! (ckeller, 3/5/15)
           CALL Do_Mixing( Input_Opt,  State_Chm, State_Diag, &
                           State_Grid, State_Met, RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Do_Mixing"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1471,8 +1416,6 @@ PROGRAM GEOS_Chem
              ! Call the appropriate convection routine
              CALL Do_Convection( Input_Opt,  State_Chm, State_Diag, &
                                  State_Grid, State_Met, RC )
-
-             ! Trap potential errors
              IF ( RC /= GC_SUCCESS ) THEN
                 ErrMsg = 'Error encountered in "Do_Convection"!'
                 CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1502,8 +1445,6 @@ PROGRAM GEOS_Chem
           ! the call to HEMCO emissions driver EMISSIONS_RUN. (bmy, 3/20/15)
           CALL Get_Overhead_O3_For_FastJ( Input_Opt,  State_Chm,             &
                                           State_Grid, State_Met, RC         )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Get_Overhead_O3_for_FastJ"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1517,8 +1458,6 @@ PROGRAM GEOS_Chem
                 CALL Set_H2O_Trac( .FALSE., &
                                    Input_Opt , State_Chm,    &
                                    State_Grid, State_Met, RC )
-
-                ! Trap potential errors
                 IF ( RC /= GC_SUCCESS ) THEN
                    ErrMsg = 'Error encountered in "Set_H2O_Trac" #2!'
                    CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1528,8 +1467,6 @@ PROGRAM GEOS_Chem
              ! Do GEOS-Chem chemistry
              CALL Do_Chemistry( Input_Opt,  State_Chm, State_Diag, &
                                 State_Grid, State_Met, RC )
-
-             ! Trap potential errors
              IF ( RC /= GC_SUCCESS ) THEN
                 ErrMsg = 'Error encountered in "Do_Chemistry"!'
                 CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1552,10 +1489,8 @@ PROGRAM GEOS_Chem
           ENDIF
 
           ! Do wet deposition
-          CALL Do_WetDep( Input_Opt, State_Chm, State_Diag, State_Grid, &
-                          State_Met, RC )
-
-          ! Trap potential errors
+          CALL Do_WetDep( Input_Opt,  State_Chm, State_Diag,                 &
+                          State_Grid, State_Met, RC                         )
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Do_WetDep"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1583,8 +1518,6 @@ PROGRAM GEOS_Chem
           ! (skim, 02/05/11)
           CALL Recompute_OD( Input_Opt,  State_Chm, State_Diag, &
                              State_Grid, State_Met, RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Recompute_OD"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -1672,8 +1605,6 @@ PROGRAM GEOS_Chem
                                       DT_3D      = DT_3D,                  &
                                       HR_3D      = HR_3D,                  &
                                       RC         = RC                     )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "Do_RRTMG_Rad_Transfer", ' // &
                       'for RRTMG output = ' // &
@@ -1730,173 +1661,166 @@ PROGRAM GEOS_Chem
 
        !=====================================================================
        !         ***** D I A G N O S T I C S   A R C H I V A L *****
+       !
+       ! NOTE: If emissions, chemistry, or drydep is active, then diagnostic
+       ! archival will be performed at the end of the chemistry timestep.
+       ! See https://github.com/geoschem/geos-chem/issues/3117 for info.
        !=====================================================================
        IF ( notDryRun ) THEN
 
-          !------------------------------------------------------------------
-          !            ***** H I S T O R Y   U P D A T E  *****
-          !------------------------------------------------------------------
           IF ( Input_Opt%useTimers ) THEN
              CALL Timer_Start( "Diagnostics", RC )
           ENDIF
 
-          ! Set State_Diag arrays that rely on state at end of timestep
-          CALL Set_Diagnostics_EndofTimestep( Input_Opt,  State_Chm,  &
-                                              State_Diag, State_Grid, &
-                                              State_Met,  RC )
-
-          ! Trap potential errors
-          IF ( RC /= GC_SUCCESS ) THEN
-             ErrMsg = 'Error encountered in "Set_Diagnostics_EndOfTimestep"!'
-             CALL Error_Stop( ErrMsg, ThisLoc )
-          ENDIF
-
-          ! Archive aerosol mass and PM2.5 diagnostics
-          IF ( State_Diag%Archive_AerMass ) THEN
-             CALL Set_AerMass_Diagnostic( Input_Opt,  State_Chm, State_Diag, &
-                                          State_Grid, State_Met, RC )
-          ENDIF
-
-          ! Trap potential errors
-          IF ( RC /= GC_SUCCESS ) THEN
-             ErrMsg = 'Error encountered in "Set_AerMass_Diagnostic"!'
-             CALL Error_Stop( ErrMsg, ThisLoc )
-          ENDIF
-
-          ! Turn off diagnostics timer
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "Diagnostics", RC )
-          ENDIF
-
           !------------------------------------------------------------------
-          ! Set species concentration back to v/v dry air (mol/mol dry air)
-          ! prior to setting restart file arrays. Doing this conversion
-          ! every timestep is required for bit-for-bit reproducibility when
-          ! breaking up runs in time.
+          !    ***** A R C H I V E   D I A G N O S T I C S  (1 of 2) *****
           !------------------------------------------------------------------
-          CALL Convert_Spc_Units(                                            &
-               Input_Opt  = Input_Opt,                                       &
-               State_Chm  = State_Chm,                                       &
-               State_Grid = State_Grid,                                      &
-               State_Met  = State_Met,                                       &
-               new_units  = previous_units,                                  &
-               RC         = RC                                              )
+          IF ( Its_Time_For_Diag() ) THEN
 
-          ! Turn diagnostics timer back on
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "Diagnostics", RC )
-          ENDIF
-
-          ! Set diagnostics arrays in State_Diag that are in mol/mol
-          CALL Set_SpcConc_Diags_VVDry( Input_Opt,  State_Chm, State_Diag,   &
-                                        State_Grid, State_Met, RC           )
-
-          ! Increment the timestep values by the heartbeat time
-          ! This is because we need to write out data with the timestamp
-          ! at the end of the heartbeat timestep (i.e. at end of run)
-          !
-          ! NOTE: This should now go before HISTORY_UPDATE, so that we
-          ! can recompute the update alarm interval properly for monthly
-          ! or yearly intervals spanning leap years. (bmy, 3/5/19)
-          CALL History_SetTime( Input_Opt, RC )
-
-          ! Trap potential errors
-          IF ( RC /= GC_SUCCESS ) THEN
-             ErrMsg = 'Error encountered in "History_SetTime"!'
-             CALL Error_Stop( ErrMsg, ThisLoc )
-          ENDIF
-
-          ! Update each HISTORY ITEM from its data source
-          CALL History_Update( Input_Opt, State_Diag, RC )
-
-          ! Trap potential errors
-          IF ( RC /= GC_SUCCESS ) THEN
-             ErrMsg = 'Error encountered in "History_Update"!'
-             CALL Error_Stop( ErrMsg, ThisLoc )
-          ENDIF
-
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "Diagnostics", RC )
-          ENDIF
-
-          !------------------------------------------------------------------
-          !         ***** O B S P A C K   D I A G N O S T I C S *****
-          !------------------------------------------------------------------
-          IF ( Input_Opt%Do_ObsPack ) THEN
-
-             IF ( Input_Opt%useTimers ) THEN
-                CALL Timer_Start( "Diagnostics", RC )
-             ENDIF
-
-             ! Sample the observations in today's ObsPack file
-             CALL ObsPack_Sample( NYMD,      NHMS,       Input_Opt,          &
-                                  State_Chm, State_Diag, State_Grid,         &
-                                  State_Met, RC                             )
-
-             IF ( Input_Opt%useTimers ) THEN
-                CALL Timer_End( "Diagnostics", RC )
-             ENDIF
-
-          ENDIF
-
-          !------------------------------------------------------------------
-          !    ***** P L A N E F L I G H T   D I A G   S E T U P  *****
-          !------------------------------------------------------------------
-          IF ( Input_Opt%Do_Planeflight .and. ITS_A_NEW_DAY() ) THEN
-
-             IF ( Input_Opt%useTimers ) THEN
-                CALL Timer_Start( "Diagnostics", RC)
-             ENDIF
-
-             ! Initialize planeflight diagnostic
-             CALL Setup_PlaneFlight( Input_Opt, State_Chm, State_Grid, &
-                                     State_Met, RC )
+             ! Set State_Diag arrays that rely on state at end of timestep
+             CALL Set_Diagnostics_EndofTimestep( Input_Opt,  State_Chm,      &
+                                                 State_Diag, State_Grid,     &
+                                                 State_Met,  RC             )
 
              ! Trap potential errors
              IF ( RC /= GC_SUCCESS ) THEN
-                ErrMsg = 'Error encountered in "Setup_Planeflight"!'
+                ErrMsg = &
+                   'Error encountered in "Set_Diagnostics_EndOfTimestep"!'
                 CALL Error_Stop( ErrMsg, ThisLoc )
              ENDIF
 
-             IF ( Input_Opt%useTimers ) THEN
-                CALL Timer_End( "Diagnostics", RC )
+             ! Archive aerosol mass and PM2.5 diagnostics
+             IF ( State_Diag%Archive_AerMass ) THEN
+                CALL Set_AerMass_Diagnostic( Input_Opt,  State_Chm,          &
+                                             State_Diag, State_Grid,         &
+                                             State_Met,  RC                 )
              ENDIF
 
+             ! Trap potential errors
+             IF ( RC /= GC_SUCCESS ) THEN
+                ErrMsg = 'Error encountered in "Set_AerMass_Diagnostic"!'
+                CALL Error_Stop( ErrMsg, ThisLoc )
+             ENDIF
           ENDIF
 
           !------------------------------------------------------------------
-          !  ***** C H 4   S I M U L A T I O N   D I A G N O S I C S *****
+          !            ***** U N I T   C O N V E R S I O N  *****
           !
-          ! Get CH4 columns by applying satellite observational operators
+          ! Set species concentration back to v/v dry air (mol/mol dry air)
+          ! prior to setting restart file arrays. Doing this conversion
+          ! every timestep is required for bit-for-bit reproducibility when
+          ! breaking up runs in time.  This has to be done before calling
+          ! routine Set_SpcConc_Diags_VVDry.
           !------------------------------------------------------------------
-          IF ( Input_Opt%Satellite_CH4_Columns ) THEN
-             IF ( ITS_A_NEW_HOUR() ) THEN
-                IF ( Input_Opt%useTimers ) THEN
-                   CALL Timer_Start( "Diagnostics", RC)
+          IF ( Input_Opt%useTimers ) THEN
+             CALL Timer_End( "Diagnostics", RC )
+          ENDIF
+
+          ! Convert units
+          CALL Convert_Spc_Units(                                            &
+                  Input_Opt  = Input_Opt,                                    &
+                  State_Chm  = State_Chm,                                    &
+                  State_Grid = State_Grid,                                   &
+                  State_Met  = State_Met,                                    &
+                  new_units  = previous_units,                               &
+                  RC         = RC                                           )
+
+          IF ( Input_Opt%useTimers ) THEN
+             CALL Timer_Start( "Diagnostics", RC )
+          ENDIF
+
+          !------------------------------------------------------------------
+          !       ***** H I S T O R Y   U P D A T E   T I M E *****
+          !
+          ! Increment the timestep values by the heartbeat time.  This is
+          ! because we need to write out diagnostic quantities at the end
+          ! of the diagnostic timestep before the actual alarm timestep
+          ! (If archiving diagnostics hourly, write at 50 past the hour)
+          !------------------------------------------------------------------
+          CALL History_SetTime( Input_Opt, RC )
+
+          !------------------------------------------------------------------
+          !    ***** A R C H I V E   D I A G N O S T I C S  (2 of 2) *****
+          !------------------------------------------------------------------
+          IF ( Its_Time_For_Diag() ) THEN
+
+             ! Set diagnostics arrays in State_Diag that are in mol/mol
+             CALL Set_SpcConc_Diags_VVDry( Input_Opt,  State_Chm,            &
+                                           State_Diag, State_Grid,           &
+                                           State_Met,  RC                   )
+             IF ( RC /= GC_SUCCESS ) THEN
+                ErrMsg = 'Error encountered in "History_SetTime"!'
+                CALL Error_Stop( ErrMsg, ThisLoc )
+             ENDIF
+
+             ! Update each HISTORY ITEM from its data source
+             CALL History_Update( Input_Opt, State_Diag, RC )
+             IF ( RC /= GC_SUCCESS ) THEN
+                ErrMsg = 'Error encountered in "History_Update"!'
+                CALL Error_Stop( ErrMsg, ThisLoc )
+             ENDIF
+
+             !------------------------------------------------------------------
+             !         ***** O B S P A C K   D I A G N O S T I C S *****
+             !------------------------------------------------------------------
+             IF ( Input_Opt%Do_ObsPack ) THEN
+
+                ! Sample the observations in today's ObsPack file
+                CALL ObsPack_Sample( NYMD,      NHMS,       Input_Opt,       &
+                                     State_Chm, State_Diag, State_Grid,      &
+                                     State_Met, RC                          )
+
+             ENDIF
+
+             !------------------------------------------------------------------
+             !    ***** P L A N E F L I G H T   D I A G   S E T U P  *****
+             !
+             ! Initialize the Planeflight diagnostic only if it's a new day
+             !------------------------------------------------------------------
+             IF ( Input_Opt%Do_Planeflight .and. ITS_A_NEW_DAY() ) THEN
+
+                ! Initialize planeflight diagnostic
+                CALL Setup_PlaneFlight( Input_Opt, State_Chm, State_Grid, &
+                                        State_Met, RC )
+                IF ( RC /= GC_SUCCESS ) THEN
+                   ErrMsg = 'Error encountered in "Setup_Planeflight"!'
+                   CALL Error_Stop( ErrMsg, ThisLoc )
                 ENDIF
 
-                ! CH4 columns from the GOSAT instrument
-                IF ( Input_Opt%GOSAT_CH4_OBS ) THEN
-                   CALL CALC_GOSAT_CH4_FORCE( Input_Opt,  State_Chm,         &
-                                              State_Grid, State_Met         )
-                ENDIF
+             ENDIF
 
-                ! CH4 columns from the AIRS instrument
-                IF ( Input_Opt%AIRS_CH4_OBS ) THEN
-                   CALL CALC_AIRS_CH4_FORCE( Input_Opt,  State_Chm,          &
-                                             State_Grid, State_Met          )
-                ENDIF
+             !---------------------------------------------------------------
+             !    ***** C H 4   C O L U M N   D I A G N O S T I C S *****
+             !
+             ! Get CH4 columns by applying satellite observational operators
+             !---------------------------------------------------------------
+             IF ( Input_Opt%Satellite_CH4_Columns ) THEN
+                IF ( ITS_A_NEW_HOUR() ) THEN
 
-                ! CH4 columns from the TCCON instrument
-                IF ( Input_Opt%TCCON_CH4_OBS ) THEN
-                   CALL CALC_TCCON_CH4_FORCE( Input_Opt,  State_Chm,         &
-                                              State_Grid, State_Met         )
-                ENDIF
+                   ! CH4 columns from the GOSAT instrument
+                   IF ( Input_Opt%GOSAT_CH4_OBS ) THEN
+                      CALL CALC_GOSAT_CH4_FORCE( Input_Opt,  State_Chm,      &
+                                                 State_Grid, State_Met      )
+                   ENDIF
 
-                IF ( Input_Opt%useTimers ) THEN
-                   CALL Timer_End( "Diagnostics", RC )
+                   ! CH4 columns from the AIRS instrument
+                   IF ( Input_Opt%AIRS_CH4_OBS ) THEN
+                      CALL CALC_AIRS_CH4_FORCE( Input_Opt,  State_Chm,       &
+                                                State_Grid, State_Met       )
+                   ENDIF
+
+                   ! CH4 columns from the TCCON instrument
+                   IF ( Input_Opt%TCCON_CH4_OBS ) THEN
+                      CALL CALC_TCCON_CH4_FORCE( Input_Opt,  State_Chm,      &
+                                                 State_Grid, State_Met      )
+                   ENDIF
                 ENDIF
              ENDIF
+          ENDIF
+
+          ! Stop diagnostics timer
+          IF ( Input_Opt%useTimers ) THEN
+             CALL Timer_End( "Diagnostics", RC )
           ENDIF
        ENDIF
 
@@ -1913,34 +1837,37 @@ PROGRAM GEOS_Chem
           CALL Debug_Msg( '### MAIN: after SET_ELAPSED_SEC' )
        ENDIF
 
-       IF ( notDryRun ) THEN
-          !==================================================================
-          !       ***** D I A G N O S T I C S   A R C H I V A L *****
-          !
-          !                 ***** C O N T I N U E D *****
-          !==================================================================
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_Start( "Diagnostics", RC )
-          ENDIF
 
-          !------------------------------------------------------------------
-          !    ***** P L A N E F L I G H T   D I A G N O S T I C  *****
-          !------------------------------------------------------------------
-          IF ( Input_Opt%Do_Planeflight ) THEN
+       !=====================================================================
+       !      ***** P L A N E F L I G H T   D I A G N O S T I C  *****
+       !
+       ! Archive quantities along flight track each diagnostic timestep
+       !=====================================================================
+       IF ( Input_Opt%Do_PlaneFlight ) THEN
+          IF ( notDryRun .and. Its_Time_For_Diag() ) THEN
+
+             ! Start timer
+             IF ( Input_Opt%useTimers ) THEN
+                CALL Timer_Start( "Diagnostics", RC )
+             ENDIF
+
              ! Archive data along the flight track
-             CALL PLANEFLIGHT( Input_Opt,  State_Chm, State_Diag, &
-                               State_Grid, State_Met, RC )
-
-             ! Trap potential errors
+             CALL PlaneFlight( Input_Opt,  State_Chm, State_Diag,            &
+                               State_Grid, State_Met, RC                    )
              IF ( RC /= GC_SUCCESS ) THEN
                 ErrMsg = 'Error encountered in "Planeflight"!'
                 CALL Error_Stop( ErrMsg, ThisLoc )
              ENDIF
-          ENDIF
-          IF ( VerboseAndRoot ) CALL Debug_Msg( '### MAIN: after Planeflight' )
 
-          IF ( Input_Opt%useTimers ) THEN
-             CALL Timer_End( "Diagnostics", RC )
+             ! Debug output
+             IF ( VerboseAndRoot ) THEN
+                CALL Debug_Msg( '### MAIN: after Planeflight' )
+             ENDIF
+
+             ! Stop timer
+             IF ( Input_Opt%useTimers ) THEN
+                CALL Timer_End( "Diagnostics", RC )
+             ENDIF
           ENDIF
        ENDIF
 
@@ -1976,19 +1903,18 @@ PROGRAM GEOS_Chem
           ENDIF
        ENDIF
 
-       !---------------------------------------------------------------------
+       !=====================================================================
        !               ***** H I S T O R Y   W R I T E *****
-       !---------------------------------------------------------------------
+       !
+       ! Archive diagnostics to netCDF files (or skip if it isn't time yet)
+       !=====================================================================
        IF ( notDryRun ) THEN
           IF ( Input_Opt%useTimers ) THEN
              CALL Timer_Start( "Diagnostics", RC )
           ENDIF
 
-          ! Write HISTORY ITEMS in each diagnostic collection to disk
-          ! (or skip writing if it is not the proper output time.
+          ! Write diagnostics to netCDF files
           CALL History_Write( Input_Opt, State_Chm, State_Diag, RC )
-
-          ! Trap potential errors
           IF ( RC /= GC_SUCCESS ) THEN
              ErrMsg = 'Error encountered in "History_Write"!'
              CALL Error_Stop( ErrMsg, ThisLoc )
@@ -2022,8 +1948,6 @@ PROGRAM GEOS_Chem
 
     ! Force the output of a HEMCO restart file (ckeller, 4/1/15)
     CALL HCOI_GC_WriteDiagn( Input_Opt, .TRUE., RC )
-
-    ! Trap potential errors
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered in "HCOI_GC_WriteDiagn"!'
        CALL Error_Stop( ErrMsg, ThisLoc )
@@ -2034,9 +1958,9 @@ PROGRAM GEOS_Chem
     ENDIF
 
     !------------------------------------------------------------------------
-    !         ***** O B S P A C K   D I A G N O S T I C S *****
+    !            ***** O B S P A C K   D I A G N O S T I C S *****
     !
-    ! Flush any unwritten ObsPack data to disk and finalize
+    ! Flush any unwritten ObsPack data to disk and finalize data arrays.
     !------------------------------------------------------------------------
     IF ( Input_Opt%Do_ObsPack ) THEN
 

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -856,7 +856,7 @@ PROGRAM GEOS_Chem
           !------------------------------------------------------------------
           ! %%%%% HISTORY (netCDF diagnostics) %%%%%
           !
-          ! Certain diagnostics need to be zeroed out at the start
+          ! Certain diagnostics need to be zeroed out at the start of
           ! each timestep, before operations like drydep, wetdep, and
           ! convection are executed.
           !------------------------------------------------------------------
@@ -1673,7 +1673,9 @@ PROGRAM GEOS_Chem
           ENDIF
 
           !------------------------------------------------------------------
-          !    ***** A R C H I V E   D I A G N O S T I C S  (1 of 2) *****
+          !    ***** A R C H I V E   D I A G N O S T I C S  (1 of 3) *****
+          !
+          ! Once per diagnostic timestep = MAX( Ts_Dyn, Ts_Chem )
           !------------------------------------------------------------------
           IF ( Its_Time_For_Diag() ) THEN
 
@@ -1730,17 +1732,9 @@ PROGRAM GEOS_Chem
           ENDIF
 
           !------------------------------------------------------------------
-          !       ***** H I S T O R Y   U P D A T E   T I M E *****
+          !    ***** A R C H I V E   D I A G N O S T I C S  (2 of 3) *****
           !
-          ! Increment the timestep values by the heartbeat time.  This is
-          ! because we need to write out diagnostic quantities at the end
-          ! of the diagnostic timestep before the actual alarm timestep
-          ! (If archiving diagnostics hourly, write at 50 past the hour)
-          !------------------------------------------------------------------
-          CALL History_SetTime( Input_Opt, RC )
-
-          !------------------------------------------------------------------
-          !    ***** A R C H I V E   D I A G N O S T I C S  (2 of 2) *****
+          ! Once per diagnostic timestep = MAX( Ts_Dyn, Ts_Chem )
           !------------------------------------------------------------------
           IF ( Its_Time_For_Diag() ) THEN
 
@@ -1753,12 +1747,39 @@ PROGRAM GEOS_Chem
                 CALL Error_Stop( ErrMsg, ThisLoc )
              ENDIF
 
-             ! Update each HISTORY ITEM from its data source
-             CALL History_Update( Input_Opt, State_Diag, RC )
-             IF ( RC /= GC_SUCCESS ) THEN
-                ErrMsg = 'Error encountered in "History_Update"!'
-                CALL Error_Stop( ErrMsg, ThisLoc )
-             ENDIF
+          ENDIF
+
+          !------------------------------------------------------------------
+          !            ***** H I S T O R Y   U P D A T E ****
+          !------------------------------------------------------------------
+
+          ! As we are now at the end of the current dynamic timestep (i.e.
+          ! at time T + Ts_Dyn), call "History_SetTime" to increment the
+          ! elapsed time field in each diagnostic collection.  This will be
+          ! used to update the alarms that determine when fields will be
+          ! updated and when files will be written.
+          CALL History_SetTime( Input_Opt, RC )
+
+          ! Also call "History_Update" to update each diagnostic field from
+          ! its data source.  Make sure that this call happens on each
+          ! dynamic timestep, as this will ensure that fields belonging to
+          ! the Restart collection will be updated on the dynamic timestep
+          ! prior to the file write time.  All other collection fields will
+          ! be updated once per diagnostic timestep = MAX( Ts_Dyn, Ts_Chem )
+          ! in order to prevent values before the end of a chemistry timestep
+          ! from being included in the diagnostic averaging.
+          CALL History_Update( Input_Opt, State_Diag, RC )
+          IF ( RC /= GC_SUCCESS ) THEN
+             ErrMsg = 'Error encountered in "History_Update"!'
+             CALL Error_Stop( ErrMsg, ThisLoc )
+          ENDIF
+
+          !------------------------------------------------------------------
+          !    ***** A R C H I V E   D I A G N O S T I C S  (3 of 3) *****
+          !
+          ! Once per diagnostic timestep = MAX( Ts_Dyn, Ts_Chem )
+          !------------------------------------------------------------------
+          IF ( Its_Time_For_Diag() ) THEN
 
              !------------------------------------------------------------------
              !         ***** O B S P A C K   D I A G N O S T I C S *****


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #3208.  We have fixed several issues in the implementation of PR #3138 that had caused fields belonging to the GC-Classic Restart collection to be all zeroes.  Namely:

1. In `Interfaces/GCClassic/main.F90`:
     - We have moved the call to `History_Update` out of the `IF ( Its_Time_for_Diag() )` block, where it was placed in PR #3138.  This caused the Restart file collection fields to not be updated at the proper times.

3. In routine `History_Read_Collection_Data` (located in `History/history_mod.F90`):
    - We have updated the logic so that the default update frequency for time-averaged collections is set to the diagnostic timestep `= MAX( Ts_Dyn, Ts_Chem )` instead of the dynamic (heartbeat) timestep (`Ts_Dyn`).  
    - We have added an error trap to halt the run with an informative error message if any collection's frequency is smaller than the diagnostic timestep.  This will prevent spurious values (as described by @ltmurray in #3117) from being added into the diagnostic archiving.
    - Fixed the algorithms that compute `HeartBeatHms` and `DiagTimeHms` variables.  These broke down if either the heartbeat timestep or the diagnostic timestep were 3600 seconds.

### Expected changes
With this fix, values in the restart file are no longer zero, as shown by this mass table from a pair of short runs:
```
#########################################################################################################
### Global mass (Gg) (Trop + Strat)                                                                   ###
###                                                                                                   ###
### Ref = 14.7.0 at 20190701T02                                                                       ###
### Dev = 14.8.0+bug_fix at 20190701T02                                                               ###
###                                                                                                   ###
### Dev and Ref show 276 differences                                                                  ###
#########################################################################################################
                                    Ref                 Dev           Dev - Ref              % diff diffs
A3O2               :           0.082096            0.082096            0.000000            0.000000  
ACET               :        6369.163420         6368.661128           -0.502292           -0.007886   * 
ACO3               :           0.002486            0.002486            0.000000            0.000000  
ACR                :           4.203823            4.139045           -0.064778           -1.540936   * 
ACRO2              :           0.004317            0.004317            0.000000            0.000000  
ACTA               :         401.096500          401.155608            0.059108            0.014737   * 
AERI               :           6.424546            6.433432            0.008886            0.138317   * 
ALD2               :         273.513227          272.176608           -1.336620           -0.488686   * 
ALK4               :         234.934215          234.419386           -0.514829           -0.219137   * 
ALK4N1             :           0.006039            0.006039            0.000000            0.000000  
ALK4N2             :           9.231802            9.237344            0.005542            0.0600
...
```
Also, if a user attempts to define a GC-Classic History collection having an update frequency that is smaller than the diagnostic timestep, e.g.:
```
COLLECTIONS: 'Restart',
             ...
             'SpeciesConcInst',
             ...
#==============================================================================
# %%%%% THE SpeciesConc COLLECTION %%%%%
#
# GEOS-Chem species concentrations (default = all species)
#
# Available for all simulations
#
# Concentrations may be saved out as SpeciesConcVV  [v/v dry air] or
#                                    SpeciesConcMND [molec/cm3]
#==============================================================================
  SpeciesConcInst.template:       '%y4%m2%d2_%h2%n2z.nc4',
  SpeciesConcInst.frequency:      00000000 001000           #  <== Smaller than diagnostic timestep 002000
  SpeciesConcInst.duration:       00000000 010000
  SpeciesConcInst.mode:           'instantaneous'
  SpeciesConcInst.fields:         'SpeciesConcVV_?ALL?           ',
::
```
This will now cause the simulation to be halted with an instructive error message:
```
HISTORY (INIT): Opening ./HISTORY.rc
===============================================================================
GEOS-Chem ERROR: The SpeciesConcInst.frequency setting (001000) is smaller 
than the the diagnostic timestep (002000)!  This can lead to spurious results 
in the diagnostic archival such as were described in 
https://github.com/geoschem/geos-chem/issues/3117. Please set 
SpeciesConcInst.frequency equal to or greater greater than 002000.
 -> at History_ReadCollectionData (in module History/history_mod.F90)
===============================================================================

===============================================================================
GEOS-Chem ERROR: Error encountered in "History_ReadCollectionData"!
 -> at History_Init (in module History/history_mod.F90)
===============================================================================

===============================================================================
GEOS-CHEM ERROR: Error encountered in "History_Init"!
STOP at  -> at GEOS-Chem (in GeosCore/main.F90)
===============================================================================
```


### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue

- Closes #3208 