### PR TITLE
Added files for the GEOS-Chem "science codebase" GitHub repo suggested by Claude Code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Normalize line endings to LF for text files by default.
+# This repo is built and run on Linux/HPC clusters, so CRLF endings in
+# scripts/source break shebangs, Fortran preprocessing, and compilation.
+* text=auto eol=lf
+
+# Binary assets — never diff/merge as text.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,7 @@ If this is a science update, please provide a literature citation.
 ### Related Github Issue
 
 Please link to the corresponding Github issue(s) here. If fixing a bug, there should be an issue describing it with steps to reproduce.
+
+### AI disclosure
+
+Please disclose if AI tools (e.g. Claude, ChatGPT) were used in the preparation of this pull request.

--- a/.release/changeVersionNumbers.sh
+++ b/.release/changeVersionNumbers.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+#EOC
+#------------------------------------------------------------------------------
+#                  GEOS-Chem Global Chemical Transport Model                  !
+#------------------------------------------------------------------------------
+#BOP
+#
+# !MODULE: changeVersionNumbers.sh
+#
+# !DESCRIPTION: Bash script to change the version numbers in the appropriate
+#  files in the GEOS-Chem "science codebase" directory structure.  Run this
+#  before releasing a new GEOS-Chem version.
+#\\
+#\\
+# !CALLING SEQUENCE:
+#  $ ./changeVersionNumbers.sh X.Y.Z        # X.Y.Z = GCClassic version number
+#EOP
+#------------------------------------------------------------------------------
+#BOC
+
+function replace() {
+
+    #========================================================================
+    # Function to replace text in a file via sed.
+    #
+    # 1st argument: Search pattern
+    # 2nd argument: Replacement text
+    # 3rd argument: File in which to search and replace
+    #========================================================================
+
+    sed -i -e "s/${1}/${2}/" "${3}"
+}
+
+
+function exitWithError() {
+
+    #========================================================================
+    # Display and error message and exit
+    #========================================================================
+
+    echo "Could not update version numbers in ${1}... Exiting!"
+    exit 1
+}
+
+
+function main() {
+
+    #========================================================================
+    # Replaces the version number in the files listed.
+    #
+    # 1st argument: New version number to use
+    #========================================================================
+
+    # New version number
+    version="${1}"
+
+    # Current date
+    date=$(date -Idate)
+
+    # Save this directory path and change to root directory
+    thisDir=$(pwd -P)
+    cd ..
+
+    #========================================================================
+    # Update version number and date in CHANGELOG.md
+    #========================================================================
+
+    # Pattern to match: "[Unreleased] - TBD"
+    pattern='\[.*Unreleased.*\].*'
+
+    # List of files to replace
+    files=(                                  \
+        "CHANGELOG.md"                       \
+        "KPP/fullchem/CHANGELOG_fullchem.md" \
+    )
+
+    # Replace version numbers in files
+    for file in ${files[@]}; do
+	replace "${pattern}" "\[${version}\] - ${date}" "${file}"
+        [[ $? -ne 0 ]] && exitWithError "${file}"
+        echo "GCClassic version updated to ${version} in ${file}"
+    done
+
+    #========================================================================
+    # Update date and version in CITATION.cff
+    # NOTE: Only update version but not cff-version
+    #========================================================================
+
+    # Pattern to match: X.Y.Z
+    pattern='^version: .*'
+    replace "${pattern}" "version: ${version}" "CITATION.cff"
+
+    # Pattern to match: YYYY-MM-DD
+    pattern='^date-released: .*'
+    replace "${pattern}" "date-released: ${date}" "CITATION.cff"
+
+    # Return to the starting directory
+    cd "${thisDir}"
+}
+
+# ---------------------------------------------------------------------------
+
+# Expect 1 argument, or exit with error
+if [[ $# -ne 1 ]]; then
+    echo "Usage: ./changeVersionNumbers.sh VERSION"
+    exit 1
+fi
+
+# Replace version numbers
+main "${1}"
+
+# Return status
+exit $?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `.gitattributes`, `CITATION.cff`, `GOVERNANCE.md`, `SECURITY.md` for GitHub
 - Added `CLAUDE.md`, which gives guidance to Claude Code AI
 - Added `.release/changeVersionNumbers.sh` to change version numbers in relevant files in this repository
+- Added AI disclosure section to `.github/PULL_REQUEST_TEMPLATE.md`
 
 ### Changed
 - Renamed `State_Chm%Isorrop*` fields to `State_Chm%Ate*` (aerosol thermodynamical equilibrium), as ISORROPIA is no longer used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added GCHP utility script extractPerformance.sh to scrape allPEs.log for timing summary in GCHP run directories
 - Added GCHP build scripts to GCHP runScriptSamples for Harvard
 - Added several additional run, build, and utility scripts to GCHP runScriptSamples for Harvard and AWS pcluster
+- Added `.gitattributes`, `CITATION.cff`, `GOVERNANCE.md`, `SECURITY.md` for GitHub
+- Added `CLAUDE.md`, which gives guidance to Claude Code AI
+- Added `.release/changeVersionNumbers.sh` to change version numbers in relevant files in this repository
 
 ### Changed
 - Renamed `State_Chm%Isorrop*` fields to `State_Chm%Ate*` (aerosol thermodynamical equilibrium), as ISORROPIA is no longer used

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "GEOS-Chem"
+type: software
+authors:
+  - name: "The International GEOS-Chem User Community"
+version: 14.7.1
+date-released: 2026-04-13
+doi: 10.5281/zenodo.1343546
+url: "https://geos-chem.readthedocs.io"
+repository-code: "https://github.com/geoschem/geos-chem"
+license: MIT
+keywords:
+  - atmospheric-chemistry
+  - atmospheric-composition
+  - atmospheric-modeling
+  - aws
+  - climate-modeling
+  - cloud-computing
+  - geos-chem
+  - atmospheric-computing
+  - scientific-computing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repository is
+
+This is the **GEOS-Chem science codebase** (`geoschem/geos-chem`) — the Fortran source for GEOS-Chem, a global 3-D model of atmospheric chemistry. It is almost never built or tested standalone; it is consumed as a git submodule by two superproject wrapper repos:
+
+- **GCClassic** (`geoschem/GCClassic`) — builds this code as a standalone executable ("GEOS-Chem Classic")
+- **GCHP** (`geoschem/GCHP`) — builds this code as an ESMF/MAPL gridded component inside the GEOS/NASA modeling framework ("GCHP")
+
+Both superprojects vendor this repo at `src/GEOS-Chem`, and symlink `run/`, `test/`, and `spack/` from it up to their own top level. If you were pointed here from a GCClassic or GCHP checkout, you are actually editing *this* repo — commits/PRs belong here (geoschem/geos-chem), not in the wrapper repo.
+
+Preprocessor macros `MODEL_CLASSIC` / `MODEL_GCHP` (set by the superproject's CMake) gate code paths that only apply to one implementation (e.g. `Interfaces/GCClassic/main.F90` is wrapped in `#ifdef MODEL_CLASSIC`). When reading or editing shared modules, check which macros surround a block before assuming it runs in both implementations.
+
+## Repository layout
+
+Source is organized by role, not by scientific topic — a given "feature" (e.g. dry deposition) typically spans several of these:
+
+| Directory | Contents |
+|---|---|
+| `GeosCore/` | Core science drivers: chemistry, transport, convection, deposition, emissions coupling, per-simulation-type modules (`tagged_o3_mod.F90`, `mercury_mod.F90`, `tomas_mod.F90`, `carbon_mod.F90`, etc.) |
+| `Headers/` | Shared derived types and utilities used everywhere: `state_chm_mod.F90`, `state_met_mod.F90`, `state_grid_mod.F90`, `state_diag_mod.F90`, `species_database_mod.F90`, `species_mod.F90`, `precision_mod.F90` |
+| `History/` | The netCDF diagnostics framework (`history_mod.F90` and the `Hist*` container types) that HISTORY.rc/diagnostics are built on |
+| `KPP/` | Chemical mechanisms. Each subdirectory (`fullchem/`, `carbon/`, `Hg/`, `custom/`, `aciduptake/`, `stubs/`) is a KPP-generated solver plus mechanism-specific Fortran (e.g. `fullchem_RateLawFuncs.F90`, `fullchem_SulfurChemFuncs.F90`). `KPP/standalone` is a separate submodule (KPP-Standalone box model, built when `-DKPPSA=y`). Never hand-edit KPP-generated solver files (`gckpp_*`) — regenerate with `build_mechanism.sh` |
+| `Interfaces/GCClassic/` | GEOS-Chem Classic driver (`main.F90`), built only when `MODEL_CLASSIC` |
+| `Interfaces/GCHP/` | GCHP gridded-component glue (`Chem_GridCompMod.F90`, `gchp_chunk_mod.F90`), built only when `MODEL_GCHP` |
+| `GeosUtil/`, `NcdfUtil/` | Generic utilities (string parsing, netCDF I/O wrappers, YAML config parsing via `qfyaml_mod.F90`) with no science content |
+| `GTMM/`, `APM/`, `GeosRad/`, `PKUCPL/`, `ObsPack/` | Optional/pluggable components (Global Terrestrial Mercury Model, aerosol microphysics, RRTMG radiative transfer, ObsPack diagnostics) enabled by their own CMake switches |
+| `run/GCClassic/`, `run/GCHP/`, `run/shared/`, `run/CESM/`, `run/GEOS/`, `run/WRF/` | Run-directory creation scripts (`createRunDir.sh`) and config-file templates (`geoschem_config.yml`, `HEMCO_Config.rc`, `HISTORY.rc`, etc.) for each implementation |
+| `test/` | Integration/parallel/difference test drivers (see below) |
+| `CMakeScripts/` | `GC-Helpers.cmake` — shared CMake macros (`gc_pretty_print`, version detection) used by this repo's `CMakeLists.txt` |
+
+`CMakeLists.txt` at the repo root is included by the superproject's build, not invoked standalone — it expects `GEOSChemBuildProperties` and options like `MECH`, `MODEL_CLASSIC`/`MODEL_GCHP` to already be defined by the caller.
+
+## Building
+
+There is no standalone build here — always build via a superproject run directory. From a GCClassic or GCHP checkout with this repo as its `src/GEOS-Chem` submodule:
+
+```console
+cd run/GCClassic && ./createRunDir.sh      # or run/GCHP/createRunDir.sh
+cd /path/to/rundir/build
+cmake ../CodeDir -DRUNDIR=..
+make -j && make install
+```
+
+Relevant CMake options that live in *this* repo (`KPP/CMakeLists.txt`, root `CMakeLists.txt`):
+- `MECH` — `fullchem` (default), `carbon`, `custom`, `Hg` — selects which `KPP/<mech>` subdirectory is built
+- `KPPSA` — also builds `KPP/standalone` (KPP-Standalone box model) alongside `fullchem`/`custom`
+- Supported Fortran compilers are Intel and GNU only (`GEOSChem_Fortran_FLAGS_{Intel,GNU}`); anything else is a hard CMake `FATAL_ERROR`
+
+## Modifying a chemical mechanism
+
+Do not hand-edit the KPP-generated solver files under `KPP/<mechanism>/` (files prefixed `gckpp_`). Instead edit the mechanism's `.eqn`/`.spc`/`.kpp` definition files, then regenerate:
+
+```console
+cd KPP
+./build_mechanism.sh fullchem   # or Hg, custom
+```
+
+This requires KPP 3.4.0+ (see root `CHANGELOG.md` for the currently-required version) and preserves the heterogeneous-chemistry files while regenerating the solver. Hand-written mechanism support code (rate laws, heterogeneous chemistry hookups) lives alongside the generated files, e.g. `KPP/fullchem/fullchem_RateLawFuncs.F90`, `KPP/fullchem/fullchem_SulfurChemFuncs.F90`, `KPP/fullchem_HetStateFuncs.F90` / `KPP/stubs/stub_fullchem_HetStateFuncs.F90` (a stub is required for every mechanism that doesn't implement heterogeneous chemistry).
+
+## Testing
+
+Test infrastructure lives under `test/` and is symlinked to the same path in GCClassic/GCHP superprojects. All test scripts require a real (non-conda) netCDF — `conda deactivate` first, or the scripts abort immediately.
+
+- `test/integration/GCClassic/` and `test/integration/GCHP/` — compile + optionally run several out-of-the-box run-directory configurations, to catch build/run regressions:
+  ```console
+  cd test/integration/GCClassic
+  ./integrationTest.sh -d <root-dir> -t compile   # compile-only
+  ./integrationTest.sh -d <root-dir> -t all        # compile and run short sims
+  ./integrationTest.sh -d <root-dir> -t compile -q # quick subset, for local dev
+  ```
+- `test/parallel/GCClassic/` — same idea but sweeps OpenMP thread counts, to catch parallelization bugs.
+- `test/difference/` — bit-for-bit diff of output between two integration/parallel test runs (e.g. before/after a structural, non-science change).
+- `test/shared/commonFunctionsForTests.sh` — functions/settings shared by all of the above; source this rather than duplicating logic when adding new test scripts.
+
+## Versioning and changes
+
+- Root `CHANGELOG.md` follows Keep a Changelog / SemVer and documents changes to this repo specifically (GCClassic's own CHANGELOG.md separately tracks submodule-pointer bumps and wrapper-level changes).
+  Individual KPP mechanisms may keep their own changelog, e.g. `KPP/fullchem/CHANGELOG_fullchem.md` — update that too when changing fullchem's chemistry.
+- This is a community-governed, grass-roots model (see `README.md` and geos-chem.org). Substantive science/structural changes are expected to go through the GEOS-Chem Steering Committee / User Working Group process, not just a code review.
+- Any structural (non-science) change should be accompanied by a difference test (`test/difference/`) against the prior version to confirm bit-for-bit identical results.
+- Config/run-directory changes should be mirrored across `run/GCClassic/` and `run/GCHP/` (and `run/CESM`, `run/GEOS`, `run/WRF` where applicable) since they share the same underlying `geoschem_config.yml` / `HEMCO_Config.rc` / `HISTORY.rc` schema.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,31 @@
+# Governance
+
+GEOS-Chem is a grass-roots, open-access model owned by its [users](https://geoschem.github.io/community.html). This document summarizes how development priorities are set and how code moves from a contributor's changes into an official release.
+
+## Roles
+
+### GEOS-Chem Steering Committee (GCSC)
+
+The [GEOS-Chem Steering Committee](https://geoschem.github.io/steering-committee.html) provides scientific direction for the model. It meets quarterly to set [GEOS-Chem model development priorities](http://wiki.geos-chem.org/GEOS-Chem_model_development_priorities) and to slate submitted updates for inclusion into upcoming GEOS-Chem versions.
+
+### Working Groups
+
+[GEOS-Chem Working Groups](https://geoschem.github.io/working-groups.html) identify priority development needs within their science areas and advise the GCSC accordingly. Working Group chairs are the first point of contact for contributors who want to propose a model update, and can advise on timing for submitting code tied to a mature development.
+
+### GEOS-Chem Support Team (GCST)
+
+The [GEOS-Chem Support Team](https://geoschem.github.io/support-team.html), based at Harvard University and Washington University in St. Louis, manages this codebase day to day: it reviews and merges pull requests into the development branch for an upcoming version, and validates incoming updates with [benchmark simulations](http://wiki.geos-chem.org/GEOS-Chem_benchmarking) before release. If a benchmark reveals a problem with a submitted update, the GCST works with the contributor on corrective action.
+
+## How a change becomes an official release
+
+1. A contributor proposes an update to their relevant Working Group chair(s).
+
+2. The Working Group forwards the request to the GCSC, which sets its priority and target version at a quarterly meeting.
+
+3. The contributor submits the update as a pull request against this repository. Structural (non-science) changes should include a difference test (see `test/difference/`) confirming bit-for-bit identical results, and all changes should include a `CHANGELOG.md` entry.
+
+4. The GCST reviews and merges the update into the development branch, then benchmarks and includes it in the next tagged release. Releases here are picked up as pinned submodule updates by the [GCClassic](https://github.com/geoschem/GCClassic) and [GCHP](https://github.com/geoschem/GCHP) wrapper repositories.
+
+## Sponsors
+
+GEOS-Chem development is supported by the US NASA Earth Science Division, the Canadian National Sciences and Engineering Research Council, and the Nanjing University of Information Science and Technology.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+GEOS-Chem does not maintain long-term-support branches. Security fixes are only provided for the most recently released version, listed in `CHANGELOG.md`.
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in this repository — for example, a supply-chain issue in a GitHub Actions workflow, or an issue in a run-directory/data-download script (`run/shared/download_data.py`, `createRunDir.sh`, etc.) that could lead to unintended code execution — please report it privately using GitHub's **[Report a vulnerability](https://github.com/geoschem/geos-chem/security/advisories/new)** feature (Security tab) rather than opening a public issue.
+
+If the issue is specific to the wrapper repositories that consume this codebase (GCClassic or GCHP) or to another submodule (HEMCO, Cloud-J, HETP), please report it in that repository instead.
+
+This project is maintained by the **GEOS-Chem Support Team (GCST)** on a best-effort basis, so there is no guaranteed response SLA, but we will acknowledge reports as promptly as we can and work with you on a fix and coordinated disclosure.
+
+## Out of Scope
+
+Scientific-correctness bugs, numerical issues, and general "how do I..." questions are **not** security reports. Please use the normal channels — [GitHub issues](https://github.com/geoschem/geos-chem/issues/new/choose) or the [GEOS-Chem user manual](https://geos-chem.readthedocs.io/en/stable) — for those instead.


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

We have added the following files (suggested by Claude Code):

| File | Description |
|---|---|
| `.gitattributes` | Specifies Git behavior regarding line endings |
| `CITATION.cff` | Instructions on how to cite if you use the GEOS-Chem science codebase |
| `CLAUDE.md` | Provides guidance to Claude Code AI |
| `GOVERNANCE.md` | Summarizes the GEOS-Chem governance structure (taken from existing documentation), |
| `SECURITY.md` | Specifies the security policy used for this repo |
| `.release/changeVersionNumbers.sh` | Changes version number & date in `CITATION.cff` and changelog files in this repository 

The following files were modified:

| File | Description |
|---|---|
| `CHANGELOG.md` | Updated accordingly |

### Expected changes
This is a zero-diff update.