### PR TITLE
Feature/remove r4 from gchp upwardsmassflux diag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed definition of `State_Grid%MaxChemLev` and `State_Grid%MaxStratLev` to be the 1 hPa level
 - Moved `MaxChemLev` and `MaxStratLev` fields from `State_Grid` to `State_Met`
 - Removed `State_Grid%MaxTropLev` field
+- Renamed GCHP history diagnostics for upwards mass flux to remove the '_R4' suffix
 
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -544,7 +544,7 @@ COLLECTIONS: 'Emissions',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux       ', 'GCHPctmEnv',
                                     'PLE0_R4               ', 'GCHPctmEnv',
                                     'PLE1_R4               ', 'GCHPctmEnv',
                                     'DryPLE0_R4            ', 'GCHPctmEnv',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -266,7 +266,7 @@ COLLECTIONS: 'SpeciesConc',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux       ', 'GCHPctmEnv',
                                     'PLE0_R4               ', 'GCHPctmEnv',
                                     'PLE1_R4               ', 'GCHPctmEnv',
                                     'DryPLE0_R4            ', 'GCHPctmEnv',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -636,7 +636,7 @@ COLLECTIONS: @#'DefaultCollection',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux       ', 'GCHPctmEnv',
                                     'PLE0_R4               ', 'GCHPctmEnv',
                                     'PLE1_R4               ', 'GCHPctmEnv',
                                     'DryPLE0_R4            ', 'GCHPctmEnv',


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR changes the GCHP diagnostic name `UpwardsMassFlux_R4` to `UpwardsMassFlux`. It goes with a GCHP PR which fixes a bug in which that diagnostic was all zeros since 14.7.0.

**This update requires GCHP PR https://github.com/geoschem/GCHP/pull/545 and FVdycoreCubed_GridComp PR https://github.com/geoschem/FVdycoreCubed_GridComp/pull/13 merged at the same time.**

### Expected changes

Together with the companion GCHP PR, we expect the GCHP diagnostic name for upwards mass flux to change from `UpwardsMassFlux_R4` to `UpwardsMassFlux`, and no longer be filled with zeros.

### Reference(s)

None

### Related Github Issue

https://github.com/geoschem/GCHP/issues/544