### PR TITLE
Apply fixes to enable APM to successfully run with debug flags on

### DIFF
--- a/APM/apm_phys_mod.F
+++ b/APM/apm_phys_mod.F
@@ -317,6 +317,13 @@
 
       ATOM4N=0.d0
 
+      ! Initialize values set later to get past FPE errors when debug flags on
+      zfv(:) = 0.d0
+      zfv_sp(:) = 0.d0
+      RLOSULF = 0.d0
+      MSULFLV = 0.d0
+      SUMXVA1 = 0.d0
+
 !      CLVSOG0 = 4.d6
       CLVSOG0 = 5.d5
 
@@ -1470,7 +1477,9 @@
 
 ! Scavenging of sulfate particles by other types of aerosols
           IF((TCS-CSSULF).GT.1.E-5) THEN
-           RLOSULF = MSULFLV/(SUMXVA1*DENSULF*1.d3)   !ratio of LO mass on SULF to total mass
+           IF ( SUMXVA1.GT.0.0d0 .AND. DENSULF.GT.0.0d0 ) then
+              RLOSULF = MSULFLV/(SUMXVA1*DENSULF*1.d3) !ratio of LO mass on SULF to total mass
+           ENDIF
            RLOSULF = MIN(RLOSULF, 1.0d0)
 
            CALL APM_COAGSCAV(
@@ -1651,10 +1660,10 @@
 
 
       IF(CACID.LT.0.0) THEN
-         WRITE(6,*) "CACID < 0, set it to 1E2/cc"
-        WRITE(6,99)II,JJ,LL,CACID,CACID0,PACID,YJAVE,CSSULF, 
-     &   GFGAS,MMSA,MNIT,MNH4,MSOA,MSO4, 
-     &   TCSOTHER,TOTCONDOTH,MCONDOTH,MDSTS
+!        WRITE(6,*) "CACID < 0, set it to 1E2/cc"
+!         WRITE(6,99)II,JJ,LL,CACID,CACID0,PACID,YJAVE,CSSULF,
+!     &   GFGAS,MMSA,MNIT,MNH4,MSOA,MSO4,
+!     &   TCSOTHER,TOTCONDOTH,MCONDOTH,MDSTS
          CACID = 1.E2
       ENDIF
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug in creating GCHP run directories using raw GEOS-IT C180 meteorology
 - Fixed bugs in Jacobian tracers simulation
 - Fixed missing entries in `SpeciesConc`, `CloudConvFlux`, `WetLossConv`, and `WetLossLS` collections in the GCHP `HISTORY.rc.fullchem` template file
+- Fixed minor issues causing APM simulation failure when debug flags turned on
 
 ### Removed
 - Removed obsolete code in dust_mod.F90


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes problems running APM with debug flags on. Fixes include initialization of a couple variables used only in if statements, enclosing a statement in a divide by zero check, and commenting out a problematic write statement (string type issue).

Note that the APM code is very old (Fortran 77) and issues when debug flags are turned on using other compilers may pop up. I used GNU 14 for my tests and only addressed the issues flagged with that compiler. Ideally the APM code would be overhauled to ensure there is no possibilities for divide-by-zero, etc.

### Expected changes

This is a zero diff update.

### Reference(s)

None

### Related Github Issue

https://github.com/geoschem/geos-chem/issues/2962
