### PR TITLE
Fixes run directory git tracking bug introduced in 14.8.0

### DIFF
--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -894,7 +894,7 @@ while [ "$valid_response" -eq 0 ]; do
 	printf "\n"
 	git init
         for f in *.rc *.sh *.yml *.yaml *.py input.nml; do
-	    if [[ -f "${f}" ]]; then
+            if [[ -f "${f}" ]]; then
                 git add "${f}"
             fi
         done

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -893,14 +893,11 @@ while [ "$valid_response" -eq 0 ]; do
 	printf "\n\nChanges to the following run directory files are tracked by git:\n\n" >> ${version_log}
 	printf "\n"
 	git init
-	for f in *.rc *.sh *.yml *.yaml input.nml; do
-    		if [[ -f "${f}" ]]; then
-        		git add "${f}"
-    		fi
+	for f in *.rc *.sh *.yml *.yaml *.py input.nml; do
+    	    if [[ -f "${f}" ]]; then
+     	        git add "${f}"
+    	    fi
 	done
-	if [[ "x${sim_name}" == "xfullchem" || "x${sim_name}" == "xcarbon" ]]; then
-	    git add *.py
-	fi
 	printf " " >> ${version_log}
 	git commit -m "Initial run directory" >> ${version_log}
 	cd ${srcrundir}

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -896,7 +896,7 @@ while [ "$valid_response" -eq 0 ]; do
         for f in *.rc *.sh *.yml *.yaml *.py input.nml; do
 	    if [[ -f "${f}" ]]; then
                 git add "${f}"
-        fi
+            fi
         done
 	printf " " >> ${version_log}
 	git commit -m "Initial run directory" >> ${version_log}

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -893,7 +893,11 @@ while [ "$valid_response" -eq 0 ]; do
 	printf "\n\nChanges to the following run directory files are tracked by git:\n\n" >> ${version_log}
 	printf "\n"
 	git init
-	git add --ignore-missing *.rc *.sh *.yml *.yaml input.nml
+	for f in *.rc *.sh *.yml *.yaml input.nml; do
+    		if [[ -f "${f}" ]]; then
+        		git add "${f}"
+    		fi
+	done
 	if [[ "x${sim_name}" == "xfullchem" || "x${sim_name}" == "xcarbon" ]]; then
 	    git add *.py
 	fi

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -893,7 +893,7 @@ while [ "$valid_response" -eq 0 ]; do
 	printf "\n\nChanges to the following run directory files are tracked by git:\n\n" >> ${version_log}
 	printf "\n"
 	git init
-	git add *.rc *.sh *.yml *.yaml input.nml
+	git add --ignore-missing *.rc *.sh *.yml *.yaml input.nml
 	if [[ "x${sim_name}" == "xfullchem" || "x${sim_name}" == "xcarbon" ]]; then
 	    git add *.py
 	fi

--- a/run/GCHP/createRunDir.sh
+++ b/run/GCHP/createRunDir.sh
@@ -893,11 +893,11 @@ while [ "$valid_response" -eq 0 ]; do
 	printf "\n\nChanges to the following run directory files are tracked by git:\n\n" >> ${version_log}
 	printf "\n"
 	git init
-	for f in *.rc *.sh *.yml *.yaml *.py input.nml; do
-    	    if [[ -f "${f}" ]]; then
-     	        git add "${f}"
-    	    fi
-	done
+        for f in *.rc *.sh *.yml *.yaml *.py input.nml; do
+	    if [[ -f "${f}" ]]; then
+                git add "${f}"
+        fi
+        done
 	printf " " >> ${version_log}
 	git commit -m "Initial run directory" >> ${version_log}
 	cd ${srcrundir}


### PR DESCRIPTION
### Name and Institution (Required)

Name: Helena McDonald
Institution: Harvard University

### Describe the update

GCHP directories missing a .yaml file (fullchem and carbon) have almost all files not under version control when git add fails to find any *.yaml. This fix changes the approach to git add so that an individual missing file type does not prevent version control for all the others. 

No update to the CHANGELOG since this bug was introduced in 14.8.0 when *.yaml was added. 

### Expected changes

No diff to chemistry. 