### PR TITLE
Stop integration & parallel tests if a conda environment with netCDF is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added cloud fraction and cloud top pressure to the SatDiagn diagnostic collection
 - Added new field `Input_Opt%CloudJ_Verbose`
 - Added `cloud-j:verbose` YAML tag (with default setting `false`) to  `geoschem_config.yml` templates for GC-Classic, GCHP, GEOS, CESM, and WRF
+- Added error traps to prevent integration tests and parallel tests from running if a conda environment with netCDF is active
 
 ### Changed
 - Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product

--- a/test/integration/GCClassic/integrationTest.sh
+++ b/test/integration/GCClassic/integrationTest.sh
@@ -37,6 +37,16 @@
 #BOC
 
 #=============================================================================
+# Throw error if there is a conda environment active with netCDF,
+# which can cause the code to be linked against the wrong netCDF version.
+#=============================================================================
+if [[ -n "$CONDA_DEFAULT_ENV" || \
+      "$(which nc-config 2>/dev/null)" == *conda* ]]; then
+   echo "ERROR: Conda netCDF detected. Run 'conda deactivate' first."
+   exit 1
+fi
+
+#=============================================================================
 # Initialize
 #=============================================================================
 this="$(basename ${0})"

--- a/test/integration/GCHP/integrationTest.sh
+++ b/test/integration/GCHP/integrationTest.sh
@@ -37,6 +37,16 @@
 #BOC
 
 #=============================================================================
+# Throw error if there is a conda environment active with netCDF,
+# which can cause the code to be linked against the wrong netCDF version.
+#=============================================================================
+if [[ -n "$CONDA_DEFAULT_ENV" || \
+      "$(which nc-config 2>/dev/null)" == *conda* ]]; then
+   echo "ERROR: Conda netCDF detected. Run 'conda deactivate' first."
+   exit 1
+fi
+
+#=============================================================================
 # Initialize
 #=============================================================================
 this="$(basename ${0})"

--- a/test/parallel/GCClassic/parallelTest.sh
+++ b/test/parallel/GCClassic/parallelTest.sh
@@ -37,6 +37,16 @@
 #BOC
 
 #=============================================================================
+# Throw error if there is a conda environment active with netCDF,
+# which can cause the code to be linked against the wrong netCDF version.
+#=============================================================================
+if [[ -n "$CONDA_DEFAULT_ENV" || \
+      "$(which nc-config 2>/dev/null)" == *conda* ]]; then
+   echo "ERROR: Conda netCDF detected. Run 'conda deactivate' first."
+   exit 1
+fi
+
+#=============================================================================
 # Initialize
 #=============================================================================
 this="$(basename ${0})"

--- a/test/shared/utils/cannon/integrationTest/redoIntegrationTestCompile.sh
+++ b/test/shared/utils/cannon/integrationTest/redoIntegrationTestCompile.sh
@@ -18,6 +18,14 @@
 #------------------------------------------------------------------------------
 #BOC
 
+# Throw error if there is a conda environment active with netCDF,
+# which can cause the code to be linked against the wrong netCDF version.
+if [[ -n "$CONDA_DEFAULT_ENV" || \
+      "$(which nc-config 2>/dev/null)" == *conda* ]]; then
+   echo "ERROR: Conda netCDF detected. Run 'conda deactivate' first."
+   exit 1
+fi
+
 # Current directory
 thisDir=$(realpath .)
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR places error checks to stop integration and parallel tests from proceeding if the netCDF library comes from a conda environment.   

When a conda enviroment (such as gcpy_env) is activated, the netCDF library from conda may be placed higher up in the search path than the netCDF library that is desired.  This can cause the executable to be linked against the wrong netCDF library.

### Expected changes
If an integration or parallel test is submitted while a conda environment with netCDF is active, the user will receive this error message:
```console
ERROR: Conda netCDF detected. Run 'conda deactivate' first.
```
This should prevent GCHP integration tests from failing with a MAPL "status 51" error, which can be caused when GCHP is linked against a netCDF library without HDF5/MPI support. 

### Related Github Issue
- See https://github.com/geoschem/GCHP/issues/520.  Perhaps we can extend this later to the build sequence but for now we will only add the error check for integration & parallel tests.

Tagging @lizziel