### PR TITLE
TOMAS bug fix to add missing leading zero in two lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed definition of `State_Grid%MaxChemLev` and `State_Grid%MaxStratLev` to be the 1 hPa level
 - Moved `MaxChemLev` and `MaxStratLev` fields from `State_Grid` to `State_Met`
 - Removed `State_Grid%MaxTropLev` field
-
+- Changed NK5 to NK05 and NK8 to NK08 in fullchem_mod.F90 to fix missing leading zero bug for TOMAS
+	
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`
 - Fixed typo in the call to `Finalize` for the `State_Diag%ProdOCPIfromOCPO` diagnostic array

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -3575,8 +3575,8 @@ CONTAINS
     id_SALC     = Ind_( 'SALC'         )
     id_SALCAL   = Ind_( 'SALCAL'       )
 #ifdef TOMAS
-    id_NK05     = Ind_( 'NK5'          )
-    id_NK08     = Ind_( 'NK8'          )
+    id_NK05     = Ind_( 'NK05'          )
+    id_NK08     = Ind_( 'NK08'          )
     id_NK10     = Ind_( 'NK10'         )
     id_NK20     = Ind_( 'NK20'         )
 #endif


### PR DESCRIPTION
### Name and Institution (Required)

Name: Betty Croft
Institution: Washington University in St. Louis

### Describe the update

Two lines with missing leading zeros are corrected for TOMAS simulations.

### Expected changes

Calculation of smallest activating bin for distribution of sulfate from aqueous production is corrected. With the bug the smallest bin was often fixed or too large due to erroneous indices for its calculation.

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue

This bug fixes addresses the issue #3281 
