### PR TITLE
Removing duplicate DynHeating entry in fullchem ExtData.rc file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.8.0] 
+### Removed
+- Removed duplicate Dynamical Heating entry in gchp fullchem ExtData.rc file.
+
+
 ## [14.7.1] - 2026-04-08
 ### Added
 - Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP

--- a/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
+++ b/run/GCHP/ExtData.rc.templates/ExtData.rc.fullchem
@@ -52,10 +52,11 @@ CONV_DEPTH 1 Y Y F1980-%m2-01T00:00:00 none none CTH   ./HcoDir/OFFLINE_LIGHTNIN
 #==============================================================================
 # --- Fields for RRTMG ---
 # Dynamical heating data is only read in when RRTMG FDH/SEFDH is used and
-# must be generated in a reference (companion) run. The time after P at
+# IMPORT_DYN_HEATING setting set to 1 in GCHP.rc
+# DynHeating data must be generated in a reference (companion) run. The time after P at
 # the end should be the RRTMG time step (3 hours by default)
 #==============================================================================
-DynHeating 1 N N F%y4-%m2-%d2T%h2:00:00 none none DynHeating ./DynHeating/GEOSChem.DynHeating.%y4%m2%d2_%h2%n2z.nc4 2000-01-01T00:00:00P03:00
+DynHeating Kday-1 N N F%y4-%m2-%d2T%h2:00:00 none none DynHeating ./DynHeating/GEOSChem.DynHeating.%y4%m2%d2_%h2%n2z.nc4 2000-01-01T00:00:00P03:00
 #
 ###############################################################################
 ###
@@ -2182,9 +2183,6 @@ TES_CLIM_CFC12 ppbv N Y - none none CFC12 ./HcoDir/RRTMG/v2018-11/species_clim_p
 TES_CLIM_CFC22 ppbv N Y - none none CFC22 ./HcoDir/RRTMG/v2018-11/species_clim_profiles.2x25.nc
 TES_CLIM_CH4   ppbv N Y - none none CH4   ./HcoDir/RRTMG/v2018-11/species_clim_profiles.2x25.nc
 TES_CLIM_N2O   ppbv N Y - none none N2O   ./HcoDir/RRTMG/v2018-11/species_clim_profiles.2x25.nc
-#
-# Dynamical heating rates from a previous reference (baseline) simulation
-DynHeating Kday-1 N N F%y4-%m2-%d2T%h2:00:00 none none DynHeating ./Heating_Baseline/GEOSChem.DynHeating.%y4%m2%d2_%h2%n2z.nc4 2000-01-01T00:00:00P03:00
 #
 #==============================================================================
 # --- Surface VMR (SfcVMR) ---


### PR DESCRIPTION
### Name and Institution (Required)

Name: Helena McDonald
Institution: Harvard University

### Describe the update

Removed a duplicate entry for dynamical heating import data in the fullchem ExtData.rc file. The only difference between the two is the expected units. The metadata check in state_diag_mod.f90 (PR #2010) expects units of Kday-1 for dynamical heating, so that extdata line is preserved.

### Expected changes

No diff. 