### PR TITLE
Fix a timestep mismatch between GCHP C180 and GCC 0.5x0.625

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 This file documents all notable changes to the GEOS-Chem repository starting in version 14.0.0, including all GEOS-Chem Classic and GCHP run directory updates.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
+## [Unreleased] - TBD
+## Fixed
+- Fixed timestep mismatch between GCHP C180 and GCC 0.5x0.625
 ## [14.7.0] - 2026-02-05
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -194,7 +194,7 @@ CS_RES_EFFECTIVE=${CS_RES}
 if [[ ${STRETCH_GRID} == 'ON' ]]; then
     CS_RES_EFFECTIVE=$( echo $CS_RES $STRETCH_FACTOR | awk '{printf "%.0f",$1*$2}' )
 fi
-if [[ $CS_RES_EFFECTIVE -le 180 ]]; then
+if [[ $CS_RES_EFFECTIVE -lt 180 ]]; then
     ChemEmiss_Timestep_sec=1200
     TransConv_Timestep_sec=600
     TransConv_Timestep_HHMMSS=001000


### PR DESCRIPTION
### Name and Institution (Required)

Name: Yuanjian Zhang
Institution: WashU

### Describe the update

Fix a timestep mismatch between GCHP C180 and GCC 0.5x0.625.
Per discussion, GCHP C180 should follow a 5/10min transport and chemistry timestep as GCC 0.5x0.625

### Expected changes

No-diff-to-benchmark

### Related Github Issue

#2839 
