### PR TITLE
Fix inconsistency in GCHP pressures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug in creating GCHP run directories using raw GEOS-IT C180 meteorology
 - Fixed bugs in Jacobian tracers simulation
 - Fixed missing entries in `SpeciesConc`, `CloudConvFlux`, `WetLossConv`, and `WetLossLS` collections in the GCHP `HISTORY.rc.fullchem` template file
+- Fixed initializing surface pressure in GCHP per timestep by changing from pre-advection to post-advection met pressure
 
 ### Removed
 - Removed obsolete code in dust_mod.F90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug in creating GCHP run directories using raw GEOS-IT C180 meteorology
 - Fixed bugs in Jacobian tracers simulation
 - Fixed missing entries in `SpeciesConc`, `CloudConvFlux`, `WetLossConv`, and `WetLossLS` collections in the GCHP `HISTORY.rc.fullchem` template file
-- Fixed initializing surface pressure in GCHP per timestep by changing from pre-advection to post-advection met pressure
+- Fixed floating surface pressures in GCHP to be post-advection rather than pre-advection
 
 ### Removed
 - Removed obsolete code in dust_mod.F90

--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -946,8 +946,8 @@ CONTAINS
     CALL SET_DRY_SURFACE_PRESSURE( State_Grid, State_Met, 2 )
 
     ! Initialize surface pressures to match the post-advection pressures
-    State_Met%PSC2_WET = State_Met%PS1_WET
-    State_Met%PSC2_DRY = State_Met%PS1_DRY
+    State_Met%PSC2_WET = State_Met%PS2_WET
+    State_Met%PSC2_DRY = State_Met%PS2_DRY
     CALL SET_FLOATING_PRESSURES( State_Grid, State_Met, RC )
     IF ( RC /= GC_SUCCESS ) RETURN
 

--- a/Interfaces/GCHP/gchp_chunk_mod.F90
+++ b/Interfaces/GCHP/gchp_chunk_mod.F90
@@ -946,6 +946,7 @@ CONTAINS
     CALL SET_DRY_SURFACE_PRESSURE( State_Grid, State_Met, 2 )
 
     ! Initialize surface pressures to match the post-advection pressures
+    ! and use them to set floating pressure in pressure module
     State_Met%PSC2_WET = State_Met%PS2_WET
     State_Met%PSC2_DRY = State_Met%PS2_DRY
     CALL SET_FLOATING_PRESSURES( State_Grid, State_Met, RC )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes a bug reported by Yuanjian Zhang (WashU) in https://github.com/geoschem/geos-chem/issues/3335.

Understanding this fix requires understanding the various pressure arrays used in GCHP. I will go over that here to give context for the implications of the bug.

Surface pressures are read from meteorology files and time-interpolated within MAPL ExtData from instantaneous values. ExtData field `PS1` is interpolated to _start_ of timestep, and is used for surface pressure _before_ advection. ExtData field `PS2` is interpolated to `end` of timestep, and is used for surface pressure `after` advection. Both of these pressures are moist air pressure not dry.

These pressures are used within the GCHPctmEnv gridded component to compute moist pressure edge profiles for before and after advection, `PLE0` and `PLE1`, as well as dry pressure edge profiles, `DryPLE0` and `DryPLE1`. The dry edge pressure computation uses instantaneous specific humidity read from meteorology files and time-interpolated to before or after advection time (`SPHU0` and `SPHU1`). All of these edge pressure profiles are then exported to the FV3 gridded component for use in advecting GEOS-Chem species. By default, dry pressure is used for the advection.

The moist pressure profile computed in GCHPctmEnv to represent `after` advection (`PLE1`) is also passed to the GEOS-Chem gridded component. As a reminder, this is constructed in GCHPctmEnv from the ExtData field `PS2`. In GEOS-Chem it is used to set `State_Met%PEDGE` and other arrays derived from it, e.g. `State_Met%DELP`.

Within GEOS-Chem there are several other `State_Met` fields for pressure. For this PR, the important one is `State_Met%PSC2_WET` and `State_Met%PSC2_DRY`. The former is supposed to be the instantaneous meteorology surface pressure time-interpolated to the time after advection, which is `PS2`. The latter is supposed to be the dry air equivalent. However, currently in GCHP both are set to surface pressures for time `before` advection. This PR fixes that.

`State_Met%PSC2_WET` and `State_Met%PSC2_DRY` are used only to set module variables `PFLT_WET` and `PFLT_DRY` (floating pressures) in `pressure_mod.F90`.`State_Met%PSC2_WET` is not used at all in GCHP; in GC-Classic it is used to compute `State_Met%PEDGE` but in GCHP `State_Met%PEDGE` is set to `PLE1` computed in GCHPctmEnv from `PS2` (as described earlier). However, `State_Met%PSC2_DRY` is used in GCHP to set `State_Met%PEDGE_DRY` and `State_Met%DELPDRY`, which are then used to derive `State_Met%AD` (dry air mass), `State_Met%AIRDEN` (dry air density), `State_Met%BXHEIGHT` (grid box height), and `State_Met%PMIDDRY` (grid box mid-point dry pressure).

`State_Met%SPHU` (specific humidity), and `State_Met%AVGW` which is computed from it, also change with this update in the full chemistry simulation. I believe this is because `State_Met%SPHU` is allowed to deviate from the offline meteorology within the UCX module. Those fields do not change in the transport tracer simulation.

I think that with this fix the dry pressures are still not quite right. The specific humidity in GCHP is set to the average of before and after advection. However, the dry surface pressure uses the end-of-advection specific humidity. It is possible this is by design for some reason I do not know, or it may be a bug. There may be other inconsistencies as well worth exploring. @yuanjianz, what are your thoughts on this?

### Expected changes

This fix will cause minor changes in all GCHP simulations because of a small pressure changes in `State_Met%PEDGE_DRY` and `State_Met%DELP_DRY` computed in GEOS-Chem, as well as the dry air quantities derived from them.

Benchmarks will change by a small amount for all species in GCHP. This is a no diff update for GC-Classic.

Mass conservation was not evaluated for this update and should be checked in the next transport tracer benchmark.

### Reference(s)

None

### Related Github Issue

closes https://github.com/geoschem/geos-chem/issues/3335
