### PR TITLE
Fix GCHP run directory creation bug when using raw GEOS-IT C180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed GCHP transport tracers extdata.yaml to include valid_range for CEDS
 - Fixed OpenMP parallelization error in `GeosCore/tomas_mod.F90`
 - Fixed typos (extra `:` characters) in `run/shared/kpp_standalone_interface.yml`
+- Fixed bug in creating GCHP run directories using raw GEOS-IT C180 meteorology
 
 ### Removed
 - Removed obsolete code in dust_mod.F90

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -509,7 +509,7 @@ while [ "${valid_met}" -eq 0 ]; do
 	            elif [[ ${adv_flux_src} = "3hr_wind" ]]; then
 			RUNDIR_VARS+="$(cat ${metSettingsDir}/geosit/discover/geosit.raw_3hr_c180_wind.txt)\n"
 		    fi
-		    RUNDIR_VARS+="$(cat ${metSettingsDir}/geosit/discover/geosit.raw_c180.txt)\n"
+		    RUNDIR_VARS+="$(cat ${metSettingsDir}/geosit/discover/geosit.nonadv_raw_c180.txt)\n"
 		fi
 
 	    else
@@ -522,7 +522,7 @@ while [ "${valid_met}" -eq 0 ]; do
 	            elif [[ ${adv_flux_src} = "3hr_wind" ]]; then
 			RUNDIR_VARS+="$(cat ${metSettingsDir}/geosit/advection_met/geosit.raw_3hr_c180_wind.txt)\n"
 		    fi
-		    RUNDIR_VARS+="$(cat ${metSettingsDir}/geosit/geosit.raw_c180.txt)\n"
+		    RUNDIR_VARS+="$(cat ${metSettingsDir}/geosit/geosit.nonadv_raw_c180.txt)\n"
 		fi
 
 	    fi


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update fixes the configured filename in GCHP run directory creation for raw GEOS-IT C180 files. The filename changed in the 14.7.0 release but the run directory creation script for GCHP was not updated for it.

While using raw meteorology fields in GCHP is supported, it is not usually done. However, raw GEOS-IT is always used on the NASA discover cluster and this bug prevented run directory creation on that cluster using GEOS-IT fields.

### Expected changes

This is a no diff update for all GEOS-Chem simulations.

### Reference(s)

None

### Related Github Issue

None
