### PR TITLE
Fixes for Jacobian runs in GCHP IMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed GCHP transport tracers extdata.yaml to include valid_range for CEDS
 - Fixed OpenMP parallelization error in `GeosCore/tomas_mod.F90`
 - Fixed typos (extra `:` characters) in `run/shared/kpp_standalone_interface.yml`
+- Fixed bugs in Jacobian tracers simulation
 
 ### Removed
 - Removed obsolete code in dust_mod.F90

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -2703,12 +2703,31 @@ CONTAINS
           ! Get Internal state
           CALL MAPL_Get ( STATE, INTERNAL_ESMF_STATE=INTERNAL, __RC__ )
 
+
+#ifdef JACOBIAN
+          ! Set Jacobian local variables
+          primarySpcName = ''
+          primarySpcId = -1
+          DO N = 1, State_Chm%nSpecies
+             ThisSpc => State_Chm%SpcData(N)%Info
+             IF ( ThisSpc%Is_JacobianTracer .AND. primarySpcID == -1 ) THEN
+                ThisSpc => State_Chm%SpcData(N)%Info
+                primarySpcName = ThisSpc%Name(1:LEN(trim(ThisSpc%Name))-8)
+                primarySpcId = IND_(trim(primarySpcName))
+                EXIT
+             ENDIF
+          ENDDO
+#endif
+
           ! Loop over all species and get info from spc db
           DO N = 1, State_Chm%nSpecies
              ThisSpc => State_Chm%SpcData(N)%Info
              IF ( TRIM(ThisSpc%Name) == '' ) CYCLE
              IND = IND_( TRIM(ThisSpc%Name ) )
              IF ( IND < 0 ) CYCLE
+#ifdef JACOBIAN
+             IF ( ThisSpc%Is_JacobianTracer ) CYCLE
+#endif
 
              ! Determine if species in restart file
              CALL ESMF_StateGet( INTERNAL, TRIM(SPFX) // TRIM(ThisSpc%Name),  &
@@ -2717,13 +2736,20 @@ CONTAINS
                   VALUE=RST, RC=STATUS )
 
              ! Set spc conc to background value if rst skipped or var not there
-             IF ( ( RC  /= ESMF_SUCCESS           .OR.     &
-                    RST == MAPL_RestartBootstrap  .OR.     &
-                    RST == MAPL_RestartSkipInitial  )      &
+             IF ( ( RC  /= ESMF_SUCCESS         .OR.     &
+                  RST == MAPL_RestartBootstrap  .OR.     &
+                  RST == MAPL_RestartSkipInitial  ) THEN
+
 #ifdef JACOBIAN
-                    .AND. .NOT. ThisSpc%Is_JacobianTracer  &
+                ! Exit with error if the primary species is not found in restart
+                IF ( primarySpcId == IND ) THEN
+                   WRITE(*,*) '   ERROR: Cannot find primary species used to initialize ' &
+                        'Jacobian tracers in restart file: ' // trim(primarySpcName)
+                   STATUS = GC_FAILURE
+                   _VERIFY(STATUS)
+                ENDIF
 #endif
-                    ) THEN
+
                 DO L = 1, State_Grid%NZ
                 DO J = 1, State_Grid%NY
                 DO I = 1, State_Grid%NX
@@ -2745,26 +2771,34 @@ CONTAINS
                 ENDIF
              ENDIF
 
+             ThisSpc => NULL()
+          ENDDO
+
 #ifdef JACOBIAN
-             ! Do special handling if this is a Jacobian tracer and not found in restart file
-             IF ( ThisSpc%Is_JacobianTracer ) THEN
-                IF ( RC  /= ESMF_SUCCESS         .OR.     &
-                     RST == MAPL_RestartBootstrap  .OR.     &
-                     RST == MAPL_RestartSkipInitial  ) THEN
-                   primarySpcName = ThisSpc%Name(1:LEN(trim(ThisSpc%Name))-8)
-                   primarySpcId = IND_(trim(primarySpcName))
-                   State_Chm%Species(IND)%Conc = State_Chm%Species(primarySpcId)%Conc
-                   IF ( MAPL_am_I_Root()) THEN
-                      WRITE(*,*) '   INFO: using the initial concentration of ' &
-                           // trim(primarySpcName) //' for the Jacobian tracer ' &
-                           // trim(ThisSpc%Name)
-                   ENDIF
+          ! Set Jacobian species to primary species values if the Jacobian
+          ! species is missing in the restart file
+          DO N = 1, State_Chm%nSpecies
+             ThisSpc => State_Chm%SpcData(N)%Info
+             IF ( .NOT. ThisSpc%Is_JacobianTracer ) CYCLE
+
+             CALL ESMF_StateGet( INTERNAL, TRIM(SPFX) // TRIM(ThisSpc%Name),  &
+                  trcFIELD, RC=RC )
+             CALL ESMF_AttributeGet( trcFIELD, NAME="RESTART", VALUE=RST, RC=STATUS )
+             IF ( RC  /= ESMF_SUCCESS           .OR.     &
+                  RST == MAPL_RestartBootstrap  .OR.     &
+                  RST == MAPL_RestartSkipInitial  ) THEN
+                State_Chm%Species(IND)%Conc = State_Chm%Species(primarySpcId)%Conc
+                IF ( MAPL_am_I_Root()) THEN
+                   WRITE(*,*) '   INFO: using the initial concentration of ' &
+                        // trim(primarySpcName) //' for the Jacobian tracer ' &
+                        // trim(ThisSpc%Name)
                 ENDIF
              ENDIF
-#endif
 
              ThisSpc => NULL()
           ENDDO
+#endif
+
        ENDIF
 
        !=======================================================================

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -2746,15 +2746,19 @@ CONTAINS
              ENDIF
 
 #ifdef JACOBIAN
-             ! Do special handling if this is a Jacobian tracer             
+             ! Do special handling if this is a Jacobian tracer and not found in restart file
              IF ( ThisSpc%Is_JacobianTracer ) THEN
-                primarySpcName = ThisSpc%Name(1:LEN(trim(ThisSpc%Name))-8)
-                primarySpcId = IND_(trim(primarySpcName))
-                State_Chm%Species(IND)%Conc = State_Chm%Species(primarySpcId)%Conc
-                IF ( MAPL_am_I_Root()) THEN
-                   WRITE(*,*) '   INFO: using the initial concentration of ' &
-                        // trim(primarySpcName) //' for the Jacobian tracer ' &
-                        // trim(ThisSpc%Name)
+                IF ( RC  /= ESMF_SUCCESS         .OR.     &
+                     RST == MAPL_RestartBootstrap  .OR.     &
+                     RST == MAPL_RestartSkipInitial  ) THEN
+                   primarySpcName = ThisSpc%Name(1:LEN(trim(ThisSpc%Name))-8)
+                   primarySpcId = IND_(trim(primarySpcName))
+                   State_Chm%Species(IND)%Conc = State_Chm%Species(primarySpcId)%Conc
+                   IF ( MAPL_am_I_Root()) THEN
+                      WRITE(*,*) '   INFO: using the initial concentration of ' &
+                           // trim(primarySpcName) //' for the Jacobian tracer ' &
+                           // trim(ThisSpc%Name)
+                   ENDIF
                 ENDIF
              ENDIF
 #endif

--- a/KPP/carbon/carbon.eqn.jacobian.5
+++ b/KPP/carbon/carbon.eqn.jacobian.5
@@ -30,23 +30,8 @@ CO2                 = IGNORE;  { Active carbon dioxide species                  
 PCOfromCH4          = IGNORE;  { Tracks P(CO) from CH4 for diagnostics           }
 PCOfromNMVOC        = IGNORE;  { Tracks P(CO) from NMVOC for diagnostics         }
 LCH4byOH            = IGNORE;  { Dummy spc to track loss of CH4 by OH            }
-LCH4byOH_jac0001    = IGNORE;  { Dummy spc to track loss of CH4_jac0001 by OH    }
-LCH4byOH_jac0002    = IGNORE;  { Dummy spc to track loss of CH4_jac0002 by OH    }
-LCH4byOH_jac0003    = IGNORE;  { Dummy spc to track loss of CH4_jac0003 by OH    }
-LCH4byOH_jac0004    = IGNORE;  { Dummy spc to track loss of CH4_jac0004 by OH    }
-LCH4byOH_jac0005    = IGNORE;  { Dummy spc to track loss of CH4_jac0005 by OH    }
 LCH4byCl            = IGNORE;  { Dummy spc to track loss of CH4 by Cl            }
-LCH4byCl_jac0001    = IGNORE;  { Dummy spc to track loss of CH4_jac0001 by Cl    }
-LCH4byCl_jac0002    = IGNORE;  { Dummy spc to track loss of CH4_jac0002 by Cl    }
-LCH4byCl_jac0003    = IGNORE;  { Dummy spc to track loss of CH4_jac0003 by Cl    }
-LCH4byCl_jac0004    = IGNORE;  { Dummy spc to track loss of CH4_jac0004 by Cl    }
-LCH4byCl_jac0005    = IGNORE;  { Dummy spc to track loss of CH4_jac0005 by Cl    }
 LCH4inStrat         = IGNORE;  { Dummy spc to track loss of CH4 in strat         }
-LCH4inStrat_jac0001 = IGNORE;  { Dummy spc to track loss of CH4_jac0001 in strat }
-LCH4inStrat_jac0002 = IGNORE;  { Dummy spc to track loss of CH4_jac0002 in strat }
-LCH4inStrat_jac0003 = IGNORE;  { Dummy spc to track loss of CH4_jac0003 in strat }
-LCH4inStrat_jac0004 = IGNORE;  { Dummy spc to track loss of CH4_jac0004 in strat }
-LCH4inStrat_jac0005 = IGNORE;  { Dummy spc to track loss of CH4_jac0005 in strat }
 LCObyOH             = IGNORE;  { Dummy spc to track loss of CO by OH             }
 LCOinStrat          = IGNORE;  { Dummy spc to track loss of CO in strat          }
 
@@ -65,19 +50,19 @@ DummyNMVOC            = IGNORE;  { Dummy placeholder for NMVOC reactant       }
 //
 // Rate [1/s] is from JPL 1997
 CH4         + FixedOH = LCH4byOH           : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
-CH4_jac0001 + FixedOH = LCH4byOH_jac0001   : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
-CH4_jac0002 + FixedOH = LCH4byOH_jac0002   : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
-CH4_jac0003 + FixedOH = LCH4byOH_jac0003   : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
-CH4_jac0004 + FixedOH = LCH4byOH_jac0004   : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
-CH4_jac0005 + FixedOH = LCH4byOH_jac0005   : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
+CH4_jac0001 + FixedOH = LCH4byOH           : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
+CH4_jac0002 + FixedOH = LCH4byOH           : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
+CH4_jac0003 + FixedOH = LCH4byOH           : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
+CH4_jac0004 + FixedOH = LCH4byOH           : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
+CH4_jac0005 + FixedOH = LCH4byOH           : 2.45d-12*EXP(-1775.0d0/TEMP)*TROP;
 //
 // Rate [1/s] is from Kirschke et al, 2013 (Nature Geosci.)
 CH4         + FixedCl = LCH4byCl           : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
-CH4_jac0001 + FixedCl = LCH4byCl_jac0001   : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
-CH4_jac0002 + FixedCl = LCH4byCl_jac0002   : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
-CH4_jac0003 + FixedCl = LCH4byCl_jac0003   : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
-CH4_jac0004 + FixedCl = LCH4byCl_jac0004   : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
-CH4_jac0005 + FixedCl = LCH4byCl_jac0005   : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
+CH4_jac0001 + FixedCl = LCH4byCl           : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
+CH4_jac0002 + FixedCl = LCH4byCl           : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
+CH4_jac0003 + FixedCl = LCH4byCl           : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
+CH4_jac0004 + FixedCl = LCH4byCl           : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
+CH4_jac0005 + FixedCl = LCH4byCl           : 9.60d-12*EXP(-1360.0d0/TEMP)*TROP;
 //
 // Rate k_Trop(1) [1/s] is set to HEMCO-supplied P(CO) from CH4
 DummyCH4trop         = CO + PCOfromCH4         : k_Trop(1);
@@ -97,11 +82,11 @@ DummyNMVOC           = CO + PCOfromNMVOC       : k_Trop(3);
 //
 // Rate k_Strat(1) [1/s] is set to HEMCO-supplied loss of CH4 by OH
 CH4         = LCH4inStrat          : k_Strat(1);
-CH4_jac0001 = LCH4inStrat_jac0001  : k_Strat(1);
-CH4_jac0002 = LCH4inStrat_jac0002  : k_Strat(1);
-CH4_jac0003 = LCH4inStrat_jac0003  : k_Strat(1);
-CH4_jac0004 = LCH4inStrat_jac0004  : k_Strat(1);
-CH4_jac0005 = LCH4inStrat_jac0005  : k_Strat(1);
+CH4_jac0001 = LCH4inStrat          : k_Strat(1);
+CH4_jac0002 = LCH4inStrat          : k_Strat(1);
+CH4_jac0003 = LCH4inStrat          : k_Strat(1);
+CH4_jac0004 = LCH4inStrat          : k_Strat(1);
+CH4_jac0005 = LCH4inStrat          : k_Strat(1);
 //
 // DummyCH4 is a placeholder species set to 1 molec/cm3.
 // This is a KPP "trick" in order to set the final CO concentration

--- a/KPP/carbon/util/expand_carbon_eqn.py
+++ b/KPP/carbon/util/expand_carbon_eqn.py
@@ -60,55 +60,14 @@ for line in lines:
                     f"CH4_jac{idx}   = IGNORE;  {{ Active methane Jacobian tracer }}\n"
                 )
 
-        # LCH4byOH -> LCH4byOH_jac000N
-        elif key == "LCH4byOH":
-            for k in range(1, Njac + 1):
-                idx = f"{k:04d}"
-                out_lines.append(
-                    f"LCH4byOH_jac{idx} = IGNORE;  "
-                    f"{{ Dummy spc to track loss of CH4_jac{idx} by OH     }}\n"
-                )
-
-        # LCH4byCl -> LCH4byCl_jac000N
-        elif key == "LCH4byCl":
-            for k in range(1, Njac + 1):
-                idx = f"{k:04d}"
-                out_lines.append(
-                    f"LCH4byCl_jac{idx} = IGNORE;  "
-                    f"{{ Dummy spc to track loss of CH4_jac{idx} by Cl     }}\n"
-                )
-
-        # LCH4inStrat -> LCH4inStrat_jac000N
-        elif key == "LCH4inStrat":
-            for k in range(1, Njac + 1):
-                idx = f"{k:04d}"
-                out_lines.append(
-                    f"LCH4inStrat_jac{idx} = IGNORE;  "
-                    f"{{ Dummy spc to track loss of CH4_jac{idx} in strat }}\n"
-                )
-
     # =====================================================
     # 2) EQUATIONS expansions: CH4 reactions -> CH4_jac000N
     # =====================================================
     if in_equations and tokens and tokens[0] == "CH4":
-        # We need to find the product species (right after "=")
+
         eq_pos = line.find("=")
         if eq_pos == -1:
             continue  # not an equation line we care about
-
-        # substring after "=" up to ":" (if present)
-        rest = line[eq_pos + 1 :]
-        colon_pos = rest.find(":")
-        if colon_pos != -1:
-            lhs_products = rest[:colon_pos]
-        else:
-            lhs_products = rest
-
-        lhs_products_stripped = lhs_products.strip()
-        if not lhs_products_stripped:
-            continue
-
-        prod = lhs_products_stripped.split()[0]  # e.g. LCH4byOH, LCH4byCl, LCH4inStrat
 
         for k in range(1, Njac + 1):
             idx = f"{k:04d}"
@@ -116,14 +75,6 @@ for line in lines:
 
             # Replace CH4 with CH4_jacXXXX as a whole word (avoid touching LCH4...)
             new_line = re.sub(r"\bCH4\b", f"CH4_jac{idx}", new_line)
-
-            # Replace the product species once with product_jacXXXX
-            new_line = re.sub(
-                rf"\b{re.escape(prod)}\b",
-                f"{prod}_jac{idx}",
-                new_line,
-                count=1,
-            )
 
             out_lines.append(new_line)
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

Assorted fixes for Jacobian runs in the IMI:
1. Remove dummy Jacobian species from carbon.eqn file (GCHP and GC-Classic)
2. Fail with error if primary species used to initialize missing Jacobian restart variables is missing in restart (GCHP only)
3. Only set Jacobian tracer values to primary species values if the Jacobian tracer is missing in the restart file (GCHP only)

This update fixes the issue of introducing differences when breaking up a Jacobian run in time. It also reduces the size of the Jacobian restart files.

### Expected changes

This is a zero diff updates for standard GC-Classic and GCHP. However, for the IMI, testing is needed to determine is removal of the dummy species introduces unintended differences, which is a known issue in GEOS-Chem.

### Reference(s)

None

### Related Github Issue

None
