### PR TITLE
Add Is_DryAlt flag for SO4, NIT, NH4, SOAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - TBD
 ### Added
+- Added `Is_DryAlt` flag for SO4, NIT, NH4, SOAS in `run/shared/species_database.yml` to enable the `SpeciesConcALT1` diagnostic (concentration at a user-specified altitude above the surface) for these secondary aerosol species
 - Added PSO4AQ and PH2SO4 as a product to certain reactions; see `KPP/fullchem/CHANGELOG_fullchem.md`
 - Added methanediol (MDL) as a transported gas-phase species and to the KPP fullchem and custom mechanisms
 - Added routine `Cloud_CH2O_MDL` in `KPP/fullchem/fullchem_SulfurChemFuncs.F90`

--- a/run/shared/species_database.yml
+++ b/run/shared/species_database.yml
@@ -3508,6 +3508,7 @@ NH4:
   Formula: NH4
   FullName: Ammonium
   Is_Aerosol: true
+  Is_DryAlt: true
   Is_DryDep: true
   Is_WetDep: true
   MW_g: 18.05
@@ -3536,6 +3537,7 @@ NIT:
   DD_Hstar: 0.0
   FullName: Inorganic nitrates
   Is_Aerosol: true
+  Is_DryAlt: true
   Is_DryDep: true
   Is_Photolysis: true
   Is_WetDep: true
@@ -4803,6 +4805,7 @@ SO4:
   Formula: SO4
   FullName: Sulfate
   Is_Aerosol: true
+  Is_DryAlt: true
   Is_DryDep: true
   Is_HygroGrowth: true
   Is_Photolysis: true
@@ -4931,6 +4934,7 @@ SOAS:
   DD_Hstar: 0.0
   FullName: SOA Simple - simplified non-volatile SOA parameterization
   Is_Aerosol: true
+  Is_DryAlt: true
   Is_DryDep: true
   Is_WetDep: true
   MW_g: 150.0


### PR DESCRIPTION
This enables output of concentrations for these four secondary aerosol species at a user-specified altitude above the surface (e.g. 2m), matching the existing capability for O3 and HNO3. This is useful for comparison with surface monitoring networks, which typically measure at 2m above ground, as demonstrated in:

Li, Y., Martin, R. V., Li, C., Boys, B. L., van Donkelaar, A., Meng, J., and Pierce, J. R.: Development and evaluation of processes affecting simulation of diel fine particulate matter variation in the GEOS-Chem model, Atmos. Chem. Phys., 23, 12525-12543,
https://doi.org/10.5194/acp-23-12525-2023, 2023.

Li, Y., Martin, R. V., Zhang, Y., Zhang, D., van Donkelaar, A., Zhu, H., and Meng, J.: Interpreting Measurements of the Global Diurnal Variation of Fine Particulate Matter Using the GEOS-Chem Model, ACS EST Air, 2(8), 1575-1585, https://doi.org/10.1021/acsestair.5c00068, 2025.

Name: Yanshun Li
Institution: WashU