### PR TITLE
Avoid numerical differences when verbose is turned on in GC-Classic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added cloud fraction and cloud top pressure to the SatDiagn diagnostic collection
 - Added new field `Input_Opt%CloudJ_Verbose`
 - Added `cloud-j:verbose` YAML tag (with default setting `false`) to  `geoschem_config.yml` templates for GC-Classic, GCHP, GEOS, CESM, and WRF
+- Added routine `Print_Species_Global_Mass_From_VVDry` in `GeosUtil/print_mod.F90`
 
 ### Changed
 - Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product
@@ -22,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Moved the population of coordinate variables for History netCDF  output from `grid_registry_mod.F90` to `history_mod.F90` (in routine `History_InitCoordVars`)
 - Updated `run/GCHP/setCommonRunSettings.template` to disable the HEMCO PARANOx extension for C360 or C720 grids
 - Updated `createRunDir.sh` scripts for GC-Classic and GCHP to turn on offline bulk seasalt emissions and bulk dust emissions in TOMAS simulations
+- Updated `Interfaces/GCClassic/main.F90` to call`Print_Species_Global_Mass_from_VVDry` (instead of`Print_Species_Global_Mass`) in order to avoid numerical differences when verbose printout is on
 
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`

--- a/GeosUtil/print_mod.F90
+++ b/GeosUtil/print_mod.F90
@@ -34,6 +34,7 @@ MODULE Print_Mod
 !
   PUBLIC :: Print_Species_Min_Max_Sum
   PUBLIC :: Print_Species_Global_Mass
+  PUBLIC :: Print_Species_Global_Mass_From_VVDry
 !
 ! !REMARKS:
 !
@@ -150,18 +151,27 @@ CONTAINS
 !
 
     CHARACTER(LEN=*), INTENT(IN)           :: msg        ! Message to print
-    TYPE(OptInput),   INTENT(IN)           :: Input_Opt  ! Input Options object
-    TYPE(ChmState),   INTENT(INOUT)        :: State_Chm  ! Chemistry State object
-    TYPE(MetState),   INTENT(IN)           :: State_Met  ! Meteorology State object
+    TYPE(OptInput),   INTENT(IN)           :: Input_Opt  ! Input Options
+    TYPE(MetState),   INTENT(IN)           :: State_Met  ! Meteorology State
     TYPE(GrdState),   INTENT(IN)           :: State_Grid ! Grid State object
-    INTEGER,          INTENT(IN), OPTIONAL :: nStart     ! Index of 1st species to print
-    INTEGER,          INTENT(IN), OPTIONAL :: nStop      ! Index of last species to print
+    INTEGER,          INTENT(IN), OPTIONAL :: nStart     ! Index of 1st spc
+    INTEGER,          INTENT(IN), OPTIONAL :: nStop      ! Index of last spc
+!
+! INPUT/OUTPUT PARAMETERS:
+!
+
+    TYPE(ChmState),   INTENT(INOUT)        :: State_Chm  ! Chemistry State
 !
 ! !OUTPUT PARAMETERS:
 !
-    INTEGER,          INTENT(OUT)   :: RC     ! Success or failure?
+    INTEGER,          INTENT(OUT)          :: RC         ! Success or failure?
 !
 ! !REMARKS:
+!  You may see very small numerical differences when comparing results
+!  from a simulation where Print_Species_Global_Mass has been called to a
+!  simulation where it has not been called.  This is because there is an
+!  additional unit conversion in Print_Species_Global_Mass, which may
+!  cause numerical noise in the species concentration array.
 !
 ! !REVISION HISTORY:
 !  07 Oct 2024 - E. Lundgren - Initial version
@@ -191,39 +201,132 @@ CONTAINS
     N_STOP = State_Chm%nSpecies
 
     ! Override with optional args
-    IF ( PRESENT(nStart) ) N_START = nStart
-    IF ( PRESENT(nStop ) ) N_STOP  = nStop
+    IF ( PRESENT( nStart) ) N_START = nStart
+    IF ( PRESENT( nStop ) ) N_STOP  = nStop
 
     ! Convert species to kg if needed
-    CALL Convert_Spc_Units(                &
-         Input_Opt      = Input_Opt,       &
-         State_Chm      = State_Chm,       &
-         State_Grid     = State_Grid,      &
-         State_Met      = State_Met,       &
-         new_units      = KG_SPECIES,      &
-         previous_units = previous_units,  &
-         RC             = RC              )
+    CALL Convert_Spc_Units(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Grid     = State_Grid,                                        &
+         State_Met      = State_Met,                                         &
+         new_units      = KG_SPECIES,                                        &
+         previous_units = previous_units,                                    &
+         RC             = RC                                                )
 
     ! Write to log
-    WRITE(6,*) 'Global mass sum of each species [kg]'
     IF ( Input_Opt%amIRoot ) THEN
+       WRITE( 6, '(a)' ) 'Global mass sum of each species [kg]'
+       IF ( LEN_TRIM ( msg ) > 0 ) WRITE( 6, '(a)' ) TRIM( msg )
        DO N = N_START, N_STOP
-          WRITE( 6, 130 ) N, TRIM( State_Chm%SpcData(N)%Info%Name ), &
-               SUM( State_Chm%Species(N)%Conc(:,:,:) )
+          WRITE( 6, 130 ) N, TRIM( State_Chm%SpcData(N)%Info%Name ),         &
+                             SUM( State_Chm%Species(N)%Conc )
        ENDDO
     ENDIF
 
     ! Convert species to original units
-    CALL Convert_Spc_Units(                   &
-         Input_Opt      = Input_Opt,          &
-         State_Chm      = State_Chm,          &
-         State_Grid     = State_Grid,         &
-         State_Met      = State_Met,          &
-         new_units      = previous_units,     &
-         RC             = RC                 )
+    CALL Convert_Spc_Units(                                                  &
+         Input_Opt      = Input_Opt,                                         &
+         State_Chm      = State_Chm,                                         &
+         State_Grid     = State_Grid,                                        &
+         State_Met      = State_Met,                                         &
+         new_units      = previous_units,                                    &
+         RC             = RC                                                )
 
 130 FORMAT( '   Species ', i3, ', ', a9, ': Global mass = ', es15.9 )
 
   END SUBROUTINE Print_Species_Global_Mass
+!EOC
+!------------------------------------------------------------------------------
+!                  GEOS-Chem Global Chemical Transport Model                  !
+!------------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: Print_Species_Global_Mass
+!
+! !DESCRIPTION: Subroutine Print\_Species\_Global\_Mass prints the
+!   global sum of species mass in kg on the root thread to log.
+!   The default is to write all species. Arguments can be passed to
+!   to specify start index and stop index of State_Chm%Species array to
+!   limit species to one species or a consecutive sequence.
+!\\
+!\\
+! !INTERFACE:
+!
+  SUBROUTINE Print_Species_Global_Mass_From_VVDry( msg,        Input_Opt,    &
+                                                   State_Chm,  State_Met,    &
+                                                   State_Grid, RC,           &
+                                                   nStart,     nStop        )
+!
+! !INPUT PARAMETERS:
+!
+
+    CHARACTER(LEN=*), INTENT(IN)    :: msg        ! Message to print
+    TYPE(OptInput),   INTENT(IN)    :: Input_Opt  ! Input Options object
+    TYPE(MetState),   INTENT(IN)    :: State_Met  ! Meteorology State object
+    TYPE(GrdState),   INTENT(IN)    :: State_Grid ! Grid State object
+    INTEGER,          OPTIONAL      :: nStart     ! Index of 1st species
+    INTEGER,          OPTIONAL      :: nStop      ! Index of last species
+!
+! INPUT/OUTPUT PARAMETERS:
+!
+    TYPE(ChmState),   INTENT(INOUT) :: State_Chm  ! Chemistry State object
+!
+! !OUTPUT PARAMETERS:
+!
+    INTEGER,          INTENT(OUT)   :: RC         ! Success or failure?
+!
+! !REMARKS:
+!  This routine prints species global masses without modifying the
+!  State_Chm%Species array.  This should prevent very small numerical
+!  differences caused by roundoff.
+!
+! !REVISION HISTORY:
+!  05 Mar 2026 - R. Yantosca - Initial version
+!  See https://github.com/geoschem/geos-chem for complete history
+!EOP
+!------------------------------------------------------------------------------
+!BOC
+!
+! !LOCAL VARIABLES:
+!
+    ! Scalars
+    INTEGER            :: N,       N_Start, N_Stop
+
+    ! Arrays
+    REAL(fp)           :: conv(State_Grid%NX,State_Grid%NY,State_Grid%NZ)
+
+    !========================================================================
+    ! Print_Species_Global_Mass_From_VVDry begins here!
+    !========================================================================
+
+    ! Set defaults
+    N_START = 1
+    N_STOP = State_Chm%nSpecies
+
+    ! Override with optional args
+    IF ( PRESENT( nStart ) ) N_START = nStart
+    IF ( PRESENT( nStop  ) ) N_STOP  = nStop
+
+    ! Write to log
+    IF ( Input_Opt%amIRoot ) THEN
+       WRITE( 6, '(a)' ) 'Global mass sum of each species [kg]'
+       IF ( LEN_TRIM ( msg ) > 0 ) WRITE( 6, '(a)' ) TRIM( msg )
+
+       ! Loop over species
+       DO N = N_START, N_STOP
+
+          ! Conversion from [mol/mol dry] -> [kg]
+          conv = State_Met%AD * ( State_Chm%SpcData(N)%Info%MW_g / AIRMW )
+
+          ! Print species mass in kg
+          WRITE( 6, 10 ) N, TRIM( State_Chm%SpcData(N)%Info%Name  ),         &
+                            SUM( State_Chm%Species(N)%Conc * conv )
+       ENDDO
+    ENDIF
+
+ 10 FORMAT( '   Species ', i3, ', ', a9, ': Global mass = ', es15.9 )
+
+  END SUBROUTINE Print_Species_Global_Mass_From_VVDry
 !EOC
 END MODULE Print_Mod

--- a/Interfaces/GCClassic/main.F90
+++ b/Interfaces/GCClassic/main.F90
@@ -862,8 +862,9 @@ PROGRAM GEOS_Chem
 
           ! If verbose, print global mass per species at start of timestep
           IF ( VerboseAndRoot ) THEN
-             CALL Print_Species_Global_Mass('', Input_Opt, &
-                  State_Chm, State_Met, State_Grid, RC )
+             CALL Print_Species_Global_Mass_from_VVDry(                      &
+                  '',        Input_Opt,  State_Chm,                          &
+                  State_Met, State_Grid, RC                                 )
           ENDIF
 
           !------------------------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #2656, in which @lizziel discovered that very small numerical differences were being introduced in the species concentration output when verbose printout was activated in GC-Classic simulations.

This PR introduces a new routine `Print_Species_Global_Mass_Kg_from_VVDry` in `GeosUtil/print_mod.F90`, which prints species mass in kg when verbose output is selected.  This new routine computes species mass in kg in a non-destructive manner (i.e. without modifying the `State_Chm%Species` concentrations).   

The previous routine that was used (`Print_Species_Global_Mass`) introduced an additional unit conversion on the `State_Chm%Species` array that was not done when verbose output was turned off.  This additional unit conversion proved to be the source of the numerical differences.

### Expected changes
Species concentrations will now be identical in GC-Classic simulations, regardless of whether verbose printout is turned on or off.

### Related Github Issue

- Closes #2656