### PR TITLE
Remove optional valid_range in ExtData2G yaml file for transport trac…

### DIFF
--- a/run/GCHP/ExtData2G.yaml.templates/extdata.yaml.TransportTracers
+++ b/run/GCHP/ExtData2G.yaml.templates/extdata.yaml.TransportTracers
@@ -5,22 +5,16 @@ Collections:
   # Meteorology collections
   #-------------------------------------------------------------------
   MERRA2.A3dyn.05x0625.nc4:
-    valid_range: "2009-01-01/2024-12-31T00:00"
     template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A3dyn.05x0625.nc4
   MERRA2.I3.05x0625.nc4:
-    valid_range: "2009-01-01/2024-12-31T00:00"
     template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.I3.05x0625.nc4
   MERRA2.A1.05x0625.nc4:
-    valid_range: "2009-01-01/2024-12-31T00:00"
     template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A1.05x0625.nc4
   MERRA2.A3cld.05x0625.nc4:
-    valid_range: "2009-01-01/2024-12-31T00:00"
     template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A3cld.05x0625.nc4
   MERRA2.A3mstC.05x0625.nc4:
-    valid_range: "2009-01-01/2024-12-31T00:00"
     template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A3mstC.05x0625.nc4
   MERRA2.A3mstE.05x0625.nc4:
-    valid_range: "2009-01-01/2024-12-31T00:00"
     template: ./MetDir/%y4/%m2/MERRA2.%y4%m2%d2.A3mstE.05x0625.nc4
   MERRA2.20150101.CN.05x0625.nc4:
     template: ./MetDir/2015/01/MERRA2.20150101.CN.05x0625.nc4
@@ -31,44 +25,32 @@ Collections:
   Olson_2001_Land_Map.025x025.generic.nc:
     template: ./ChemDir/Olson_Land_Map_201203/Olson_2001_Land_Map.025x025.generic.nc
   Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc:
-    valid_range: "2000-01-01/2020-12-31T00:00"
     template: ./HcoDir/Yuan_XLAI/v2021-06/Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
 
   #-------------------------------------------------------------------
   # SF6, CO, and Rn222 emissions collections
   #-------------------------------------------------------------------
   EDGAR_v42_SF6_IPCC_2.generic.01x01.nc:
-    valid_range: "1970-01-01/2008-01-01T00:00"
     template: ./HcoDir/SF6/v2019-01/EDGAR_v42_SF6_IPCC_2.generic.01x01.nc
   EDGAR_v43.CO.ENG.0.1x0.1.nc:
-    valid_range: "1970-01-01/2010-01-01T00:00"
     template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.ENG.0.1x0.1.nc
   EDGAR_v43.CO.FFF.0.1x0.1.nc:
-    valid_range: "1970-01-01/2010-01-01T00:00"
     template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.FFF.0.1x0.1.nc
   EDGAR_v43.CO.IND.0.1x0.1.nc:
-    valid_range: "1970-01-01/2010-01-01T00:00"
     template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.IND.0.1x0.1.nc
   EDGAR_v43.CO.POW.0.1x0.1.nc:
-    valid_range: "1970-01-01/2010-01-01T00:00"
     template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc
   EDGAR_v43.CO.PPA.0.1x0.1.nc:
-    valid_range: "1970-01-01/2010-01-01T00:00"
     template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.PPA.0.1x0.1.nc
   EDGAR_v43.CO.RCO.0.1x0.1.nc:
-    valid_range: "1970-01-01/2010-01-01T00:00"
     template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.RCO.0.1x0.1.nc
   EDGAR_v43.CO.SWD.0.1x0.1.nc:
-    valid_range: "1970-01-01/2010-01-01T00:00"
     template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.SWD.0.1x0.1.nc
   EDGAR_v43.CO.TNG.0.1x0.1.nc:
-    valid_range: "1970-01-01/2010-01-01T00:00"
     template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.TNG.0.1x0.1.nc
   EDGAR_v43.CO.TRO.0.1x0.1.nc:
-    valid_range: "1970-01-01/2010-01-01T00:00"
     template: ./HcoDir/EDGARv43/v2016-11/EDGAR_v43.CO.TRO.0.1x0.1.nc
   CEDS_CO_0.1x0.1_%y4.nc:
-    valid_range: "1980-01-01/2019-12-01T00:00"
     template: ./HcoDir/CEDS/v2024-06/%y4/CEDS_CO_0.1x0.1_%y4.nc
   Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc:
     template: ./HcoDir/ZHANG_Rn222/v2021-11/Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc
@@ -77,7 +59,6 @@ Collections:
   # Timezones collection
   #-------------------------------------------------------------------
   timezones_vohra_2017_0.1x0.1.nc:
-    valid_range: "2017-01-01/2017-12-31T00:00"
     template: ./HcoDir/TIMEZONES/v2024-02/timezones_vohra_2017_0.1x0.1.nc
 
   #-------------------------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR removes the `valid_range` option in the new ExtData2G yaml file for the Transport Tracers simulation introduced in this version as beta in GCHP. The `valid_range` option works fine on the Harvard cluster because the full span of all available emissions and meteorology data is present locally. However, the model crashes on a different cluster with only the data needed for a short run downloaded. This is because the `valid_range` for each data collection in the file is set for the time range of all data available remotely in the GEOS-Chem input data repository rather than just the data needed for the run. ExtData2G crashes when it cannot find all of the data even if it is not actually needed.

From the MAPL ExtData2G user guide:

> valid_range - character string of form "IOS time 1/ISO time 2" specify the valid range of times for the dataset. You are telling the application that you should be able to find a valid file on disk by applying any time between that range to the template (within the constraints of the reference time and reference frequency of course). This does not mean you have to use all the data, this is simply telling you what is available. This is only needed if you need to perform some option that extrapolates outside of the range of the data. Right now this can be detected in limited cases (no tokens in the template), detection in general is yet to be implemented. Obviously could be expensive as there is really no way but brute forcing this without help from the user.

No update to the Changelog is needed because the yaml file has not yet been released.

### Expected changes

None. This is a no diff update.

### Reference(s)

https://github.com/GEOS-ESM/MAPL/wiki/ExtData-Next-Generation---User-Guide

### Related Github Issue

https://github.com/geoschem/GCHP/pull/537
