### PR TITLE
Restored missing line for CH4_BBN in species_database.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed `NK5` to `NK05` and `NK8` to `NK08` in `fullchem_mod.F90` to fix missing leading zero bug for TOMAS
 - Renamed GCHP history diagnostics for upwards mass flux to remove the `_R4` suffix
 
+### Fixed
+- Restored missing line `CH4_BBN:` to `run/shared/species_database.yml
+
 ## [14.7.1] - 2026-04-08
 ### Added
 - Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -967,6 +967,7 @@ CH4:
   Background_VV: 1.8e-6
   FullName: Methane
   MW_g: 16.04
+CH4_BBN:
   << : *CH4properties
   Background_VV: 1.0e-20
   FullName: Methane from biomass burning emissions


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #3280.   We have restored the `CH4_BBN:` YAML tag immediately following the `CH4:` tag in the `run/shared/species_database.yml file.  This had been inadvertently deleted in a previous commit.

### Expected changes
This is a no-diff-to-benchmark update.

### Related Github Issue
- Closes #3280