### PR TITLE
Prevent infinite loop if newlines are present at end of HISTORY.rc (GC-Classic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 This file documents all notable changes to the GEOS-Chem repository starting in version 14.0.0, including all GEOS-Chem Classic and GCHP run directory updates.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased] - TBD
 ### Fixed
 - Fixed a syntax error in mass flux scaling calculation
+- Fixed an I/O error that caused an infinite loop reading when extra newlines are present at the end of `HISTORY.rc` (GC-Classic only)
 
 ## [Unreleased] - TBD
 ### Added

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -874,14 +874,14 @@ CONTAINS
     !=======================================================================
     DO
 
-       ! Read a single line, and strip leading/trailing spaces
+       ! Read a single line, strip leading/trailing spaces,
        ! and keep track of the line number for error output
  500   CONTINUE
        Line    = ReadOneLine( fId, EOF, IOS, Squeeze=.TRUE. )
        LineNum = LineNum + 1
 
        ! Exit the loop if it's the end of the file
-       IF ( EOF ) EXIT
+       IF ( EOF ) GOTO 999
 
        ! If it's a real I/O error, quit w/ error message
        IF ( IOS > 0 ) THEN
@@ -1278,14 +1278,31 @@ CONTAINS
 
              ! This means skipping over all of the fields listed under
              ! this collection until we get to the :: separator
-             CALL Search_CollList( Input_Opt%amIRoot, CollList, CName, Found, RC )
+             CALL Search_CollList( Input_Opt%amIRoot, CollList,              &
+                                   CName,             Found,    RC          )
              IF ( .not. Found ) THEN
                 DO
+                   ! Read a single line, strip leading/trailing spaces,
+                   ! and keep track of the line number for error output
                    Line    = ReadOneLine( fId, EOF, IOS, Squeeze=.TRUE. )
                    LineNum = LineNum + 1
-                   CALL StrSqueeze( Line )
+
+                   ! Exit the loop if it's the end of the file
+                   IF ( EOF ) GOTO 999
+
+                   ! If it's a real I/O error, quit w/ error message
+                   IF ( IOS > 0 ) THEN
+                      ErrMsg = 'Unexpected end-of-file in "'              // &
+                           TRIM( Input_Opt%HistoryInputFile )
+                      WRITE( ErrorLine, 250 ) LineNum
+                      CALL GC_Error( ErrMsg, RC, ThisLoc, ErrorLine )
+                      RETURN
+                   ENDIF
+
+                   ! If it's the end of the collection, cycle to next line
                    IF ( TRIM( Line ) == '::' ) GOTO 500
                 ENDDO
+
              ENDIF
 
              !--------------------------------------------------------------
@@ -1697,11 +1714,12 @@ CONTAINS
                 ! first substring of the line.
                 !----------------------------------------------------------
 
-                ! Read a single line, and strip leading/trailing spaces
+                ! Read a single line, strip leading/trailing spaces,
+                ! and keep track of the line number for error output
                 Line    = ReadOneLine( fId, EOF, IOS, Squeeze=.TRUE. )
                 LineNum = LineNum + 1
 
-                ! IF we have hit the end of file then
+                ! Exit the loop if it's the end of the file
                 iF ( EOF ) GOTO 999
 
                 ! If it's a real I/O error, quit w/ error message
@@ -1889,12 +1907,28 @@ CONTAINS
 
              ! Search for this collection in the list of active collections
              ! and skip to the next collection if not found
-             CALL Search_CollList( Input_Opt%amIRoot, CollList, CName, Found, RC )
+             CALL Search_CollList( Input_Opt%amIRoot, CollList,              &
+                                   CName,             Found,    RC          )
              IF ( .not. Found ) THEN
                 DO
+                   ! Read a single line, strip leading/trailing spaces,
+                   ! and keep track of the line number for error output
                    Line    = ReadOneLine( fId, EOF, IOS, Squeeze=.TRUE. )
                    LineNum = LineNum + 1
-                   CALL StrSqueeze( Line )
+
+                   ! Exit the loop if it's the end of the file
+                   IF ( EOF ) GOTO 999
+
+                   ! If it's a real I/O error, quit w/ error message
+                   IF ( IOS > 0 ) THEN
+                      ErrMsg = 'Unexpected end-of-file in "'              // &
+                           TRIM( Input_Opt%HistoryInputFile )
+                      WRITE( ErrorLine, 250 ) LineNum
+                      CALL GC_Error( ErrMsg, RC, ThisLoc, ErrorLine )
+                      RETURN
+                   ENDIF
+
+                   ! If it's the end of the collection, cycle to next line
                    IF ( TRIM( Line ) == '::' ) GOTO 500
                 ENDDO
              ENDIF


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #3241.  In that issue @1Dandan found that if extra newlines were present at the end of a GEOS-Chem Classic `HISTORY.rc` file, this would cause an infinite loop.

In this PR we have fixed this problem by:

1. Adding checks for end-of-file and I/O errors after each call to function `ReadOneLine` in `History/history_mod.F90`.

2. Changing  `IF ( EOF ) EXIT` to `IF ( EOF ) GOTO 999`.  In some locations, the call to `ReadOneLine` is within a nested loop, and `EXIT` will only exit that loop but not the main loop.

3. Removing `CALL StrSqueeze( Line )` statements in `History/history_mod.F90`.  The `StrSqueeze` routine is already called from within `ReadOneLine` when the `Squeeze=.TRUE.` keyword is passed.

4. Updating comments for clarity.

### Expected changes
This will allow a GEOS-Chem Classic simulation to proceed normally if newlines are present at the end of `HISTORY.rc`, rather than hanging in an infinite loop.

### Related Github Issue

- Closes #3241 
