### PR TITLE
Update SpeciesConcVV and SpeciesConcMND on chemistry timestep only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added methanediol (MDL) as a transported gas-phase species and to the KPP fullchem and custom mechanisms
 - Added routine `Cloud_CH2O_MDL` in `KPP/fullchem/fullchem_SulfurChemFuncs.F90`
 
+### Changed
+- Changed frequency of SpeciesConcVV and SpeciesConcMND diagnostic update to every chemistry timestep (previously dynamic timestep) to avoid value oscillation for certain species when dynamic timestep is less than chemistry timestep
+
 ## [14.7.0] - 2026-02-05
 ### Added
 - Added entries for FINNv25 biomass burning emissions to template HEMCO configuration files

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -71,6 +71,7 @@ CONTAINS
     USE State_Grid_Mod,   ONLY : GrdState
     USE PhysConstants,    ONLY : AIRMW,  AVO
     USE TIME_MOD,         ONLY : GET_LOCALTIME
+    USE Time_Mod,         ONLY : Its_Time_for_Chem
 !
 ! !INPUT PARAMETERS:
 !
@@ -125,14 +126,16 @@ CONTAINS
     ! Set species concentration for diagnostics in units of
     ! molec/cm3 (hplin, 11/21/21)
     !-----------------------------------------------------------------------
-    CALL Set_SpcConc_Diags_MND  ( Input_Opt,  State_Chm, State_Diag,         &
-                                  State_Grid, State_Met, RC                 )
+    IF ( Its_Time_for_Chem() ) THEN
+       CALL Set_SpcConc_Diags_MND  ( Input_Opt,  State_Chm, State_Diag,         &
+            State_Grid, State_Met, RC                 )
 
-    ! Trap potential errors
-    IF ( RC /= GC_SUCCESS ) THEN
-       ErrMsg = 'Error encountered setting SpeciesConcMND diagnostic'
-       CALL GC_ERROR( ErrMsg, RC, ThisLoc )
-       RETURN
+       ! Trap potential errors
+       IF ( RC /= GC_SUCCESS ) THEN
+          ErrMsg = 'Error encountered setting SpeciesConcMND diagnostic'
+          CALL GC_ERROR( ErrMsg, RC, ThisLoc )
+          RETURN
+       ENDIF
     ENDIF
 
 #ifdef ADJOINT
@@ -583,6 +586,7 @@ CONTAINS
     USE State_Diag_Mod, ONLY : DgnState
     USE State_Grid_Mod, ONLY : GrdState
     USE Time_Mod,       ONLY : Get_LocalTime
+    USE Time_Mod,       ONLY : Its_Time_for_Chem
     USE UnitConv_Mod,   ONLY : Check_Units, MOLES_SPECIES_PER_MOLES_DRY_AIR
 !
 ! !INPUT PARAMETERS:
@@ -638,7 +642,7 @@ CONTAINS
     !=======================================================================
     ! Copy species to SpeciesConc (concentrations diagnostic) [v/v dry]
     !=======================================================================
-    IF ( State_Diag%Archive_SpeciesConcVV ) THEN
+    IF ( State_Diag%Archive_SpeciesConcVV .AND. Its_Time_for_Chem() ) THEN
 
        ! Point to mapping obj specific to SpeciesConcVV diagnostic collection
        mapData => State_Diag%Map_SpeciesConcVV

--- a/GeosCore/diagnostics_mod.F90
+++ b/GeosCore/diagnostics_mod.F90
@@ -664,7 +664,7 @@ CONTAINS
     !=======================================================================
     ! Copy species to SatDiagn (satellite diagnostic output) [v/v dry]
     !=======================================================================
-    IF ( State_Diag%Archive_SatDiagnConc ) THEN
+    IF ( State_Diag%Archive_SatDiagnConc .AND. Its_Time_for_Chem() ) THEN
 
        ! Loop over longitudes
        !$OMP PARALLEL DO                                                    &
@@ -695,7 +695,7 @@ CONTAINS
     !=======================================================================
     ! Copy species to SpeciesBC (transport boundary conditions) [v/v dry]
     !=======================================================================
-    IF ( State_Diag%Archive_SpeciesBC ) THEN
+    IF ( State_Diag%Archive_SpeciesBC .AND. Its_Time_for_Chem() ) THEN
 
        ! Point to mapping obj specific to species boundary conditions
        mapData => State_Diag%Map_SpeciesBC
@@ -756,7 +756,7 @@ CONTAINS
     !      distribution, sources, and processes" Atmos. Chem. Phys.,
     !      12, 4,539-4,4554, 2012.
     !=======================================================================
-    IF ( State_Diag%Archive_ConcAboveSfc ) THEN
+    IF ( State_Diag%Archive_ConcAboveSfc .AND. Its_Time_for_Chem() ) THEN
 
        ! Loop over the number of drydep species that we wish
        ! to save at a user-specified altitude above the surface


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes the issue identified by @ltmurray of NO surface concentrations oscillating in time in diagnostics output the same frequency as the dynamic timestep. That issue was identified in https://github.com/geoschem/geos-chem/issues/3117. The fix is update species concentration diagnostics only during chemistry timesteps. This allows all components to execute, including photolysis for short-lived species such as NO, prior to archiving values.

### Expected changes

Coming soon.

### Reference(s)

None

### Related Github Issue

- Closes https://github.com/geoschem/geos-chem/issues/3117
