### PR TITLE
Added a separate verbose tag for Cloud-J in geoschem_config.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `State_Grid` as an argument to History routines `History_Init`, `History_AddItemToCollection`,`History_NetCdf_Define`, `History_Write`, and `IndexVarList_Create`
 - Added routine `History_InitCoordVars` to `history_mod.F90`
 - Added cloud fraction and cloud top pressure to the SatDiagn diagnostic collection
+- Added new field `Input_Opt%CloudJ_Verbose`
+- Added `cloud-j:verbose` YAML tag (with default setting `false`) to  `geoschem_config.yml` templates for GC-Classic, GCHP, GEOS, CESM, and WRF
 
 ### Changed
 - Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -444,10 +444,13 @@ CONTAINS
        LPRTJ = .false.
        I_PRT = 20
        J_PRT = 20
-       IF ( I .eq. I_PRT .and. J .eq. J_PRT .and. Input_Opt%Verbose ) THEN
-          print *, "cldj_interface_mod.F90: Cloud-J prints on for lat, lon: ", &
-                   State_Grid%GlobalYMid(I,J), State_Grid%GlobalXMid(I,J)
-          LPRTJ = .true.
+       IF ( Input_Opt%CloudJ_Verbose ) THEN
+          IF ( I == I_PRT .and. J == J_PRT ) THEN
+             print*, &
+               "cldj_interface_mod.F90: Cloud-J prints on for lat, lon: ", &
+               State_Grid%GlobalYMid(I,J), State_Grid%GlobalXMid(I,J)
+             LPRTJ = .true.
+          ENDIF
        ENDIF
 
        !-----------------------------------------------------------------

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -2845,6 +2845,29 @@ CONTAINS
     ENDIF
     Input_Opt%CloudJ_DIR = TRIM( v_str )
 
+    ! Turn on verbose output
+    key   = "operations%photolysis%cloud-j%verbose"
+    v_bool = MISSING_BOOL
+    CALL QFYAML_Add_Get( Config, TRIM( key ), v_bool, "", RC )
+    IF ( RC /= GC_SUCCESS ) THEN
+       errMsg = 'Error parsing ' // TRIM( key ) // '!'
+       CALL GC_Error( errMsg, RC, thisLoc )
+       RETURN
+    ENDIF
+
+    ! Should Cloud-J verbose output be printed only on root or on all cores?
+    SELECT CASE ( TRIM( Input_Opt%VerboseOnCores ) )
+       CASE( 'ROOT' )
+          Input_Opt%CloudJ_Verbose = ( v_bool .and. Input_Opt%amIRoot )
+       CASE( 'ALL' )
+          Input_Opt%CloudJ_Verbose = v_bool
+       CASE DEFAULT
+          errMsg = 'Invalid selection!' // NEW_LINE( 'a' ) //                &
+               'simulation:verbose:on_cores must be either "root" or "all"'
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+    END SELECT
+
     ! Number levels with clouds to use in photolysis (Cloud-J var LWEPAR)
     key   = "operations%photolysis%cloud-j%num_levs_with_cloud"
     v_int = MISSING_INT
@@ -3134,6 +3157,7 @@ CONTAINS
        WRITE( 6,90  ) 'PHOTOLYSIS SETTINGS'
        WRITE( 6,95  ) '-------------------'
        WRITE( 6,100 ) 'Turn on photolysis?         : ', Input_Opt%Do_Photolysis
+       WRITE( 6,100 ) 'Print Cloud-J debug output? : ', Input_Opt%CloudJ_Verbose
        WRITE( 6,120 ) 'FAST-JX input directory     : ',                      &
                        TRIM( Input_Opt%FAST_JX_DIR )
        WRITE( 6,120 ) 'Cloud-J input directory     : ',                      &

--- a/Headers/input_opt_mod.F90
+++ b/Headers/input_opt_mod.F90
@@ -195,7 +195,7 @@ MODULE Input_Opt_Mod
      LOGICAL                     :: USE_ONLINE_O3
      LOGICAL                     :: USE_O3_FROM_MET
      LOGICAL                     :: USE_TOMS_O3
-     ! for nitrate aerosol photolysis (TMS, 23/08/2018)
+     LOGICAL                     :: CloudJ_Verbose     ! sets Cloud-J var LPRTJ
      LOGICAL                     :: hvAerNIT
      REAL(fp)                    :: hvAerNIT_JNIT
      REAL(fp)                    :: hvAerNIT_JNITs
@@ -693,11 +693,12 @@ CONTAINS
     Input_Opt%USE_ONLINE_O3         = .FALSE.
     Input_Opt%USE_O3_FROM_MET       = .FALSE.
     Input_Opt%USE_TOMS_O3           = .FALSE.
-    Input_Opt%hvAerNIT               = .FALSE.
-    Input_Opt%hvAerNIT_JNIT          = 0.0_fp
-    Input_Opt%hvAerNIT_JNITs         = 0.0_fp
-    Input_Opt%JNITChanA              = 0.0_fp
-    Input_Opt%JNITChanB              = 0.0_fp
+    Input_Opt%hvAerNIT              = .FALSE.
+    Input_Opt%CloudJ_Verbose        = .FALSE.
+    Input_Opt%hvAerNIT_JNIT         = 0.0_fp
+    Input_Opt%hvAerNIT_JNITs        = 0.0_fp
+    Input_Opt%JNITChanA             = 0.0_fp
+    Input_Opt%JNITChanB             = 0.0_fp
 
     !----------------------------------------
     ! RADIATION MENU fields (for RRTMG only)

--- a/run/CESM/geoschem_config.yml
+++ b/run/CESM/geoschem_config.yml
@@ -48,6 +48,7 @@ operations:
     activate: true
     cloud-j:
       cloudj_input_dir: /see/namelist/file
+      verbose: false
       num_levs_with_cloud: 22
       cloud_scheme_flag: 3
       opt_depth_increase_factor: 1.050

--- a/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCClassic/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -91,6 +91,7 @@ operations:
     activate: true
     cloud-j:
       cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2025-01/
+      verbose: false
       num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
       cloud_scheme_flag: 3
       opt_depth_increase_factor: 1.050

--- a/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
+++ b/run/GCHP/geoschem_config.yml.templates/geoschem_config.yml.fullchem
@@ -74,6 +74,7 @@ operations:
     activate: true
     cloud-j:
       cloudj_input_dir: ${RUNDIR_DATA_ROOT}/CHEM_INPUTS/CLOUD_J/v2025-01/
+      verbose: false
       num_levs_with_cloud: ${RUNDIR_PHOT_CLD_NLEV}
       cloud_scheme_flag: 3
       opt_depth_increase_factor: 1.050

--- a/run/GEOS/geoschem_config.yml
+++ b/run/GEOS/geoschem_config.yml
@@ -61,6 +61,7 @@ operations:
     activate: true
     cloud-j:
       cloudj_input_dir: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/CLOUD_J/v2025-01/
+      verbose: false
       num_levs_with_cloud: 34
       cloud_scheme_flag: 3
       opt_depth_increase_factor: 1.050

--- a/run/WRF/fullchem/geoschem_config.yml
+++ b/run/WRF/fullchem/geoschem_config.yml
@@ -69,6 +69,7 @@ operations:
     activate: true
     cloud-j:
       cloudj_input_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/CHEM_INPUTS/CLOUD_J/v2025-01/
+      verbose: false
       num_levs_with_cloud: 20
       cloud_scheme_flag: 3
       opt_depth_increase_factor: 1.050


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard

### Describe the update
This is the companion PR to #2648, in which issues with Cloud-J verbose were reported by @foesterstroem and @eamarais.

In this PR we have done the following:

1. Added a new verbose tag specifically for Cloud-J, that operates separatly from the general verbose tag in all `geoschem_config.yml` templates:

```yaml
  photolysis:
    activate: true
    cloud-j:
      cloudj_input_dir: /n/holylfs06/LABS/jacob_lab/Everyone/GEOS-CHEM/gcgrid/gcdata/ExtData/CHEM_INPUTS/CLOUD_J/v2025-01/
      verbose: false
      num_levs_with_cloud: 34
   ... etc ...
```

2. Added a new `Input_Opt%CloudJ_Verbose` field to hold the value of the Cloud-J verbose toggle.

3. Wrapped the debug print statement and setting of `LFASTJ = .TRUE.` within an IF block that only executes if the Cloud-J verbose toggle is set to true in `geoschem_config.yml`.

```F90
       ! Debug prints in Cloud-J. Limit to one grid cell so not excessive.
       ! Use this for debugging purposes only.
       LPRTJ = .false.
       I_PRT = 20
       J_PRT = 20
       IF ( Input_Opt%CloudJ_Verbose ) THEN
          IF ( I == I_PRT .and. J == J_PRT ) THEN
             print*, &
               "cldj_interface_mod.F90: Cloud-J prints on for lat, lon: ", &
               State_Grid%GlobalYMid(I,J), State_Grid%GlobalXMid(I,J)
             LPRTJ = .true.
          ENDIF
       ENDIF
```

### Expected changes
This will disable Cloud-J debug printout unless explicitly requested.  This also separates Cloud-J debug printout from the general verbose printout. 

### Related Github Issue

- See #2648 

Tagging @lizziel @foesterstroem @eamarais. 

Integration tests are running.