### PR TITLE
Allow State_Chm%phCloud and State_Chm%isCloud to vary (supersedes #3328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Fixed error where `State_Chm%phCloud` was always being reset to 4.5
+
 ## [14.7.1] - 2026-04-08
 ### Added
 - Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -2588,10 +2588,20 @@ CONTAINS
     Spc                  => State_Chm%Species
     H2O2s                => State_Chm%H2O2AfterChem
     SO2s                 => State_Chm%SO2AfterChem
-    State_Chm%isCloud    =  0.0_fp
+!    State_Chm%isCloud    =  0.0_fp
 !    State_Chm%pHcloud    =  0.0_fp
-    State_Chm%pHcloud    =  4.5_fp
-    State_Chm%QLxpHcloud =  0.0_fp
+!    State_Chm%pHcloud    =  4.5_fp
+!    State_Chm%QLxpHcloud =  0.0_fp
+    ! Only reset isCloud, pHcloud, and QLxpHcloud if sulfate_mod
+    ! owns cloud chemistry (Do_SulfateMod_Cld=.TRUE. i.e. offline run).
+    ! If Do_SulfateMod_Cld=.FALSE., KPP/SET_SO2 is responsible for
+    ! setting isCloud -- does not overwrite it here.
+    IF ( State_Chm%Do_SulfateMod_Cld ) THEN
+       State_Chm%isCloud    =  0.0_fp
+!       State_Chm%pHcloud    =  0.0_fp
+       State_Chm%pHcloud    =  4.5_fp
+       State_Chm%QLxpHcloud =  0.0_fp
+    ENDIF
 #ifdef LUO_WETDEP
     State_Chm%pHrain     =  5.6_fp
     State_Chm%QQpHrain   =  0.0_fp

--- a/GeosCore/sulfate_mod.F90
+++ b/GeosCore/sulfate_mod.F90
@@ -2588,25 +2588,32 @@ CONTAINS
     Spc                  => State_Chm%Species
     H2O2s                => State_Chm%H2O2AfterChem
     SO2s                 => State_Chm%SO2AfterChem
-!    State_Chm%isCloud    =  0.0_fp
-!    State_Chm%pHcloud    =  0.0_fp
-!    State_Chm%pHcloud    =  4.5_fp
-!    State_Chm%QLxpHcloud =  0.0_fp
+
+    ! CHEM_SO2 used to unconditionally reset State_Chm%isCloud to 0 and
+    ! State_Chm%pHcloud to 4.5 on every call, clobbering the values that
+    ! KPP/SET_SO2 computes for online (full-chem) runs, so isCloud and
+    ! pHcloud never varied in output. See geoschem/geos-chem PR #3328
+    ! and PR #3367.
+    !
     ! Only reset isCloud, pHcloud, and QLxpHcloud if sulfate_mod
     ! owns cloud chemistry (Do_SulfateMod_Cld=.TRUE. i.e. offline run).
     ! If Do_SulfateMod_Cld=.FALSE., KPP/SET_SO2 is responsible for
     ! setting isCloud -- does not overwrite it here.
+    !
+    ! If using Luo et al 2023 wetdep scheme, assume cloud pH = 5.6.
+    ! If using the default wetdep scheme, assume cloud pH = 4.5.
     IF ( State_Chm%Do_SulfateMod_Cld ) THEN
        State_Chm%isCloud    =  0.0_fp
-!       State_Chm%pHcloud    =  0.0_fp
-       State_Chm%pHcloud    =  4.5_fp
        State_Chm%QLxpHcloud =  0.0_fp
-    ENDIF
 #ifdef LUO_WETDEP
-    State_Chm%pHrain     =  5.6_fp
-    State_Chm%QQpHrain   =  0.0_fp
-    State_Chm%QQrain     =  0.0_fp
+       State_Chm%pHrain     =  5.6_fp
+       State_Chm%pHCloud    =  5.6_fp
+       State_Chm%QQpHrain   =  0.0_fp
+       State_Chm%QQrain     =  0.0_fp
+#else
+       State_Chm%pHcloud    =  4.5_fp
 #endif
+    ENDIF
 
     ! Set a flag for when to call the SeaSalt_Chem routine
     DO_SEASALT_CHEM =                                                        &


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca (Harvard) on behalf of Sierra Dabby (U. Washington)

### Describe the update

This PR supersedes the original PR #3328.  The original PR was based off of 14.7.1, but we have merged this on top of 14.8.0-alpha.15 in order to avoid a compilation error (due to an update to the HETP module made for the multiphase sulfate update that will go into 14.8.0).

Sierra Dabby (@sdabby) wrote:

> I edited sulfate_mod.F90 to fix the isCloud and pHCloud diagnostics. My edits start at line 2591 and end at 2605. Mainly, I just commented out some reset lines and added an if statement. The if statement says that if sulfate is online, don't reset the values of isCloud and pHCloud inside sulfate_mod.F90. 
### Expected changes

@sdabby wrote:
> This update should make pHCloud vary, previously it would output pH as 4.5 everywhere. It should also allow isCloud to vary between 0 and 1, previously it was 0 everywhere. 

We also have added a fix to prevent the updates in this PR from affecting simulations using the Luo et al. 2023 wetdep scheme, which sets `State_Chm%phCloud` to a constant value of 5.6.

See discussion in PR #3328 for further information.

### Related Github Issue

- Supersedes #3328
- Closes #3310