### PR TITLE
Run directory updates to default GCHP to c90 resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed 
+- Updated default GCHP resolution in createRunDir.sh from c24 for GCHP and c30 for GEOS-IT to c90 in all cases.
+
+
 ## [14.7.1] - 2026-04-08
 ### Added
 - Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - TBD
 ### Changed 
-- Updated default GCHP resolution in createRunDir.sh from c24 for GCHP and c30 for GEOS-IT to c90 in all cases.
-
+- Updated default GCHP resolution in createRunDir.sh from c24 for MERRA2/GEOS-FP and c30 for GEOS-IT to c90 in all cases.
 
 ## [14.7.1] - 2026-04-08
 ### Added

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -756,11 +756,9 @@ else
 fi
 
 # Set default grid resolution
-if [[ "${met}" == "geosit" && "${adv_flux_src}" == "1hr_mass_flux" ]]; then
-    RUNDIR_VARS+="RUNDIR_CS_RES='30'\n"
-else
-    RUNDIR_VARS+="RUNDIR_CS_RES='24'\n"
-fi
+# Modified as of 14.8.0 to default to C90 in all cases
+RUNDIR_VARS+="RUNDIR_CS_RES='90'\n"
+
 
 # Assign appropriate file paths and settings in HEMCO_Config.rc
 if [[ "${sim_extra_option}" == "benchmark" ]]; then

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -756,7 +756,6 @@ else
 fi
 
 # Set default grid resolution
-# Modified as of 14.8.0 to default to C90 in all cases
 RUNDIR_VARS+="RUNDIR_CS_RES='90'\n"
 
 

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -23,6 +23,16 @@ NUM_CORES_PER_NODE=${RUNDIR_CORES_PER_NODE}
 # NOTE: If using mass flux inputs then grid resolution must be evenly divisible
 # by input mass flux resolution, or vice versa. Acceptable resolutions for GEOS-IT
 # when using mass fluxes are therefore in set [10,30,90,180,360,540,720,etc]
+#
+# ATTN: As of GCHP 14.8.0, the default grid resolution is now C90, approximately 
+# equal to 1x1 degrees. C90 is the recommended minimum resolution for most scientific 
+# applications, as representation of transport processes begins to degrade below 
+# this threshold. Switching from C24 to C90 will likely result in increased 
+# computational cost and longer run times; think carefully about your specific
+# requirements before submitting new jobs. For a more detailed explanantion, see the
+# GCHP Horizontal Grids section of the GCHP ReadTheDocs.
+# 
+# C24 and C48 are still available and are recommended primarily for test runs. 
 
 CS_RES=${RUNDIR_CS_RES}
 

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -20,20 +20,24 @@ NUM_CORES_PER_NODE=${RUNDIR_CORES_PER_NODE}
 #------------------------------------------------
 # Even integer representing number of grid cells per cubed-sphere face side
 #
-# NOTE: If using mass flux inputs then grid resolution must be evenly divisible
-# by input mass flux resolution, or vice versa. Acceptable resolutions for GEOS-IT
-# when using mass fluxes are therefore in set [10,30,90,180,360,540,720,etc]
+# IMPORTANT NOTES:
 #
-# ATTN: As of GCHP 14.8.0, the default grid resolution is now C90, approximately 
-# equal to 1x1 degrees. C90 is the recommended minimum resolution for most scientific 
-# applications, as representation of transport processes begins to degrade below 
-# this threshold. Switching from C24 to C90 will likely result in increased 
-# computational cost and longer run times; think carefully about your specific
-# requirements before submitting new jobs. For a more detailed explanantion, see the
-# GCHP Horizontal Grids section of the GCHP ReadTheDocs.
-# 
-# C24 and C48 are still available and are recommended primarily for test runs. 
-
+# (1) C90 is the recommended minimum resolution for most scientific applications, 
+# as the representation of transport processes begins to degrade below this threshold. 
+# Lower resolutions of c24, c30, and c48 are recommended primarily for testing and 
+# debugging purposes. See
+# https://gchp.readthedocs.io/en/latest/supplement/horizontal-grids.html
+# for more information about available grids.
+#
+# (2) Higher resolution results in increased computation cost and longer run times.
+# Think carefully about your specific requirements before submitting new jobs. If doing
+# your first GCHP run on a new system, we recommend using c24 with few cores.
+#
+# (3) If using mass flux inputs then grid resolution must be evenly divisible by input 
+# mass flux resolution, or vice versa. Acceptable resolutions for GEOS-IT when using 
+# mass fluxes are therefore in set [10,30,90,180,360,540,720,etc]
+#
+#
 CS_RES=${RUNDIR_CS_RES}
 
 #------------------------------------------------

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -26,10 +26,8 @@ NUM_CORES_PER_NODE=${RUNDIR_CORES_PER_NODE}
 # available resources when choosing a grid resolution. Higher-resolution 
 # simulations provide a more faithful representation of transport. While most 
 # users should find C90 sufficient for their research needs, current 
-# GCHP applications commonly span within C48 to C360. Lower resolutions 
-# of C24, C30, and C48 are recommended primarily for testing and 
-# debugging purposes. See
-# https://gchp.readthedocs.io/en/latest/supplement/horizontal-grids.html
+# GCHP applications commonly span within C48 to C360.
+# See https://gchp.readthedocs.io/en/latest/supplement/horizontal-grids.html
 # for more information about available grids.
 #
 # (2) Higher resolution results in increased computation cost and longer run times.

--- a/run/GCHP/setCommonRunSettings.sh.template
+++ b/run/GCHP/setCommonRunSettings.sh.template
@@ -22,9 +22,12 @@ NUM_CORES_PER_NODE=${RUNDIR_CORES_PER_NODE}
 #
 # IMPORTANT NOTES:
 #
-# (1) C90 is the recommended minimum resolution for most scientific applications, 
-# as the representation of transport processes begins to degrade below this threshold. 
-# Lower resolutions of c24, c30, and c48 are recommended primarily for testing and 
+# (1) Users are encouraged to think carefully about their run's needs and 
+# available resources when choosing a grid resolution. Higher-resolution 
+# simulations provide a more faithful representation of transport. While most 
+# users should find C90 sufficient for their research needs, current 
+# GCHP applications commonly span within C48 to C360. Lower resolutions 
+# of C24, C30, and C48 are recommended primarily for testing and 
 # debugging purposes. See
 # https://gchp.readthedocs.io/en/latest/supplement/horizontal-grids.html
 # for more information about available grids.


### PR DESCRIPTION
### Name and Institution (Required)

Name: Helena McDonald
Institution: Harvard University 

### Describe the update

Changes to setCommonRunSettings.template.sh and createRunDir.sh to default resolution to c90 for all simulations - removing separate logic for GEOS-IT. Additional notes directing users to the documentation and to think critically about their necessary run resolution. 

### Expected changes

No diff to chemistry. 

### Related Github Issue

- See https://github.com/geoschem/GCHP/issues/555