### PR TITLE
Merge updates from dev/no-diff-to-benchmark into dev/14.8.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Renamed GCHP history diagnostics for upwards mass flux to remove the `_R4` suffix
 
 ### Fixed
-- Restored missing line `CH4_BBN:` to `run/shared/species_database.yml
+- Restored missing line `CH4_BBN:` to `run/shared/species_database.yml`
+- Fixed a bug preventing GC-Classic HISTORY collection subsetting with `LON_RANGE` and `LAT_RANGE` from working properly
 
 ## [14.7.1] - 2026-04-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed definition of `State_Grid%MaxChemLev` and `State_Grid%MaxStratLev` to be the 1 hPa level
 - Moved `MaxChemLev` and `MaxStratLev` fields from `State_Grid` to `State_Met`
 - Removed `State_Grid%MaxTropLev` field
-
+- Changed NK5 to NK05 and NK8 to NK08 in fullchem_mod.F90 to fix missing leading zero bug for TOMAS
+	
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`
 - Fixed typo in the call to `Finalize` for the `State_Diag%ProdOCPIfromOCPO` diagnostic array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed `NK5` to `NK05` and `NK8` to `NK08` in `fullchem_mod.F90` to fix missing leading zero bug for TOMAS
 - Renamed GCHP history diagnostics for upwards mass flux to remove the `_R4` suffix
 
+### Fixed
+- Restored missing line `CH4_BBN:` to `run/shared/species_database.yml
+
 ## [14.7.1] - 2026-04-08
 ### Added
 - Added `HTAP_SHIP` toggle in `HEMCO_Config.rc.carbon` templates for GC-Classic and GCHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed definition of `State_Grid%MaxChemLev` and `State_Grid%MaxStratLev` to be the 1 hPa level
 - Moved `MaxChemLev` and `MaxStratLev` fields from `State_Grid` to `State_Met`
 - Removed `State_Grid%MaxTropLev` field
+- Renamed GCHP history diagnostics for upwards mass flux to remove the '_R4' suffix
 
 ### Fixed
 - Fixed incorrect unit conversion from v/v -> molec/cm3 in `planeflight_mod.F90`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Changed `NK5` to `NK05` and `NK8` to `NK08` in `fullchem_mod.F90` to fix missing leading zero bug for TOMAS
 - Renamed GCHP history diagnostics for upwards mass flux to remove the `_R4` suffix
+- Updated utility script `run/shared/rtd_species_by_simulation.py` to read the `species_database.yml` for Hg simulations
 
 ### Fixed
-- Restored missing line `CH4_BBN:` to `run/shared/species_database.yml
+- Restored missing line `CH4_BBN:` to `run/shared/species_database.yml`
 
 ## [14.7.1] - 2026-04-08
 ### Added

--- a/GeosCore/fullchem_mod.F90
+++ b/GeosCore/fullchem_mod.F90
@@ -3575,8 +3575,8 @@ CONTAINS
     id_SALC     = Ind_( 'SALC'         )
     id_SALCAL   = Ind_( 'SALCAL'       )
 #ifdef TOMAS
-    id_NK05     = Ind_( 'NK5'          )
-    id_NK08     = Ind_( 'NK8'          )
+    id_NK05     = Ind_( 'NK05'          )
+    id_NK08     = Ind_( 'NK08'          )
     id_NK10     = Ind_( 'NK10'         )
     id_NK20     = Ind_( 'NK20'         )
 #endif

--- a/History/history_mod.F90
+++ b/History/history_mod.F90
@@ -173,7 +173,13 @@ CONTAINS
     ENDIF
 
     !=======================================================================
-    ! Then determine the fields that will be saved to each collection
+    ! Then, initialize the netCDF coordinate variables,
+    ! which are stored as fields of the State_Grid object.
+    !=======================================================================
+    CALL History_InitCoordVars( State_Grid )
+
+    !=======================================================================
+    ! Finally, determine the fields that will be saved to each collection
     ! NOTE: For dry-run, enter to print out file name & status
     !=======================================================================
     CALL History_ReadCollectionData( Input_Opt,  State_Chm, State_Diag,      &
@@ -185,12 +191,6 @@ CONTAINS
        CALL GC_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
-
-    !=======================================================================
-    ! Finally, initialize the netCDF coordinate variables,
-    ! which are stored as fields of the State_Grid object.
-    !=======================================================================
-    CALL History_InitCoordVars( State_Grid )
 
   END SUBROUTINE History_Init
 !EOC
@@ -589,7 +589,7 @@ CONTAINS
     USE Species_Mod,           ONLY : Species
     USE State_Chm_Mod
     USE State_Diag_Mod
-    USE State_Grid_Mod,        ONLY : GrdState, Lookup_Grid
+    USE State_Grid_Mod,        ONLY : GrdState
     USE State_Met_Mod
 !
 ! !INPUT PARAMETERS:
@@ -675,12 +675,8 @@ CONTAINS
     TYPE(Species),       POINTER :: ThisSpc
 
     ! Pointer arrays
-    REAL(f8),            POINTER :: Grid_Lat (:    )
-    REAL(f8),            POINTER :: Grid_LatE(:    )
-    REAL(f8),            POINTER :: Grid_Lon (:    )
-    REAL(f8),            POINTER :: Grid_LonE(:    )
-    REAL(fp),            POINTER :: Ptr3d    (:,:,:)
-    REAL(f4),            POINTER :: Ptr3d_4  (:,:,:)
+    REAL(fp),            POINTER :: Ptr3d  (:,:,:)
+    REAL(f4),            POINTER :: Ptr3d_4(:,:,:)
 
     !=======================================================================
     ! Initialize
@@ -732,10 +728,6 @@ CONTAINS
        Ptr3d          => NULL()
        Ptr3d_4        => NULL()
        ThisSpc        => NULL()
-       Grid_Lat       => NULL()
-       Grid_LatE      => NULL()
-       Grid_Lon       => NULL()
-       Grid_LonE      => NULL()
 
        ! Initialize Strings
        Description    =  ''
@@ -771,58 +763,6 @@ CONTAINS
 
        ! Compute the length of the simulation, in elapsed seconds
        SimLengthSec   = NINT( ( JulianDateEnd - JulianDate ) * SECONDS_PER_DAY )
-
-       !====================================================================
-       ! Get pointers to the grid longitudes and latitudes
-       !====================================================================
-
-       ! Lookup latitude centers
-       CALL Lookup_Grid( Input_Opt  = Input_Opt,                             &
-                         State_Grid = State_Grid,                            &
-                         Variable   = 'GRID_LAT',                            &
-                         Ptr1d_8    = Grid_Lat,                              &
-                         RC         = RC                                    )
-       IF ( RC /= GC_SUCCESS ) THEN
-          ErrMsg = 'Could not get pointer to latitudes (aka GRID_LAT)!'
-          CALL GC_Error( ErrMsg, RC, ThisLoc )
-          RETURN
-       ENDIF
-
-       ! Lookup latitude edges
-       CALL Lookup_Grid( Input_Opt  = Input_Opt,                             &
-                         State_Grid = State_Grid,                            &
-                         Variable   = 'GRID_LATE',                           &
-                         Ptr1d_8    = Grid_LatE,                             &
-                         RC         = RC                                    )
-       IF ( RC /= GC_SUCCESS ) THEN
-          ErrMsg = 'Could not get pointer to latitude edges (aka GRID_LATE)!'
-          CALL GC_Error( ErrMsg, RC, ThisLoc )
-          RETURN
-       ENDIF
-
-       ! Lookup longitude centers
-       CALL Lookup_Grid( Input_Opt  = Input_Opt,                             &
-                         State_Grid = State_Grid,                            &
-                         Variable   = 'GRID_LON',                            &
-                         Ptr1d_8    = Grid_Lon,                              &
-                         RC         = RC                                    )
-       IF ( RC /= GC_SUCCESS ) THEN
-          ErrMsg = 'Could not get pointer to longitudes (aka GRID_LON)!'
-          CALL GC_Error( ErrMsg, RC, ThisLoc)
-          RETURN
-       ENDIF
-
-       ! Lookup longitude edges
-       CALL Lookup_Grid( Input_Opt  = Input_Opt,                             &
-                         State_Grid = State_Grid,                            &
-                         Variable   = 'GRID_LONE',                           &
-                         Ptr1d_8    = Grid_LonE,                             &
-                         RC         = RC                                    )
-       IF ( RC /= GC_SUCCESS ) THEN
-          ErrMsg = 'Could not get pointer to longitude edges (aka GRID_LONE)!'
-          CALL GC_Error( ErrMsg, RC, ThisLoc)
-          RETURN
-       ENDIF
     ENDIF
 
     !=======================================================================
@@ -1097,13 +1037,13 @@ CONTAINS
              ENDIF
 
              ! Find the longitude indices for lonMin and lonMax values
-             DO X = 1, SIZE( Grid_LonE )-1
-                IF ( Grid_LonE(X  ) <= Subset(1)  .and.                      &
-                     Grid_LonE(X+1) >  Subset(1) ) THEN
+             DO X = 1, SIZE( State_Grid%LonE )-1
+                IF ( State_Grid%LonE(X  ) <= Subset(1)  .and.                &
+                     State_Grid%LonE(X+1) >  Subset(1) ) THEN
                    CollectionSubsetInd(1,C) = X
                 ENDIF
-                IF ( Grid_LonE(X  ) <= Subset(2)  .and.                      &
-                     Grid_LonE(X+1) >  Subset(2) ) THEN
+                IF ( State_Grid%LonE(X  ) <= Subset(2)  .and.                &
+                     State_Grid%LonE(X+1) >  Subset(2) ) THEN
                    CollectionSubsetInd(2,C) = X
                 ENDIF
              ENDDO
@@ -1122,7 +1062,7 @@ CONTAINS
           ENDIF
        ENDIF
 
-       ! "LON_RANGE": Specifies a latitude range for subsetting
+       ! "LAT_RANGE": Specifies a latitude range for subsetting
        ! the data grid. The required order is: latMin, latMax
        Pattern = 'LAT_RANGE'
        Subset  =  UNDEFINED_DBL
@@ -1150,13 +1090,13 @@ CONTAINS
              ENDIF
 
              ! Find the latitude indices for latMin and latMax values
-             DO Y = 1, SIZE( Grid_LatE )-1
-                IF ( Grid_LatE(Y  ) <= Subset(1)  .and.                      &
-                     Grid_LatE(Y+1) >  Subset(1) ) THEN
+             DO Y = 1, SIZE( State_Grid%LatE )-1
+                IF ( State_Grid%LatE(Y  ) <= Subset(1)  .and.                &
+                     State_Grid%LatE(Y+1) >  Subset(1) ) THEN
                    CollectionSubsetInd(3,C) = Y
                 ENDIF
-                IF ( Grid_LatE(Y  ) <= Subset(2)  .and.                      &
-                     Grid_LatE(Y+1) >  Subset(2) ) THEN
+                IF ( State_Grid%LatE(Y  ) <= Subset(2)  .and.                &
+                     State_Grid%LatE(Y+1) >  Subset(2) ) THEN
                    CollectionSubsetInd(4,C) = Y
                 ENDIF
              ENDDO
@@ -1962,12 +1902,6 @@ CONTAINS
     ! Cleanup and quit
     !=======================================================================
 999 CONTINUE
-
-    ! Free pointers
-    Grid_Lat  => NULL()
-    Grid_LatE => NULL()
-    Grid_Lon  => NULL()
-    Grid_LonE => NULL()
 
     ! Close the file
     CLOSE( fId )

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.TransportTracers
@@ -544,7 +544,7 @@ COLLECTIONS: 'Emissions',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux       ', 'GCHPctmEnv',
                                     'PLE0_R4               ', 'GCHPctmEnv',
                                     'PLE1_R4               ', 'GCHPctmEnv',
                                     'DryPLE0_R4            ', 'GCHPctmEnv',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.carbon
@@ -266,7 +266,7 @@ COLLECTIONS: 'SpeciesConc',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux       ', 'GCHPctmEnv',
                                     'PLE0_R4               ', 'GCHPctmEnv',
                                     'PLE1_R4               ', 'GCHPctmEnv',
                                     'DryPLE0_R4            ', 'GCHPctmEnv',

--- a/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
+++ b/run/GCHP/HISTORY.rc.templates/HISTORY.rc.fullchem
@@ -636,7 +636,7 @@ COLLECTIONS: @#'DefaultCollection',
   GCHPctmEnvLevEdge.frequency:      010000
   GCHPctmEnvLevEdge.duration:       010000
   GCHPctmEnvLevEdge.mode:           'time-averaged'
-  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux_R4    ', 'GCHPctmEnv',
+  GCHPctmEnvLevEdge.fields:         'UpwardsMassFlux       ', 'GCHPctmEnv',
                                     'PLE0_R4               ', 'GCHPctmEnv',
                                     'PLE1_R4               ', 'GCHPctmEnv',
                                     'DryPLE0_R4            ', 'GCHPctmEnv',

--- a/run/shared/rtd_species_by_simulation.py
+++ b/run/shared/rtd_species_by_simulation.py
@@ -23,11 +23,15 @@ def read_species_from_eqn_file(simulation_name):
     Reads a geoschem_config.yml template file for a given GEOS-Chem
     simulation and returns the list of transported species
 
-    Args
-    simulation_name     : str : Name of the GEOS-Chem simulation
+    Parameters
+    ----------
+    simulation_name : str
+        Name of the GEOS-Chem simulation
 
-    returns
-    transported_species : list : List of transported species
+    Returns
+    -------
+    transported_species : list
+        List of transported species
     """
     verify_variable_type(simulation_name, str)
 
@@ -52,11 +56,15 @@ def read_transported_species(simulation_name):
     Reads a geoschem_config.yml template file for a given GEOS-Chem
     simulation and returns the list of transported species
 
-    Args
-    simulation_name     : str : Name of the GEOS-Chem simulation
+    Parameters
+    ----------
+    simulation_name : str
+        Name of the GEOS-Chem simulation
 
-    returns
-    transported_species : list : List of transported species
+    Returns
+    -------
+    transported_species : list
+        List of transported species
     """
     verify_variable_type(simulation_name, str)
 
@@ -95,10 +103,12 @@ def read_species_database():
     Reads the GEOS-Chem Species Database.
 
     Returns
-    species_database : dict : GEOS-Chem Species Database object
+    -------
+    species_database : dict
+        GEOS-Chem Species Database object
     """
     count = 0
-    for sim in ["", "_apm", "_hg", "_tomas"]:
+    for sim in ["", "_apm", "_tomas"]:
         filename = os.path.expanduser(SPECIES_DB.replace("XX", sim))
         if count == 0:
             species_database = read_config_file(filename, quiet=True)
@@ -116,12 +126,17 @@ def get_species_metadata(species, species_database):
     Compares a species against the species database and returns
     selected metadata fields.
 
-    Args
-    species          : list : List of species names
-    species_database : dict : GEOS-Chem Species Database
+    Parameters
+    ----------
+    species : list
+        List of species names
+    species_database : dict
+        GEOS-Chem Species Database
 
     Returns
-    metadata         : dict : Selected species metadata fields
+    -------
+    metadata : dict
+        Selected species metadata fields
     """
     verify_variable_type(species, list)
     verify_variable_type(species_database, dict)
@@ -149,13 +164,14 @@ def create_rtd_list_table(metadata, table_file, title=None):
     Creates a ReadTheDocs list table displaying the transported species
     for a given GEOS-Chem simulation.
 
-    Args
-    metadata   : dict : Selected species metadata fields
-    table_file : str  : File where the list table will be written
-
-    Kwargs
-    title      : str  : Table title
-
+    Parameters
+    ----------
+    metadata : dict
+        Selected species metadata fields
+    table_file : str
+        File where the list table will be written
+    title : str, optional
+        Table title
     """
     verify_variable_type(metadata, dict)
     verify_variable_type(table_file, str)
@@ -191,9 +207,12 @@ def main(simulation_name, table_file):
     """
     Main program.  Calls subroutines to create the list table.
 
-    Args
-    simulation_name : str : Name of a GEOS-Chem simulation
-    table_file      : str : File where the list table will be written
+    Parameters
+    ----------
+    simulation_name : str
+        Name of a GEOS-Chem simulation
+    table_file : str
+        File where the list table will be written
     """
     verify_variable_type(simulation_name, str)
     verify_variable_type(table_file, str)

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -967,6 +967,7 @@ CH4:
   Background_VV: 1.8e-6
   FullName: Methane
   MW_g: 16.04
+CH4_BBN:
   << : *CH4properties
   Background_VV: 1.0e-20
   FullName: Methane from biomass burning emissions


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR seeks to bring updates from the `dev/no-diff-to-benchmark` branch into the `dev/14.8.0` branch, in advance of the 14.8.0 release. 

| Feature | Contributor(s) |  Notes and references |
| --- | --- | --- |
| Fix bug preventing subsetting of GC-Classic History collections with LON_RANGE and LAT_RANGE | Eloise Marais (UCL)<br>Bob Yantosca (Harvard) | [geos-chem PR #3305](https://github.com/geoschem/geos-chem/pull/3305) |
| Utility script `rtd_species_by_simulation.py` now reads from `species_database.yml` for Hg simulation | Bob Yantosca (Harvard) | [geos-chem PR #3295](https://github.com/geoschem/geos-chem/pull/3295) |
| Fixed bug in GCHP UpwardsMassFlux diagnostic | Lizzie Lundgren (Harvard) | <ul><li>[FVdycore PR #13](https://github.com/geoschem/FVdycoreCubed_GridComp/pull/13)</li><li>[geos-chem PR #3276](https://github.com/geoschem/geos-chem/pull/3276)</li><li>[GCHP PR #545](https://github.com/geoschem/GCHP/pull/545)</li></ul> |
| Miscellaneous netCDF (standard) input bug fixes | Haipeng Lin (NCAR) | [HEMCO PR #357](https://github.com/geoschem/HEMCO/pull/357) |
| Fix remaining memory leaks in HEMCO | Bob Yantosca (Harvard) | [HEMCO PR #255](https://github.com/geoschem/HEMCO/pull/255) |
| Restored missing line for CH4_BBN in species_database.yml | Bob Yantosca (Harvard) | [geos-chem PR #3283](https://github.com/geoschem/geos-chem/pull/3283) |
| TOMAS bug fix: Rename `NK5` to `NK05` and `NK8` to `NK08` | Betty Croft (WashU) |  [geos-chem PR #3282](https://github.com/geoschem/geos-chem/pull/3282) |

### Expected changes

These are all no-diff-to-benchmark changes.

### Related GitHub issues
- Must be merged concurrrently with https://github.com/geoschem/gchp/pull/569 and https://github.com/geoschem/GCHP/pull/569