### PR TITLE
Utility script "rtd_species_by_simulation.py" now reads from "species_database.yml" for Hg simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Changed `NK5` to `NK05` and `NK8` to `NK08` in `fullchem_mod.F90` to fix missing leading zero bug for TOMAS
 - Renamed GCHP history diagnostics for upwards mass flux to remove the `_R4` suffix
+- Updated utility script `run/shared/rtd_species_by_simulation.py` to read the `species_database.yml` for Hg simulations
 
 ### Fixed
-- Restored missing line `CH4_BBN:` to `run/shared/species_database.yml
+- Restored missing line `CH4_BBN:` to `run/shared/species_database.yml`
 
 ## [14.7.1] - 2026-04-08
 ### Added

--- a/run/shared/rtd_species_by_simulation.py
+++ b/run/shared/rtd_species_by_simulation.py
@@ -23,11 +23,15 @@ def read_species_from_eqn_file(simulation_name):
     Reads a geoschem_config.yml template file for a given GEOS-Chem
     simulation and returns the list of transported species
 
-    Args
-    simulation_name     : str : Name of the GEOS-Chem simulation
+    Parameters
+    ----------
+    simulation_name : str
+        Name of the GEOS-Chem simulation
 
-    returns
-    transported_species : list : List of transported species
+    Returns
+    -------
+    transported_species : list
+        List of transported species
     """
     verify_variable_type(simulation_name, str)
 
@@ -52,11 +56,15 @@ def read_transported_species(simulation_name):
     Reads a geoschem_config.yml template file for a given GEOS-Chem
     simulation and returns the list of transported species
 
-    Args
-    simulation_name     : str : Name of the GEOS-Chem simulation
+    Parameters
+    ----------
+    simulation_name : str
+        Name of the GEOS-Chem simulation
 
-    returns
-    transported_species : list : List of transported species
+    Returns
+    -------
+    transported_species : list
+        List of transported species
     """
     verify_variable_type(simulation_name, str)
 
@@ -95,10 +103,12 @@ def read_species_database():
     Reads the GEOS-Chem Species Database.
 
     Returns
-    species_database : dict : GEOS-Chem Species Database object
+    -------
+    species_database : dict
+        GEOS-Chem Species Database object
     """
     count = 0
-    for sim in ["", "_apm", "_hg", "_tomas"]:
+    for sim in ["", "_apm", "_tomas"]:
         filename = os.path.expanduser(SPECIES_DB.replace("XX", sim))
         if count == 0:
             species_database = read_config_file(filename, quiet=True)
@@ -116,12 +126,17 @@ def get_species_metadata(species, species_database):
     Compares a species against the species database and returns
     selected metadata fields.
 
-    Args
-    species          : list : List of species names
-    species_database : dict : GEOS-Chem Species Database
+    Parameters
+    ----------
+    species : list
+        List of species names
+    species_database : dict
+        GEOS-Chem Species Database
 
     Returns
-    metadata         : dict : Selected species metadata fields
+    -------
+    metadata : dict
+        Selected species metadata fields
     """
     verify_variable_type(species, list)
     verify_variable_type(species_database, dict)
@@ -149,13 +164,14 @@ def create_rtd_list_table(metadata, table_file, title=None):
     Creates a ReadTheDocs list table displaying the transported species
     for a given GEOS-Chem simulation.
 
-    Args
-    metadata   : dict : Selected species metadata fields
-    table_file : str  : File where the list table will be written
-
-    Kwargs
-    title      : str  : Table title
-
+    Parameters
+    ----------
+    metadata : dict
+        Selected species metadata fields
+    table_file : str
+        File where the list table will be written
+    title : str, optional
+        Table title
     """
     verify_variable_type(metadata, dict)
     verify_variable_type(table_file, str)
@@ -191,9 +207,12 @@ def main(simulation_name, table_file):
     """
     Main program.  Calls subroutines to create the list table.
 
-    Args
-    simulation_name : str : Name of a GEOS-Chem simulation
-    table_file      : str : File where the list table will be written
+    Parameters
+    ----------
+    simulation_name : str
+        Name of a GEOS-Chem simulation
+    table_file : str
+        File where the list table will be written
     """
     verify_variable_type(simulation_name, str)
     verify_variable_type(table_file, str)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR fixes an issue in the utility script `run/shared/rtd_species_by_simulation.py`, which creates a ReadTheDocs list-table of all species belonging to a particular simulation.

In PR #3113, we consolidated all species metadata for the Hg simulation into `species_database.yml` and removed the `species_database_hg.yml` file.  However, at that time we did not update `rtd_species_by_simulation.py`.  This means that `rtd_species_by_simulation.py` is still trying to look for the nonexistent `species_database_hg.yml` file, which results in an error.

```console
(gcpy_env) $ python -m rtd_species_by_simulation fullchem ~/fullchem.rst
Traceback (most recent call last):
  File "/n/home09/ryantosca/python/gcpy/gcpy/util.py", line 1998, in read_config_file
    with open(config_file, encoding=ENCODING) as stream:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: './species_database_hg.yml'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/n/netscratch/jacob_lab/Lab/ryantosca/tests/code/14.8.0/gcc.14.8.0-alpha.9/src/GEOS-Chem/run/shared/rtd_species_by_simulation.py", line 264, in <module>
    main(argv[1], argv[2])
    ~~~~^^^^^^^^^^^^^^^^^^
  File "/n/netscratch/jacob_lab/Lab/ryantosca/tests/code/14.8.0/gcc.14.8.0-alpha.9/src/GEOS-Chem/run/shared/rtd_species_by_simulation.py", line 202, in main
    species_database = read_species_database()
  File "/n/netscratch/jacob_lab/Lab/ryantosca/tests/code/14.8.0/gcc.14.8.0-alpha.9/src/GEOS-Chem/run/shared/rtd_species_by_simulation.py", line 106, in read_species_database
    species_database = species_database | read_config_file(
                                          ~~~~~~~~~~~~~~~~^
        filename, quiet=True
        ^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/n/home09/ryantosca/python/gcpy/gcpy/util.py", line 2002, in read_config_file
    raise Exception(msg) from err
Exception: Error reading configuration in ./species_database_hg.yml: [Errno 2] No such file or directory: './species_database_hg.yml'
```
### Expected changes
This PR will fix the above error and generate list-table output such as:

```rest
.. list-table:: Advected species
   :header-rows: 1
   :align: left

   * - Species
     - Description
     - Formula
     - MW (g)
   * - ACET
     - Acetone
     - CH3C(O)CH3
     - 58.09
   * - ACTA
     - Acetic acid
     - CH3C(O)OH
     - 60.06
   * - ACR
     - Acrolein
     - C3H4O
     - 56.06
   * - AERI
     - Iodine on aerosol
     - I
     - 126.9
   * - ALD2
     - Acetaldehyde
     - CH3CHO
     - 44.06
   * - ALK4
     - Lumped C4+C5 Alkanes
     - not listed
     - 58.12
```

### Related Github Issue
- See PR #3113