### PR TITLE
Fixed incorrect treatment of e90_s/n and nh_5/50 tracer in TransportTracer simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Fixed incorrect treatment of e90_s/n and nh_5/50 tracer in TransportTracer simulation
+
 ## [14.7.1] - 2026-04-08
 ### Added
 - Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP

--- a/GeosCore/tracer_mod.F90
+++ b/GeosCore/tracer_mod.F90
@@ -256,7 +256,7 @@ CONTAINS
           DO I = 1, State_Grid%NX
 
              ! Set mask to zero outside of latitude zone
-             IF ( State_Grid%YMid(I,J) < SpcInfo%Src_LatMin .and. &
+             IF ( State_Grid%YMid(I,J) < SpcInfo%Src_LatMin .or. &
                   State_Grid%YMid(I,J) > SpcInfo%Src_LatMax ) THEN
                 Mask(I,J,:) = 0.0_fp
              ENDIF
@@ -389,12 +389,11 @@ CONTAINS
           DO L = 1, State_Grid%NZ
           DO J = 1, State_Grid%NY
           DO I = 1, State_Grid%NX
-             IF ( Mask(I,J,L) > 0 ) THEN
-                Local_Tally = Local_Tally &
-                   + ( SpcInfo%Src_Value - State_Chm%Species(N)%Conc(I,J,L) ) &
-                   * ( State_Met%AIRNUMDEN(I,J,L) / AVO )                     &
-                   *  State_Met%AIRVOL(I,J,L)
-             ENDIF
+             ! Integrate over the entire domain instead only over source regions
+             Local_Tally = Local_Tally &
+                + ( SpcInfo%Src_Value - State_Chm%Species(N)%Conc(I,J,L) ) &
+                * ( State_Met%AIRNUMDEN(I,J,L) / AVO )                     &
+                *  State_Met%AIRVOL(I,J,L)
           ENDDO
           ENDDO
           ENDDO

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -3455,7 +3455,7 @@ nh_PROP: &nhproperties
   Src_Lats: [30.0, 50.0]
   Src_Units: ppbv
   Src_Value: 100
-  Src_Vert: all
+  Src_Vert: surface
 nh_5:
   << : *nhproperties
   FullName: Northern Hemisphere 5 day tracer


### PR DESCRIPTION
### Name and Institution (Required)

Name: Yuanjian Zhang
Institution: WashU

### Describe the update

See #3357 

### Expected changes

e90_n, e90_s, nh_5 and nh_50 should work properly. Validation is running.


### Related Github Issue

#3357 
