### PR TITLE
Fixed pHcloud to be nonconstant and isCloud to vary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Fixed error where `State_Chm%phCloud` was always being reset to 4.5
+
 ## [14.7.1] - 2026-04-08
 ### Added
 - Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -2588,10 +2588,20 @@ CONTAINS
     Spc                  => State_Chm%Species
     H2O2s                => State_Chm%H2O2AfterChem
     SO2s                 => State_Chm%SO2AfterChem
-    State_Chm%isCloud    =  0.0_fp
+!    State_Chm%isCloud    =  0.0_fp
 !    State_Chm%pHcloud    =  0.0_fp
-    State_Chm%pHcloud    =  4.5_fp
-    State_Chm%QLxpHcloud =  0.0_fp
+!    State_Chm%pHcloud    =  4.5_fp
+!    State_Chm%QLxpHcloud =  0.0_fp
+    ! Only reset isCloud, pHcloud, and QLxpHcloud if sulfate_mod
+    ! owns cloud chemistry (Do_SulfateMod_Cld=.TRUE. i.e. offline run).
+    ! If Do_SulfateMod_Cld=.FALSE., KPP/SET_SO2 is responsible for
+    ! setting isCloud -- does not overwrite it here.
+    IF ( State_Chm%Do_SulfateMod_Cld ) THEN
+       State_Chm%isCloud    =  0.0_fp
+!       State_Chm%pHcloud    =  0.0_fp
+       State_Chm%pHcloud    =  4.5_fp
+       State_Chm%QLxpHcloud =  0.0_fp
+    ENDIF
 #ifdef LUO_WETDEP
     State_Chm%pHrain     =  5.6_fp
     State_Chm%QQpHrain   =  0.0_fp


### PR DESCRIPTION
### Name and Institution (Required)

Name: Sierra Dabby
Institution: University of Washington

### Describe the update

I edited sulfate_mod.F90 to fix the isCloud and pHCloud diagnostics. My edits start at line 2591 and end at 2605. Mainly, I just commented out some reset lines and added an if statement. The if statement says that if sulfate is online, don't reset the values of isCloud and pHCloud inside sulfate_mod.F90. 

### Expected changes

This update should make pHCloud vary, previously it would output pH as 4.5 everywhere. It should also allow isCloud to vary between 0 and 1, previously it was 0 everywhere. 

### Reference(s)

No lit citations. 

### Related Github Issue

Link to corresponding GitHub issue: [https://github.com/geoschem/geos-chem/issues/3310]
