### PR TITLE
Hotfix: Update Harvard Cannon environment files to point to new library location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed time cycle for GFAS data in the `gc_4x5_merra2_carbon_CH4_straddle_00z` from `EFY` to `C` to avoid runtime error
 - Changed `#MINVERSION` to 3.5.0 in `Hg.kpp`, `fullchem.kpp` and `carbon.kpp` files
 - Gave all dummy species `KPP_AbsTol = 1.0e25` in `run/shared/species_database.yml` so that they would be not included in the Rosenbrock error norm
+- Updated Harvard Cannon environment files for GCHP & GCClassic to refer to new library location
 
 ### Fixed
 - Fixed incorrect variable names and removed unused variables in `NcdfUtil/ncdf_mod.F90`

--- a/run/GCClassic/runScriptSamples/operational_examples/harvard_cannon/gcclassic.gcc14_cannon_rocky.env
+++ b/run/GCClassic/runScriptSamples/operational_examples/harvard_cannon/gcclassic.gcc14_cannon_rocky.env
@@ -1,7 +1,7 @@
 ###############################################################################
-# gcclassic.rocky+gnu14.minimal.env
+# gcclassic.gcc14_cannon_rocky.env
 #
-# Environment file for GCClassic + Rocky Linux + GNU Compiler Collection 10.4.0
+# Environment file for GCClassic + Rocky Linux + GNU Compiler Collection 14.2.0
 #
 # Does not include any Spack-built modules, only FASRC-built modules.
 # Useful for running in the Cannon queues, or to start fresh Spack builds.
@@ -25,29 +25,22 @@ if [[ "x${SPACK_ROOT}" != "x" ]]; then
 fi
 
 #==============================================================================
-# Load FASRC-built software packages for Rocky Linux and GNU 10.2.0
+# Load FASRC-built software packages for Rocky Linux and GNU 14.2.0
 #==============================================================================
 if [[ $- = *i* ]] ; then
   echo "... Loading FASRC-built software, please wait ..."
 fi
 
-# Load FASRC-built modules
+# Minimum set of modules
 module load gcc/14.2.0-fasrc01             # gcc / g++ / gfortran
 module load openmpi/5.0.5-fasrc01          # MPI
 module load netcdf-c/4.9.2-fasrc06         # netcdf-c
 module load netcdf-fortran/4.6.1-fasrc04   # netcdf-fortran
-module load flex/2.6.4-fasrc01             # Flex lexer (needed for KPP)
 module load cmake/3.25.2-fasrc01           # CMake (needed to compile)
-
-# Additional FASRC-built modules
-# Uncomment if you need to use these
-#module load IDL/8.7.2-fasrc01               # IDL language (needed for GAMAP)
-##module load R/4.2.2-fasrc01                # R language
-##module load matlab/R2022b-fasrc01          # matlab language
 
 #==============================================================================
 # Environment variables and related settings
-# (NOTE: Lmod will define <module>_HOME variables for each loaded module
+# (NOTE: Lmod will define <module>_HOME variables for each loaded module)
 #==============================================================================
 
 # Make all files world-readable by default
@@ -72,29 +65,16 @@ export F77="${FC}"
 
 # netCDF
 if [[ "x${NETCDF_HOME}" == "x" ]]; then
-   export NETCDF_HOME="${NETCDF_C_HOME}"
+    export NETCDF_HOME="${NETCDF_C_HOME}"
 fi
 export NETCDF_C_ROOT="${NETCDF_HOME}"
-export NETCDF_FORTRAN_ROOT="${NETCDF_FORTRAN_HOME}"
-
-# KPP 3.0.0+
-export KPP_FLEX_LIB_DIR="${FLEX_HOME}/lib64"
-
-# If you are using GEOS-Chem 12.6.0 or earlier,
-# uncomment these lines and source this file again.
-#export GC_INCLUDE=$NETCDF_INCLUDE
-#export GC_BIN=$NETCDF_HOME/bin
-#export GC_LIB=$NETCDF_LIB
-#export GC_F_INCLUDE=$NETCDF_FORTRAN_INCLUDE
-#export GC_F_LIB=$NETCDF_FORTRAN_LIB
-#export GC_F_BIN=$NETCDF_FORTRAN_HOME/bin
+export NETCDF_FORTRAN_ROOT=${NETCDF_FORTRAN_HOME}
 
 #==============================================================================
 # Set limits
 #==============================================================================
 
-#ulimit -c unlimited   # coredumpsize
-ulimit -u 50000       # maxproc
+ulimit -u unlimited   # maxproc
 ulimit -v unlimited   # vmemoryuse
 ulimit -s unlimited   # stacksize
 
@@ -110,7 +90,7 @@ echo ""
 echo "CC                  : ${CC}"
 echo "CXX                 : ${CXX}"
 echo "FC                  : ${FC}"
-echo "KPP_FLEX_LIB_DIR    : ${KPP_FLEX_LIB_DIR}"
+echo "MPI_HOME            : ${MPI_HOME}"
 echo "NETCDF_HOME         : ${NETCDF_HOME}"
 echo "NETCDF_FORTRAN_HOME : ${NETCDF_FORTRAN_HOME}"
 echo "OMP_NUM_THREADS     : ${OMP_NUM_THREADS}"

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.gcc12_openmpi4_cannon_rocky.env
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.gcc12_openmpi4_cannon_rocky.env
@@ -1,5 +1,5 @@
 ################################################################################
-# gchp.rocky+gnu12.minimal.env
+# gchp.gcc12_openmpi4_cannon_rocky_env
 #
 # Environment file for GCHP + Rocky Linux + GNU Compiler Collection 12.2.0
 #
@@ -31,19 +31,12 @@ if [[ $- = *i* ]] ; then
   echo "... Loading FASRC-built software, please wait ..."
 fi
 
-# FASRC-built modules needed for GEOS-Chem
+# Minimum set of modules
 module load gcc/12.2.0-fasrc01             # gcc / g++ / gfortran
 module load openmpi/4.1.4-fasrc01          # MPI
 module load netcdf-c/4.9.2-fasrc01         # netcdf-c
 module load netcdf-fortran/4.6.0-fasrc02   # netcdf-fortran
-module load flex/2.6.4-fasrc01             # Flex lexer (needed for KPP)
 module load cmake/3.25.2-fasrc01           # CMake (needed to compile)
-
-# Additional FASRC-built modules
-# Uncomment if you need to use these
-#module load IDL/8.7.2-fasrc01              # IDL language (needed for GAMAP)
-#module load R/4.2.2-fasrc01                # R language
-#module load matlab/R2022b-fasrc01          # matlab language
 
 #==============================================================================
 # Environment variables and related settings
@@ -71,8 +64,8 @@ export NETCDF_FORTRAN_ROOT="${NETCDF_FORTRAN_HOME}"
 # ESMF
 export ESMF_COMPILER="gfortran"
 export ESMF_COMM="openmpi"
-export ESMF_DIR="/n/jacob_lab/Lab/RockyLinux/ESMF/ESMF_8_6_1"
-export ESMF_INSTALL_PREFIX="${ESMF_DIR}/INSTALL_gnu12_openmpi4"
+export ESMF_DIR="/n/lab_storage/jacob_lab/Everyone/RockyLinux/ESMF/esmf"
+export ESMF_INSTALL_PREFIX="/n/lab_storage/jacob_lab/Everyone/RockyLinux/ESMF/8.6.1/INSTALL_gnu12_openmpi4"
 export ESMF_ROOT="${ESMF_INSTALL_PREFIX}"
 #----------------------------------------------------------------------------
 # ESMF does not build with GCC12 without the following work-around
@@ -80,14 +73,11 @@ export ESMF_ROOT="${ESMF_INSTALL_PREFIX}"
 export ESMF_F90COMPILEOPTS="-fallow-argument-mismatch -fallow-invalid-boz"
 #----------------------------------------------------------------------------
 
-# KPP 3.0.0+
-export KPP_FLEX_LIB_DIR="${FLEX_HOME}/lib64"
-
 #==============================================================================
 # Set limits
 #==============================================================================
 
-ulimit -u 50000       # maxproc
+ulimit -u unlimited   # maxproc
 ulimit -v unlimited   # vmemoryuse
 ulimit -s unlimited   # stacksize
 
@@ -108,7 +98,6 @@ echo "ESMF_COMPILER       : ${ESMF_COMPILER}"
 echo "ESMF_DIR            : ${ESMF_DIR}"
 echo "ESMF_INSTALL_PREFIX : ${ESMF_INSTALL_PREFIX}"
 echo "ESMF_ROOT           : ${ESMF_ROOT}"
-echo "KPP_FLEX_LIB_DIR    : ${KPP_FLEX_LIB_DIR}"
 echo "MPI_HOME            : ${MPI_HOME}"
 echo "NETCDF_HOME         : ${NETCDF_HOME}"
 echo "NETCDF_FORTRAN_HOME : ${NETCDF_FORTRAN_HOME}"

--- a/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.gcc14_openmpi5_cannon_rocky.env
+++ b/run/GCHP/runScriptSamples/operational_examples/harvard_cannon/gchp.gcc14_openmpi5_cannon_rocky.env
@@ -1,7 +1,7 @@
-###############################################################################
-# gcclassic.gcc12_cannon_rocky.env
+################################################################################
+# gchp.gcc14_openmpi5_cannon_rocky.env
 #
-# Environment file for GCClassic + Rocky Linux + GNU Compiler Collection 12.2.0
+# Environment file for GCHP + Rocky Linux + GNU Compiler Collection 14.2.0
 #
 # Does not include any Spack-built modules, only FASRC-built modules.
 # Useful for running in the Cannon queues, or to start fresh Spack builds.
@@ -9,7 +9,7 @@
 
 # Display message (if we are in a terminal window)
 if [[ $- = *i* ]] ; then
-  echo "Loading modules for GEOS-Chem Classic, please wait ..."
+  echo "Loading modules for GCHP, please wait ..."
 fi
 
 #==============================================================================
@@ -25,50 +25,48 @@ if [[ "x${SPACK_ROOT}" != "x" ]]; then
 fi
 
 #==============================================================================
-# Load FASRC-built software packages for Rocky Linux and GNU 12.2.0
+# Load FASRC-built software packages for Rocky Linux and GNU 14.2.0
 #==============================================================================
 if [[ $- = *i* ]] ; then
   echo "... Loading FASRC-built software, please wait ..."
 fi
 
 # Minimum set of modules
-module load gcc/12.2.0-fasrc01             # gcc / g++ / gfortran
-module load openmpi/4.1.4-fasrc01          # MPI
-module load netcdf-c/4.9.2-fasrc01         # netcdf-c
-module load netcdf-fortran/4.6.0-fasrc02   # netcdf-fortran
+module load gcc/14.2.0-fasrc01             # gcc / g++ / gfortran
+module load openmpi/5.0.5-fasrc01          # MPI
+module load netcdf-c/4.9.2-fasrc06         # netcdf-c
+module load netcdf-fortran/4.6.1-fasrc04   # netcdf-fortran
 module load cmake/3.25.2-fasrc01           # CMake (needed to compile)
 
 #==============================================================================
 # Environment variables and related settings
-# (NOTE: Lmod will define <module>_HOME variables for each loaded module)
+# NOTE: <module>_HOME env vars are defined for each loaded <module>
 #==============================================================================
 
 # Make all files world-readable by default
 umask 022
 
-# Set number of threads for OpenMP.  If running in a SLURM environment,
-# use the number of requested cores.  Otherwise use 8 cores for OpenMP.
-if [[ "x${SLURM_CPUS_PER_TASK}" == "x" ]]; then
-    export OMP_NUM_THREADS=8
-else
-    export OMP_NUM_THREADS="${SLURM_CPUS_PER_TASK}"
-fi
-
-# Max out the stacksize memory limit
-export OMP_STACKSIZE="500m"
-
-# Compilers
+# Specify compilers
 export CC="gcc"
 export CXX="g++"
 export FC="gfortran"
 export F77="${FC}"
 
+# MPI
+export MPI_ROOT="${MPI_HOME}"
+
 # netCDF
 if [[ "x${NETCDF_HOME}" == "x" ]]; then
     export NETCDF_HOME="${NETCDF_C_HOME}"
 fi
-export NETCDF_C_ROOT="${NETCDF_HOME}"
-export NETCDF_FORTRAN_ROOT=${NETCDF_FORTRAN_HOME}
+export NETCDF_FORTRAN_ROOT="${NETCDF_FORTRAN_HOME}"
+
+# ESMF
+export ESMF_COMPILER="gfortran"
+export ESMF_COMM="openmpi"
+export ESMF_DIR="/n/lab_storage/jacob_lab/Everyone/RockyLinux/ESMF/esmf"
+export ESMF_INSTALL_PREFIX="/n/lab_storage/jacob_lab/Everyone/RockyLinux/ESMF/8.9.0/INSTALL_gnu14.2.0_openmpi5.0.5"
+export ESMF_ROOT="${ESMF_INSTALL_PREFIX}"
 
 #==============================================================================
 # Set limits
@@ -90,9 +88,13 @@ echo ""
 echo "CC                  : ${CC}"
 echo "CXX                 : ${CXX}"
 echo "FC                  : ${FC}"
+echo "ESMF_COMM           : ${ESMF_COMM}"
+echo "ESMF_COMPILER       : ${ESMF_COMPILER}"
+echo "ESMF_DIR            : ${ESMF_DIR}"
+echo "ESMF_INSTALL_PREFIX : ${ESMF_INSTALL_PREFIX}"
+echo "ESMF_ROOT           : ${ESMF_ROOT}"
 echo "MPI_HOME            : ${MPI_HOME}"
 echo "NETCDF_HOME         : ${NETCDF_HOME}"
 echo "NETCDF_FORTRAN_HOME : ${NETCDF_FORTRAN_HOME}"
-echo "OMP_NUM_THREADS     : ${OMP_NUM_THREADS}"
 echo ""
 echo "Done sourcing ${BASH_SOURCE[0]}"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR updates the Harvard Cannon environment files for GCClassic and GCHP.  We have updated comments, removed obsolete information, and now point to the rebuilt ESMF library paths in `/n/lab_storage/jacob_lab/Everyone/RockyLinux/ESMF/...'.

### Expected changes
This is a zero-diff update, but will allow integration tests to proceed (as integration tests default to the environment files in runScriptSamples).