### PR TITLE
Meteorology consistency in GCHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed `#MINVERSION` to 3.5.0 in `Hg.kpp`, `fullchem.kpp` and `carbon.kpp` files
 - Gave all dummy species `KPP_AbsTol = 1.0e25` in `run/shared/species_database.yml` so that they would be not included in the Rosenbrock error norm
 - Updated Harvard Cannon environment files for GCHP & GCClassic to refer to new library location
+- Change State_Met%T and State_Met%SPHU in GCHP to be post-advection values rather than mid-point for consistency with State_Met%PEDGE
 
 ### Fixed
 - Fixed incorrect variable names and removed unused variables in `NcdfUtil/ncdf_mod.F90`

--- a/Interfaces/GCHP/Includes_Before_Run.H
+++ b/Interfaces/GCHP/Includes_Before_Run.H
@@ -105,14 +105,15 @@
     State_Met%PFLLSAN(:,:,:)   = State_Met%PFLLSAN(:,:,z_ub:z_lb:-1)
   end if
 
-  ! NOTE: PLE (imported from advection) is reversed in the vertical!
-  ! Note that this will end up affecting DELP and therefore
-  ! State_Met%PEDGE_DRY, but that the major dry pressure variables are
-  ! derived from PS1_DRY and PS2_DRY.
-  ! These will, in turn, be determined from PS1_WET and PS2_WET, which
-  ! are set in the block above.
-
-  ! Convert Pa -> hPa
+  ! Set edge pressures, convert Pa -> hPa, and vertically flip
+  !
+  ! NOTE: PLE is post-advection pressure edges computed in the
+  ! GCHPctmEnv gridded component, passed to FV3, and then passed
+  ! (unchanged) to GEOS-Chem. Note that it is reversed in the vertical
+  ! because it was prepared for and used in FV3. It was constructed from
+  ! the instantaneous meteorology surface pressures PS1 and PS2 through
+  ! time-interpolation to time after advection. This means PEDGE in
+  ! GEOS-Chem represents post-advection pressure.
   State_Met%PEDGE  (:,:,1:State_Grid%NZ+1) = PLE(:,:,State_Grid%NZ:0:-1) / 1d2
 
   ! These will be set based on PS1_WET and PS2_WET in gchp_chunk_mod.F90
@@ -198,8 +199,10 @@
     endif
   endif
 
-  State_Met%SPHU                =(State_Met%SPHU1+State_Met%SPHU2)*0.5d0
-  State_Met%T                   =(State_Met%TMPU1+State_Met%TMPU2)*0.5d0
+  ! Set specific humidity and temperature to post-advection values
+  ! for consistency with pressure PEDGE (see note above)
+  State_Met%SPHU                = State_Met%SPHU2
+  State_Met%T                   = State_Met%TMPU2
 
   ! Create total optical depth field                         ! 1
   State_Met%OPTD                = State_Met%TAUCLI + State_Met%TAUCLW


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR changes `State_Met%T` and `State_Met%SPHU` in GCHP from timestep mid-point to post-advection values. The motivation of this change is to make all of the meteorology set in `calc_met_mod` per timestep consistent with instantaneous values time-interpolated to post-advection time. Previously edge pressures (`State_Met%PEDGE` and `State_Met%PEDGE_DRY`) were end-of-timestep (following a fix from beginning-of-timestep) while temperature and specific humidity were set to mid-point (average of pre-advection and post-advection).

I am not labelling this PR as a bug fix because setting humidity and temperature to timestep mid-point was implemented long ago and was intentional at the time. The motivation was to match the GEOS CTM but there was no evidence-based rationale for it being that way in that model. The change in this PR makes more logical sense and is considered an objective improvement rather than a bug fix.

Tagging @yuanjianz, @sdeastham 

### Expected changes

This PR will cause minor differences in all species in all GCHP simulations. `State_Met` variables related to temperature and humidity will change. `State_Met%PEDGE_DRY` will not change because it was already computed using `SPHU2` (post-advection humidity).

This is a no diff update for GEOS-Chem Classic.

### Reference(s)

None

### Related Github Issue/PR

Fix inconsistency in GCHP pressures- #3363
