### PR TITLE
Miscellaneous netCDF (standard) input bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added DSTbin{1..7}, SO2, SO4, and pFE species ID flags to the `SetStateHet` routine in `KPP/fullchem_HetStateFuncs.F90` and `KPP/stubs/stub_fullchem_HetStateFuncs.F90`
 - Updated `run/shared/download_data.py` and `run/shared/setupForRestarts.sh` to read APM restart file paths
 
+### Fixed
+- Fixed incorrect variable names and removed unused variables in `NcdfUtil/ncdf_mod.F90`
+
 ## [14.7.1] - 2026-04-08
 ### Added
 - Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP

--- a/NcdfUtil/ncdf_mod.F90
+++ b/NcdfUtil/ncdf_mod.F90
@@ -424,12 +424,12 @@ CONTAINS
        ! If "time:calendar" is found, then throw an error for
        ! climatological calendars without leap years.
        IF ( RC == 0 ) THEN
-        SELECT CASE( TRIM( v_name ) )
+        SELECT CASE( TRIM( timeCalendar ) )
           CASE( '360_day', '365_day', '366_day', 'all_leap',                 &
                 'allleap', 'no_leap', 'noleap'                              )
              WRITE( 6, '(/,a)' ) REPEAT( '=', 79 )
              WRITE( 6, '(a  )' ) 'HEMCO does not support calendar type '  // &
-                                 TRIM( v_name )
+                                 TRIM( timeCalendar )
              WRITE( 6, '(/,a)' )  'HEMCO supports the following calendars:'
              WRITE( 6, '(a)'   )  ' - standard (i.e. mixed gregorian/julian)'
              WRITE( 6, '(a)'   )  ' - gregorian'
@@ -2167,9 +2167,9 @@ CONTAINS
           ncVar = 'lat_edges'
        ENDIF
        IF ( PRESENT(EDGE4) ) THEN
-          CALL NC_READ_VAR( fID, 'lon_edges', nEdge, ThisUnit, Edge4, RC )
+          CALL NC_READ_VAR( fID, TRIM(ncVar), nEdge, ThisUnit, Edge4, RC )
        ELSE
-          CALL NC_READ_VAR( fID, 'lon_edges', nEdge, ThisUnit, Edge8, RC )
+          CALL NC_READ_VAR( fID, TRIM(ncVar), nEdge, ThisUnit, Edge8, RC )
        ENDIF
        IF ( RC /= 0 ) RETURN
     ENDIF
@@ -2433,7 +2433,6 @@ CONTAINS
     INTEGER            :: a_type    ! netCDF attribute type
 
     ! Straings
-    CHARACTER(LEN=255) :: stdname
     CHARACTER(LEN=255) :: a_name    ! netCDF attribute name
     CHARACTER(LEN=255) :: a_val     ! netCDF attribute value
 
@@ -2512,7 +2511,7 @@ CONTAINS
 
        ! NOTE: for now, only hybrid sigma coordinates are supported!
        ! So exit with error if we get this far
-       WRITE(*,*) 'Invalid level standard name: ', TRIM(stdname),            &
+       WRITE(*,*) 'Invalid level standard name: ', TRIM(a_val),              &
             ' in ', TRIM(ncFile)
        RC = -999
        RETURN


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to https://github.com/geoschem/HEMCO/pull/357 by @jimmielin.  We have added the corresponding fixes from `HEMCO/src/Shared/NcdfUtil/hco_ncdf_mod.F90` to `NcdfUtil/ncdf_mod.F90`, namely:

| Routine | Fix | 
| --------- | ---- |
| `NC_READ_TIME` | Replaced incorrect variable name `v_name` with `timeCalendar` in the `SELECT CASE` statement |
| `NC_GET_GRID_EDGES_C` | Replaced hardwired `lon_edges` in calls to `NC_READ_VAR` with `TRIM(NcVar)` |
| `NC_GET_SIGMA_LEVELS_C` | Removed unused `stdname` local variable |

### Expected changes
This should be a no-diff-to-benchmark update.

### Related Github Issue
- Merge concurrently with https://github.com/geoschem/HEMCO/pull/357