### PR TITLE
Fix typo bug preventing GCHP build

### DIFF
--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -2736,7 +2736,7 @@ CONTAINS
                   VALUE=RST, RC=STATUS )
 
              ! Set spc conc to background value if rst skipped or var not there
-             IF ( ( RC  /= ESMF_SUCCESS         .OR.     &
+             IF ( RC  /= ESMF_SUCCESS           .OR.     &
                   RST == MAPL_RestartBootstrap  .OR.     &
                   RST == MAPL_RestartSkipInitial  ) THEN
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes a bug introduced in https://github.com/geoschem/geos-chem/pull/3347 that causes GCHP to fail build. An extraneous parenthesis was present and is now removed.

### Expected changes

This is a no diff update

### Reference(s)

None

### Related Github Issue

None