### PR TITLE
ExtData2G capability in GCHP transport tracer simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `cloud-j:verbose` YAML tag (with default setting `false`) to  `geoschem_config.yml` templates for GC-Classic, GCHP, GEOS, CESM, and WRF
 - Added routine `Print_Species_Global_Mass_From_VVDry` in `GeosUtil/print_mod.F90`
 - Added build setting `MPI_LOAD_BALANCE` to enable MPI load balancing in chemistry to speed up GCHP runs
+- Added GCHP run option in setCommonRunSettings.sh to use ExtData2G
+- Added ExtData2G yaml configuration file for GCHP transport tracer simulation
 
 ### Changed
 - Update termite CH4 emissions to the CAMS-GLOB-TERM_v1.1 product

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -139,6 +139,7 @@ MODULE Chem_GridCompMod
   LOGICAL                          :: met_wind_is_top_down
   LOGICAL                          :: met_humidity_is_top_down
   LOGICAL                          :: met_nonadv_is_top_down
+  LOGICAL                          :: use_extdata2g
 
 #if defined( MODEL_GEOS )
   ! Is GEOS-Chem the provider for AERO, RATS, and/or Analysis OX?
@@ -460,8 +461,12 @@ CONTAINS
 #endif
 
     !=======================================================================
-    ! Get meteorology vertical index orientation
+    ! Get meteorology vertical index orientation, dependent on which
+    ! MAPL ExtData is used
     !=======================================================================
+    call ESMF_ConfigGetAttribute(myState%myCF,value=use_extdata2g, &
+         label='USE_EXTDATA2G:', Default=.false., __RC__ )
+
     call ESMF_ConfigGetAttribute(myState%myCF,value=met_wind_is_top_down, &
          label='MET_WIND_IS_TOP_DOWN:', Default=.false., __RC__ )
 
@@ -470,11 +475,16 @@ CONTAINS
 
     call ESMF_ConfigGetAttribute(myState%myCF,value=met_nonadv_is_top_down, &
          label='MET_NONADVECTION_IS_TOP_DOWN:', Default=.false., __RC__ )
-    if (met_nonadv_is_top_down) then
-       call lgr%info('Configured to expect ''top-down'' for non-advection met-fields')
+
+    if ( use_extdata2g ) then
+       call lgr%info('Using MAPL ExtData2G; all ''top-down'' meteorological data will be automatically flipped to ''bottom-up'' prior to exporting to other gridcomps.')
     else
-       call lgr%info('Configured to expect ''bottom-up'' for non-advection met-fields')
-    end if
+       if (met_nonadv_is_top_down) then
+          call lgr%info('Configured to expect ''top-down'' for non-advection met-fields')
+       else
+          call lgr%info('Configured to expect ''bottom-up'' for non-advection met-fields')
+       end if
+    endif
 
 #if defined( MODEL_GEOS )
     ! Define imports to fill met fields needed for lightning

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -461,8 +461,9 @@ CONTAINS
 #endif
 
     !=======================================================================
-    ! Get meteorology vertical index orientation, dependent on which
-    ! MAPL ExtData is used
+    ! Get meteorology vertical index orientation and ExtData version.
+    ! Whether met will be flipped to be bottom-up is dependent on ExtData
+    ! version (1G requires flipping here, while 2G already flipped by MAPL)
     !=======================================================================
     call ESMF_ConfigGetAttribute(myState%myCF,value=use_extdata2g, &
          label='USE_EXTDATA2G:', Default=.false., __RC__ )
@@ -476,13 +477,24 @@ CONTAINS
     call ESMF_ConfigGetAttribute(myState%myCF,value=met_nonadv_is_top_down, &
          label='MET_NONADVECTION_IS_TOP_DOWN:', Default=.false., __RC__ )
 
+    ! Print information to log about expectation of vertical direction of met-fields
     if ( use_extdata2g ) then
-       call lgr%info('Using MAPL ExtData2G; all ''top-down'' meteorological data will be automatically flipped to ''bottom-up'' prior to exporting to other gridcomps.')
+       call lgr%info('Using MAPL ExtData2G; all ''top-down'' meteorological data is automatically flipped to ''bottom-up'' within MAPL')
     else
-       if (met_nonadv_is_top_down) then
-          call lgr%info('Configured to expect ''top-down'' for non-advection met-fields')
+       if (met_wind_is_top_down) then
+          call lgr%info('Configured to expect ''top-down'' wind met-field imports in Chem_GridCompMod')
        else
-          call lgr%info('Configured to expect ''bottom-up'' for non-advection met-fields')
+          call lgr%info('Configured to expect ''bottom-up'' wind met-field imports in Chem_GridCompMod')
+       end if
+       if (met_humidity_is_top_down) then
+          call lgr%info('Configured to expect ''top-down'' for humidity met-field imports in Chem_GridCompMod')
+       else
+          call lgr%info('Configured to expect ''bottom-up'' for humidity met-field imports in Chem_GridCompMod')
+       end if
+       if (met_nonadv_is_top_down) then
+          call lgr%info('Configured to expect ''top-down'' for non-advection met-field imports in Chem_GridCompMod')
+       else
+          call lgr%info('Configured to expect ''bottom-up'' for non-advection met-field imports in Chem_GridCompMod')
        end if
     endif
 

--- a/run/GCHP/ExtData2G.yaml.templates/extdata.yaml.TransportTracers
+++ b/run/GCHP/ExtData2G.yaml.templates/extdata.yaml.TransportTracers
@@ -1,0 +1,1129 @@
+######################################################################
+Collections:
+######################################################################
+  #-------------------------------------------------------------------
+  # Meteorology collections
+  #-------------------------------------------------------------------
+  MERRA2.A3dyn.05x0625.nc4:
+    valid_range: "2009-01-01/2024-12-31T00:00"
+    template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A3dyn.05x0625.nc4
+  MERRA2.I3.05x0625.nc4:
+    valid_range: "2009-01-01/2024-12-31T00:00"
+    template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.I3.05x0625.nc4
+  MERRA2.A1.05x0625.nc4:
+    valid_range: "2009-01-01/2024-12-31T00:00"
+    template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A1.05x0625.nc4
+  MERRA2.A3cld.05x0625.nc4:
+    valid_range: "2009-01-01/2024-12-31T00:00"
+    template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A3cld.05x0625.nc4
+  MERRA2.A3mstC.05x0625.nc4:
+    valid_range: "2009-01-01/2024-12-31T00:00"
+    template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A3mstC.05x0625.nc4
+  MERRA2.A3mstE.05x0625.nc4:
+    valid_range: "2009-01-01/2024-12-31T00:00"
+    template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A3mstE.05x0625.nc4
+  MERRA2.20150101.CN.05x0625.nc4:
+    template: ./MetDir/2015/01/MERRA2.20150101.CN.05x0625.nc4
+
+  #-------------------------------------------------------------------
+  # Land map and LAI collections
+  #-------------------------------------------------------------------
+  Olson_2001_Land_Map.025x025.generic.nc:
+    template: ./ChemDir/Olson_Land_Map_201203/Olson_2001_Land_Map.025x025.generic.nc
+  Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc:
+    valid_range: "2000-01-01/2020-12-31T00:00"
+    template: ./HcoDir/Yuan_XLAI/v2021-06/Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
+
+  #-------------------------------------------------------------------
+  # SF6, CO, and Rn222 emissions collections
+  #-------------------------------------------------------------------
+  EDGAR_v42_SF6_IPCC_2.generic.01x01.nc:
+    valid_range: "1970-01-01/2008-01-01T00:00"
+    template: ./HcoDir/SF6/v2019-01/EDGAR_v42_SF6_IPCC_2.generic.01x01.nc
+  EDGAR_v43.CO.ENG.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01T00:00"
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.ENG.0.1x0.1.nc
+  EDGAR_v43.CO.FFF.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01T00:00"
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.FFF.0.1x0.1.nc
+  EDGAR_v43.CO.IND.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01T00:00"
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.IND.0.1x0.1.nc
+  EDGAR_v43.CO.POW.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01T00:00"
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc
+  EDGAR_v43.CO.PPA.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01T00:00"
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.PPA.0.1x0.1.nc
+  EDGAR_v43.CO.RCO.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01T00:00"
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.RCO.0.1x0.1.nc
+  EDGAR_v43.CO.SWD.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01T00:00"
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.SWD.0.1x0.1.nc
+  EDGAR_v43.CO.TNG.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01T00:00"
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.TNG.0.1x0.1.nc
+  EDGAR_v43.CO.TRO.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01T00:00"
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.TRO.0.1x0.1.nc
+  CEDS_CO_0.1x0.1_%y4.nc:
+    valid_range: "1980-01-01/2019-12-01T00:00"
+    template: ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
+  Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc:
+    template: ./HcoDir/ZHANG_Rn222/v2021-11/Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc
+
+  #-------------------------------------------------------------------
+  # Timezones collection
+  #-------------------------------------------------------------------
+  timezones_vohra_2017_0.1x0.1.nc:
+    valid_range: "2017-01-01/2017-12-31T00:00"
+    template: ./HcoDir/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc
+
+  #-------------------------------------------------------------------
+  # Scale factors collections
+  #-------------------------------------------------------------------
+  AnnualScalar.geos.1x1.nc:
+    template: ./HcoDir/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc
+  EDGAR_v43.Seasonal.1x1.nc:
+    template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.Seasonal.1x1.nc
+
+######################################################################
+# Samplings (rules for data read and interpolation)
+######################################################################
+Samplings:
+  #-------------------------------------------------------------------
+  # Sampling rules for dynamic meteorology
+  #-------------------------------------------------------------------
+  offset_1hr30min_nointerp:
+    update_offset: PT1H30M
+    time_interpolation: False
+
+  offset_30min_nointerp:
+    update_offset: PT30M
+    time_interpolation: False
+
+  offset_10min_interp:
+    update_offset: PT10M
+    time_interpolation: True
+
+  #-------------------------------------------------------------------
+  # Sampling rule for constants
+  #-------------------------------------------------------------------
+  constant:
+    extrapolation: persist_closest
+
+  #-------------------------------------------------------------------
+  # Sampling rule for monthly and daily
+  #-------------------------------------------------------------------
+  monthly_nointerp:
+    update_frequency: P1M
+    extrapolation: clim
+    time_interpolation: False
+    update_reference_time: '0'
+
+  annual_nointerp:
+    update_frequency: P1Y
+    extrapolation: clim
+    time_interpolation: False
+    update_reference_time: '0'
+
+  #-------------------------------------------------------------------
+  # Sampling rule for daily with interpolation
+  #-------------------------------------------------------------------
+  daily_interp:
+    update_frequency: PT24H
+    time_interpolation: True
+    update_reference_time: '0'
+
+######################################################################
+# Exports (each entry is equivalent to one row in ExtData.rc)
+######################################################################
+Exports:
+  #-------------------------------------------------------------------
+  # Fields from MERRA2.A3dyn.05x0625.nc4:
+  #-------------------------------------------------------------------
+  DTRAIN:
+    collection: MERRA2.A3dyn.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: DTRAIN
+  OMEGA:
+    collection: MERRA2.A3dyn.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: OMEGA
+  RH:
+    collection: MERRA2.A3dyn.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: RH
+  UA;VA:
+    collection: MERRA2.A3dyn.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: U;V
+
+  #-------------------------------------------------------------------
+  # Fields from MERRA2.I3.05x0625.nc4:
+  #-------------------------------------------------------------------
+  PS1:
+    collection: MERRA2.I3.05x0625.nc4
+    linear_transformation:
+      - 0.0
+      - 0.01
+    regrid: CONSERVE
+    variable: PS
+  PS2:
+    collection: MERRA2.I3.05x0625.nc4
+    linear_transformation:
+      - 0.0
+      - 0.01
+    regrid: CONSERVE
+    sample: offset_10min_interp
+    variable: PS
+  SPHU1:
+    collection: MERRA2.I3.05x0625.nc4
+    regrid: CONSERVE
+    variable: QV
+  SPHU2:
+    collection: MERRA2.I3.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_10min_interp
+    variable: QV
+  TMPU1:
+    collection: MERRA2.I3.05x0625.nc4
+    regrid: CONSERVE
+    variable: T
+  TMPU2:
+    collection: MERRA2.I3.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_10min_interp
+    variable: T
+
+  #-------------------------------------------------------------------
+  # Fields from MERRA2.A1.05x0625.nc4:
+  #-------------------------------------------------------------------
+  ALBD:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: ALBEDO
+  CLDFRC:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: CLDTOT
+  EFLUX:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: EFLUX
+  EVAP:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: EVAP
+  FRSEAICE:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: FRSEAICE
+  FRSNO:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: FRSNO
+  GRN:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: GRN
+  GWETROOT:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: GWETROOT
+  GWETTOP:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: GWETTOP
+  HFLUX:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: HFLUX
+  LAI:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: LAI
+  PARDF:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: PARDF
+  PARDR:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: PARDR
+  PBLH:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: PBLH
+  PRECANV:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: PRECANV
+  PRECCON:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: PRECCON
+  PRECLSC:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: PRECLSC
+  PRECSNO:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: PRECSNO
+  PRECTOT:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: PRECTOT
+  QV2M:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: QV2M
+  RADSWG:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SWGDN
+  SEAICE00:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE00
+  SEAICE10:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE10
+  SEAICE20:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE20
+  SEAICE30:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE30
+  SEAICE40:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE40
+  SEAICE50:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE50
+  SEAICE60:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE60
+  SEAICE70:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE70
+  SEAICE80:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE80
+  SEAICE90:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SEAICE90
+  SLP:
+    collection: MERRA2.A1.05x0625.nc4
+    linear_transformation:
+      - 0.0
+      - 0.01
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SLP
+  SNODP:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SNODP
+  SNOMAS:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: SNOMAS
+  TO3:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: TO3
+  TROPP:
+    collection: MERRA2.A1.05x0625.nc4
+    linear_transformation:
+      - 0.0
+      - 0.01
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: TROPPT
+  TS:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: T2M
+  TSKIN:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: TS
+  U10M:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: U10M
+  USTAR:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: USTAR
+  V10M:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: V10M
+  Z0:
+    collection: MERRA2.A1.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_30min_nointerp
+    variable: Z0M
+
+  #-------------------------------------------------------------------
+  # Fields from MERRA2.A3cld.05x0625.nc4:
+  #-------------------------------------------------------------------
+  CLDF:
+    collection: MERRA2.A3cld.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: CLOUD
+  OPTDEP:
+    collection: MERRA2.A3cld.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: OPTDEPTH
+  QI:
+    collection: MERRA2.A3cld.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: QI
+  QL:
+    collection: MERRA2.A3cld.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: QL
+  TAUCLI:
+    collection: MERRA2.A3cld.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: TAUCLI
+  TAUCLW:
+    collection: MERRA2.A3cld.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: TAUCLW
+
+  #-------------------------------------------------------------------
+  # Fields from MERRA2.A3mstC.05x0625.nc4:
+  #-------------------------------------------------------------------
+  REEVAPCN:
+    collection: MERRA2.A3mstC.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: REEVAPCN
+  REEVAPLS:
+    collection: MERRA2.A3mstC.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: REEVAPLS
+  DQRCU:
+    collection: MERRA2.A3mstC.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: DQRCU
+  DQRLSAN:
+    collection: MERRA2.A3mstC.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: DQRLSAN
+
+  #-------------------------------------------------------------------
+  # Fields from MERRA2.A3mstE.05x0625.nc4:
+  #-------------------------------------------------------------------
+  CMFMC:
+    collection: MERRA2.A3mstE.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: CMFMC
+  PFICU:
+    collection: MERRA2.A3mstE.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: PFICU
+  PFILSAN:
+    collection: MERRA2.A3mstE.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: PFILSAN
+  PFLCU:
+    collection: MERRA2.A3mstE.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: PFLCU
+  PFLLSAN:
+    collection: MERRA2.A3mstE.05x0625.nc4
+    regrid: CONSERVE
+    sample: offset_1hr30min_nointerp
+    variable: PFLLSAN
+
+  #-------------------------------------------------------------------
+  # Fields from MERRA2.20150101.CN.05x0625.nc4:
+  #-------------------------------------------------------------------
+  FRLAKE:
+    collection: MERRA2.20150101.CN.05x0625.nc4
+    regrid: CONSERVE
+    sample: constant
+    variable: FRLAKE
+  FRLAND:
+    collection: MERRA2.20150101.CN.05x0625.nc4
+    regrid: CONSERVE
+    sample: constant
+    variable: FRLAND
+  FRLANDIC:
+    collection: MERRA2.20150101.CN.05x0625.nc4
+    regrid: CONSERVE
+    sample: constant
+    variable: FRLANDIC
+  FROCEAN:
+    collection: MERRA2.20150101.CN.05x0625.nc4
+    regrid: CONSERVE
+    sample: constant
+    variable: FROCEAN
+  OCEAN_MASK:
+    collection: MERRA2.20150101.CN.05x0625.nc4
+    regrid: CONSERVE
+    sample: constant
+    variable: FROCEAN
+  PHIS:
+    collection: MERRA2.20150101.CN.05x0625.nc4
+    regrid: CONSERVE
+    sample: constant
+    variable: PHIS
+
+  #-------------------------------------------------------------------
+  # Fields from Olson land map
+  #-------------------------------------------------------------------
+  OLSON00:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;0
+    sample: constant
+    variable: OLSON
+  OLSON01:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;1
+    sample: constant
+    variable: OLSON
+  OLSON02:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;2
+    sample: constant
+    variable: OLSON
+  OLSON03:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;3
+    sample: constant
+    variable: OLSON
+  OLSON04:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;4
+    sample: constant
+    variable: OLSON
+  OLSON05:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;5
+    sample: constant
+    variable: OLSON
+  OLSON06:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;6
+    sample: constant
+    variable: OLSON
+  OLSON07:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;7
+    sample: constant
+    variable: OLSON
+  OLSON08:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;8
+    sample: constant
+    variable: OLSON
+  OLSON09:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;9
+    sample: constant
+    variable: OLSON
+  OLSON10:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;10
+    sample: constant
+    variable: OLSON
+  OLSON11:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;11
+    sample: constant
+    variable: OLSON
+  OLSON12:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;12
+    sample: constant
+    variable: OLSON
+  OLSON13:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;13
+    sample: constant
+    variable: OLSON
+  OLSON14:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;14
+    sample: constant
+    variable: OLSON
+  OLSON15:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;15
+    sample: constant
+    variable: OLSON
+  OLSON16:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;16
+    sample: constant
+    variable: OLSON
+  OLSON17:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;17
+    sample: constant
+    variable: OLSON
+  OLSON18:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;18
+    sample: constant
+    variable: OLSON
+  OLSON19:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;19
+    sample: constant
+    variable: OLSON
+  OLSON20:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;20
+    sample: constant
+    variable: OLSON
+  OLSON21:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;21
+    sample: constant
+    variable: OLSON
+  OLSON22:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;22
+    sample: constant
+    variable: OLSON
+  OLSON23:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;23
+    sample: constant
+    variable: OLSON
+  OLSON24:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;24
+    sample: constant
+    variable: OLSON
+  OLSON25:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;25
+    sample: constant
+    variable: OLSON
+  OLSON26:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;26
+    sample: constant
+    variable: OLSON
+  OLSON27:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;27
+    sample: constant
+    variable: OLSON
+  OLSON28:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;28
+    sample: constant
+    variable: OLSON
+  OLSON29:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;29
+    sample: constant
+    variable: OLSON
+  OLSON30:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;30
+    sample: constant
+    variable: OLSON
+  OLSON31:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;31
+    sample: constant
+    variable: OLSON
+  OLSON32:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;32
+    sample: constant
+    variable: OLSON
+  OLSON33:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;33
+    sample: constant
+    variable: OLSON
+  OLSON34:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;34
+    sample: constant
+    variable: OLSON
+  OLSON35:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;35
+    sample: constant
+    variable: OLSON
+  OLSON36:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;36
+    sample: constant
+    variable: OLSON
+  OLSON37:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;37
+    sample: constant
+    variable: OLSON
+  OLSON38:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;38
+    sample: constant
+    variable: OLSON
+  OLSON39:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;39
+    sample: constant
+    variable: OLSON
+  OLSON40:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;40
+    sample: constant
+    variable: OLSON
+  OLSON41:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;41
+    sample: constant
+    variable: OLSON
+  OLSON42:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;42
+    sample: constant
+    variable: OLSON
+  OLSON43:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;43
+    sample: constant
+    variable: OLSON
+  OLSON44:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;44
+    sample: constant
+    variable: OLSON
+  OLSON45:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;45
+    sample: constant
+    variable: OLSON
+  OLSON46:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;46
+    sample: constant
+    variable: OLSON
+  OLSON47:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;47
+    sample: constant
+    variable: OLSON
+  OLSON48:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;48
+    sample: constant
+    variable: OLSON
+  OLSON49:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;49
+    sample: constant
+    variable: OLSON
+  OLSON50:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;50
+    sample: constant
+    variable: OLSON
+  OLSON51:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;51
+    sample: constant
+    variable: OLSON
+  OLSON52:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;52
+    sample: constant
+    variable: OLSON
+  OLSON53:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;53
+    sample: constant
+    variable: OLSON
+  OLSON54:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;54
+    sample: constant
+    variable: OLSON
+  OLSON55:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;55
+    sample: constant
+    variable: OLSON
+  OLSON56:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;56
+    sample: constant
+    variable: OLSON
+  OLSON57:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;57
+    sample: constant
+    variable: OLSON
+  OLSON58:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;58
+    sample: constant
+    variable: OLSON
+  OLSON59:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;59
+    sample: constant
+    variable: OLSON
+  OLSON60:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;60
+    sample: constant
+    variable: OLSON
+  OLSON61:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;61
+    sample: constant
+    variable: OLSON
+  OLSON62:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;62
+    sample: constant
+    variable: OLSON
+  OLSON63:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;63
+    sample: constant
+    variable: OLSON
+  OLSON64:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;64
+    sample: constant
+    variable: OLSON
+  OLSON65:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;65
+    sample: constant
+    variable: OLSON
+  OLSON66:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;66
+    sample: constant
+    variable: OLSON
+  OLSON67:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;67
+    sample: constant
+    variable: OLSON
+  OLSON68:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;68
+    sample: constant
+    variable: OLSON
+  OLSON69:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;69
+    sample: constant
+    variable: OLSON
+  OLSON70:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;70
+    sample: constant
+    variable: OLSON
+  OLSON71:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;71
+    sample: constant
+    variable: OLSON
+  OLSON72:
+    collection: Olson_2001_Land_Map.025x025.generic.nc
+    regrid: FRACTION;72
+    sample: constant
+    variable: OLSON
+
+  #-------------------------------------------------------------------
+  # Fields from Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc:
+  #-------------------------------------------------------------------
+  XLAIMULTI:
+    collection: Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
+    regrid: CONSERVE
+    sample: daily_interp
+    variable: XLAIMULTI
+
+  #-------------------------------------------------------------------
+  # Fields from EDGAR_v42_SF6_IPCC_2.generic.01x01.nc:
+  #-------------------------------------------------------------------
+  EDGAR_SF6:
+    collection: EDGAR_v42_SF6_IPCC_2.generic.01x01.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_sf6
+
+  #-------------------------------------------------------------------
+  # Fields from EDGAR_v43.CO.***.0.1x0.1.nc:
+  #-------------------------------------------------------------------
+  EDGAR_CO_25_ENG:
+    collection: EDGAR_v43.CO.ENG.0.1x0.1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_co
+  EDGAR_CO_25_FFF:
+    collection: EDGAR_v43.CO.FFF.0.1x0.1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_co
+  EDGAR_CO_25_IND:
+    collection: EDGAR_v43.CO.IND.0.1x0.1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_co
+  EDGAR_CO_25_POW:
+    collection: EDGAR_v43.CO.POW.0.1x0.1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_co
+  EDGAR_CO_25_PPA:
+    collection: EDGAR_v43.CO.PPA.0.1x0.1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_co
+  EDGAR_CO_25_RCO:
+    collection: EDGAR_v43.CO.RCO.0.1x0.1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_co
+  EDGAR_CO_25_SWD:
+    collection: EDGAR_v43.CO.SWD.0.1x0.1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_co
+  EDGAR_CO_25_TNG:
+    collection: EDGAR_v43.CO.TNG.0.1x0.1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_co
+  EDGAR_CO_25_TRO:
+    collection: EDGAR_v43.CO.TRO.0.1x0.1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: emi_co
+
+  #-------------------------------------------------------------------
+  # Fields from CEDS_CO_0.1x0.1_%y4.nc:
+  #-------------------------------------------------------------------
+  CEDS_CO_25_AGR:
+    collection: CEDS_CO_0.1x0.1_%y4.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: CO_agr
+  CEDS_CO_25_ENE:
+    collection: CEDS_CO_0.1x0.1_%y4.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: CO_ene
+  CEDS_CO_25_IND:
+    collection: CEDS_CO_0.1x0.1_%y4.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: CO_ind
+  CEDS_CO_25_RCO:
+    collection: CEDS_CO_0.1x0.1_%y4.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: CO_rco
+  CEDS_CO_25_SHP:
+    collection: CEDS_CO_0.1x0.1_%y4.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: CO_shp
+  CEDS_CO_25_SLV:
+    collection: CEDS_CO_0.1x0.1_%y4.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: CO_slv
+  CEDS_CO_25_TRA:
+    collection: CEDS_CO_0.1x0.1_%y4.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: CO_tra
+  CEDS_CO_25_WST:
+    collection: CEDS_CO_0.1x0.1_%y4.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: CO_wst
+
+  #-------------------------------------------------------------------
+  # Fields from Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc:
+  #-------------------------------------------------------------------
+  ZHANG_Rn222_EMIS:
+    collection: Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: rnemis
+
+  #-------------------------------------------------------------------
+  # Fields from timezones_vohra_2017_0.1x0.1.nc:
+  #-------------------------------------------------------------------
+  TIMEZONES:
+    collection: timezones_vohra_2017_0.1x0.1.nc
+    regrid: VOTE
+    sample: monthly_nointerp
+    variable: UTC_OFFSET
+
+  #-------------------------------------------------------------------
+  # Fields from AnnualScalar.geos.1x1.nc:
+  #-------------------------------------------------------------------
+  LIQFUEL_2008_2010:
+    collection: AnnualScalar.geos.1x1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: COscalar
+  LIQFUEL_THISYR:
+    collection: AnnualScalar.geos.1x1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: COscalar
+
+  #-------------------------------------------------------------------
+  # Fields from EDGAR_v43.Seasonal.1x1.nc:
+  #-------------------------------------------------------------------
+  AGR:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: annual_nointerp
+    variable: AGR
+  AWB:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: AW
+  ENG:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: ENG
+  FFF:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: FFF
+  IND:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: IND
+  POW:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: POW
+  PPA:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: PPA
+  RCO:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: RCO
+  SOL:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: SOL
+  SWD:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: SWD
+  TNG:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: TNG
+  TRO:
+    collection: EDGAR_v43.Seasonal.1x1.nc
+    regrid: CONSERVE
+    sample: monthly_nointerp
+    variable: TRO
+
+  #-------------------------------------------------------------------
+  # Fields from /dev/null
+  #-------------------------------------------------------------------
+  CONV_DEPTH:
+    collection: /dev/null
+    variable: CONV_DEPTH
+  FLASH_DENS:
+    collection: /dev/null
+    variable: FLASH_DENS

--- a/run/GCHP/GCHP.rc.template
+++ b/run/GCHP/GCHP.rc.template
@@ -49,6 +49,11 @@ CORRECT_MASS_FLUX_FOR_HUMIDITY: 1
 #-----------------------------------------------------------------------
 PRINT_MASS_IN_ADVECTION: 0
 
+# Use ExtData2G?
+# Set to .true. (use legacy ExtData) or .false. (use ExtData2G)
+#-----------------------------------------------------------------------
+USE_EXTDATA2G: .false.
+
 # Use when running a perturbation
 # scenario with RRTMG's FDH or SEFDH
 # options. Set to 0 to CALCULATE dynamical

--- a/run/GCHP/GCHP.rc.template
+++ b/run/GCHP/GCHP.rc.template
@@ -49,8 +49,7 @@ CORRECT_MASS_FLUX_FOR_HUMIDITY: 1
 #-----------------------------------------------------------------------
 PRINT_MASS_IN_ADVECTION: 0
 
-# Use ExtData2G?
-# Set to .true. (use legacy ExtData) or .false. (use ExtData2G)
+# Use ExtData2G? (.true. or .false.)
 #-----------------------------------------------------------------------
 USE_EXTDATA2G: .false.
 

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -640,9 +640,16 @@ cp ./setRestartLink.sh                ${rundir}
 cp ./checkRunSettings.sh              ${rundir}
 cp ./gitignore                        ${rundir}/.gitignore
 
+# Only copy extdata.yaml used in ExtData2G if using Transport Tracers
+# (extdata.yaml not yet available for other simulations)
+if [[ "x${sim_name}" == "xTransportTracers" ]]; then
+    cp ./ExtData2G.yaml.templates/extdata.yaml.${sim_name} ${rundir}/extdata.yaml
+fi
+
 # Copy file to auto-update common settings
 cp ./setCommonRunSettings.sh.template  ${rundir}/setCommonRunSettings.sh
 
+# Copy metrics.py file to computing global OH
 if [[ "x${sim_name}" == "xfullchem" || "x${sim_name}" == "xcarbon" ]]; then
     cp -r ${gcdir}/run/shared/metrics.py  ${rundir}
     chmod 744 ${rundir}/metrics.py

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -923,7 +923,7 @@ printf "\n     https://readthedocs.org/projects/gchp/\n\n"
 
 if [[ "x${sim_name}" == "xTransportTracers" ]]; then
     printf "\n\n*** NOTE: ExtData2G is now available as beta! ***\n"
-    printf " - New configuration file extdata.yaml is located to your run directory\n"
+    printf " - New configuration file extdata.yaml is located in your run directory\n"
     printf " - It is configured for use with MERRA2 meteorology at grid resolutions <= C180\n"
     printf " - Set Use_ExtData2G to true in setCommonRunSetting.sh to enable\n"
     printf " - Edit extdata.yaml for use with other meteorology sources or mass fluxes\n"

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -921,6 +921,16 @@ printf "\n  -- Example run scripts are in the runScriptSamples subdirectory"
 printf "\n  -- For more information visit the GCHP user guide at"
 printf "\n     https://readthedocs.org/projects/gchp/\n\n"
 
+if [[ "x${sim_name}" == "xTransportTracers" ]]; then
+    printf "\n\n*** NOTE: ExtData2G is now available as beta! ***\n"
+    printf " - New configuration file extdata.yaml is located to your run directory\n"
+    printf " - It is configured for use with MERRA2 meteorology at grid resolutions <= C180\n"
+    printf " - Set Use_ExtData2G to true in setCommonRunSetting.sh to enable\n"
+    printf " - Edit extdata.yaml for use with other meteorology sources or mass fluxes\n"
+    printf " - Edit extdata.yaml to match changes to ExtData.rc if using grid resolution > C180\n"
+    printf " - See ExtData2G User Guide at https://github.com/GEOS-ESM/MAPL/wiki/ExtData-Next-Generation---User-Guide#451-mask-functions\n"
+fi
+
 #-----------------------------------------------------------------
 # Ask user whether to build the KPP-standalone box model
 #-----------------------------------------------------------------

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -399,9 +399,9 @@ Model_Phase=FORWARD
 #------------------------------------------------
 #   MAPL ExtData versions
 #------------------------------------------------
-# Set to 2G to use ExtData2G; else will use legacy ExtData
+# Set to true to use ExtData2G in MAPL (requires yaml input file)
 
-ExtData_version=
+Use_ExtData2G=false
 
 
 ###############################
@@ -701,14 +701,15 @@ replace_val NY            ${NY}                 GCHP.rc
 replace_val CoresPerNode  ${NUM_CORES_PER_NODE} HISTORY.rc
 
 ###  Set which version of ExtData will be used
-if [[ ${ExtData_version} == "2G" ]]; then
-    replace_val USE_EXTDATA2G  .TRUE.  CAP.rc
+if [[ ${Use_ExtData2G} == "true" ]]; then
+    replace_val USE_EXTDATA2G  .TRUE.   CAP.rc
     replace_val USE_EXTDATA2G  .true.   GCHP.rc
-    # NOTE: updates needs to be made in this script to all places that
-    # edit ExtData.rc... extdata.yaml needs to be added.
-else
+elif [[ ${Use_ExtData2G} == "false" ]]; then
     replace_val USE_EXTDATA2G  .FALSE. CAP.rc
     replace_val USE_EXTDATA2G  .false. GCHP.rc
+else
+    echo "ERROR: Use_ExtData2G in setCommonRunSettings.sh must be either true or false."
+    exit 1
 fi
 
 ###  Make sure adjoint diagnostics (if present) are commented out if using

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -396,6 +396,13 @@ fi
 
 Model_Phase=FORWARD
 
+#------------------------------------------------
+#   MAPL ExtData versions
+#------------------------------------------------
+# Set to 2G to use ExtData2G; else will use legacy ExtData
+
+ExtData_version=
+
 
 ###############################
 ####   ERROR CHECKS
@@ -692,6 +699,17 @@ print_msg "------------------"
 replace_val NX            ${NX}                 GCHP.rc
 replace_val NY            ${NY}                 GCHP.rc
 replace_val CoresPerNode  ${NUM_CORES_PER_NODE} HISTORY.rc
+
+###  Set which version of ExtData will be used
+if [[ ${ExtData_version} == "2G" ]]; then
+    replace_val USE_EXTDATA2G  .TRUE.  CAP.rc
+    replace_val USE_EXTDATA2G  .true.   GCHP.rc
+    # NOTE: updates needs to be made in this script to all places that
+    # edit ExtData.rc... extdata.yaml needs to be added.
+else
+    replace_val USE_EXTDATA2G  .FALSE. CAP.rc
+    replace_val USE_EXTDATA2G  .false. GCHP.rc
+fi
 
 ###  Make sure adjoint diagnostics (if present) are commented out if using
 ### forward model, and uncommented if using adjoint.


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update enables using MAPL ExtData2G, rather than legacy MAPL ExtData, for handling imports in GCHP as an option for the transport tracers simulation. A yaml configuration file for that simulation is included in this pull request. The primary noticeable difference between ExtData and ExtData2G is the retirement of the `ExtData.rc` configuration file, replaced with yaml-format file `ExtData.yaml`. Other simulations may work with ExtData2G but we have not yet developed yaml files for them. These will be released in a later version of GCHP.

Legacy MAPL ExtData will still be the default MAPL component used for imports. However, ExtData2G will now be available for users to try out, particularly to learn the new format of the configuration file and how to configure it. This PR is a stepping stone towards updating to use MAPL3.

This update requires two other concurrent PR merges: https://github.com/geoschem/MAPL/pull/41 and https://github.com/geoschem/GCHP/pull/537

For more information about this update, including expected differences and important things to be aware of, see the GCHP pull request https://github.com/geoschem/GCHP/pull/537.

### Expected changes

This is a zero diff update for all simulations.

### Reference(s)

None

### Related Github Issues/PRs

- https://github.com/geoschem/MAPL/pull/41
- https://github.com/geoschem/GCHP/pull/537
