### PR TITLE
Fixed parallelization error and optimized parallel loops in TOMAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Selected RODAS3.1 as the default integration method for the fullchem mechanism; Regenerated fullchem solver files with KPP 3.4.0
 - Updated the minimum version of KPP needed to build the fullchem mechanism from 3.2.0 to 3.4.0
 - Changed C-preprocessor switch MODEL_ to MODEL_EXTERNAL, and ESMF_ to USE_ESMF
+- Changed the order of DO loops in `GeosCore/tomas_mod.F90` from `I-J-L` to `L-J-I` and added `!$OMP COLLAPSE( 3 )` statements
 
 ### Fixed
 - Fixed incorrect variable names and removed unused variables in `NcdfUtil/ncdf_mod.F90`
 - Fixed incorrect Arrhenius "A" coefficient (1.97d-12 --> 1.97d-11) in C3H8 + OH = A3O2 rxn
 - Fixed GCHP transport tracers extdata.yaml to include valid_range for CEDS
+- Fixed OpenMP parallelization error in `GeosCore/tomas_mod.F90`
 
 ### Removed
 - Removed obsolete code in dust_mod.F90

--- a/GeosCore/carbon_mod.F90
+++ b/GeosCore/carbon_mod.F90
@@ -408,13 +408,6 @@ CONTAINS
     REAL(fp)           :: EMITRATE(State_Grid%NX,State_Grid%NY)
 #endif
 
-#ifdef TOMAS
-  ! ---------------------------------------------------------- SamO
-    IF (.NOT. ALLOCATED (ORG_NUC)) THEN
-      ALLOCATE(ORG_NUC(State_Grid%NX,State_Grid%NY,State_Grid%NZ))
-    ENDIF
-  ! ---------------------------------------------------------- SamO
-#endif
 
     !=================================================================
     ! CHEMCARBON begins here!
@@ -5061,12 +5054,6 @@ CONTAINS
                id_OCOB01 > 1 ) ) THEN
       CALL ERROR_STOP ( 'TOMAS Species not defined!', LOC )
    ENDIF
-
-   ! ---------------------------------------------------------- SamO
-    IF (.NOT. ALLOCATED (ORG_NUC)) THEN
-      ALLOCATE(ORG_NUC(State_Grid%NX,State_Grid%NY,State_Grid%NZ))
-    ENDIF
-  ! ---------------------------------------------------------- SamO
 
    ! Emission timestep [seconds]
    DTSRCE = HcoState%TS_EMIS

--- a/GeosCore/tomas_mod.F90
+++ b/GeosCore/tomas_mod.F90
@@ -187,6 +187,7 @@ MODULE TOMAS_MOD
   REAL(fp), ALLOCATABLE, PUBLIC :: ORG_NUC(:,:,:) ! SamO
   REAL(fp), PRIVATE :: ORG_NUC2                              ! SamO
 
+
 CONTAINS
 !EOC
 !------------------------------------------------------------------------------
@@ -497,7 +498,6 @@ CONTAINS
     !$OMP PRIVATE( fn1,      num_iter,    Nknuc,    Mknuc,      Nkcond      )&
     !$OMP PRIVATE( Mkcond,   ERRORSWITCH, tot_s_1a, tot_n_1a,   ERR_VAR     )&
     !$OMP PRIVATE( ERR_MSG,  ERR_IND,     TRACNUM,  NH3_TO_NH4, SURF_AREA   )&
-    !$OMP PRIVATE( ORG_NUC2                                                 )&
     !$OMP SCHEDULE( DYNAMIC, 24                                             )&
     !$OMP COLLAPSE( 3                                                       )
     DO L = 1, State_Grid%NZ
@@ -7110,6 +7110,10 @@ CONTAINS
     IF ( AS /= 0 ) CALL ALLOC_ERR( 'H2SO4_RATE' )
     H2SO4_RATE = 0.0e+0_fp
 
+    ALLOCATE( ORG_NUC(State_Grid%NX,State_Grid%NY,State_Grid%NZ), STAT=AS)
+    IF ( AS /= 0 ) CALL ALLOC_ERR( 'ORG_NUC' )
+    ORG_NUC = 0.0e+0_fp
+
     ALLOCATE( PSO4AQ_RATE(State_Grid%NX,State_Grid%NY,State_Grid%NZ), STAT=AS )
     IF ( AS /= 0 ) CALL ALLOC_ERR( 'PSO4AQ_RATE' )
     PSO4AQ_RATE = 0.0e+0_fp
@@ -11349,6 +11353,7 @@ CONTAINS
     IF ( ALLOCATED( MOLWT       ) ) DEALLOCATE( MOLWT       )
     IF ( ALLOCATED( MOLWT       ) ) DEALLOCATE( MOLWT       )
     IF ( ALLOCATED( H2SO4_RATE  ) ) DEALLOCATE( H2SO4_RATE  )
+    IF ( ALLOCATED( ORG_NUC     ) ) DEALLOCATE( ORG_NUC     )
     IF ( ALLOCATED( PSO4AQ_RATE ) ) DEALLOCATE( PSO4AQ_RATE )
 
   END SUBROUTINE CLEANUP_TOMAS

--- a/GeosCore/tomas_mod.F90
+++ b/GeosCore/tomas_mod.F90
@@ -185,8 +185,6 @@ MODULE TOMAS_MOD
   INTEGER, PRIVATE :: id_SS01
 
   REAL(fp), ALLOCATABLE, PUBLIC :: ORG_NUC(:,:,:) ! SamO
-  REAL(fp), PRIVATE :: ORG_NUC2                              ! SamO
-
 
 CONTAINS
 !EOC
@@ -343,6 +341,7 @@ CONTAINS
     REAL(fp)            :: QSAT     !used in RH calculation
     INTEGER             :: TRACNUM
     REAL(fp)            :: FRAC
+    REAL(fp)            :: ORG_NUC2 ! SamO
     CHARACTER(LEN=255)  :: MSG, LOC ! species unit check
 
     ! Arguments for CHECK_VALUE; avoids array temporaries (bmy, 1/28/14)
@@ -498,6 +497,7 @@ CONTAINS
     !$OMP PRIVATE( fn1,      num_iter,    Nknuc,    Mknuc,      Nkcond      )&
     !$OMP PRIVATE( Mkcond,   ERRORSWITCH, tot_s_1a, tot_n_1a,   ERR_VAR     )&
     !$OMP PRIVATE( ERR_MSG,  ERR_IND,     TRACNUM,  NH3_TO_NH4, SURF_AREA   )&
+    !$OMP PRIVATE( ORG_NUC2                                                 )&
     !$OMP SCHEDULE( DYNAMIC, 24                                             )&
     !$OMP COLLAPSE( 3                                                       )
     DO L = 1, State_Grid%NZ
@@ -704,7 +704,7 @@ CONTAINS
           CALL COND_NUC(Nk,Mk,Gc,Nkout,Mkout,Gcout,fn,fn1, &
                         H2SO4rate_o,adt,num_iter,Nknuc,Mknuc,Nkcond,Mkcond, &
                         ionrate, surf_area, BOXVOL, BOXMASS, TEMPTMS, PRES, &
-                        RHTOMAS, ERRORSWITCH, l, I, J, L)
+                        RHTOMAS, ERRORSWITCH, l, I, J, L, ORG_NUC2)
 
           !sfdebug if(printdebug) then
           !sfdebug    !print*,'Before COND_NUC Gc(srtso4)=',Gc(srtso4)
@@ -1007,7 +1007,7 @@ CONTAINS
   SUBROUTINE COND_NUC(Nki,Mki,Gci,Nkf,Mkf,Gcf,fnavg,fn1avg, &
                       H2SO4rate,dti,num_iter,Nknuc,Mknuc,Nkcond,Mkcond, &
                       ionrate, surf_area, BOXVOL, BOXMASS, TEMPTMS, PRES, &
-                      RHTOMAS, errswitch, lev,I1,J1,L1)
+                      RHTOMAS, errswitch, lev,I1,J1,L1, ORG_NUC2)
 !
 ! !INPUT PARAMETERS:
 !
@@ -1042,6 +1042,7 @@ CONTAINS
     INTEGER          I1,J1,L1     ! lat, lon, level SamO
     REAL(fp)   surf_area
     REAL(fp)   ionrate
+    REAL(fp)   ORG_NUC2
 !
 ! !REVISION HISTORY:
 !  See https://github.com/geoschem/geos-chem for complete history
@@ -1133,7 +1134,7 @@ CONTAINS
     call getH2SO4conc(Nk1, Mk1, H2SO4rate, CS1, Gc1(srtnh4), &
                       gasConc, ionrate, surf_area, &
                       BOXVOL, BOXMASS, TEMPTMS, PRES, RHTOMAS, lev, &
-                      I1,J1,L1)
+                      I1,J1,L1, ORG_NUC2)
     if( pdbg) print*,'gasConc',gasConc
     Gc1(srtso4) = gasConc
     addt = min_tstep
@@ -1145,7 +1146,7 @@ CONTAINS
     !Get change size distribution due to nucleation with initial guess
     call nucleation(Nk1,Mk1,Gc1,Nk2,Mk2,Gc2,fn,fn1,totmass,nuc_bin, &
                     addt, ionrate, surf_area, BOXVOL, BOXMASS, TEMPTMS, &
-                    PRES, RHTOMAS, PDBG, lev,I1,J1,L1)
+                    PRES, RHTOMAS, PDBG, lev,I1,J1,L1, ORG_NUC2)
 
     if(pdbg) then
        print*,'COND_NUC: Found an error at nucleation --> TERMINATE'
@@ -1281,7 +1282,7 @@ CONTAINS
           call getH2SO4conc(Nk1, Mk1, H2SO4rate, CS1, Gc1(srtnh4), &
                             gasConc, ionrate, surf_area, &
                             BOXVOL, BOXMASS, TEMPTMS, PRES, RHTOMAS, lev, &
-                            I1,J1,L1)
+                            I1,J1,L1, ORG_NUC2)
           Gc1(srtso4) = gasConc
        endif
        if( pdbg)    print*,'gasConc',gasConc
@@ -1301,7 +1302,7 @@ CONTAINS
        tempvar = pdbg
        call nucleation(Nk1,Mk1,Gc1,Nk2,Mk2,Gc2,fn,fn1,totmass, &
                        nuc_bin,addt, ionrate, surf_area, BOXVOL, BOXMASS, &
-                       TEMPTMS, PRES, RHTOMAS, PDBG, lev,I1,J1,L1)
+                       TEMPTMS, PRES, RHTOMAS, PDBG, lev,I1,J1,L1, ORG_NUC2)
 
        if(pdbg) then
           print*,'COND_NUC: Error at nucleation[2] --> TERMINATE'
@@ -1904,7 +1905,7 @@ CONTAINS
 !
   SUBROUTINE getH2SO4conc(Nk, Mk, H2SO4rate, CS, NH3conc, gasConc, &
                           ionrate, surf_area, BOXVOL, BOXMASS, &
-                          TEMPTMS, PRES, RHTOMAS, lev,I1,J1,L1)
+                          TEMPTMS, PRES, RHTOMAS, lev,I1,J1,L1, ORG_NUC2)
 !
 ! !USES:
 !
@@ -1925,6 +1926,7 @@ CONTAINS
     REAL*4, INTENT(IN)  :: BOXVOL,  BOXMASS, TEMPTMS
     REAL*4, INTENT(IN)  :: PRES,    RHTOMAS
     integer                lev
+    REAL(fp), INTENT(IN) :: ORG_NUC2
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -2022,7 +2024,7 @@ CONTAINS
     
     call getNucRate(Nk, Mk, Gci,fn,mnuc,nflg,ionrate, surf_area, &
                     BOXVOL, BOXMASS, TEMPTMS, PRES, RHTOMAS, lev,&
-                    I1,J1,L1)
+                    I1,J1,L1, ORG_NUC2)
     
 
     if (fn.gt.0.e+0_fp) then      ! nucleation occured
@@ -2034,7 +2036,7 @@ CONTAINS
        Gci(srtso4) = gasConc_lo*1.000001e+0_fp
        call getNucRate(Nk,Mk,Gci,fn1,mnuc1,nflg,ionrate,surf_area, &
                        BOXVOL, BOXMASS, TEMPTMS, PRES, RHTOMAS, lev,&
-                       I1,J1,L1)
+                       I1,J1,L1, ORG_NUC2)
        if (fn1.gt.0.e+0_fp) then
           massnuc = mnuc1*fn1*boxvol*98.e+0_fp/96.e+0_fp
           !massnuc = 4.e+0_fp/3.e+0_fp*pi*(rnuc1*1.e-9_fp)**3*1350.*fn1*boxvol*
@@ -2085,7 +2087,7 @@ CONTAINS
           Gci(srtso4) = gasConc
           call getNucRate(Nk, Mk,Gci,fn,mnuc,nflg,ionrate,surf_area, &
                           BOXVOL, BOXMASS, TEMPTMS, PRES, RHTOMAS, lev,&
-                          I1,J1,L1)
+                          I1,J1,L1, ORG_NUC2)
           massnuc = mnuc*fn*boxvol*98.e+0_fp/96.e+0_fp
           res = H2SO4rate - CS*gasConc - massnuc
           !print*,'res',res
@@ -2133,7 +2135,7 @@ CONTAINS
 !
   SUBROUTINE getNucRate(Nk, Mk, Gci,fn,mnuc,nflg, ionrate,surf_area, &
                         BOXVOL, BOXMASS, TEMPTMS, PRES, RHTOMAS, lev,&
-                        I1,J1,L1)
+                        I1,J1,L1, ORG_NUC2)
 !
 ! !USES:
 !
@@ -2148,6 +2150,7 @@ CONTAINS
     REAL*4,   INTENT(IN)       :: BOXVOL,  BOXMASS, TEMPTMS
     REAL*4,   INTENT(IN)       :: PRES,    RHTOMAS
     REAL(fp), INTENT(IN)       :: Gci(icomp-1)
+    REAL(fp), INTENT(IN)       :: ORG_NUC2
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -2976,7 +2979,7 @@ CONTAINS
 !
   SUBROUTINE NUCLEATION(Nki,Mki,Gci,Nkf,Mkf,Gcf,fn,fn1,totsulf, &
                         nuc_bin,dt,ionrate, surf_area, BOXVOL, BOXMASS, &
-                        TEMPTMS, PRES, RHTOMAS, pdbg,lev,I1,J1,L1)
+                        TEMPTMS, PRES, RHTOMAS, pdbg,lev,I1,J1,L1, ORG_NUC2)
 !
 ! !USES:
 !
@@ -3017,6 +3020,7 @@ CONTAINS
 
     REAL(fp)                     ionrate
     REAL(fp)                     surf_area
+    REAL(fp), INTENT(IN) :: ORG_NUC2
 !
 ! !REVISION HISTORY:
 !  See https://github.com/geoschem/geos-chem for complete history

--- a/GeosCore/tomas_mod.F90
+++ b/GeosCore/tomas_mod.F90
@@ -486,26 +486,23 @@ CONTAINS
     ! NOTE: This doesn't have to be !$OMP+PRIVATE (bmy, 2/7/20)
     ADT = GET_TS_CHEM()
 
-    !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    !%%% NOTE: THIS PARALLEL LOOP MAY BE ABLE TO BE REVERSED TO L-J-I
-    !%%% WHICH IS MUCH MORE EFFICIENT (bmy, 1/28/14)
-    !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    !$OMP PARALLEL DO         &
-    !$OMP DEFAULT( SHARED )   &
-    !$OMP PRIVATE( I, J, L )  &
-    !$OMP PRIVATE( PRES, TEMPTMS, BOXMASS, RHTOMAS, BOXVOL )       &
-    !$OMP PRIVATE( printneg, ionrate, lev, weight, GC, N, NK, JC ) &
-    !$OMP PRIVATE( MK, H2SO4rate_o, tot_n_1, k, tot_s_1, MPNUM )   &
-    !$OMP PRIVATE( Nkd, Mkd, TOT_NK, TOT_MK, TRANSFER )            &
-    !$OMP PRIVATE( Nkout,Mkout,Gcout,fn,fn1 )                      &
-    !$OMP PRIVATE( num_iter,Nknuc,Mknuc,Nkcond )                   &
-    !$OMP PRIVATE( Mkcond, ERRORSWITCH, tot_s_1a, tot_n_1a )       &
-    !$OMP PRIVATE( ERR_VAR, ERR_MSG, ERR_IND )                     &
-    !$OMP PRIVATE( TRACNUM, NH3_TO_NH4, SURF_AREA )                &
-    !$OMP SCHEDULE( DYNAMIC )
-    DO I = 1, State_Grid%NX
-    DO J = 1, State_Grid%NY
+    !$OMP PARALLEL DO                                                        &
+    !$OMP DEFAULT( SHARED                                                   )&
+    !$OMP PRIVATE( I,        J,           PRES,     TEMPTMS,    BOXMASS     )&
+    !$OMP PRIVATE( RHTOMAS,  BOXVOL,      printneg, ionrate,    lev         )&
+    !$OMP PRIVATE( weight,   GC,          N,        NK,         JC          )&
+    !$OMP PRIVATE( MK,       H2SO4rate_o, tot_n_1,  k,          tot_s_1     )&
+    !$OMP PRIVATE( MPNUM,    Nkd,         Mkd,      TOT_NK,     TOT_MK      )&
+    !$OMP PRIVATE( TRANSFER, Nkout,       Mkout,    Gcout,      fn          )&
+    !$OMP PRIVATE( fn1,      num_iter,    Nknuc,    Mknuc,      Nkcond      )&
+    !$OMP PRIVATE( Mkcond,   ERRORSWITCH, tot_s_1a, tot_n_1a,   ERR_VAR     )&
+    !$OMP PRIVATE( ERR_MSG,  ERR_IND,     TRACNUM,  NH3_TO_NH4, SURF_AREA   )&
+    !$OMP PRIVATE( ORG_NUC2                                                 )&
+    !$OMP SCHEDULE( DYNAMIC, 24                                             )&
+    !$OMP COLLAPSE( 3                                                       )
     DO L = 1, State_Grid%NZ
+    DO J = 1, State_Grid%NY
+    DO I = 1, State_Grid%NX
 
        ! Skip non-chemgrid boxes
        IF ( .not. State_Met%InChemGrid(I,J,L) ) CYCLE
@@ -8110,11 +8107,12 @@ CONTAINS
     CALL CHECKMN( 0, 0, 0, Input_Opt, State_Chm, State_Grid, State_Met, &
                   State_Diag, 'AERO_DIADEN called from DEPVEL', RC )
 
-    !$OMP PARALLEL DO       &
-    !$OMP DEFAULT( SHARED ) &
-    !$OMP PRIVATE( MECIL, MECOB, MOCIL, MOCOB, MDUST ) &
-    !$OMP PRIVATE( BIN, I, J, TRACID, WID, MH2O, MSO4, MNACL ) &
-    !$OMP SCHEDULE( DYNAMIC )
+    !$OMP PARALLEL DO                                                        &
+    !$OMP DEFAULT( SHARED                                                   )&
+    !$OMP PRIVATE( MECIL, MECOB, MOCIL,  MOCOB, MDUST,  BIN                 )&
+    !$OMP PRIVATE( I,     J,     TRACID, WID  , MH2O,   MSO4, MNACL         )&
+    !$OMP SCHEDULE( DYNAMIC, 24                                             )&
+    !$OMP COLLAPSE( 3                                                       )
     DO J = 1, State_Grid%NY
     DO I = 1, State_Grid%NX
     DO BIN = 1, IBINS
@@ -8292,15 +8290,17 @@ CONTAINS
        L2 = LL
     ENDIF
 
-    !$OMP PARALLEL DO        &
-    !$OMP DEFAULT( SHARED )  &
-    !$OMP PRIVATE( I, J, L ) &
-    !$OMP PRIVATE( Nk, Nkd, Mk, Mkd, K, TRACNUM, JC, MPNUM, BOXVOL, BOXMASS ) &
-    !$OMP PRIVATE( GC, GCd, ERRORSWITCH ) &
-    !$OMP SCHEDULE( DYNAMIC )
-    DO I = I1, I2
-    DO J = J1, J2
+    !$OMP PARALLEL DO                                                        &
+    !$OMP DEFAULT( SHARED                                                   )&
+    !$OMP PRIVATE( I,           J,      L,       Nk,      Nkd               )&
+    !$OMP PRIVATE( Mk,          Mkd,    K,       TRACNUM, JC                )&
+    !$OMP PRIVATE( MPNUM,       BOXVOL, BOXMASS, GC,      GCd               )&
+    !$OMP PRIVATE( ERRORSWITCH                                              )&
+    !$OMP SCHEDULE( DYNAMIC, 24                                             )&
+    !$OMP COLLAPSE( 3                                                       )
     DO L = L1, L2
+    DO J = J1, J2
+    DO I = I1, I2
 
        BOXVOL  = State_Met%AIRVOL(I,J,L) * 1.e6 !convert from m3 -> cm3
        BOXMASS = State_Met%AD(I,J,L) !kg


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #3308, in which we have found a parallelization that was introduced in the TOMAS updates PR #3257.  In this PR we have done the following:

1. Added the `ORG_NUC2` variable to the `!$OMP PRIVATE` statement in the parallel loop in the `DO_TOMAS` routine.  This was causing the numerical noise cited in #3308.

2. Switched loop indices from `I-J-L` to `L-J-I`, which is the order in which Fortran lays out the arrays in memory (column-major).  In this way we should reduce cache misses, which will make the loops more efficient.

3. Changed `!$OMP SCHEDULE( DYNAMIC )` to `!$OMP SCHEDULE( DYNAMIC, 24 )` to group grid boxes 24 at a time.

4. Added `!$OMP COLLAPSE( 3 )` to vectorize the loops over all dimensions.

### Expected changes
This should remove the numerical noise differences as seen in PR #3308.  Also the loops should execute much faster, as they were not properly optimized.

### Related Github Issue

- Closes #3308

Integration tests are running.

Tagging @BettyCroft 