### PR TITLE
Implement brown carbon with photolysis

### DIFF
--- a/GeosCore/aerosol_mod.F90
+++ b/GeosCore/aerosol_mod.F90
@@ -92,12 +92,13 @@ MODULE AEROSOL_MOD
   INTEGER :: id_ASOA1,   id_ASOA2,   id_ASOA3,   id_DUST01
   INTEGER :: id_SOAS,    id_SALACL,  id_HMS,     id_SOAGX
   INTEGER :: id_SOAIE,   id_INDIOL,  id_LVOCOA
+  INTEGER :: id_BrC
 
   ! Index to map between NRHAER and species database hygroscopic species
   ! NOTE: Increasing value of NRHAER in CMN_SIZE_Mod.F90 (e.g. if there is
   ! a new hygroscopic species) requires manual update of this mapping
   ! (ewl, 1/23/17)
-  INTEGER :: Map_NRHAER(5)
+  INTEGER :: Map_NRHAER(6)
 
   
 CONTAINS
@@ -122,6 +123,7 @@ CONTAINS
 !
 ! !USES:
 !
+    USE CMN_SIZE_Mod,    ONLY : NRHAER
     USE ErrCode_Mod
     USE ERROR_MOD
 
@@ -527,6 +529,17 @@ CONTAINS
           IF ( IS_OCPI ) THEN
              State_Chm%AerMass%OCPI(I,J,L) = Spc(id_OCPI)%Conc(I,J,L) &
                            * State_chm%AerMass%OCFOPOA(I,J) / AIRVOL(I,J,L)
+          ENDIF
+
+          ! BrC [kg/m3]
+          ! Species concentrations are KG_SPECIES within AEROSOL_CONC. (MH,5/6/26)
+          IF ( NRHAER == 6 ) THEN
+             State_Chm%AerMass%WAERSL(I,J,L,6) = 0.0_fp
+             IF ( id_BrC > 0 ) THEN
+                State_Chm%AerMass%WAERSL(I,J,L,6) =                    &
+                     State_Chm%AerMass%WAERSL(I,J,L,6) +               &
+                     Spc(id_BrC)%Conc(I,J,L) / AIRVOL(I,J,L)
+             ENDIF
           ENDIF
 
           ! Now avoid division by zero (bmy, 4/20/04)
@@ -1460,6 +1473,9 @@ CONTAINS
     ENDIF
     MSDENS(4) = State_Chm%SpcData(id_SALA)%Info%Density
     MSDENS(5) = State_Chm%SpcData(id_SALC)%Info%Density
+    IF ( NRHAER == 6 .and. id_BrC > 0 ) THEN
+       MSDENS(6) = State_Chm%SpcData(id_BrC)%Info%Density
+    ENDIF
 
     ! These default values unused (actively retrieved from ucx_mod)
     MSDENS(NRHAER+1) = 1700.0d0 ! SSA/STS
@@ -2473,6 +2489,7 @@ CONTAINS
        id_NIT        = Ind_( 'NIT'     )
        id_OCPO       = Ind_( 'OCPO'    )
        id_OCPI       = Ind_( 'OCPI'    )
+       id_BrC        = Ind_( 'BRC'     )
        id_SOAS       = Ind_( 'SOAS'    )
        id_SALA       = Ind_( 'SALA'    )
        id_SALC       = Ind_( 'SALC'    )
@@ -2544,9 +2561,11 @@ CONTAINS
                 Map_NRHAER(N) = 4
              CASE ( 'SALC' )
                 Map_NRHAER(N) = 5
+             CASE ( 'BRC' )
+                Map_NRHAER(N) = 6
              CASE DEFAULT
                 ErrMsg = 'WARNING: aerosol diagnostics not defined' // &
-                         ' for NRHAER greater than 5!'
+                         ' for NRHAER greater than 6!'
                 CALL GC_ERROR( ErrMsg, RC, 'Init_Aerosol in aerosol_mod.F90' )
                 SpcInfo => NULL()
                 RETURN
@@ -2739,7 +2758,7 @@ CONTAINS
     ! info but ref index is similar e.g. Scarchilli et al. (2005)
     !(DAR 05/2015)
     SPECFIL = (/ "so4.dat  ", "soot.dat ", "org.dat  ", "ssa.dat  ",         &
-                 "ssc.dat  ", "h2so4.dat", "h2so4.dat", "dust.dat "        /)
+                 "ssc.dat  ", "brc.dat  ", "h2so4.dat", "dust.dat "        /)
 
     ! Loop over the array of filenames
     DO k = 1, State_Chm%Phot%NSPAA

--- a/GeosCore/carbon_mod.F90
+++ b/GeosCore/carbon_mod.F90
@@ -272,7 +272,7 @@ MODULE CARBON_MOD
   INTEGER :: id_TSOG3,   id_XYLE,   id_LBRO2N, id_LBRO2H, id_LTRO2N
   INTEGER :: id_LTRO2H,  id_LXRO2N, id_LXRO2H, id_LNRO2N, id_LNRO2H
   INTEGER :: id_LISOPOH, id_LISOPNO3
-  INTEGER :: id_SOAS,    id_SOAP
+  INTEGER :: id_SOAS,    id_SOAP,   id_BRC
 
 #ifdef APM
   REAL(fp), ALLOCATABLE :: BCCONVNEW(:,:,:)
@@ -7676,6 +7676,7 @@ CONTAINS
    id_OH       = IND_('OH'      )
    id_OCPO     = IND_('OCPO'    )
    id_OCPI     = IND_('OCPI'    )
+   id_BRC      = IND_('BRC'     )
    id_OPOA1    = IND_('OPOA1'   )
    id_OPOG1    = IND_('OPOG1'   )
    id_OPOA2    = IND_('OPOA2'   )

--- a/GeosCore/cldj_interface_mod.F90
+++ b/GeosCore/cldj_interface_mod.F90
@@ -221,7 +221,7 @@ CONTAINS
 !
     CHARACTER(LEN=255) :: ErrMsg, ThisLoc
     INTEGER            :: A, I, J, L, K, N, S, MaxLev, RH_ind
-    INTEGER            :: SO4_ind, BC_ind, OC_ind, SALA_ind, SALC_ind
+    INTEGER            :: SO4_ind, BC_ind, OC_ind, SALA_ind, SALC_ind, BrC_ind
     INTEGER            :: S_rh0, S_rhx, K_rh0, K_rhx, ind_1000
     REAL(8)            :: MW_g, BoxHt, Delta_P, IWC, LWC
     REAL(8)            :: FRAC, RAA_eff, QAA_eff, SAA_eff
@@ -314,11 +314,13 @@ CONTAINS
     REAL(fp) :: SPHU_kgkg
     REAL(fp) :: H2O_kgkgdry
     REAL(fp) :: MW_kg
+    REAL(fp) :: BrC_kgm3
 
     ! Species ids
     INTEGER, SAVE :: id_H2O
     INTEGER, SAVE :: id_O3
     INTEGER, SAVE :: id_SO4
+    INTEGER, SAVE :: id_BRC
 
     ! Index for Cloud-J prints if GEOS-Chem verbose is on
     INTEGER :: I_PRT, J_PRT
@@ -364,6 +366,7 @@ CONTAINS
     OC_ind   = 3
     SALA_ind = 4
     SALC_ind = 5
+    BrC_ind = 6
 
     ! Relative humidities in FJX_spec-aer.dat
     RH_lut(1) = 0.d0
@@ -392,6 +395,7 @@ CONTAINS
        id_H2O  = Ind_('H2O')
        id_O3   = Ind_('O3')
        id_SO4  = Ind_('SO4')
+       id_BRC = Ind_('BRC')
        IF ( id_O3 <= 0 ) THEN
           ErrMsg = 'O3 is not a defined species but is required for Cloud-J photolysis!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -671,7 +675,7 @@ CONTAINS
                 IF ( Input_Opt%LSULF .AND. State_Met%InTroposphere(I,J,L) ) THEN
 
                    ! Get indexes to optical property LUT
-                   S_rh0 = 3 + NDUST + NRHAER*(SO4_ind-1) + 1  ! SO4 index for RH=0 in NDXAER
+                   S_rh0 = 3 + NDUST + NRH*(SO4_ind-1) + 1  ! SO4 index for RH=0 in NDXAER
                    S_rhx = S_rh0 + RH_ind - 1  ! Sulfate index for this RH
                    K_rh0 = NDXAER(L,S_rh0)     ! index for RH=0 in FJX_spec-aer.dat
                    K_rhx = NDXAER(L,S_rhx)     ! index for this RH in FJX_spec-aer.dat
@@ -707,7 +711,7 @@ CONTAINS
                    !----------------------------------------------------
 
                    ! Get indexes to optical property LUT
-                   S_rh0 = 3 + NDUST + NRHAER*(BC_ind-1) + 1  ! BC index for RH=0 in NDXAER
+                   S_rh0 = 3 + NDUST + NRH*(BC_ind-1) + 1  ! BC index for RH=0 in NDXAER
                    S_rhx = S_rh0 + RH_ind - 1  ! BC index for this RH
                    K_rh0 = NDXAER(L,S_rh0)     ! index for RH=0 in FJX_spec-aer.dat
                    K_rhx = NDXAER(L,S_rhx)     ! index for this RH in FJX_spec-aer.dat
@@ -756,7 +760,7 @@ CONTAINS
                    !----------------------------------------------------
 
                    ! Get indexes to optical property LUT
-                   S_rh0 = 3 + NDUST + NRHAER*(OC_ind-1) + 1  ! OC index for RH=0 in NDXAER
+                   S_rh0 = 3 + NDUST + NRH*(OC_ind-1) + 1  ! OC index for RH=0 in NDXAER
                    S_rhx = S_rh0 + RH_ind - 1  ! OC index for this RH
                    K_rh0 = NDXAER(L,S_rh0)     ! index for RH=0 in FJX_spec-aer.dat
                    K_rhx = NDXAER(L,S_rhx)     ! index for this RH in FJX_spec-aer.dat
@@ -781,6 +785,42 @@ CONTAINS
                         * dry_to_wet_factor * Q_interp_factor / R_interp_factor ) ) &
                         * 1.d3 * BoxHt
 
+                   !----------------------------------------------------
+                   ! Brown carbon (Hammer et al. 2016), MH 5/6/26
+                   !----------------------------------------------------
+
+                   ! Get indexes to optical property LUT
+                   S_rh0 = 3 + NDUST + NRH*(BrC_ind-1) + 1  ! BrC index for RH=0 in NDXAER
+                   S_rhx = S_rh0 + RH_ind - 1
+                   K_rh0 = NDXAER(L,S_rh0)
+                   K_rhx = NDXAER(L,S_rhx)
+
+                   ! Get interpolated effective radius and extinction for RH in this grid box
+                   IF ( RH_ind == NRH ) THEN
+                      RAA_eff = RAA(K_rhx)
+                      QAA_eff = QAA(ind_1000,K_rhx)
+                   ELSE
+                      FRAC = ( State_Met%RH(I,J,L) - RH_lut(RH_ind) ) &
+                             / ( RH_lut(RH_ind+1) - RH_lut(RH_ind) )
+                      RAA_eff = RAA(K_rhx) + FRAC * ( RAA(K_rhx+1) - RAA(K_rhx) )
+                      QAA_eff = QAA(ind_1000,K_rhx) + FRAC * ( QAA(ind_1000,K_rhx+1) - QAA(ind_1000,K_rhx) )
+                   ENDIF
+                   dry_to_wet_factor = ( RAA_eff / RAA(K_rh0) )**3
+                   R_interp_factor = RAA_eff / RAA(K_rhx)
+                   Q_interp_factor = QAA_eff / QAA(ind_1000,K_rhx)
+
+                   BrC_kgm3 = 0.d0
+                   IF ( id_BRC > 0 ) THEN
+                      BrC_kgm3 = State_Chm%Species(id_BRC)%Conc(I,J,L)  &
+                                * State_Chm%SpcData(id_BRC)%Info%MW_g    &
+                                / AVO * 1.d3
+                   ENDIF
+
+                   ! BrC is hygroscopic. Set concentration, converting [dry kg/m3] -> [wet g/m2]
+                   AERSP(L,S_rhx) = BrC_kgm3 * dry_to_wet_factor  &
+                         * Q_interp_factor / R_interp_factor    &
+                         * 1.d3 * BoxHt
+
                 ENDIF
 
                 !----------------------------------------------------
@@ -794,7 +834,7 @@ CONTAINS
                    !----------------------------------------------------
 
                    ! Get indexes to optical property LUT
-                   S_rh0 = 3 + NDUST + NRHAER*(SALA_ind-1) + 1  ! SALA index for RH=0 in NDXAER
+                   S_rh0 = 3 + NDUST + NRH*(SALA_ind-1) + 1  ! SALA index for RH=0 in NDXAER
                    S_rhx = S_rh0 + RH_ind - 1  ! SALA index for this RH
                    K_rh0 = NDXAER(L,S_rh0)     ! index for RH=0 in FJX_spec-aer.dat
                    K_rhx = NDXAER(L,S_rhx)     ! index for this RH in FJX_spec-aer.dat
@@ -822,7 +862,7 @@ CONTAINS
                    !----------------------------------------------------
 
                    ! Get indexes to optical property LUT
-                   S_rh0 = 3 + NDUST + NRHAER*(SALC_ind-1) + 1  ! SALC index for RH=0 in NDXAER
+                   S_rh0 = 3 + NDUST + NRH*(SALC_ind-1) + 1  ! SALC index for RH=0 in NDXAER
                    S_rhx = S_rh0 + RH_ind - 1  ! SALC index for this RH
                    K_rh0 = NDXAER(L,S_rh0)     ! index for RH=0 in FJX_spec-aer.dat
                    K_rhx = NDXAER(L,S_rhx)     ! index for this RH in FJX_spec-aer.dat
@@ -859,14 +899,14 @@ CONTAINS
              ! depth computed in GEOS-Chem is non-zero.
 
              !  SSA/LBS/STS
-             IF ( State_Chm%Phot%ODAER(I,J,L,State_Chm%Phot%IWV1000,6) > 0._fp ) THEN
-                AERSP(L,36) = State_Chm%Species(id_SO4)%Conc(I,J,L) &
+             IF ( State_Chm%Phot%ODAER(I,J,L,State_Chm%Phot%IWV1000,7) > 0._fp ) THEN
+                AERSP(L,41) = State_Chm%Species(id_SO4)%Conc(I,J,L) &
                      * MW_g / AVO * BoxHt * 1e+6_fp
              ENDIF
 
              !  NAT/ice PSCs
-             IF ( State_Chm%Phot%ODAER(I,J,L,State_Chm%Phot%IWV1000,7) > 0._fp ) THEN
-                AERSP(L,37) = State_Chm%Species(id_SO4)%Conc(I,J,L) &
+             IF ( State_Chm%Phot%ODAER(I,J,L,State_Chm%Phot%IWV1000,8) > 0._fp ) THEN
+                AERSP(L,42) = State_Chm%Species(id_SO4)%Conc(I,J,L) &
                      * MW_g / AVO * BoxHt * 1e+6_fp
              ENDIF
 
@@ -887,8 +927,8 @@ CONTAINS
        !IF ( .NOT. use_oc       ) AERSP(:,21:25) = 0.d0
        !IF ( .NOT. use_sala     ) AERSP(:,26:30) = 0.d0
        !IF ( .NOT. use_salc     ) AERSP(:,31:35) = 0.d0
-       !IF ( .NOT. use_stratso4 ) AERSP(:,36)    = 0.d0
-       !IF ( .NOT. use_psc      ) AERSP(:,37)    = 0.d0
+       !IF ( .NOT. use_stratso4 ) AERSP(:,41)    = 0.d0
+       !IF ( .NOT. use_psc      ) AERSP(:,42)    = 0.d0
 
        !-----------------------------------------------------------------
        ! Set remaining inputs needed for Cloud_JX

--- a/GeosCore/input_mod.F90
+++ b/GeosCore/input_mod.F90
@@ -1650,7 +1650,7 @@ CONTAINS
     !------------------------------------------------------------------------
     ! Use brown carbon aerosols?
     !------------------------------------------------------------------------
-    key    = "aerosols%carbon%use_brown_carbon"
+    key    = "aerosols%carbon%brown_carbon"
     v_bool = MISSING_BOOL
     CALL QFYAML_Add_Get( Config, TRIM( key ), v_bool, "", RC )
     IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/photolysis_mod.F90
+++ b/GeosCore/photolysis_mod.F90
@@ -838,7 +838,7 @@ CONTAINS
     MIEDX => State_Chm%Phot%MIEDX
 
     ! Taken from aerosol_mod.F
-    IND = (/22,29,36,43,50/)
+    IND = (/22,29,36,43,50,57/)
 
     DO I=1,AN_
        MIEDX(I) = 0

--- a/Headers/CMN_SIZE_mod.F90
+++ b/Headers/CMN_SIZE_mod.F90
@@ -43,7 +43,7 @@ MODULE CMN_SIZE_MOD
   INTEGER, PARAMETER :: NDUST = 7
 
   ! Number of aerosols undergoing hygroscopic growth
-  INTEGER, PARAMETER :: NRHAER = 5
+  INTEGER, PARAMETER :: NRHAER = 6
 
   ! Number of stratospheric aerosols (SDE 04/17/13)
   INTEGER, PARAMETER :: NSTRATAER = 2

--- a/Headers/state_chm_mod.F90
+++ b/Headers/state_chm_mod.F90
@@ -712,7 +712,7 @@ CONTAINS
     CHARACTER(LEN=255)      :: chmId,      thisLoc
 
     ! String arrays
-    CHARACTER(LEN=31)       :: fieldId(14)
+    CHARACTER(LEN=31)       :: fieldId(15)
 
     ! Objects
     TYPE(Species),  POINTER :: ThisSpc
@@ -1053,7 +1053,9 @@ CONTAINS
                     'AeroAreaMDUST7   ', 'AeroAreaSULF     ',                &
                     'AeroAreaBC       ', 'AeroAreaOC       ',                &
                     'AeroAreaSSA      ', 'AeroAreaSSC      ',                &
-                    'AeroAreaBGSULF   ', 'AeroAreaICEI     '                /)
+                    'AeroAreaBRC      ', 'AeroAreaBGSULF   ',                &
+                    'AeroAreaICEI     '                                     /)
+
 
        ! Allocate and register each field individually
        DO N = 1, State_Chm%nAeroType
@@ -1083,7 +1085,8 @@ CONTAINS
                     'AeroRadiMDUST7   ', 'AeroRadiSULF     ',                &
                     'AeroRadiBC       ', 'AeroRadiOC       ',                &
                     'AeroRadiSSA      ', 'AeroRadiSSC      ',                &
-                    'AeroRadiBGSULF   ', 'AeroRadiICEI     '               /)
+                    'AeroRadiBRC      ', 'AeroRadiBGSULF   ',                &
+                    'AeroRadiICEI     '                                     /)
 
        ! Allocate and register each field individually
        DO N = 1, State_Chm%nAeroType
@@ -1113,7 +1116,8 @@ CONTAINS
                     'WetAeroAreaMDUST7', 'WetAeroAreaSULF  ',                &
                     'WetAeroAreaBC    ', 'WetAeroAreaOC    ',                &
                     'WetAeroAreaSSA   ', 'WetAeroAreaSSC   ',                &
-                    'WetAeroAreaBGSULF', 'WetAeroAreaICEI  '               /)
+                    'WetAeroAreaBRC   ', 'WetAeroAreaBGSULF',                &
+                    'WetAeroAreaICEI  '                                     /)
 
        ! Allocate and register each field individually
        DO N = 1, State_Chm%nAeroType
@@ -1143,7 +1147,8 @@ CONTAINS
                     'WetAeroRadiMDUST7', 'WetAeroRadiSULF  ',                &
                     'WetAeroRadiBC    ', 'WetAeroRadiOC    ',                &
                     'WetAeroRadiSSA   ', 'WetAeroRadiSSC   ',                &
-                    'WetAeroRadiBGSULF', 'WetAeroRadiICEI  '               /)
+                    'WetAeroRadiBRC   ', 'WetAeroRadiBGSULF',                &
+                    'WetAeroRadiICEI  '                                     /)
 
        ! Allocate and register each field individually
        DO N = 1, State_Chm%nAeroType
@@ -1173,8 +1178,8 @@ CONTAINS
                     'AeroH2OMDUST7    ', 'AeroH2OSNA       ',                &
                     'AeroH2OBC        ', 'AeroH2OOC        ',                &
                     'AeroH2OSSA       ', 'AeroH2OSSC       ',                &
-                    'AeroH2OBGSULF    ', 'AeroH2OICEI      '               /)
-
+                    'AeroH2OBrC       ', 'AeroH2OBGSULF    ',                &
+                    'AeroH2OICEI      '                                     /)
        ! Allocate and register each field individually
        DO N = 1, State_Chm%nAeroType
           CALL Init_and_Register(                                            &
@@ -1792,7 +1797,8 @@ CONTAINS
                     'KhetiSLABrNO3HCl ', 'KhetiSLAHOClHCl  ',             &
                     'KhetiSLAHOClHBr  ', 'KhetiSLAHOBrHCl  ',             &
                     'KhetiSLAHOBrHBr  ', '                 ',             &
-                    '                 ', '                 '            /)
+                    '                 ', '                 ',             &
+                    '                 '                                 /)
 
        ! Allocate and register each field individually
        nKHLSA = 11
@@ -4062,6 +4068,11 @@ CONTAINS
           IF ( isUnits ) Units = 'cm2 cm-3'
           IF ( isRank  ) Rank  = 3
 
+       CASE ( 'AEROAREABRC' )
+          IF ( isDesc  ) Desc  = 'Dry aerosol area for brown carbon'
+          IF ( isUnits ) Units = 'cm2 cm-3'
+          IF ( isRank  ) Rank  = 3
+
        CASE ( 'AEROAREABGSULF' )
           IF ( isDesc  ) Desc  = 'Dry aerosol area for background' &
                                    // ' stratospheric sulfate'
@@ -4138,6 +4149,11 @@ CONTAINS
           IF ( isUnits ) Units = 'cm'
           IF ( isRank  ) Rank  = 3
 
+       CASE ( 'AERORADIBRC' )
+          IF ( isDesc  ) Desc  = 'Dry aerosol radius for brown carbon'
+          IF ( isUnits ) Units = 'cm'
+          IF ( isRank  ) Rank  = 3
+
        CASE ( 'AERORADIBGSULF' )
           IF ( isDesc  ) Desc  = 'Dry aerosol radius for background' &
                                  // ' stratospheric sulfate'
@@ -4182,6 +4198,11 @@ CONTAINS
 
        CASE ( 'WETAEROAREAMDUST7' )
           IF ( isDesc  ) Desc  = 'Wet aerosol area for mineral dust (4.0 um)'
+          IF ( isUnits ) Units = 'cm2 cm-3'
+          IF ( isRank  ) Rank  = 3
+       
+       CASE ( 'WETAEROAREABRC' )
+          IF ( isDesc  ) Desc  = 'Wet aerosol area for brown carbon'
           IF ( isUnits ) Units = 'cm2 cm-3'
           IF ( isRank  ) Rank  = 3
 
@@ -4255,6 +4276,11 @@ CONTAINS
 
        CASE ( 'WETAERORADIMDUST7' )
           IF ( isDesc  ) Desc  = 'Wet aerosol radius for mineral dust (4.0 um)'
+          IF ( isUnits ) Units = 'cm'
+          IF ( isRank  ) Rank  = 3
+
+       CASE ( 'WETAERORADIBRC' )
+          IF ( isDesc  ) Desc  = 'Wet aerosol radius for brown carbon'
           IF ( isUnits ) Units = 'cm'
           IF ( isRank  ) Rank  = 3
 
@@ -4352,6 +4378,11 @@ CONTAINS
 
        CASE ( 'AEROH2OMDUST7' )
           IF ( isDesc  ) Desc  = 'Aerosol H2O content for mineral dust (4.0 um)'
+          IF ( isUnits ) Units = 'cm3(H2O) cm-3(air)'
+          IF ( isRank  ) Rank  = 3
+
+       CASE ( 'AEROH2OBRC' )
+          IF ( isDesc  ) Desc  = 'Aerosol H2O content for brown carbon'
           IF ( isUnits ) Units = 'cm3(H2O) cm-3(air)'
           IF ( isRank  ) Rank  = 3
 

--- a/KPP/fullchem/commonIncludeVars.H
+++ b/KPP/fullchem/commonIncludeVars.H
@@ -94,8 +94,8 @@
   !$OMP THREADPRIVATE( K_CLD )
 
   ! Liquid water conversion factor
-  ! - Size = number of aerosol types (nAeroType)
-  REAL(dp) :: CVFAC(14)
+  ! - Size = number of aerosol types (nAeroType = 15 with BrC aerosol)
+  REAL(dp) :: CVFAC(15)
   !$OMP THREADPRIVATE( CVFAC )
 
   ! Proton activity [unitless] and H+ concentration [M]
@@ -191,11 +191,11 @@
      REAL(dp) :: vAir           ! Volume of air [cm3]
      REAL(dp) :: vIce           ! Ice volume [cm3]
      REAL(dp) :: vLiq           ! Liquid volume [cm3]
-     REAL(dp) :: wetArea(14)    ! Aerosol specific wet sfc area [cm2/cm3]
-     REAL(dp) :: xArea(14)      ! Aerosol specific sfc area  [cm2/cm3]
-     REAL(dp) :: xH2O(14)       ! Aerosol water content [cm3/cm3]
-     REAL(dp) :: xRadi(14)      ! Aerosol effective radius [cm]
-     REAL(dp) :: xVol(14)       ! Aerosol specific volume [cm3/cm3]
+     REAL(dp) :: wetArea(15)    ! Aerosol specific wet sfc area [cm2/cm3]
+     REAL(dp) :: xArea(15)      ! Aerosol specific sfc area  [cm2/cm3]
+     REAL(dp) :: xH2O(15)       ! Aerosol water content [cm3/cm3]
+     REAL(dp) :: xRadi(15)      ! Aerosol effective radius [cm]
+     REAL(dp) :: xVol(15)       ! Aerosol specific volume [cm3/cm3]
      !
      ! Additional fields only used by the Hg simulation
      !

--- a/KPP/fullchem/fullchem_RateLawFuncs.F90
+++ b/KPP/fullchem/fullchem_RateLawFuncs.F90
@@ -25,7 +25,7 @@ MODULE fullchem_RateLawFuncs
 !
 ! !DEFINED PARAMETERS:
 !
-  ! Indices for aerosol type (1 .. NAEROTYPE=14)
+  ! Indices for aerosol type (1 .. NAEROTYPE=15)
   INTEGER,  PRIVATE, PARAMETER :: DU1            = 1  ! Dust (Reff = 0.151 um)
   INTEGER,  PRIVATE, PARAMETER :: DU2            = 2  ! Dust (Reff = 0.253 um)
   INTEGER,  PRIVATE, PARAMETER :: DU3            = 3  ! Dust (Reff = 0.402 um)
@@ -38,8 +38,9 @@ MODULE fullchem_RateLawFuncs
   INTEGER,  PRIVATE, PARAMETER :: ORC            = 10 ! Organic Carbon
   INTEGER,  PRIVATE, PARAMETER :: SSA            = 11 ! Accum-mode sea salt
   INTEGER,  PRIVATE, PARAMETER :: SSC            = 12 ! Coarse-mode sea salt
-  INTEGER,  PRIVATE, PARAMETER :: SLA            = 13 ! Strat sulfate liq aer
-  INTEGER,  PRIVATE, PARAMETER :: IIC            = 14 ! Irregular ice cloud
+  INTEGER,  PRIVATE, PARAMETER :: BRC            = 13 ! Brown carbon
+  INTEGER,  PRIVATE, PARAMETER :: SLA            = 14 ! Strat sulfate liq aer
+  INTEGER,  PRIVATE, PARAMETER :: IIC            = 15 ! Irregular ice cloud
 
   ! Indices for Fine and Coarse sea-salt indices
   INTEGER,  PRIVATE, PARAMETER :: SS_FINE        = 1
@@ -1481,6 +1482,7 @@ CONTAINS
     k = k + Ars_L1k( H%xArea(ORC), H%xRadi(ORC), H%gamma_HO2, srMw )
     k = k + Ars_L1k( H%xArea(SSA), H%xRadi(SSA), H%gamma_HO2, srMw )
     k = k + Ars_L1k( H%xArea(SSC), H%xRadi(SSC), H%gamma_HO2, srMw )
+    k = k + Ars_L1k( H%xArea(BRC), H%xRadi(BRC), H%gamma_HO2, srMw )
   END FUNCTION HO2uptk1stOrd
 
   !=========================================================================


### PR DESCRIPTION
### Name and Institution (Required)

Name: Megan He
Institution: Harvard University

### Describe the update

This PR implements brown carbon (BrC) in GEOS-Chem following the optical property approach of Hammer et al. (2016), with the main purpose of investigating its effect on photolysis and global [OH]. Rather than introducing a new BrC tracer, we apply Hammer et al.'s effective imaginary refractive index values at BrC/POC = 1.0. From Hammer et al.: _"The columns with effective k values for BrC/POC fraction of unity offer the convenience of representing the effective absorption by BrC without needing to assume an arbitrary BrC/POC fraction, or to introduce a separate BrC tracer. The effective k values for unity BrC/POC fraction can be thought of as the effective imaginary refractive index for an internal mixture of BrC and colorless POC."_

BrC optical properties are read from the existing `/n/holylfs06/LABS/jacob_lab/Everyone/GEOS-CHEM/gcgrid/gcdata/ExtData/CHEM_INPUTS/CLOUD_J/v2025-01/FJX_scat-aer.dat` entries derived from Hammer et al., with density = 1.3 g/cm3. BrC is treated as hygroscopic. Many of the changes are related to aerosol indexing due to the additional aerosol species.

### Expected changes

Gao et al. (2026) treats all organic aerosol originated from residential combustion sector as BrC. So in a 1-year 2024 test simulation, 100% of biofuel OC (CEDS, DICE-Africa) and biomass burning OC (GFED4) is treated as fresh BrC, which is consistent with the BrC/POC = 1.0 approach in Hammer et al. Note that applying Hammer et al.'s optical properties to biofuel BrC is likely a conservative lower bound on biofuel BrC absorption.

JO1D values and OH concentrations decrease most strongly in biomass burning and biofuel regions, but global mean differences are minimal (<0.5%). Difference plots between the 1-year 2024 test simulation (with 6-month spinup) and a reference simulation for Jan and July at the surface and at 500 hPa are attached below. (In the OH surface plots, I masked out where reference OH was very low/near zero, essentially NH in winter.)

<img width="2032" height="760" alt="image" src="https://github.com/user-attachments/assets/e85fb40b-e8e0-4cd8-8203-93f6b573accd" />
<img width="2032" height="760" alt="image" src="https://github.com/user-attachments/assets/6f46ff87-aea0-4904-98ec-1fa6c52fb70e" />
<img width="2061" height="763" alt="image" src="https://github.com/user-attachments/assets/c61d531f-afda-4d24-a866-ab86853c31e7" />
<img width="2061" height="763" alt="image" src="https://github.com/user-attachments/assets/68fbf15d-2739-445a-b539-f29f9f6215bc" />

### Reference(s)

Hammer, M. S., Martin, R. V., van Donkelaar, A., Buchard, V., Torres, O., Ridley, D. A., and Spurr, R. J. D. (2016). Interpreting the ultraviolet aerosol index observed with the OMI satellite instrument to understand absorption by organic aerosols: implications for atmospheric oxidation and direct radiative effects, Atmos. Chem. Phys., 16, 2507–2523. https://doi.org/10.5194/acp-16-2507-2016

Gao, Y., Liu, M., Zhou, R., Cai, X., Zhang, H., Song, Y., et al. (2026). Significant radiative absorption of brown carbon aerosols from residential fuel combustion in developing regions. Geophysical Research Letters, 53, e2026GL121829. https://doi.org/10.1029/2026GL121829
